### PR TITLE
chore - add installation target for incan-lsp and automate VS Code extension

### DIFF
--- a/.github/workflows/vscode_vsix_release.yml
+++ b/.github/workflows/vscode_vsix_release.yml
@@ -1,0 +1,32 @@
+name: VS Code Extension VSIX
+
+on:
+  push:
+    tags:
+      - "v*"  # TODO: revisit this once we finalize our release process
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    name: Build VSIX and Upload Release Asset
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: editors/vscode
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm ci
+      - name: Compile extension
+        run: npm run compile
+      - name: Package VSIX
+        run: npx @vscode/vsce package
+      - name: Upload VSIX to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: editors/vscode/*.vsix

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,13 @@ lsp:
 	@cargo build --release --bin incan-lsp
 	@echo "\033[32m✓ LSP server built: target/release/incan-lsp\033[0m"
 
+.PHONY: install-lsp  ## tool - Install incan-lsp to ~/.cargo/bin
+install-lsp:
+	@echo "\033[1mInstalling incan-lsp...\033[0m"
+	@cargo install --path . --bin incan-lsp --force
+	@echo "\033[32m✓ Installed to ~/.cargo/bin/incan-lsp\033[0m"
+	@echo "\033[33mℹ Ensure ~/.cargo/bin is on your PATH\033[0m"
+
 .PHONY: test-incan-canary  ## test - End-to-end Incan test canary (assertion codegen)
 test-incan-canary: release
 	@echo "\033[1mRunning Incan assertion canary...\033[0m"
@@ -180,7 +187,9 @@ examples-nested-project-build: release
 .PHONY: vscode-package  ## tool - Package VS Code extension
 vscode-package:
 	@echo "\033[1mPackaging VS Code extension...\033[0m"
-	@cd editors/vscode && vsce package
+	@cd editors/vscode && npm ci
+	@cd editors/vscode && npm run compile
+	@cd editors/vscode && npx @vscode/vsce package
 	@echo "\033[32m✓ Extension packaged\033[0m"
 
 .PHONY: watch  ## tool - Watch for changes and rebuild (requires cargo-watch)

--- a/workspaces/docs-site/docs/tooling/how-to/editor_setup.md
+++ b/workspaces/docs-site/docs/tooling/how-to/editor_setup.md
@@ -20,21 +20,24 @@ On this page:
 
 The Incan extension provides full syntax highlighting for `.incn` files.
 
-**Installation:**
+**Installation (recommended):**
 
-1. Copy the `editors/vscode/` folder to your VS Code extensions directory:
+1. Download the `.vsix` from the latest Incan GitHub release.
+2. In VS Code/Cursor: Extensions → “Install from VSIX…”
+3. Restart VS Code/Cursor
+4. Open any `.incn` file - syntax highlighting should work automatically
 
-   ```bash
-   # macOS/Linux
-   cp -r editors/vscode ~/.vscode/extensions/incan-language
-   
-   # Or for Cursor
-   cp -r editors/vscode ~/.cursor/extensions/incan-language
-   ```
+**Installation (dev/fallback):**
 
-2. Restart VS Code/Cursor
+If you’re working from a clone of this repo, you can copy the extension folder directly:
 
-3. Open any `.incn` file - syntax highlighting should work automatically
+```bash
+# macOS/Linux
+cp -r editors/vscode ~/.vscode/extensions/incan-language
+
+# Or for Cursor
+cp -r editors/vscode ~/.cursor/extensions/incan-language
+```
 
 **Features:**
 

--- a/workspaces/docs-site/docs/tooling/how-to/lsp.md
+++ b/workspaces/docs-site/docs/tooling/how-to/lsp.md
@@ -29,10 +29,19 @@ Add the binary to your PATH:
 export PATH="$PATH:/path/to/incan-programming-language/target/release"
 ```
 
-Or symlink it:
+If you prefer installing the binary into a user-writable location, you can run:
 
 ```bash
-sudo ln -s /path/to/incan-programming-language/target/release/incan-lsp /usr/local/bin/
+cd /path/to/incan-programming-language
+cargo install --path . --bin incan-lsp --force
+```
+
+This installs to `~/.cargo/bin` by default, which is typically already on PATH.
+
+If you're in the Incan repo, you can also use the Makefile shortcut:
+
+```bash
+make install-lsp
 ```
 
 ### 3. Install VS Code Extension


### PR DESCRIPTION
## Summary

Thin, v0.1-friendly editor setup improvements: remove `sudo` from the LSP install path, add a user‑writable `incan-lsp` install target, make VSIX packaging reproducible, and upload `.vsix` artifacts to releases for easier installation. This is a partial step toward #35 without marketplace publishing or broader tooling changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: docs now recommend VSIX install + user‑writable LSP install; `make install-lsp` and improved `make vscode-package` are available.
- **Internals**: added a CI workflow that packages the VSIX and attaches it to tagged releases.
- **Risks**: VSIX workflow depends on tag naming (`v*`) and a GitHub Release being creatable.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Built VSIX via `make vscode-package` locally.
- Installed VSIX in VS Code/Cursor; confirmed syntax highlighting.
- Confirmed `make install-lsp` installs to `~/.cargo/bin`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `docs/tooling/how-to/editor_setup.md`, `docs/tooling/how-to/lsp.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions