### PR TITLE
bug- typechecker: fix Option match exhaustiveness for `case None`

### DIFF
--- a/src/frontend/typechecker/check_expr/match_.rs
+++ b/src/frontend/typechecker/check_expr/match_.rs
@@ -174,6 +174,9 @@ impl TypeChecker {
                     Pattern::Wildcard | Pattern::Binding(_) => {
                         has_wildcard = true;
                     }
+                    Pattern::Literal(Literal::None) if subject_ty.is_option() => {
+                        covered.insert("None".to_string());
+                    }
                     Pattern::Constructor(name, _) => {
                         let variant_name = if name.contains("::") {
                             name.split("::").last().unwrap_or(name).to_string()

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -397,6 +397,19 @@ def foo() -> Option[int]:
 }
 
 #[test]
+fn test_option_match_exhaustive_some_none() {
+    let source = r#"
+def foo(value: Option[int]) -> int:
+  match value:
+    case Some(n):
+      return n
+    case None:
+      return 0
+"#;
+    assert!(check_str(source).is_ok());
+}
+
+#[test]
 fn test_result_ok() {
     let source = r#"
 def foo() -> Result[int, str]:


### PR DESCRIPTION
closes #13

Treat `Pattern::Literal(None)` as covering the `None` variant when the match scrutinee is `Option[_]`, so `case None:` no longer triggers a false `“Non-exhaustive match: missing patterns for None”` diagnostic. 

Adds a regression test for match `Option[int]` with `case Some(_)` + `case None` and verifies snapshot coverage for match statements