### PR TITLE
fix(formatter): single trailing newline at EOF (#189)

### DIFF
--- a/.agents/skills/start-work/SKILL.md
+++ b/.agents/skills/start-work/SKILL.md
@@ -18,6 +18,22 @@ If none is provided, ask the user what they want to work on.
 
 ---
 
+## Git commits — maintainer only
+
+**Do not commit unless the user explicitly asks you to** (e.g. “commit this”, “make a commit”, “git commit with message …”). The maintainer is the only person who commits code to this repository by default.
+
+Agents must **not** run, on their own initiative:
+
+- `git commit` (any variant)
+- `git merge` / `git rebase` / `git cherry-pick` when the result would create or rewrite commits the user did not ask for
+- `git push` (unless the user explicitly asked to push)
+
+**Do** create branches, apply edits, run tests, and leave the working tree ready for the user to review and commit. If finishing a task, summarize what changed and suggest a commit message **as text**; the user runs `git commit` when they are ready.
+
+This policy applies whenever this skill is used (and is the default for Incan work even without `/start-work`).
+
+---
+
 ## Workflow
 
 ### Step 1: Fetch issue/RFC context
@@ -120,6 +136,8 @@ Provide a concise summary:
 
 ### Next steps
 <Suggested first actions based on the issue/RFC>
+
+**Proposed commit message**: `<one line; include in this same summary for the maintainer to use when they commit>`
 ```
 
 ---
@@ -127,5 +145,5 @@ Provide a concise summary:
 ## Edge cases
 
 - **No GitHub CLI (`gh`)**: Fall back to reading the RFC file directly. Note that the issue could not be fetched and ask the user for context.
-- **Dirty working tree**: Warn the user about uncommitted changes before switching branches. Ask whether to stash, commit, or abort.
+- **Dirty working tree**: Warn the user about uncommitted changes before switching branches. Ask whether to stash, commit themselves, or abort — do not commit on their behalf unless they explicitly asked you to commit.
 - **Branch already exists with divergent history**: Always ask before overwriting.

--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,12 @@ pnpm-debug.log*
 
 # MkDocs build output
 site/
-# Generated files - do not commit
-workspaces/docs-site/docs/_snippets/rfcs_refs.md
-workspaces/docs-site/docs/_snippets/tables/rfcs_index.md
 
 # Documentation engines
 .obsidian/
+
+# -- Project-specific files --
+examples/advanced/test_output.txt
+# Generated files we do not want to commit
+workspaces/docs-site/docs/_snippets/rfcs_refs.md
+workspaces/docs-site/docs/_snippets/tables/rfcs_index.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,12 @@ Incan is a Python-like language that compiles to Rust. The compiler itself is wr
 > **CRITICAL — THE USER DECIDES WHAT IS RELEVANT.** Scope, PR boundaries, and which files “belong” on a branch are **the maintainer’s call**, not the agent’s. Never label work as “unrelated PR noise,” “cleanup,” or “hygiene” as a reason to remove or revert it. Always check with the user when in doubt.
 >
 > **FORBIDDEN without explicit user approval that quotes the exact paths or commands:** anything that overwrites or deletes uncommitted work — including `git checkout -- <path>`, `git restore <path>`, `git clean`, `git reset --hard`, `stash drop`, or equivalent. If you believe files should be split, reverted, or left out of a PR, **state that and ask**; do not run destructive git operations on your own initiative.
+>
+> **Commits and pushes:** The maintainer commits code unless they **explicitly** ask you to run `git commit` or `git push`. Implement and test in the working tree; offer a suggested commit message as text. The `/start-work` skill states the same rule.
 
 ## Key References
 
-|         Document         |                                         Path                                         |
+| Document                 | Path                                                                                 |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | Rust coding conventions  | [`workspaces/docs-site/docs/contributing/explanation/readable-maintainable-rust.md`] |
 | Project architecture     | [`workspaces/docs-site/docs/contributing/explanation/architecture.md`]               |
@@ -43,7 +45,7 @@ Incan is a Python-like language that compiles to Rust. The compiler itself is wr
 
 ### Common commands
 
-|                          Command                          |                     Purpose                      |
+| Command                                                   | Purpose                                          |
 | --------------------------------------------------------- | ------------------------------------------------ |
 | `make build`                                              | Debug build (fast)                               |
 | `make release`                                            | Optimized build                                  |
@@ -109,7 +111,7 @@ Agents must treat documentation updates as part of implementation, not optional 
 
 The project style guide covers broad principles. This section is a concrete quick-reference of patterns agents **must not** introduce.
 
-|                  Instead of                   |                 Prefer                 |                                Why                                |
+| Instead of                                    | Prefer                                 | Why                                                               |
 | --------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------- |
 | `.unwrap()` / `.expect("…")` **anywhere**     | `?`, `.context()`, or explicit `match` | Panics crash the compiler; deny lints reject these in CI          |
 | `.clone()` to appease the borrow checker      | Restructure ownership or borrow        | Hides design issues and adds unnecessary allocations              |
@@ -168,7 +170,7 @@ Key directories:
 
 ## Code Locations Reference
 
-|     Feature      |                         Parser                         |                             Typechecker                             |    Lowering     |    Emission     |
+| Feature          | Parser                                                 | Typechecker                                                         | Lowering        | Emission        |
 | ---------------- | ------------------------------------------------------ | ------------------------------------------------------------------- | --------------- | --------------- |
 | Field metadata   | `parser/decl.rs`                                       | `check_decl.rs`                                                     | `lower/decl.rs` | `emit/decls.rs` |
 | Alias resolution | -                                                      | `check_expr/access.rs`, `calls.rs`, `match_.rs`                     | `lower/expr.rs` | -               |
@@ -182,21 +184,21 @@ Key directories:
 
 Skills are reusable workflows in `.cursor/skills/`. Use them by name when the task matches:
 
-|      Skill       |              Trigger               |                           What it does                            |
-| ---------------- | ---------------------------------- | ----------------------------------------------------------------- |
-| `/start-work`    | Starting work on an issue or RFC   | Creates branch, gathers context from issue/RFC, checks learnings  |
-| `/test`          | Writing tests for a change         | Guides test selection, provides correct patterns per compiler stage |
-| `/review`        | Code review, PR review             | Runs the full Incan-aware review checklist                        |
-| `/write-rfc`     | Drafting a new RFC                 | Scaffolds an RFC with correct structure and conventions            |
-| `/review-rfc`    | Checking an RFC before submission  | Validates formatting, structure, content, and status-specific rules |
-| `/bump-rfc`      | Promoting an RFC status            | Handles Draft -> Planned -> In Progress -> Done transitions       |
-| `/add-learning`  | Recording a reusable insight       | Appends to learnings file with correct format and topic grouping  |
+| Skill           | Trigger                           | What it does                                                                                                                            |
+| --------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `/start-work`   | Starting work on an issue or RFC  | Creates branch, gathers context from issue/RFC, checks learnings; does **not** commit (maintainer-only commits unless explicitly asked) |
+| `/test`         | Writing tests for a change        | Guides test selection, provides correct patterns per compiler stage                                                                     |
+| `/review`       | Code review, PR review            | Runs the full Incan-aware review checklist                                                                                              |
+| `/write-rfc`    | Drafting a new RFC                | Scaffolds an RFC with correct structure and conventions                                                                                 |
+| `/review-rfc`   | Checking an RFC before submission | Validates formatting, structure, content, and status-specific rules                                                                     |
+| `/bump-rfc`     | Promoting an RFC status           | Handles Draft -> Planned -> In Progress -> Done transitions                                                                             |
+| `/add-learning` | Recording a reusable insight      | Appends to learnings file with correct format and topic grouping                                                                        |
 
 ### Agents
 
 Subagents in `.cursor/agents/` run as isolated specialists that can be delegated to:
 
-|    Agent     |                  When it's used                  |                         What it does                          |
+| Agent        | When it's used                                   | What it does                                                  |
 | ------------ | ------------------------------------------------ | ------------------------------------------------------------- |
 | `test-suite` | Validating changes, checking regressions, pre-PR | Analyzes diff, runs targeted tests, checks snapshots + clippy |
 

--- a/src/format/formatter/mod.rs
+++ b/src/format/formatter/mod.rs
@@ -63,8 +63,11 @@ impl Formatter {
             idx += consumed;
         }
 
-        // Ensure file ends with newline
-        self.writer.newline();
+        // Top-level declarations already end their emitted text with a trailing newline (`writeln`, `newline`, etc.).
+        // An extra newline here produced two blank lines at EOF after `reattach_comments` normalized output (#189).
+        if program.declarations.is_empty() {
+            self.writer.newline();
+        }
     }
 
     /// Coalesce adjacent compatible top-level imports for cleaner Black-style output.

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -489,7 +489,6 @@ mod tests {
         let formatted = format_source(source)?;
         let expected = r#"trait OrderedCollection[T] with Collection[T], Serializable:
     def sorted(self) -> OrderedCollection[T]: ...
-
 "#;
         assert_eq!(formatted, expected);
         Ok(())
@@ -507,6 +506,21 @@ mod tests {
         let source = "";
         let result = format_source(source);
         assert!(result.is_ok());
+    }
+
+    /// Regression (GitHub #189): declarations already end with a newline; an extra `newline()` at EOF produced `\n\n`.
+    #[test]
+    fn test_format_source_eof_has_single_trailing_newline_only() -> Result<(), FormatError> {
+        let source = r#"def f() -> int:
+    return 1
+"#;
+        let formatted = format_source(source)?;
+        let trailing_nl = formatted.chars().rev().take_while(|c| *c == '\n').count();
+        assert_eq!(
+            trailing_nl, 1,
+            "expected exactly one trailing newline at EOF; got {trailing_nl}: {formatted:?}"
+        );
+        Ok(())
     }
 
     #[test]
@@ -550,7 +564,6 @@ const B: int = 2
         let source = r#"def greet() -> str:
     """Return a greeting."""
     return "hi"
-
 "#;
         let formatted = format_source(source)?;
         assert_eq!(formatted, source);
@@ -574,7 +587,6 @@ pub type MutexGuard[T with Clone] = newtype RawMutexGuard[T]:
     def example(self) -> None:
         shared_counter = Mutex.new(0)  # XXX: constructor lives on Mutex
         return None
-
 "#;
         let formatted = format_source(source)?;
         assert_eq!(formatted, source);
@@ -595,7 +607,6 @@ type Middle = newtype int
 # ---- second ----
 @derive(Clone)
 type Second = newtype int
-
 "#;
         let formatted = format_source(source)?;
         assert_eq!(formatted, source);
@@ -794,7 +805,6 @@ const B: int = 2
 
 def sum_constants() -> int:
     return A + B
-
 "#;
         assert_eq!(result, expected);
         Ok(())

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -218,6 +218,7 @@ They are not intended as runtime function calls.
 - **Compiler**: Trait-typed values are now correctly assignable to supertrait return types in function returns and generic upcasts with compatible type arguments ([RFC 042], #184).
 - **Docs**: Web tutorial examples updated to `std.web` imports and namespaced decorators.
 - **Docs**: Derives and traits explanation updated to use `@rust.extern`.
+- **Tooling**: `incan fmt` no longer appends an extra blank line at end of file — output ends with a single trailing newline (#189).
 
 ## Known limitations (0.2)
 


### PR DESCRIPTION
## Summary

Fixes #189: `incan fmt` no longer emits an extra trailing newline after the last top-level declaration (so files no longer end with a spurious blank line). Declarations already finish with a newline; the unconditional `newline()` at the end of `format_program` duplicated it, and `reattach_comments` made that visible at EOF. Empty programs still get a single trailing newline. Unit expectations are updated for canonical EOF, and `test_format_source_eof_has_single_trailing_newline_only` guards the behavior.

Release notes: `workspaces/docs-site/docs/release_notes/0_2.md` Bugfixes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Formatted `.incn` output ends with exactly one trailing newline at EOF. Re-formatting existing trees may show small EOF-only diffs once.
- **Internals**: `Formatter::format_program` only calls `newline()` after the declaration loop when `program.declarations` is empty; otherwise the last declaration’s own trailing newline is sufficient.
- **Risks**: Low. Anyone who depended on the previous double-newline-at-EOF bug will see a one-time format churn.
- **Agent docs**: Clarifies that agents should not `git commit` / `git push` unless the maintainer explicitly asks; `/start-work` output includes a proposed commit message in the summary block.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [ ] Manual verification described below

**Tests:** `format` module unit tests (including `test_format_source_eof_has_single_trailing_newline_only`); updated round-trip fixtures for single `\n` at EOF.

Manual verification notes:

- Optional: format a file and confirm a single trailing newline (e.g. hex dump or editor whitespace view).

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

**Updated:**

- `workspaces/docs-site/docs/release_notes/0_2.md` — Bugfixes: formatter EOF (#189)
- `AGENTS.md` — Commits/pushes policy; `/start-work` skills table note
- `.agents/skills/start-work/SKILL.md` — Maintainer-only commits; report template includes proposed commit message

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #189