### PR TITLE
Enhance CLI with banner suppression and color control options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  INCAN_NO_BANNER: 1
 
 jobs:
   fmt:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: help
 help: build-quiet  ## Display this help message
-	@./target/debug/incan --version
+	@INCAN_NO_BANNER=1 ./target/debug/incan --version
 	@echo ""
 	@echo "\033[1mBuild:\033[0m"
 	@grep -E '^.PHONY: .*?## build - .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ".PHONY: |## build - "}; {printf "  \033[36m%-18s\033[0m %s\n", $$2, $$3}'
@@ -105,22 +105,22 @@ test:
 .PHONY: examples  ## test - Smoke test examples (check all, run entrypoints with timeout)
 examples: release
 	@echo "\033[1mRunning examples...\033[0m"
-	@INCAN_EXAMPLES_TIMEOUT=$${INCAN_EXAMPLES_TIMEOUT:-5} bash scripts/run_examples.sh
+	@INCAN_NO_BANNER=1 INCAN_EXAMPLES_TIMEOUT=$${INCAN_EXAMPLES_TIMEOUT:-5} bash scripts/run_examples.sh
 
 .PHONY: benchmarks  ## test - Run benchmark suite (requires hyperfine)
 benchmarks: release
 	@echo "\033[1mRunning benchmarks...\033[0m"
-	@bash benchmarks/run_all.sh
+	@INCAN_NO_BANNER=1 bash benchmarks/run_all.sh
 
 .PHONY: benchmarks-rust  ## test - Run benchmarks (Incan vs Rust only; no Python)
 benchmarks-rust: release
 	@echo "\033[1mRunning benchmarks (Incan vs Rust; no Python)...\033[0m"
-	@SKIP_PYTHON=true bash benchmarks/run_all.sh
+	@INCAN_NO_BANNER=1 SKIP_PYTHON=true bash benchmarks/run_all.sh
 
 .PHONY: benchmarks-incan  ## test - Smoke-check benchmark .incn files (build only; no Python/Rust runs)
 benchmarks-incan: release
 	@echo "\033[1mChecking benchmarks (Incan build only)...\033[0m"
-	@bash benchmarks/check_incan.sh
+	@INCAN_NO_BANNER=1 bash benchmarks/check_incan.sh
 
 .PHONY: smoke-test  ## test - Smoke test: build + test + examples + benchmarks-incan
 smoke-test:
@@ -162,19 +162,19 @@ lsp:
 .PHONY: test-incan-canary  ## test - End-to-end Incan test canary (assertion codegen)
 test-incan-canary: release
 	@echo "\033[1mRunning Incan assertion canary...\033[0m"
-	@./target/release/incan test tests/fixtures/test_assert_canary.incn
+	@INCAN_NO_BANNER=1 ./target/release/incan test tests/fixtures/test_assert_canary.incn
 	@echo "\033[32m✓ Incan assertion canary passed\033[0m"
 
 .PHONY: examples-web-build  ## test - Build-only web example (no run)
 examples-web-build: release
 	@echo "\033[1mBuilding web example (build-only)...\033[0m"
-	@./target/release/incan build examples/web/hello_web.incn
+	@INCAN_NO_BANNER=1 ./target/release/incan build examples/web/hello_web.incn
 	@echo "\033[32m✓ Web example built\033[0m"
 
 .PHONY: examples-nested-project-build  ## test - Build-only nested_project example (multi-module imports)
 examples-nested-project-build: release
 	@echo "\033[1mBuilding nested_project example (build-only)...\033[0m"
-	@./target/release/incan build examples/advanced/nested_project/src/main.incn
+	@INCAN_NO_BANNER=1 ./target/release/incan build examples/advanced/nested_project/src/main.incn
 	@echo "\033[32m✓ Nested project example built\033[0m"
 
 .PHONY: vscode-package  ## tool - Package VS Code extension
@@ -199,7 +199,7 @@ run:
 .PHONY: zen  ## misc - Print the Zen of Incan
 zen:
 	@cargo build --release -q 2>/dev/null
-	@./target/release/incan run -c "import this"
+	@INCAN_NO_BANNER=1 ./target/release/incan run -c "import this"
 
 .PHONY: clean  ## misc - Clean build artifacts
 clean:

--- a/workspaces/docs-site/docs/tooling/how-to/testing.md
+++ b/workspaces/docs-site/docs/tooling/how-to/testing.md
@@ -134,6 +134,9 @@ incan test -x
 
 # Include slow tests
 incan test --slow
+
+# Fail if no tests are collected
+incan test --fail-on-empty
 ```
 
 ## Output Format
@@ -161,17 +164,17 @@ ___________ test_division ___________
 
 ## Exit Codes
 
-| Code | Meaning                  |
-| ---- | ------------------------ |
-| 0    | All tests passed         |
-| 1    | One or more tests failed |
+| Code | Meaning                                                                 |
+| ---- | ----------------------------------------------------------------------- |
+| 0    | All tests passed (or no tests collected without `--fail-on-empty`)      |
+| 1    | Any test failed, no test files found, or `--fail-on-empty` found none   |
 
 ## CI Integration
 
 ```yaml
 # GitHub Actions
 - name: Run tests
-  run: incan test tests/
+  run: incan test --fail-on-empty tests/
 ```
 
 ## Fixtures

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -21,6 +21,11 @@ Commands:
 - `fmt` - Format Incan source files
 - `test` - Run tests (pytest-style)
 
+## Global options
+
+- `--no-banner`: suppress the ASCII logo banner (also via `INCAN_NO_BANNER=1`).
+- `--color=auto|always|never`: control ANSI color output (respects `NO_COLOR`).
+
 ## Global options (debug)
 
 These flags take a file and run a debug pipeline stage:
@@ -129,6 +134,9 @@ incan test -x
 
 # Include slow tests
 incan test --slow
+
+# Fail if no tests are collected
+incan test --fail-on-empty
 ```
 
 ## Outputs and paths
@@ -149,6 +157,8 @@ rm -rf target/incan/
 - **`INCAN_STDLIB`**: override the stdlib directory (usually auto-detected; set only if detection fails).
 - **`INCAN_FANCY_ERRORS`**: enable “fancy” diagnostics rendering (presence-based; output may change).
 - **`INCAN_EMIT_SERVICE=1`**: toggle codegen emit mode (internal/debug; not stable).
+- **`INCAN_NO_BANNER=1`**: disable the ASCII logo banner.
+- **`NO_COLOR`**: disable ANSI color output (standard convention).
 
 ## Exit codes
 
@@ -160,6 +170,7 @@ Specific behavior:
 - **`incan test`**:
     - returns 0 if all tests pass
     - returns 0 if test files exist but no tests are collected
+    - returns 1 if `--fail-on-empty` is set and no tests are collected
     - returns 1 if no test files are discovered under the provided path
     - returns 1 if any tests fail or an xfail unexpectedly passes (XPASS)
 - **`incan fmt --check`**: returns 1 if any files would be reformatted.


### PR DESCRIPTION
Here’s a tighter, more cohesive PR description you can paste as-is:

***

## Summary

This PR makes the CLI output predictable for scripts while preserving the Scala‑style banner for interactive use. It removes the banner from `--help`, `--version`, and parse errors; adds explicit color controls via `--color=auto|always|never` with `NO_COLOR` support; introduces `incan test --fail-on-empty` for safer CI; and updates docs and tests accordingly.

## Why

*   Ensure help/version and error output are stable and machine-friendly.
*   Allow users/CI to control ANSI color deterministically.
*   Prevent silent green runs when no tests are collected in CI.
*   Keep the banner for humans in interactive sessions, with an opt-out.

## Changes

*   **Banner control**
    *   Added `--no-banner` flag.
    *   Banner is omitted for `--help`, `--version`, and parse errors.
    *   Makefile sets `INCAN_NO_BANNER=1` for consistent, quiet outputs.
    *   CLI honors `INCAN_NO_BANNER` and `--no-banner`.

*   **Color control**
    *   Added `--color=auto|always|never`.
    *   Respects the `NO_COLOR` environment variable.

*   **Test safety**
    *   Added `incan test --fail-on-empty` to fail when no tests are collected (opt‑in; default behavior unchanged).

*   **Docs & tests**
    *   Documentation updated for new flags/env vars.
    *   New integration tests cover banner suppression, color behavior, and empty test collection.

## Resulting Behavior

*   `incan --help` and `incan --version` are banner‑free and stable for scripting.
*   The banner prints only for interactive invocations; suppress via `--no-banner` or `INCAN_NO_BANNER=1`.
*   ANSI color can be forced/disabled with `--color`; `NO_COLOR` disables colors globally.
*   `incan test --fail-on-empty` causes CI to fail if no tests are found.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**:
  - `incan --help` and `incan --version` no longer print the ASCII logo.
  - Banner prints for interactive invocations and can be suppressed via `--no-banner` or `INCAN_NO_BANNER=1`.
  - `--color=auto|always|never` controls ANSI output; `NO_COLOR` disables ANSI.
  - `incan test --fail-on-empty` exits non-zero when no tests are collected.
- **Internals**:
  - CLI now uses `try_parse` to keep parse errors banner-free.
  - Test runner output styling is centralized and conditional.
- **Risks**:
  - Behavioral changes in CLI output could affect scripts that relied on banner/ANSI output; mitigated by explicit flags.

## Testing / verification

Manual verification notes:

- `cargo test` (recommended)  
- New integration tests cover banner-free help/version/parse errors and `--fail-on-empty`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions