### PR TITLE
bug - update trait handling and diagnostics (48)

### DIFF
--- a/crates/incan_syntax/src/ast.rs
+++ b/crates/incan_syntax/src/ast.rs
@@ -196,7 +196,7 @@ pub struct ModelDecl {
     pub name: Ident,
     pub type_params: Vec<Ident>,
     // Traits adopted by this model via `with TraitA, TraitB`.
-    pub traits: Vec<Ident>,
+    pub traits: Vec<Spanned<Ident>>,
     pub fields: Vec<Spanned<FieldDecl>>,
     pub methods: Vec<Spanned<MethodDecl>>,
 }
@@ -220,7 +220,7 @@ pub struct ClassDecl {
     pub name: Ident,
     pub type_params: Vec<Ident>,
     pub extends: Option<Ident>,
-    pub traits: Vec<Ident>,
+    pub traits: Vec<Spanned<Ident>>,
     pub fields: Vec<Spanned<FieldDecl>>,
     pub methods: Vec<Spanned<MethodDecl>>,
 }
@@ -443,6 +443,8 @@ pub struct AssignmentStmt {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldAssignmentStmt {
+    /// Span of the assignment target (e.g. `self.field`).
+    pub target_span: Span,
     pub object: Spanned<Expr>,
     pub field: Ident,
     pub value: Spanned<Expr>,

--- a/crates/incan_syntax/src/diagnostics.rs
+++ b/crates/incan_syntax/src/diagnostics.rs
@@ -382,6 +382,21 @@ pub mod errors {
         CompileError::type_error(format!("Type '{}' has no field '{}'", type_name, field), span)
     }
 
+    pub fn duplicate_trait_requires_field(field: &str, span: Span) -> CompileError {
+        CompileError::type_error(format!("Duplicate @requires entry for field '{}'", field), span).with_hint(format!(
+            "Remove the duplicate or keep a single @requires({field}: Type) entry"
+        ))
+    }
+
+    pub fn trait_requires_missing_field(trait_name: &str, field: &str, span: Span) -> CompileError {
+        CompileError::type_error(
+            format!("Trait '{}' does not declare required field '{}'", trait_name, field),
+            span,
+        )
+        .with_hint(format!("Add @requires({field}: Type) to trait '{}'", trait_name))
+        .with_note("Trait default methods may only access fields declared in @requires(...)")
+    }
+
     pub fn duplicate_constructor_field(type_name: &str, field: &str, span: Span) -> CompileError {
         CompileError::type_error(
             format!(

--- a/crates/incan_syntax/src/parser/decl.rs
+++ b/crates/incan_syntax/src/parser/decl.rs
@@ -321,7 +321,7 @@ impl<'a> Parser<'a> {
         let name = self.identifier()?;
         let type_params = self.type_params()?;
         let traits = if self.match_keyword(KeywordId::With) {
-            self.identifier_list()?
+            self.identifier_list_spanned()?
         } else {
             Vec::new()
         };
@@ -368,7 +368,7 @@ impl<'a> Parser<'a> {
         };
 
         let traits = if self.match_keyword(KeywordId::With) {
-            self.identifier_list()?
+            self.identifier_list_spanned()?
         } else {
             Vec::new()
         };

--- a/crates/incan_syntax/src/parser/stmts.rs
+++ b/crates/incan_syntax/src/parser/stmts.rs
@@ -294,6 +294,7 @@ impl<'a> Parser<'a> {
                 Expr::Field(object, field) => {
                     let value = self.expression()?;
                     return Ok(Statement::FieldAssignment(FieldAssignmentStmt {
+                        target_span: expr.span,
                         object: *object,
                         field,
                         value,
@@ -340,6 +341,7 @@ impl<'a> Parser<'a> {
                     };
                     let new_value = Spanned::new(Expr::Binary(Box::new(field_expr), bin_op, Box::new(rhs)), expr.span);
                     return Ok(Statement::FieldAssignment(FieldAssignmentStmt {
+                        target_span: expr.span,
                         object: *object,
                         field,
                         value: new_value,

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -59,7 +59,8 @@ model User with Describable:
         match &program.declarations[1].node {
             Declaration::Model(m) => {
                 assert_eq!(m.name, "User");
-                assert_eq!(m.traits, vec!["Describable".to_string()]);
+                assert_eq!(m.traits.len(), 1);
+                assert_eq!(m.traits[0].node, "Describable");
             }
             _ => panic!("Expected model"),
         }
@@ -82,7 +83,9 @@ model User with A, B:
         match &program.declarations[2].node {
             Declaration::Model(m) => {
                 assert_eq!(m.name, "User");
-                assert_eq!(m.traits, vec!["A".to_string(), "B".to_string()]);
+                assert_eq!(m.traits.len(), 2);
+                assert_eq!(m.traits[0].node, "A");
+                assert_eq!(m.traits[1].node, "B");
             }
             _ => panic!("Expected model"),
         }

--- a/crates/incan_syntax/src/parser/util.rs
+++ b/crates/incan_syntax/src/parser/util.rs
@@ -21,6 +21,21 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn identifier_spanned(&mut self) -> Result<Spanned<Ident>, CompileError> {
+        match &self.peek().kind {
+            TokenKind::Ident(name) => {
+                let span = self.current_span();
+                let name = name.clone();
+                self.advance();
+                Ok(Spanned::new(name, span))
+            }
+            _ => Err(CompileError::syntax(
+                format!("Expected identifier, found {:?}", self.peek().kind),
+                self.current_span(),
+            )),
+        }
+    }
+
     /// Parse an identifier, allowing certain keywords in specific contexts (like enum variants).
     fn identifier_or_keyword(&mut self) -> Result<Ident, CompileError> {
         match &self.peek().kind {
@@ -45,6 +60,14 @@ impl<'a> Parser<'a> {
         let mut idents = vec![self.identifier()?];
         while self.match_token(&TokenKind::Punctuation(PunctuationId::Comma)) {
             idents.push(self.identifier()?);
+        }
+        Ok(idents)
+    }
+
+    fn identifier_list_spanned(&mut self) -> Result<Vec<Spanned<Ident>>, CompileError> {
+        let mut idents = vec![self.identifier_spanned()?];
+        while self.match_token(&TokenKind::Punctuation(PunctuationId::Comma)) {
+            idents.push(self.identifier_spanned()?);
         }
         Ok(idents)
     }

--- a/examples/intermediate/trait_requires.incn
+++ b/examples/intermediate/trait_requires.incn
@@ -1,0 +1,30 @@
+"""
+Trait `@requires(...)` examples
+
+This example demonstrates:
+- Traits with default methods that access adopter fields via `@requires(...)`
+- `mut self` for default methods that mutate adopter fields
+"""
+
+@requires(name: str)
+trait Loggable:
+    def log(self, msg: str) -> None:
+        println(f"[{self.name}] {msg}")
+
+
+@requires(count: int)
+trait Counter:
+    def bump(mut self) -> None:
+        self.count += 1
+
+
+class Service with Loggable, Counter:
+    name: str
+    count: int = 0
+
+
+def main() -> None:
+    mut s = Service(name="svc")
+    s.log("starting")
+    s.bump()
+    s.log(f"count={s.count}")

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -288,8 +288,8 @@ impl AstLowering {
                             }
 
                             // Generate trait impls for each trait this model implements
-                            for trait_name in &m.traits {
-                                match self.lower_trait_impl(&struct_ir.name, trait_name, &m.methods) {
+                            for trait_ref in &m.traits {
+                                match self.lower_trait_impl(&struct_ir.name, trait_ref.node.as_str(), &m.methods) {
                                     Ok(trait_impl) => {
                                         ir_program.declarations.push(IrDecl::new(IrDeclKind::Impl(trait_impl)));
                                     }
@@ -331,8 +331,8 @@ impl AstLowering {
                             }
 
                             // Generate trait impls for each trait this class implements
-                            for trait_name in &c.traits {
-                                match self.lower_trait_impl(&struct_ir.name, trait_name, &all_methods) {
+                            for trait_ref in &c.traits {
+                                match self.lower_trait_impl(&struct_ir.name, trait_ref.node.as_str(), &all_methods) {
                                     Ok(trait_impl) => {
                                         ir_program.declarations.push(IrDecl::new(IrDeclKind::Impl(trait_impl)));
                                     }

--- a/src/format/formatter.rs
+++ b/src/format/formatter.rs
@@ -225,7 +225,7 @@ impl Formatter {
                 if i > 0 {
                     self.writer.write(", ");
                 }
-                self.writer.write(trait_name);
+                self.writer.write(&trait_name.node);
             }
         }
         self.writer.writeln(":");
@@ -278,7 +278,7 @@ impl Formatter {
                 if i > 0 {
                     self.writer.write(", ");
                 }
-                self.writer.write(trait_name);
+                self.writer.write(&trait_name.node);
             }
         }
 

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -242,9 +242,11 @@ impl TypeChecker {
         }
 
         match &base_ty {
-            // Trait default methods typecheck against `Self`, so we cannot know adopter fields here.
-            // Field existence is enforced at adoption sites via `@requires(...)`.
-            ResolvedType::SelfType => ResolvedType::Unknown,
+            // Trait default methods typecheck against `Self`, but field access must be declared via
+            // `@requires(...)` on the trait.
+            ResolvedType::SelfType => self
+                .trait_required_field_type(field, span)
+                .unwrap_or(ResolvedType::Unknown),
             ResolvedType::Tuple(elements) => {
                 if let Ok(idx) = field.parse::<usize>() {
                     if idx < elements.len() {

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -247,6 +247,18 @@ impl TypeChecker {
 
         // Verify field exists on object and value type matches field type
         match &obj_ty {
+            ResolvedType::SelfType => {
+                if let Some(expected_ty) = self.trait_required_field_type(field, field_assign.target_span) {
+                    if !self.types_compatible(&value_ty, &expected_ty) {
+                        self.errors.push(errors::field_type_mismatch(
+                            field,
+                            &expected_ty.to_string(),
+                            &value_ty.to_string(),
+                            field_assign.value.span,
+                        ));
+                    }
+                }
+            }
             ResolvedType::Named(type_name) => {
                 // TODO: lots of nested ifs here, we should refactor this to be more readable.
                 if let Some(id) = self.symbols.lookup(type_name) {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -450,8 +450,8 @@ class Service with Loggable, Serializable:
         match &program.declarations[0].node {
             Declaration::Class(c) => {
                 assert_eq!(c.traits.len(), 2);
-                assert_eq!(c.traits[0], "Loggable");
-                assert_eq!(c.traits[1], "Serializable");
+                assert_eq!(c.traits[0].node, "Loggable");
+                assert_eq!(c.traits[1].node, "Serializable");
             }
             _ => panic!("Expected class"),
         }

--- a/workspaces/docs-site/docs/language/reference/derives_and_traits.md
+++ b/workspaces/docs-site/docs/language/reference/derives_and_traits.md
@@ -165,6 +165,46 @@ def main() -> None:
     println(p.describe())
 ```
 
+### `@requires(...)` (adopter contract)
+
+`@requires(...)` is a decorator you can put on a `trait` to declare **which adopter fields must exist** (and what types
+they must have).
+
+Syntax:
+
+```incan
+@requires(field_a: TypeA, field_b: TypeB)
+trait MyTrait:
+    ...
+```
+
+What the compiler enforces:
+
+- When a `class`/`model` adopts a trait (`with MyTrait`), it must provide **all required fields** with compatible types.
+- Trait default methods may access adopter fields like `self.field` **only if** that field is declared in `@requires(...)`.
+- Mutating adopter fields still requires `mut self` (same as normal methods).
+
+Example:
+
+```incan
+@requires(name: str)
+trait Loggable:
+    def log(self, msg: str) -> None:
+        println(f"[{self.name}] {msg}")
+
+class Service with Loggable:
+    name: str
+```
+
+Example (mutation):
+
+```incan
+@requires(count: int)
+trait Counter:
+    def bump(mut self) -> None:
+        self.count += 1
+```
+
 See also: [Traits (authoring)][traits-doc].
 
 ---

--- a/workspaces/docs-site/docs/language/tutorials/book/11_traits_and_derives.md
+++ b/workspaces/docs-site/docs/language/tutorials/book/11_traits_and_derives.md
@@ -39,6 +39,11 @@ Traits let you define a shared contract. In a trait, a method can either:
     **Traits** are like a typed interface (represented in Python by a `Protocol` or `abc.ABC`): “anything that implements
     these methods can be treated as this capability”.
 
+### Default methods and adopter fields (`@requires`)
+
+If a trait default method accesses adopter fields directly (for example `self.name`), the trait must declare those fields
+in `@requires(...)`. Mutating fields still requires `mut self` (same as normal methods).
+
 Example:
 
 ```incan
@@ -59,6 +64,22 @@ model User with Greetable:
 def main() -> None:
     u = User(username="alice")
     println(u.greet())  # outputs: Hello, alice!
+```
+
+Mutation uses `mut self` (and the field must be declared via `@requires(...)`):
+
+```incan
+@requires(count: int)
+trait Counter:
+    def bump(mut self) -> None:
+        self.count += 1
+
+class Thing with Counter:
+    count: int = 0
+
+def main() -> None:
+    t = Thing()
+    t.bump()
 ```
 
 ## Try it


### PR DESCRIPTION
## Summary

Implements the (missing) RFC 000 §1.5 trait contract: default methods may now reference adopter-provided fields when those fields are declared via `@requires(...)`.

**Before:** Trait default methods could not access `self.<field>` — typechecking failed because `self` was typed as the trait, not the adopter.

**After:** Trait default bodies are typechecked against `Self`, and field access is gated by `@requires(field: Type)`. Missing declarations now produce a clear error with a hint.

Example:

```incan
@requires(name: str)
trait Loggable:
    def log(self, msg: str) -> None:
        println(f"[{self.name}] {msg}")  # ✅ now works

class Service with Loggable:
    name: str
```

Closes #48

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

Traits: Better diagnostics, safer defaults, and spanned identifiers

### Highlights (User-facing)

- **Default methods in traits can access adopter fields** declared via `@requires(...)`.
- **Clearer errors for undeclared field access** inside trait bodies, with a hint:
  `Add `@requires(field: Type)` to trait 'X'`
- **Adoption-site errors** (`with Trait`) now **pinpoint the specific trait** causing the issue.
- **Duplicate `@requires` entries are rejected** with explicit diagnostics.

### Internal changes

- **AST**: `traits` in `ModelDecl` and `ClassDecl` now use `Vec<Spanned<Ident>>` to retain adoption-site spans.
- **Parser** updated to produce spanned identifiers for trait lists.
- **Type checker** gains contextual fields (`current_trait_requires`, `current_trait_name`) to track the active trait during default method checking.
- **Statements**: `FieldAssignmentStmt` now carries a `target_span` for precise assignment diagnostics.

### Compatibility & risk

- **Breaking (AST shape)**: Code that inspects `ClassDecl.traits` / `ModelDecl.traits` must unwrap `Spanned<Ident>` to access both the identifier and its span.  
*Risk is low; there are no known external consumers.*

### Quality & tests

- Added targeted tests for:
    - Trait requirements (`@requires`) behavior.
    - Duplicate `@requires` rejection.
    - Missing required fields in trait method access.
    - Improved diagnostics and span accuracy.

**TL;DR**: Traits now have more reliable default method behavior and significantly better error messages. We also track trait identifiers with spans end-to-end, enabling pinpoint diagnostics. The only breaking change is the AST type of `traits` (now `Spanned<Ident>`).

LSP was updated to support the `@requires`-keyword for traits.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Compiled the reproduction case from issue #48; confirmed `s.log("hi")` works
- Verified missing `@requires` produces hint pointing at `self.<field>` in trait body
- Verified adopter missing required field produces error at `with Trait` clause

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- `workspaces/docs-site/docs/language/reference/derives_and_traits.md` — added `@requires(...)` reference section
- `workspaces/docs-site/docs/language/tutorials/book/11_traits_and_derives.md` — added tutorial guidance + examples

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

