### PR TITLE
chore - add vocab drift guardrails and trait registry (issue #88)

### DIFF
--- a/crates/incan_core/src/bin/generate_lang_reference.rs
+++ b/crates/incan_core/src/bin/generate_lang_reference.rs
@@ -21,7 +21,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use incan_core::lang::types::{collections, numerics, stringlike};
-use incan_core::lang::{builtins, derives, errors, keywords, operators, punctuation, surface};
+use incan_core::lang::{builtins, derives, errors, keywords, operators, punctuation, surface, traits};
 
 fn trim_trailing_newlines_to_at_most_two(out: &mut String) {
     let mut count = 0usize;
@@ -77,7 +77,7 @@ fn write_language_reference(path: &Path) {
     out.push_str("!!! warning \"Generated file\"\n");
     out.push_str("    Do not edit this page by hand.\n");
     out.push_str("    If it looks wrong/outdated, regenerate it from source and commit the result.\n");
-    out.push_str("\n");
+    out.push('\n');
     out.push_str("    Regenerate with: `cargo run -p incan_core --bin generate_lang_reference`\n\n");
 
     out.push_str("## Contents\n\n");
@@ -85,6 +85,7 @@ fn write_language_reference(path: &Path) {
     out.push_str("- [Builtin exceptions](#builtin-exceptions)\n");
     out.push_str("- [Builtin functions](#builtin-functions)\n");
     out.push_str("- [Derives](#derives)\n");
+    out.push_str("- [Builtin traits](#builtin-traits)\n");
     out.push_str("- [Operators](#operators)\n");
     out.push_str("- [Punctuation](#punctuation)\n");
     out.push_str("- [Builtin types](#builtin-types)\n");
@@ -99,6 +100,7 @@ fn write_language_reference(path: &Path) {
     render_exceptions_section(&mut out);
     render_builtins_section(&mut out);
     render_derives_section(&mut out);
+    render_traits_section(&mut out);
     render_operators_section(&mut out);
     render_punctuation_section(&mut out);
     render_types_section(&mut out);
@@ -272,6 +274,36 @@ fn render_derives_section(out: &mut String) {
         let rfc = d.introduced_in_rfc;
         let since = d.since;
         let stability = format!("{:?}", d.stability);
+
+        out.push_str(&format!(
+            "| {id} | {canonical} | {aliases} | {desc} | {rfc} | {since} | {stability} |\n"
+        ));
+    }
+    out.push('\n');
+}
+
+fn render_traits_section(out: &mut String) {
+    start_section(out, "## Builtin traits");
+
+    out.push_str("| Id | Canonical | Aliases | Description | RFC | Since | Stability |\n");
+    out.push_str("|---|---|---|---|---|---|---|\n");
+
+    for t in traits::TRAITS {
+        let id = format!("{:?}", t.id);
+        let canonical = format!("`{}`", t.canonical);
+        let aliases = if t.aliases.is_empty() {
+            String::new()
+        } else {
+            t.aliases
+                .iter()
+                .map(|a| format!("`{}`", a))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let desc = t.description;
+        let rfc = t.introduced_in_rfc;
+        let since = t.since;
+        let stability = format!("{:?}", t.stability);
 
         out.push_str(&format!(
             "| {id} | {canonical} | {aliases} | {desc} | {rfc} | {since} | {stability} |\n"

--- a/crates/incan_core/src/lang/derives.rs
+++ b/crates/incan_core/src/lang/derives.rs
@@ -19,7 +19,9 @@ pub enum DeriveId {
 
     // Comparison
     Eq,
+    PartialEq,
     Ord,
+    PartialOrd,
     Hash,
 
     // Copying / defaults
@@ -62,9 +64,23 @@ pub const DERIVES: &[DeriveInfo] = &[
         Since(0, 1),
     ),
     info(
+        DeriveId::PartialEq,
+        "PartialEq",
+        "Derive partial equality comparisons.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
         DeriveId::Ord,
         "Ord",
         "Derive ordering comparisons.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        DeriveId::PartialOrd,
+        "PartialOrd",
+        "Derive partial ordering comparisons.",
         RFC::_000,
         Since(0, 1),
     ),

--- a/crates/incan_core/src/lang/mod.rs
+++ b/crates/incan_core/src/lang/mod.rs
@@ -38,4 +38,5 @@ pub mod registry;
 pub mod rust_keywords;
 pub mod stdlib;
 pub mod surface;
+pub mod traits;
 pub mod types;

--- a/crates/incan_core/src/lang/traits.rs
+++ b/crates/incan_core/src/lang/traits.rs
@@ -1,0 +1,178 @@
+//! Builtin trait vocabulary.
+//!
+//! This registry defines the canonical set of builtin trait names recognized by the compiler.
+//! Callers should avoid hard-coding trait strings and instead use [`TraitId`] for identity.
+//!
+//! ## Notes
+//! - Lookup via [`from_str`] is **case-sensitive** (trait names are case-sensitive).
+//! - This module is vocabulary only (spellings + metadata), not trait semantics.
+
+use super::registry::{LangItemInfo, RFC, RfcId, Since, Stability};
+
+/// Stable identifier for a builtin trait.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TraitId {
+    Debug,
+    Display,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Clone,
+    Default,
+    From,
+    Into,
+    TryFrom,
+    TryInto,
+    Iterator,
+    IntoIterator,
+    Error,
+}
+
+/// Metadata for a builtin trait.
+pub type TraitInfo = LangItemInfo<TraitId>;
+
+/// Registry of builtin traits.
+pub const TRAITS: &[TraitInfo] = &[
+    info(
+        TraitId::Debug,
+        "Debug",
+        "Trait for debug formatting output.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::Display,
+        "Display",
+        "Trait for user-facing string formatting.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::Eq,
+        "Eq",
+        "Trait for equality comparisons.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::PartialEq,
+        "PartialEq",
+        "Trait for partial equality comparisons.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::Ord,
+        "Ord",
+        "Trait for ordering comparisons.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::PartialOrd,
+        "PartialOrd",
+        "Trait for partial ordering comparisons.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::Hash,
+        "Hash",
+        "Trait for hashing support.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::Clone,
+        "Clone",
+        "Trait for cloning values.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::Default,
+        "Default",
+        "Trait for default value construction.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(TraitId::From, "From", "Trait for conversions.", RFC::_000, Since(0, 1)),
+    info(TraitId::Into, "Into", "Trait for conversions.", RFC::_000, Since(0, 1)),
+    info(
+        TraitId::TryFrom,
+        "TryFrom",
+        "Trait for fallible conversions.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::TryInto,
+        "TryInto",
+        "Trait for fallible conversions.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::Iterator,
+        "Iterator",
+        "Trait for iterator behavior.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::IntoIterator,
+        "IntoIterator",
+        "Trait for conversion into iterators.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        TraitId::Error,
+        "Error",
+        "Trait for error-like values.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+];
+
+/// Resolve a spelling to a builtin trait identifier.
+///
+/// ## Notes
+/// - Matching is **case-sensitive**.
+pub fn from_str(name: &str) -> Option<TraitId> {
+    TRAITS.iter().find(|t| t.canonical == name).map(|t| t.id)
+}
+
+/// Return the canonical spelling for a builtin trait.
+pub fn as_str(id: TraitId) -> &'static str {
+    info_for(id).canonical
+}
+
+/// Return the full metadata entry for a builtin trait.
+///
+/// ## Panics
+/// - If the registry is missing an entry for `id` (this indicates a programming error).
+pub fn info_for(id: TraitId) -> &'static TraitInfo {
+    TRAITS.iter().find(|t| t.id == id).expect("trait info missing")
+}
+
+const fn info(
+    id: TraitId,
+    canonical: &'static str,
+    description: &'static str,
+    introduced_in_rfc: RfcId,
+    since: Since,
+) -> TraitInfo {
+    LangItemInfo {
+        id,
+        canonical,
+        aliases: &[],
+        description,
+        introduced_in_rfc,
+        since,
+        stability: Stability::Stable,
+        examples: &[],
+    }
+}

--- a/crates/incan_stdlib/tests/errors.rs
+++ b/crates/incan_stdlib/tests/errors.rs
@@ -1,0 +1,32 @@
+//! Integration tests for `incan_stdlib::errors`.
+//!
+//! These tests exist to lock in **canonical, user-facing error string formatting** that the compiler/runtime rely on
+//! (e.g. `Kind: message` prefixes).
+//!
+//! Note: `incan_stdlib`'s `serde_json` dependency is behind the optional `json` feature, so this file uses a small
+//! `Display`-only fake error to test formatting logic without enabling features.
+
+use incan_stdlib::errors::json_decode_error_string;
+use std::fmt;
+
+struct FakeJsonError(&'static str);
+
+impl fmt::Display for FakeJsonError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[test]
+/// `json_decode_error_string` must always prefix with `JSONDecodeError: ` and preserve the
+/// underlying error text.
+fn json_decode_error_string_is_prefixed() {
+    let err = FakeJsonError("expected value at line 1 column 1");
+    let formatted = json_decode_error_string(&err);
+
+    assert_eq!(formatted, format!("JSONDecodeError: {}", err));
+    assert!(
+        formatted.contains("line") && formatted.contains("column"),
+        "expected line/column info in JSON decode error: {formatted}"
+    );
+}

--- a/crates/incan_syntax/src/diagnostics.rs
+++ b/crates/incan_syntax/src/diagnostics.rs
@@ -289,8 +289,13 @@ pub mod errors {
     }
 
     pub fn unknown_derive(name: &str, span: Span) -> CompileError {
+        let valid_derives = derives::DERIVES
+            .iter()
+            .map(|d| d.canonical)
+            .collect::<Vec<_>>()
+            .join(", ");
         CompileError::type_error(format!("Unknown derive '{}'", name), span)
-            .with_hint("Valid derives: Debug, Display, Eq, Ord, Hash, Clone, Copy, Default, Serialize, Deserialize")
+            .with_hint(format!("Valid derives: {valid_derives}"))
             .with_hint("Hint: Use 'with TraitName' syntax for custom trait implementations")
     }
 
@@ -604,11 +609,11 @@ pub mod errors {
         }
 
         match derives::from_str(trait_name) {
-            Some(DeriveId::Eq) => {
+            Some(DeriveId::Eq) | Some(DeriveId::PartialEq) => {
                 error = error.with_hint("Add @derive(Eq) to enable equality comparison (==, !=)");
                 error = error.with_hint("Or implement __eq__ manually for custom comparison logic");
             }
-            Some(DeriveId::Ord) => {
+            Some(DeriveId::Ord) | Some(DeriveId::PartialOrd) => {
                 error = error.with_hint("Add @derive(Ord) to enable ordering comparison (<, >, <=, >=)");
                 error = error.with_hint("Or implement __lt__ manually for custom ordering");
             }

--- a/src/backend/ir/lower/types.rs
+++ b/src/backend/ir/lower/types.rs
@@ -39,9 +39,9 @@ impl AstLowering {
     /// Maps container/string annotations to their frozen/static IR equivalents:
     /// - `str` -> `StaticStr`
     /// - `bytes` -> `StaticBytes`
-    /// - `List[T]` -> `NamedGeneric("FrozenList", [T])`
-    /// - `Dict[K, V]` -> `NamedGeneric("FrozenDict", [K, V])`
-    /// - `Set[T]` -> `NamedGeneric("FrozenSet", [T])`
+    /// - `List[T]` -> `NamedGeneric(FrozenList, [T])`
+    /// - `Dict[K, V]` -> `NamedGeneric(FrozenDict, [K, V])`
+    /// - `Set[T]` -> `NamedGeneric(FrozenSet, [T])`
     pub(super) fn lower_const_annotation_type(&self, ty: &ast::Type) -> IrType {
         match ty {
             ast::Type::Simple(name) => {

--- a/src/frontend/typechecker/check_expr/basics.rs
+++ b/src/frontend/typechecker/check_expr/basics.rs
@@ -7,6 +7,7 @@ use crate::frontend::ast::*;
 use crate::frontend::diagnostics::errors;
 use crate::frontend::symbols::*;
 use crate::frontend::typechecker::IdentKind;
+use incan_core::lang::types::collections::{self, CollectionTypeId};
 
 use super::TypeChecker;
 
@@ -89,7 +90,10 @@ impl TypeChecker {
             Literal::String(_) => ResolvedType::Str,
             Literal::Bytes(_) => ResolvedType::Bytes,
             Literal::Bool(_) => ResolvedType::Bool,
-            Literal::None => ResolvedType::Generic("Option".to_string(), vec![ResolvedType::Unknown]),
+            Literal::None => ResolvedType::Generic(
+                collections::as_str(CollectionTypeId::Option).to_string(),
+                vec![ResolvedType::Unknown],
+            ),
         }
     }
 

--- a/src/frontend/typechecker/check_expr/match_.rs
+++ b/src/frontend/typechecker/check_expr/match_.rs
@@ -161,9 +161,15 @@ impl TypeChecker {
             }
         } else if subject_ty.is_result() || subject_ty.is_option() {
             if subject_ty.is_result() {
-                Some(vec!["Ok".to_string(), "Err".to_string()])
+                Some(vec![
+                    constructors::as_str(ConstructorId::Ok).to_string(),
+                    constructors::as_str(ConstructorId::Err).to_string(),
+                ])
             } else {
-                Some(vec!["Some".to_string(), "None".to_string()])
+                Some(vec![
+                    constructors::as_str(ConstructorId::Some).to_string(),
+                    constructors::as_str(ConstructorId::None).to_string(),
+                ])
             }
         } else {
             None
@@ -179,7 +185,7 @@ impl TypeChecker {
                         has_wildcard = true;
                     }
                     Pattern::Literal(Literal::None) if subject_ty.is_option() => {
-                        covered.insert("None".to_string());
+                        covered.insert(constructors::as_str(ConstructorId::None).to_string());
                     }
                     Pattern::Constructor(name, _) => {
                         let variant_name = if name.contains("::") {

--- a/workspaces/docs-site/docs/language/reference/derives_and_traits.md
+++ b/workspaces/docs-site/docs/language/reference/derives_and_traits.md
@@ -109,10 +109,12 @@ Detailed pages:
 
 Some derives imply prerequisite derives (the compiler adds them automatically):
 
-| If you request | Compiler also adds |
-| --- | --- |
-| `Eq` | `PartialEq` |
-| `Ord` | `Eq`, `PartialEq`, `PartialOrd` |
+| If you request | Compiler also adds              |
+| -------------- | ------------------------------- |
+| `Eq`           | `PartialEq`                     |
+| `Ord`          | `Eq`, `PartialEq`, `PartialOrd` |
+
+Note: you may also request `PartialEq` and `PartialOrd` explicitly via `@derive(PartialEq)` / `@derive(PartialOrd)`.
 
 Semantic requirements (not “auto-added”):
 

--- a/workspaces/docs-site/docs/language/reference/language.md
+++ b/workspaces/docs-site/docs/language/reference/language.md
@@ -12,6 +12,7 @@
 - [Builtin exceptions](#builtin-exceptions)
 - [Builtin functions](#builtin-functions)
 - [Derives](#derives)
+- [Builtin traits](#builtin-traits)
 - [Operators](#operators)
 - [Punctuation](#punctuation)
 - [Builtin types](#builtin-types)
@@ -223,7 +224,9 @@ def main() -> None:
 | Debug | `Debug` |  | Derive Rust-style debug formatting. | RFC 000 | 0.1 | Stable |
 | Display | `Display` |  | Derive user-facing string formatting. | RFC 000 | 0.1 | Stable |
 | Eq | `Eq` |  | Derive equality comparisons. | RFC 000 | 0.1 | Stable |
+| PartialEq | `PartialEq` |  | Derive partial equality comparisons. | RFC 000 | 0.1 | Stable |
 | Ord | `Ord` |  | Derive ordering comparisons. | RFC 000 | 0.1 | Stable |
+| PartialOrd | `PartialOrd` |  | Derive partial ordering comparisons. | RFC 000 | 0.1 | Stable |
 | Hash | `Hash` |  | Derive hashing support (for map/set keys). | RFC 000 | 0.1 | Stable |
 | Clone | `Clone` |  | Derive deep cloning. | RFC 000 | 0.1 | Stable |
 | Copy | `Copy` |  | Derive copy semantics for simple value types. | RFC 000 | 0.1 | Stable |
@@ -231,6 +234,27 @@ def main() -> None:
 | Serialize | `Serialize` |  | Derive serialization support (e.g. JSON). | RFC 000 | 0.1 | Stable |
 | Deserialize | `Deserialize` |  | Derive deserialization support (e.g. JSON). | RFC 000 | 0.1 | Stable |
 | Validate | `Validate` |  | Enable validated construction via `TypeName.new(...)` and require a `validate(self) -> Result[Self, E]` method. | RFC 000 | 0.1 | Stable |
+
+## Builtin traits
+
+| Id | Canonical | Aliases | Description | RFC | Since | Stability |
+|---|---|---|---|---|---|---|
+| Debug | `Debug` |  | Trait for debug formatting output. | RFC 000 | 0.1 | Stable |
+| Display | `Display` |  | Trait for user-facing string formatting. | RFC 000 | 0.1 | Stable |
+| Eq | `Eq` |  | Trait for equality comparisons. | RFC 000 | 0.1 | Stable |
+| PartialEq | `PartialEq` |  | Trait for partial equality comparisons. | RFC 000 | 0.1 | Stable |
+| Ord | `Ord` |  | Trait for ordering comparisons. | RFC 000 | 0.1 | Stable |
+| PartialOrd | `PartialOrd` |  | Trait for partial ordering comparisons. | RFC 000 | 0.1 | Stable |
+| Hash | `Hash` |  | Trait for hashing support. | RFC 000 | 0.1 | Stable |
+| Clone | `Clone` |  | Trait for cloning values. | RFC 000 | 0.1 | Stable |
+| Default | `Default` |  | Trait for default value construction. | RFC 000 | 0.1 | Stable |
+| From | `From` |  | Trait for conversions. | RFC 000 | 0.1 | Stable |
+| Into | `Into` |  | Trait for conversions. | RFC 000 | 0.1 | Stable |
+| TryFrom | `TryFrom` |  | Trait for fallible conversions. | RFC 000 | 0.1 | Stable |
+| TryInto | `TryInto` |  | Trait for fallible conversions. | RFC 000 | 0.1 | Stable |
+| Iterator | `Iterator` |  | Trait for iterator behavior. | RFC 000 | 0.1 | Stable |
+| IntoIterator | `IntoIterator` |  | Trait for conversion into iterators. | RFC 000 | 0.1 | Stable |
+| Error | `Error` |  | Trait for error-like values. | RFC 000 | 0.1 | Stable |
 
 ## Operators
 


### PR DESCRIPTION
## Summary

Prevent vocab drift by centralizing builtin trait spellings in `incan_core::lang::traits` and adding guardrail tests that forbid string-literal spellings in compiler layers.

Closes #88

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: No language behavior change; this is primarily internal drift-proofing. Minor improvement: `unknown_derive` diagnostics now list valid derives directly from the registry.
- **Internals**: Adds `incan_core::lang::traits` registry; switches compiler/LSP call sites to use registries for constructors/collection type names; adds `lang_registry_guardrails.rs` tests to prevent stringly regressions.
- **Risks**: Low. Main risk is missing a registry entry or accidentally changing a spelling; guardrail tests should catch this.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [ ] Manual verification described below

Manual verification notes:

- `cargo test -p incan_core -p incan_syntax -p incan_stdlib`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/language.md`, `workspaces/docs-site/docs/language/reference/derives_and_traits.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions