### PR TITLE
release - Incan v0.1.0

### DIFF
--- a/.github/workflows/docs_site_deploy.yml
+++ b/.github/workflows/docs_site_deploy.yml
@@ -3,8 +3,8 @@ name: Docs Site Deploy
 on:
   push:
     branches: [ main ]
-    tags:
-      - "*.*.*"
+  release:
+    types: [ published ]
   workflow_dispatch:
 
 permissions:
@@ -37,19 +37,21 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy dev from main
-        if: github.ref_type == 'branch'
+        if: github.event_name != 'release'
         run: |
           export INCAN_DOCS_BASE_PREFIX="dev"
           python -m mkdocs build --strict
           mike deploy --push dev
           mike set-default --push dev
 
-      - name: Deploy minor version from tag
-        if: github.ref_type == 'tag'
+      - name: Deploy versioned docs from release
+        if: github.event_name == 'release'
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          MINOR="${TAG%.*}"
+          # Strip monorepo prefix: incan-v0.1.0 → v0.1.0 → v0.1
+          VERSION="${TAG#incan-}"
+          MINOR="${VERSION%.*}"
           export INCAN_DOCS_BASE_PREFIX="${MINOR}"
           python -m mkdocs build --strict
           mike deploy --push "${MINOR}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 dependencies = [
  "clap",
  "incan_core",
@@ -684,11 +684,11 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 
 [[package]]
 name = "incan_derive"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 dependencies = [
  "axum",
  "incan_core",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 dependencies = [
  "incan_core",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["target/incan"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.4"
+version = "0.1.0"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.85"

--- a/crates/incan_syntax/src/parser/decl.rs
+++ b/crates/incan_syntax/src/parser/decl.rs
@@ -521,6 +521,55 @@ impl<'a> Parser<'a> {
         let start = self.current_span().start;
         // Allow keywords like "None" as variant names (Rust allows this)
         let name = self.identifier_or_keyword()?;
+
+        // Detect common mistakes in enum bodies and emit targeted diagnostics.
+        if self.check_punct(PunctuationId::FatArrow) {
+            return Err(CompileError::syntax(
+                "Enum variants cannot have mapped values".to_string(),
+                self.current_span(),
+            )
+            .with_note("Enum bodies only accept variant identifiers, optionally with payload types")
+            .with_hint(
+                "To model a lookup table, use a function that returns records instead:\n\n  \
+                 def all_categories() -> list[Category]:\n      \
+                 return [Category(\"Groceries\"), Category(\"Utilities\")]",
+            ));
+        }
+        if self.check_punct(PunctuationId::Dot) {
+            return Err(CompileError::syntax(
+                "Enum variants cannot contain dots".to_string(),
+                self.current_span(),
+            )
+            .with_note("Enum bodies only accept simple identifiers, optionally with payload types")
+            .with_hint("Use plain variant names: e.g. `Inflow` instead of `Cash.Inflow`"));
+        }
+        if self.check_op(OperatorId::Eq) {
+            return Err(CompileError::syntax(
+                "Enum variants cannot have assigned values".to_string(),
+                self.current_span(),
+            )
+            .with_note("Incan enums are algebraic types, not integer-valued enums")
+            .with_hint(
+                "If you need key-value data, use a model instead:\n\n  \
+                 model Color:\n      \
+                 name: str\n      \
+                 value: int",
+            ));
+        }
+        if self.check_punct(PunctuationId::Colon) {
+            return Err(CompileError::syntax(
+                "Enum variants cannot have type annotations".to_string(),
+                self.current_span(),
+            )
+            .with_note("Enum variants use parenthesized payloads, not field-style declarations")
+            .with_hint(
+                "If you need typed fields, use a model instead:\n\n  \
+                 model MyRecord:\n      \
+                 name: str\n\n  \
+                 Or use a payload: `MyVariant(str)`",
+            ));
+        }
+
         let fields = if self.match_punct(PunctuationId::LParen) {
             let fields = self.type_list()?;
             self.expect_punct(PunctuationId::RParen, "Expected ')' after variant fields")?;

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -410,4 +410,69 @@ const ANSWER: int = 42
             _ => panic!("Expected const"),
         }
     }
+
+    // ========================================================================
+    // Enum diagnostic tests (#113)
+    // ========================================================================
+
+    #[test]
+    fn test_enum_fat_arrow_mapping_rejected_with_hint() {
+        let source = "enum Categories:\n    GROCERIES => Category(\"Groceries\")\n";
+        let err = parse_str(source).expect_err("Fat arrow in enum body should be rejected");
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("mapped values"),
+            "Expected hint about mapped values, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_enum_dotted_variant_rejected_with_hint() {
+        let source = "enum FlowType:\n    Cash.Inflow\n";
+        let err = parse_str(source).expect_err("Dotted variant in enum body should be rejected");
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("cannot contain dots"),
+            "Expected hint about dots, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_enum_assigned_value_rejected_with_hint() {
+        let source = "enum Color:\n    Red = 1\n";
+        let err = parse_str(source).expect_err("Assigned value in enum body should be rejected");
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("assigned values"),
+            "Expected hint about assigned values, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_enum_colon_annotation_rejected_with_hint() {
+        let source = "enum Fields:\n    Name: str\n";
+        let err = parse_str(source).expect_err("Type annotation in enum body should be rejected");
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("type annotations"),
+            "Expected hint about type annotations, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_valid_enum_still_parses() {
+        let source = "enum Status:\n    Pending\n    Active\n    Done(str)\n";
+        let program = parse_str(source).expect("Valid enum should parse");
+        assert_eq!(program.declarations.len(), 1);
+        match &program.declarations[0].node {
+            Declaration::Enum(e) => {
+                assert_eq!(e.variants.len(), 3);
+                assert_eq!(e.variants[0].node.name, "Pending");
+                assert_eq!(e.variants[1].node.name, "Active");
+                assert_eq!(e.variants[2].node.name, "Done");
+                assert_eq!(e.variants[2].node.fields.len(), 1);
+            }
+            _ => panic!("Expected enum"),
+        }
+    }
 }

--- a/workspaces/docs-site/docs/language/explanation/enums.md
+++ b/workspaces/docs-site/docs/language/explanation/enums.md
@@ -255,6 +255,45 @@ For serialization details, see [Derives: Serialization](../reference/derives/ser
 
 ---
 
+## Common pitfall: enums are not lookup tables
+
+Incan enums are **algebraic types** — each variant is a fixed tag, optionally carrying data.
+They are **not** key-value mappings or integer-valued constants.
+
+The compiler will catch the mistake early with a targeted error message:
+
+```incan
+# ✗ These are all rejected with clear diagnostics:
+enum Categories:
+    GROCERIES => Category("Groceries")   # "cannot have mapped values"
+
+enum FlowType:
+    Cash.Inflow                           # "cannot contain dots"
+
+enum Color:
+    Red = 1                               # "cannot have assigned values"
+```
+
+**Instead**, use plain variants for the enum and a separate model for rich data:
+
+```incan
+enum CategoryKey:
+    Groceries
+    Utilities
+
+model Category:
+    key: CategoryKey
+    description: str
+
+def all_categories() -> list[Category]:
+    return [
+        Category(key=CategoryKey.Groceries, description="Food items"),
+        Category(key=CategoryKey.Utilities, description="Gas, electric"),
+    ]
+```
+
+---
+
 ## Enums vs models vs classes
 
 | Use Case                               | Enum | Model | Class |

--- a/workspaces/docs-site/docs/release_notes/0_1.md
+++ b/workspaces/docs-site/docs/release_notes/0_1.md
@@ -1,9 +1,9 @@
 # Release 0.1
 
-This is the first published minor release line for Incan.
+This is the first published release of Incan.
 
-Incan is in **beta**: expect evolution as the language and toolchain stabilize. See the [Stability policy](../stability.md)
-for what changes are allowed in minor vs patch releases.
+Incan is a `0.x` release: expect evolution as the language and toolchain stabilize. See the
+[Stability policy](../stability.md) for what changes are allowed in minor vs patch releases.
 
 ## Highlights
 
@@ -11,15 +11,17 @@ for what changes are allowed in minor vs patch releases.
 - A make-first developer workflow (`make install`, `make smoke-test`)
 - A usable CLI surface: `incan build`, `incan run`, `incan fmt`, `incan test`
 - A generated language reference to keep documentation and implementation aligned
+- Multi-file web applications with typed route extractors
+- Model field aliases and metadata for schema-safe mapping ([RFC 021])
 
 ## Getting started (recommended)
 
 - Start at: [Language](../language/index.md) and [Tooling](../tooling/index.md)
-- For “first steps” workflows, use the CLI and Make targets referenced there.
+- For "first steps" workflows, use the CLI and Make targets referenced there.
 
 ## Looking for contributors?
 
-Incan is still early and we’d love help—whether that’s improving docs, fixing bugs, or implementing RFC-backed features.
+Incan is still early and we'd love help—whether that's improving docs, fixing bugs, or implementing RFC-backed features.
 
 - Start here: [Contributing](../contributing/index.md)
 - Good places to start:
@@ -39,31 +41,50 @@ Incan is still early and we’d love help—whether that’s improving docs, fix
 - **Language/runtime**: Evolved `incan_semantics` into `incan_core` (#20)
 - **Language/runtime**: Python-style exceptions modeled as typed errors (#21)
 - **Models**: Keyword-only construction, defaults, and reflection helpers
-- **Models**: Field aliases and metadata for schema-safe mapping (#98)
+- **Models**: Field aliases and metadata for schema-safe mapping ([RFC 021], #98)
 - **Classes**: Behavior-first types with methods, `mut self`, and inheritance (`extends`)
 - **Traits/derives**: Trait composition (`with ...`) and derives for common behavior (serialization, validation, etc.)
 - **Derives**: `@derive(Validate)` for validated construction (#49)
+- **Derives**: `@derive(...)` on enums now parsed, stored in AST, and used during lowering (#101)
+- **Derives**: Automatic `Serialize`/`Deserialize` propagation from models to referenced enums and newtypes (#103, #115)
+- **Enums**: Optional docstrings inside enum bodies (#102)
+- **Web**: Multi-path parameters, `Json[T]`/`Query[T]` extractors in generated route wrappers (#95)
+- **Web**: `Html` response wrapper with `IntoResponse` impl (#108)
+- **Web**: Web route wrappers work for nested modules via `module_path_segments` (#107)
+- **Web**: Web feature flags detected across dependency modules (#105)
+- **Web**: `SurfaceTypeId` registry extended with web types: `App`, `Response`, `Html`, `Json`, `Query` (#114)
 - **Codegen**: Optimize `while True` to `loop` in emitted Rust (#8)
+- **Codegen**: Cross-module enum variant access emits `Type::Variant` instead of `Type.Variant` (#110)
+- **Codegen**: Newtype tuple fields emitted as `pub` for cross-module construction (#104)
+- **Codegen**: `List.append` emits `.clone()` for non-Copy element types
+- **Codegen**: Associated function calls emit correctly in dependency modules (#112)
+- **Compiler**: Dependency module typechecking with `check_with_imports_allow_private` (#111)
+- **Compiler**: Targeted parser diagnostics for invalid enum body patterns (#113)
 - **Tooling**: Centralized `INCAN_VERSION` and version-agnostic codegen snapshots (#14)
 - **Tooling**: `incan --help` / `incan --version` are script-friendly (no banner/ANSI by default) (#34)
 - **Tooling**: `incan test --fail-on-empty` (non-zero when no tests are discovered) (#36)
+- **Tooling**: `incan run` executes from project root so relative paths work as expected (#109)
+- **Tooling**: Axum extractor import collisions resolved by qualifying imports (#100)
 - **Docs**: Restructured docs using the Divio system (#27)
 - **Docs**: MkDocs syntax highlighting (including `incan` fenced code blocks) (#37)
-- **Docs**: Generated language reference “Since” column populated (#39)
+- **Docs**: Generated language reference "Since" column populated (#39)
+- **Docs**: Enum documentation updated with derives, docstrings, and common pitfalls
+- **Docs**: Serialization reference expanded with enum and newtype sections
 - **DX**: Closed-set vocabulary registries and drift guardrails (#88)
 - **DX**: Remove TitleCase heuristic for associated-function emission (#52)
 - **DX**: Align docs/examples for cross-module imports and codegen status (#41)
 - **DX**: Benchmark metadata drift fixes (#40)
 - **DX**: Simplified lexer frontend (#2)
 - **Testing**: Test harness improvements (#24)
-- **Docs**: Complete docs site (Start here, Tooling, Language Guide, Reference) built with MkDocs
 
 ## Bugfixes
 
+- **Web**: Fully qualified extractor types across modules (#106)
 - **Codegen/IR**: Internal module imports in multi-file projects use correct `crate::`/`super::` prefixes (#90, #91)
 - **Parser**: Fat-arrow inline match arms now support `return` statement (#92, #96)
 - **Lowering/codegen**: `None` literal now correctly lowers to `Option::None` instead of unit `()` (#93, #97)
-- **Typechecker/traits**: Trait conformance checks are signature-aware, respect `@requires` field types, and include inherited members (#45, #46, #47, #48)
+- **Typechecker/traits**: Trait conformance checks are signature-aware, respect `@requires` field types, and include
+  inherited members (#45, #46, #47, #48)
 - **Typechecker/traits**: Models can implement traits (#42)
 - **Typechecker/newtypes**: Direct newtype construction is disallowed (#44)
 - **Typechecker/constructors**: Field defaults are applied in model/class constructors (#43)
@@ -73,7 +94,7 @@ Incan is still early and we’d love help—whether that’s improving docs, fix
 - **Codegen**: Default visibility is private (no longer `pub` everywhere) (#6)
 - **Codegen**: Avoid unnecessary `mut` function parameters (#5)
 - **Codegen**: Mixed int/float arithmetic compiles correctly (#4)
-- **Tooling**: `import this` prints “One obvious way” once (#33)
+- **Tooling**: `import this` prints "One obvious way" once (#33)
 - **Tooling/formatter**: `incan fmt --diff` output is actionable for newline-only changes (#32)
 - **Tooling/CLI**: `incan build --help` output directory default matches actual output path (#31)
 - **Examples/web**: `examples/web/hello_web.incn` compiles (#30)
@@ -84,7 +105,9 @@ Incan is still early and we’d love help—whether that’s improving docs, fix
 Incan is still evolving. A few things you may run into:
 
 - Some compiler/language features described in RFCs may be partially implemented.
-- Rust interop is available, but crate support is gated by a “known-good” list (see: [Rust interop](../language/how-to/rust_interop.md)).
+- Rust interop is available, but crate support is gated by a "known-good" list (see: [Rust interop](../language/how-to/rust_interop.md)).
+- Web route handlers and their request models must be declared `pub` for cross-module wrapper generation (#117).
+- Multi-line parenthesized imports are not yet supported; use multiple single-line imports as a workaround (#116).
 
 ## Breaking changes
 


### PR DESCRIPTION
## Summary

Finalise the 0.1.0 release: bump workspace version from `0.1.0-beta.4` to `0.1.0`, add targeted parser diagnostics for invalid enum body patterns (#113), update release notes and docs, and fix a `bytes` crate security advisory (RUSTSEC-2026-0007).

## Type of change

- [x] New feature
- [x] Bug fix
- [x] Documentation
- [x] Refactor / maintenance

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**:
  - Version string changes from `0.1.0-beta.4` → `0.1.0` (shown in `incan --version`, embedded in codegen).
  - Invalid enum patterns (fat-arrow mappings, dotted variants, assigned values, colon annotations) now produce clear, targeted diagnostics with notes and hints instead of generic parse errors (#113).
  - Enum explanation docs updated with a "Common pitfall" section showing correct patterns.

- **Internals**:
  - `Cargo.toml` workspace version + `Cargo.lock` updated.
  - `variant_decl()` in `crates/incan_syntax/src/parser/decl.rs` detects `=>`, `.`, `=`, `:` after a variant name and emits `CompileError::syntax()` with `.with_note()` / `.with_hint()`.
  - 5 new parser unit tests covering the four error patterns plus a valid-enum regression test.

- **Risks**:
  - Low. Version bump is metadata-only; parser changes only add new error branches for previously-failing syntax. No existing valid programs are affected.

## Testing / verification

- [x] `cargo test` — all tests pass (including 5 new parser tests for #113)
- [x] `cargo clippy` — clean
- [x] `cargo deny check` — passes
- [x] `cargo audit` — clean after `bytes` bump to 1.11.1
- [x] Codegen snapshot tests unchanged

Manual verification notes:

- Verified each invalid enum pattern produces the expected targeted diagnostic.
- Confirmed `incan --version` reports `0.1.0`.

## Docs impact

- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- `workspaces/docs-site/docs/language/explanation/enums.md` — new "Common pitfall" section
- `workspaces/docs-site/docs/release_notes/0_1.md` — comprehensive 0.1.0 release notes (removed beta references, added all features/fixes since beta.4)

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

**Closes #113**