### PR TITLE
bugfix - update handling of `None` and `Unit` literals in IR emission (issue 93)

### DIFF
--- a/src/backend/ir/emit/types.rs
+++ b/src/backend/ir/emit/types.rs
@@ -105,6 +105,8 @@ impl<'a> IrEmitter<'a> {
             Pattern::Literal(lit) => {
                 // Pattern literals must be emitted without .to_string() or other conversions
                 match &lit.kind {
+                    IrExprKind::Unit => quote! { () },
+                    IrExprKind::None => quote! { None },
                     IrExprKind::Bool(b) => {
                         if *b {
                             quote! { true }

--- a/src/backend/ir/lower/expr.rs
+++ b/src/backend/ir/lower/expr.rs
@@ -96,7 +96,7 @@ impl AstLowering {
                 ast::Literal::String(s) => (IrExprKind::String(s.clone()), IrType::String),
                 ast::Literal::Bytes(bytes) => (IrExprKind::Bytes(bytes.clone()), IrType::Unknown),
                 ast::Literal::Bool(b) => (IrExprKind::Bool(*b), IrType::Bool),
-                ast::Literal::None => (IrExprKind::Unit, IrType::Unit),
+                ast::Literal::None => (IrExprKind::None, IrType::Option(Box::new(IrType::Unknown))),
             },
 
             ast::Expr::SelfExpr => (

--- a/tests/snapshots/codegen_snapshot_tests__literals.snap
+++ b/tests/snapshots/codegen_snapshot_tests__literals.snap
@@ -22,7 +22,7 @@ fn test_literals() {
     let quote = "single".to_string();
     let yes = true;
     let no = false;
-    let maybe = ();
+    let maybe = None::<_>;
 }
 fn main() {
     test_literals();

--- a/tests/snapshots/codegen_snapshot_tests__lowercase_types.snap
+++ b/tests/snapshots/codegen_snapshot_tests__lowercase_types.snap
@@ -16,7 +16,7 @@ fn test_lowercase_types() {
     let data = [("a", 1), ("b", 2)].into_iter().collect::<HashMap<_, _>>();
     let unique = [1, 2, 3].into_iter().collect::<HashSet<_>>();
     let pair = (42, "hello");
-    let maybe = ();
+    let maybe = None::<_>;
     println!("{}", "All lowercase types work!");
 }
 fn main() {

--- a/tests/snapshots/codegen_snapshot_tests__match_statements.snap
+++ b/tests/snapshots/codegen_snapshot_tests__match_statements.snap
@@ -30,7 +30,7 @@ fn test_match_with_option() {
         Some(n) => {
             println!("{}", n);
         }
-        () => {
+        None => {
             println!("{}", "nothing");
         }
     };

--- a/tests/snapshots/codegen_snapshot_tests__models.snap
+++ b/tests/snapshots/codegen_snapshot_tests__models.snap
@@ -216,8 +216,8 @@ fn main() {
     };
     let data2 = OptionalData {
         required: "also must have".to_string(),
-        optional: (),
-        maybe_number: (),
+        optional: None::<_>,
+        maybe_number: None::<_>,
     };
     let student = StudentData {
         name: "Bob".to_string(),

--- a/tests/snapshots/codegen_snapshot_tests__patterns.snap
+++ b/tests/snapshots/codegen_snapshot_tests__patterns.snap
@@ -66,18 +66,18 @@ fn test_pattern_option_some() {
         Some(n) => {
             println!("{}", n);
         }
-        () => {
+        None => {
             println!("{}", "nothing");
         }
     };
 }
 fn test_pattern_option_none() {
-    let maybe = ();
+    let maybe = None::<_>;
     match maybe {
         Some(n) => {
             println!("{}", n);
         }
-        () => {
+        None => {
             println!("{}", "nothing");
         }
     };
@@ -110,10 +110,10 @@ fn test_pattern_nested_option() {
         Some(Some(n)) => {
             println!("{}", n);
         }
-        Some(()) => {
+        Some(None) => {
             println!("{}", "inner none");
         }
-        () => {
+        None => {
             println!("{}", "outer none");
         }
     };
@@ -141,7 +141,7 @@ fn test_pattern_multiple_bindings() {
         Some(x) => {
             println!("{}", "small");
         }
-        () => {
+        None => {
             println!("{}", "none");
         }
     };

--- a/tests/snapshots/codegen_snapshot_tests__type_annotations.snap
+++ b/tests/snapshots/codegen_snapshot_tests__type_annotations.snap
@@ -24,7 +24,7 @@ fn test_collection_types() {
 }
 fn test_option_types() {
     let maybe_num = Some(42);
-    let nothing = ();
+    let nothing = None::<_>;
 }
 fn test_nested_collections() {
     let matrix = vec![vec![1, 2], vec![3, 4]];


### PR DESCRIPTION
## Summary

Fixes lowering/codegen for `None` so Option-typed literals emit typed `None::<T>` instead of unit `()`, matching expected Option semantics in generated Rust and snapshots.

close #93

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `None` in `Option[T]` contexts now generates `None::<T>` instead of `()`, fixing Rust output for Option fields, annotations, and matches.
- **Internals**: `None` literals lower to `IrExprKind::None` with `IrType::Option(_)`, and expression emission uses the type to output typed `None`.
- **Risks**: Some previously-inferred `None` emissions may now be explicitly typed; should be low risk, but touches snapshot expectations.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit`
- `make smoke-test`
- `INSTA_UPDATE=always cargo test --test codegen_snapshot_tests`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): …

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions