### PR TITLE
bugfix - enhance IR code generation with internal module root handling (issue #90)

### DIFF
--- a/src/backend/ir/lower/decl.rs
+++ b/src/backend/ir/lower/decl.rs
@@ -765,6 +765,28 @@ impl AstLowering {
             ast::ImportKind::Python(s) => (vec![s.clone()], vec![]),
         };
 
+        let qualifier = match &i.kind {
+            ast::ImportKind::Module(p) => {
+                if p.parent_levels > 0 {
+                    super::super::decl::IrImportQualifier::Super(p.parent_levels)
+                } else if p.is_absolute {
+                    super::super::decl::IrImportQualifier::Crate
+                } else {
+                    super::super::decl::IrImportQualifier::Auto
+                }
+            }
+            ast::ImportKind::From { module, .. } => {
+                if module.parent_levels > 0 {
+                    super::super::decl::IrImportQualifier::Super(module.parent_levels)
+                } else if module.is_absolute {
+                    super::super::decl::IrImportQualifier::Crate
+                } else {
+                    super::super::decl::IrImportQualifier::Auto
+                }
+            }
+            _ => super::super::decl::IrImportQualifier::None,
+        };
+
         // Convert AST import items to IR import items
         let ir_items: Vec<super::super::decl::IrImportItem> = ast_items
             .iter()
@@ -775,6 +797,7 @@ impl AstLowering {
             .collect();
 
         IrDeclKind::Import {
+            qualifier,
             path,
             alias: i.alias.clone(),
             items: ir_items,

--- a/workspaces/docs-site/docs/language/how-to/rust_interop.md
+++ b/workspaces/docs-site/docs/language/how-to/rust_interop.md
@@ -18,6 +18,14 @@ from rust::std::collections import HashMap, HashSet
 import rust::serde_json::Value
 ```
 
+### Note on Rust-style imports without `rust::`
+
+Incan also supports Rust-style module paths in regular imports (e.g. `import std::fs`).
+
+- For the Rust standard library, `std::...` is supported as a convenience.
+- For crates from crates.io (e.g. `serde`, `regex`, `reqwest`), prefer `rust::...` so the compiler can manage
+  dependencies in the generated `Cargo.toml`.
+
 ## Automatic Dependency Management
 
 When you use `import rust::crate_name`, Incan automatically adds the dependency to your generated `Cargo.toml`.

--- a/workspaces/docs-site/docs/language/reference/imports_and_modules.md
+++ b/workspaces/docs-site/docs/language/reference/imports_and_modules.md
@@ -191,7 +191,7 @@ def main() -> None:
 
 ## Rust standard library access
 
-Incan can import from Rust’s standard library:
+Incan can import from Rust’s standard library.
 
 ```incan
 import std::fs
@@ -200,8 +200,22 @@ import std::path::Path
 import std::time
 ```
 
+This is equivalent to using the explicit Rust interop prefix:
+
+```incan
+import rust::std::fs
+```
+
 Note: using these requires understanding the underlying Rust types. Prefer Incan built-ins (`read_file`, `write_file`,
 etc.) where available.
+
+## Rust crates vs Incan modules (important)
+
+- **External crates**: Prefer `rust::...` imports (e.g. `import rust::serde_json`), which also enables automatic
+  dependency management for generated `Cargo.toml`.
+- **Incan project modules** (multi-file projects): imports like `from db.schema import Database` refer to modules in
+  the current crate and are emitted as `crate::db::schema::Database` in generated Rust so they compile reliably from
+  submodules.
 
 ## Current status and limitations
 


### PR DESCRIPTION
## Summary

Fixes incorrect Rust import paths for internal modules in multi-file projects by tracking internal module roots and qualifying `use` paths with `crate::` or `super::` as needed. Also adds targeted tests and clarifies docs around Rust vs Incan module imports.

closes #90

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Multi-file projects now generate Rust imports with `crate::`/`super::` prefixes so sibling module imports compile correctly. Rust external crate imports remain unprefixed.  
- **Internals**: Import IR gains an `Auto` qualifier; emit uses known internal module roots to decide prefixing, including flattened module names (e.g. `db_schema`).  
- **Risks**: Root detection for non-nested APIs relies on provided module names; incorrect module lists could still lead to missing prefixes.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [ ] Manual verification described below

Manual verification notes:

- Not run (tests only added/updated).

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/how-to/rust_interop.md`, `workspaces/docs-site/docs/language/reference/imports_and_modules.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions