### PR TITLE
bugfix - update match expression parsing to support inline return statements (issue #92)

### DIFF
--- a/crates/incan_syntax/src/parser/expr.rs
+++ b/crates/incan_syntax/src/parser/expr.rs
@@ -568,13 +568,19 @@ impl<'a> Parser<'a> {
                 Span::new(start, end),
             ))
         } else {
-            let expr = self.expression()?;
-            let end = expr.span.end;
+            let stmt = self.inline_statement()?;
+            self.match_token(&TokenKind::Newline);
+            let end = stmt.span.end;
+            let body = if let Statement::Expr(expr) = &stmt.node {
+                MatchBody::Expr(expr.clone())
+            } else {
+                MatchBody::Block(vec![stmt])
+            };
             Ok(Spanned::new(
                 MatchArm {
                     pattern,
                     guard: None,
-                    body: MatchBody::Expr(expr),
+                    body,
                 },
                 Span::new(start, end),
             ))


### PR DESCRIPTION
## Summary

Allow fat-arrow (`=>`) inline match arms to accept single inline statements (including `return`), aligning behavior with `case` arms and published docs. Adds a parser unit test to lock in the behavior.

closes #92

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `Pattern => return expr` now parses for inline match arms; this matches docs/examples.
- **Internals**: `=>` inline arms reuse `inline_statement()` and map expression statements to `MatchBody::Expr`, while `return`/`pass` become single-statement blocks.
- **Risks**: Minimal; change is localized to parser handling of inline `=>` arms.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` (pass)
- `make smoke-test` (pass)

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): …

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions