### PR TITLE
bugfix - resolve .clone() on @derive(Clone) types (#193)

### DIFF
--- a/.cursor/agents/learnings.md
+++ b/.cursor/agents/learnings.md
@@ -41,6 +41,11 @@ Reference document for AI agents. These are hard-won insights from past RFC impl
 - **LSP wiring for warnings**: after `parser::parse()` succeeds, loop `ast.warnings` and push each through `compile_error_to_diagnostic()` before typechecking.
 - **LSP is feature-gated**: `cargo build --features lsp` (or `make build`, which enables it) produces `incan-lsp`. For local dev, `make build` symlinks `~/.cargo/bin/incan-lsp` to `target/debug/incan-lsp` unless CI / `INCAN_SKIP_CARGO_BIN_LINK=1`; use `make install-lsp` or `cargo install --path . --features lsp --bin incan-lsp --force` when you need a crates.io-style install instead.
 
+## Builtin trait stubs and stdlib method lookup (#193)
+
+- **Vocabulary-only builtin traits ship with empty `methods` maps** in the symbol table. For instance method resolution, `trait_method_info_resolved` can fall back to `StdlibAstCache::lookup_trait` after `stdlib_module_segments_for_trait_methods` in `src/frontend/typechecker/check_decl.rs` maps the trait name to a stdlib module path.
+- **That path map is limited to `std.derives.{copying,string,comparison}`** (Clone/Default/Debug/Eq/…). Traits defined under other stdlib prefixes—**example:** `Serialize` / `Deserialize` in `std.serde.json`—are **not** discovered by this fallback. Extending derive-backed instance methods for those traits means adding entries (short term) or a **registry-driven** trait→module mapping (long term), not duplicating path logic in scattered call sites.
+
 ## Generic bounds and extern functions
 
 - **Store explicit generic bounds in frontend symbols**, not just type-parameter names. A per-parameter bounds map lets call checking enforce `with` contracts before lowering.

--- a/src/frontend/library_exports.rs
+++ b/src/frontend/library_exports.rs
@@ -102,6 +102,7 @@ pub struct CheckedEnumExport {
     pub name: String,
     pub type_params: Vec<CheckedTypeParam>,
     pub variants: Vec<CheckedEnumVariant>,
+    pub derives: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -345,6 +346,7 @@ fn checked_enum_export(enum_decl: &EnumDecl, checker: &TypeChecker) -> Option<Ch
         name: enum_decl.name.clone(),
         type_params: checked_type_params(&enum_decl.type_params, checker),
         variants,
+        derives: checker.extract_derive_names(&enum_decl.decorators),
     })
 }
 

--- a/src/frontend/symbols.rs
+++ b/src/frontend/symbols.rs
@@ -449,6 +449,8 @@ pub struct NewtypeInfo {
 pub struct EnumInfo {
     pub type_params: Vec<String>,
     pub variants: Vec<String>,
+    /// Names from `@derive(...)` (same vocabulary as models/classes).
+    pub derives: Vec<String>,
 }
 
 /// Trait information

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -9,6 +9,7 @@ use super::TypeChecker;
 use incan_core::interop::RustItemKind;
 use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::magic_methods;
+use incan_core::lang::traits::{self, TraitId};
 use std::collections::{HashMap, HashSet};
 
 /// Structural equality for trait method signatures (RFC 042 diamond / obligation merging).
@@ -18,6 +19,49 @@ fn method_infos_identical(a: &MethodInfo, b: &MethodInfo) -> bool {
         && a.has_body == b.has_body
         && a.params == b.params
         && a.return_type == b.return_type
+}
+
+/// Module path segments for builtin traits whose [`SymbolTable`] stubs carry no methods.
+///
+/// [`TypeChecker::trait_method_info_resolved`] uses this when symbol-table lookup finds no concrete method: it loads
+/// the full trait from the stdlib `.incn` stub so signatures like `clone(self) -> Self` exist for typechecking.
+///
+/// ## Coverage (intentional)
+///
+/// Only traits declared under **`std.derives.*`** are mapped today:
+/// - `std.derives.copying` — `Clone`, `Copy` (derive id), `Default`
+/// - `std.derives.string` — `Debug`, `Display`
+/// - `std.derives.comparison` — `Eq`, `PartialEq`, `Ord`, `PartialOrd`, `Hash`
+///
+/// Traits declared in **other** stdlib trees (e.g. `Serialize` / `Deserialize` in `std.serde.json`) return `None`
+/// here. JSON helpers are handled elsewhere (`inject_json_methods`, etc.); if you need the same empty-stub fallback
+/// for instance methods on those traits, extend this map or replace it with registry-driven discovery (trait → owning
+/// module path) rather than growing ad hoc `if` chains without a single source of truth.
+///
+/// Introduced for `@derive(Clone)` and direct `.clone()` on concrete types (GitHub #193).
+fn stdlib_module_segments_for_trait_methods(trait_name: &str) -> Option<Vec<String>> {
+    let copying = || Some(vec!["std".into(), "derives".into(), "copying".into()]);
+    let string_mod = || Some(vec!["std".into(), "derives".into(), "string".into()]);
+    let comparison = || Some(vec!["std".into(), "derives".into(), "comparison".into()]);
+
+    if trait_name == traits::as_str(TraitId::Clone)
+        || trait_name == derives::as_str(DeriveId::Copy)
+        || trait_name == traits::as_str(TraitId::Default)
+    {
+        return copying();
+    }
+    if trait_name == traits::as_str(TraitId::Debug) || trait_name == traits::as_str(TraitId::Display) {
+        return string_mod();
+    }
+    if trait_name == traits::as_str(TraitId::Eq)
+        || trait_name == traits::as_str(TraitId::PartialEq)
+        || trait_name == traits::as_str(TraitId::Ord)
+        || trait_name == traits::as_str(TraitId::PartialOrd)
+        || trait_name == traits::as_str(TraitId::Hash)
+    {
+        return comparison();
+    }
+    None
 }
 
 /// Callable signature resolved for one `interop:` adapter reference.
@@ -507,6 +551,13 @@ impl TypeChecker {
             }
         }
         let filtered = self.filter_supertrait_dominated_entries(entries);
+        if filtered.is_empty()
+            && let Some(segments) = stdlib_module_segments_for_trait_methods(adopted_trait)
+            && let Some(full_trait) = self.stdlib_cache.lookup_trait(&segments, adopted_trait)
+            && let Some(info) = full_trait.methods.get(method)
+        {
+            return Some(info.clone());
+        }
         match filtered.as_slice() {
             [] => None,
             [(_, info)] => Some(info.clone()),
@@ -1134,6 +1185,7 @@ impl TypeChecker {
 
     fn check_enum(&mut self, en: &EnumDecl) {
         self.validate_decorators(&en.decorators);
+        self.validate_derives(&en.decorators);
         // Check variant field types exist
         for variant in &en.variants {
             for field_ty in &variant.node.fields {

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -185,7 +185,65 @@ impl TypeChecker {
         }
     }
 
+    /// [`ResolvedType::SelfType`] in a trait method signature means the receiver type for this call site.
+    fn concrete_type_for_trait_self(&self, receiver: &ResolvedType) -> ResolvedType {
+        match receiver {
+            ResolvedType::Generic(name, args) => ResolvedType::Generic(name.clone(), args.clone()),
+            ResolvedType::Named(name) => {
+                let n_params = self
+                    .lookup_type_info(name)
+                    .map(|info| match info {
+                        TypeInfo::Model(m) => m.type_params.len(),
+                        TypeInfo::Class(c) => c.type_params.len(),
+                        TypeInfo::Enum(e) => e.type_params.len(),
+                        TypeInfo::Newtype(n) => n.type_params.len(),
+                        _ => 0,
+                    })
+                    .unwrap_or(0);
+                if n_params > 0 {
+                    ResolvedType::Generic(name.clone(), vec![ResolvedType::Unknown; n_params])
+                } else {
+                    receiver.clone()
+                }
+            }
+            _ => receiver.clone(),
+        }
+    }
+
+    fn substitute_self_in_resolved_type(&self, ty: ResolvedType, receiver: &ResolvedType) -> ResolvedType {
+        match ty {
+            ResolvedType::SelfType => self.concrete_type_for_trait_self(receiver),
+            ResolvedType::Generic(name, args) => ResolvedType::Generic(
+                name,
+                args.into_iter()
+                    .map(|a| self.substitute_self_in_resolved_type(a, receiver))
+                    .collect(),
+            ),
+            ResolvedType::Tuple(items) => ResolvedType::Tuple(
+                items
+                    .into_iter()
+                    .map(|a| self.substitute_self_in_resolved_type(a, receiver))
+                    .collect(),
+            ),
+            ResolvedType::FrozenList(inner) => {
+                ResolvedType::FrozenList(Box::new(self.substitute_self_in_resolved_type(*inner, receiver)))
+            }
+            ResolvedType::FrozenSet(inner) => {
+                ResolvedType::FrozenSet(Box::new(self.substitute_self_in_resolved_type(*inner, receiver)))
+            }
+            ResolvedType::FrozenDict(k, v) => ResolvedType::FrozenDict(
+                Box::new(self.substitute_self_in_resolved_type(*k, receiver)),
+                Box::new(self.substitute_self_in_resolved_type(*v, receiver)),
+            ),
+            ResolvedType::Ref(inner) => {
+                ResolvedType::Ref(Box::new(self.substitute_self_in_resolved_type(*inner, receiver)))
+            }
+            other => other,
+        }
+    }
+
     /// Resolve a method on a type's own methods or trait-adopted methods.
+    #[allow(clippy::too_many_arguments)]
     fn resolve_named_method(
         &mut self,
         methods: &std::collections::HashMap<String, MethodInfo>,
@@ -194,6 +252,7 @@ impl TypeChecker {
         args: &[CallArg],
         arg_types: &[ResolvedType],
         call_site_span: Span,
+        receiver_ty: &ResolvedType,
     ) -> Option<ResolvedType> {
         if let Some(method_info) = methods.get(method) {
             let params = method_info.params.clone();
@@ -205,7 +264,8 @@ impl TypeChecker {
             for trait_name in traits {
                 if let Some(method_info) = self.trait_method_info_resolved(trait_name, method, call_site_span) {
                     let params = method_info.params.clone();
-                    let return_type = method_info.return_type.clone();
+                    let return_type =
+                        self.substitute_self_in_resolved_type(method_info.return_type.clone(), receiver_ty);
                     self.validate_method_call_args(&params, args, arg_types);
                     return Some(return_type);
                 }
@@ -807,24 +867,58 @@ impl TypeChecker {
         {
             match type_info {
                 TypeInfo::Model(model) => {
-                    if let Some(ret) =
-                        self.resolve_named_method(&model.methods, Some(&model.traits), method, args, &arg_types, span)
-                    {
+                    let traits = self.trait_names_for_type_methods(&model.traits, &model.derives);
+                    if let Some(ret) = self.resolve_named_method(
+                        &model.methods,
+                        Some(&traits),
+                        method,
+                        args,
+                        &arg_types,
+                        span,
+                        &base_ty,
+                    ) {
                         return ret;
                     }
                 }
                 TypeInfo::Class(class) => {
-                    if let Some(ret) =
-                        self.resolve_named_method(&class.methods, Some(&class.traits), method, args, &arg_types, span)
-                    {
+                    let traits = self.trait_names_for_type_methods(&class.traits, &class.derives);
+                    if let Some(ret) = self.resolve_named_method(
+                        &class.methods,
+                        Some(&traits),
+                        method,
+                        args,
+                        &arg_types,
+                        span,
+                        &base_ty,
+                    ) {
+                        return ret;
+                    }
+                }
+                TypeInfo::Enum(en) => {
+                    let traits = self.trait_names_for_type_methods(&[], &en.derives);
+                    if let Some(ret) = self.resolve_named_method(
+                        &std::collections::HashMap::new(),
+                        Some(&traits),
+                        method,
+                        args,
+                        &arg_types,
+                        span,
+                        &base_ty,
+                    ) {
                         return ret;
                     }
                 }
                 TypeInfo::Newtype(newtype) => {
                     let resolved_method = self.resolve_newtype_method_name(&newtype, method);
-                    if let Some(ret) =
-                        self.resolve_named_method(&newtype.methods, None, resolved_method, args, &arg_types, span)
-                    {
+                    if let Some(ret) = self.resolve_named_method(
+                        &newtype.methods,
+                        None,
+                        resolved_method,
+                        args,
+                        &arg_types,
+                        span,
+                        &base_ty,
+                    ) {
                         if newtype.is_rusttype {
                             self.maybe_record_rusttype_return_coercion(&newtype, resolved_method, &ret, span);
                         }
@@ -853,39 +947,61 @@ impl TypeChecker {
                 }
                 Some(type_info) => match type_info {
                     TypeInfo::Model(model) => {
+                        let traits = self.trait_names_for_type_methods(&model.traits, &model.derives);
                         if let Some(ret) = self.resolve_named_method(
                             &model.methods,
-                            Some(&model.traits),
+                            Some(&traits),
                             method,
                             args,
                             &arg_types,
                             span,
+                            &base_ty,
                         ) {
                             return ret;
                         }
                     }
                     TypeInfo::Class(class) => {
+                        let traits = self.trait_names_for_type_methods(&class.traits, &class.derives);
                         if let Some(ret) = self.resolve_named_method(
                             &class.methods,
-                            Some(&class.traits),
+                            Some(&traits),
                             method,
                             args,
                             &arg_types,
                             span,
+                            &base_ty,
                         ) {
                             return ret;
                         }
                     }
-                    TypeInfo::Enum(_enum_info)
-                        if enum_helpers::from_str(method) == Some(enum_helpers::EnumHelperId::Message) =>
-                    {
-                        return ResolvedType::Str;
+                    TypeInfo::Enum(en) => {
+                        if enum_helpers::from_str(method) == Some(enum_helpers::EnumHelperId::Message) {
+                            return ResolvedType::Str;
+                        }
+                        let traits = self.trait_names_for_type_methods(&[], &en.derives);
+                        if let Some(ret) = self.resolve_named_method(
+                            &std::collections::HashMap::new(),
+                            Some(&traits),
+                            method,
+                            args,
+                            &arg_types,
+                            span,
+                            &base_ty,
+                        ) {
+                            return ret;
+                        }
                     }
                     TypeInfo::Newtype(nt) => {
                         let resolved_method = self.resolve_newtype_method_name(&nt, method);
-                        if let Some(ret) =
-                            self.resolve_named_method(&nt.methods, None, resolved_method, args, &arg_types, span)
-                        {
+                        if let Some(ret) = self.resolve_named_method(
+                            &nt.methods,
+                            None,
+                            resolved_method,
+                            args,
+                            &arg_types,
+                            span,
+                            &base_ty,
+                        ) {
                             // When the method body is abstract and the underlying Rust type is known,
                             // check whether the actual Rust return type needs a coercion (e.g. &str → String).
                             if nt.is_rusttype {

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -444,12 +444,14 @@ impl TypeChecker {
     /// Register an enum declaration and define symbols for each variant.
     fn collect_enum(&mut self, en: &EnumDecl, span: Span) {
         let variants: Vec<_> = en.variants.iter().map(|v| v.node.name.clone()).collect();
+        let derives = self.extract_derive_names(&en.decorators);
 
         self.symbols.define(Symbol {
             name: en.name.clone(),
             kind: SymbolKind::Type(TypeInfo::Enum(EnumInfo {
                 type_params: en.type_params.iter().map(|tp| tp.name.clone()).collect(),
                 variants: variants.clone(),
+                derives,
             })),
             span,
             scope: 0,

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -754,6 +754,7 @@ impl TypeChecker {
         EnumInfo {
             type_params: export.type_params.iter().map(|param| param.name.clone()).collect(),
             variants: export.variants.iter().map(|variant| variant.name.clone()).collect(),
+            derives: export.derives.clone(),
         }
     }
 

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -631,10 +631,16 @@ impl TypeChecker {
     }
 
     /// Whether a concrete named type declares adoption of `trait_name` (RFC 042: includes transitive supertraits).
+    ///
+    /// Also treats `@derive(T)` as implementing trait `T` when `T` is a visible trait symbol (e.g. `Clone`).
     pub(crate) fn type_implements_trait(&self, type_name: &str, trait_name: &str) -> bool {
-        let adopted = match self.lookup_type_info(type_name) {
-            Some(TypeInfo::Model(model)) => &model.traits,
-            Some(TypeInfo::Class(class)) => &class.traits,
+        let Some(info) = self.lookup_type_info(type_name) else {
+            return false;
+        };
+        let (adopted, derives) = match info {
+            TypeInfo::Model(m) => (m.traits.as_slice(), Some(m.derives.as_slice())),
+            TypeInfo::Class(c) => (c.traits.as_slice(), Some(c.derives.as_slice())),
+            TypeInfo::Enum(e) => (&[][..], Some(e.derives.as_slice())),
             _ => return false,
         };
         for t in adopted {
@@ -647,7 +653,24 @@ impl TypeChecker {
                 return true;
             }
         }
+        if let Some(derives) = derives
+            && derives.iter().any(|d| d == trait_name)
+            && self.lookup_trait_info(trait_name).is_some()
+        {
+            return true;
+        }
         false
+    }
+
+    /// Explicit `with Trait` names plus `@derive` entries that name a registered trait, for instance method lookup.
+    pub(crate) fn trait_names_for_type_methods(&self, adopted: &[String], derives: &[String]) -> Vec<String> {
+        let mut out = adopted.to_vec();
+        for d in derives {
+            if self.lookup_trait_info(d).is_some() && !out.iter().any(|t| t == d) {
+                out.push(d.clone());
+            }
+        }
+        out
     }
 
     /// Look up a variable binding by name (in any scope) and return its [`VariableInfo`].

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -91,6 +91,7 @@ fn library_index_with_mylib_exports() -> LibraryManifestIndex {
                         fields: Vec::new(),
                     },
                 ],
+                derives: Vec::new(),
             }],
             type_aliases: Vec::new(),
             newtypes: Vec::new(),
@@ -4025,6 +4026,45 @@ def main() -> Token:
         "Expected explicit generic bound error; got: {:?}",
         errs.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
+}
+
+/// GitHub #193: `@derive(Clone)` must allow `.clone()` on the concrete type (not only through unconstrained `T`).
+#[test]
+fn test_derive_clone_allows_direct_clone_on_model() {
+    let source = r#"
+@derive(Clone)
+model Issue193Foo:
+  id: int
+
+def direct(f: Issue193Foo) -> Issue193Foo:
+  return f.clone()
+
+def via_generic[T](x: T) -> T:
+  return x.clone()
+
+def main() -> Issue193Foo:
+  x = Issue193Foo(id=1)
+  _ = via_generic(x)
+  return direct(x)
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_derive_clone_allows_direct_clone_on_enum() {
+    let source = r#"
+@derive(Clone)
+enum Issue193Bar:
+  A
+  B
+
+def dup_bar(e: Issue193Bar) -> Issue193Bar:
+  return e.clone()
+
+def main() -> None:
+  pass
+"#;
+    assert_check_ok(source);
 }
 
 #[test]

--- a/src/library_manifest/model.rs
+++ b/src/library_manifest/model.rs
@@ -275,6 +275,9 @@ pub struct EnumExport {
     pub name: String,
     pub type_params: Vec<TypeParamExport>,
     pub variants: Vec<EnumVariantExport>,
+    /// `@derive(...)` names (empty for manifests predating this field).
+    #[serde(default)]
+    pub derives: Vec<String>,
 }
 
 /// One exported enum variant and its positional payload fields.
@@ -541,6 +544,7 @@ fn enum_export_from_checked(export: &CheckedEnumExport) -> EnumExport {
                 fields: variant.fields.iter().map(type_ref_from_resolved).collect(),
             })
             .collect(),
+        derives: export.derives.clone(),
     }
 }
 

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -222,6 +222,7 @@ They are not intended as runtime function calls.
 
 ## Bugfixes
 
+- **Compiler**: Types with `@derive(Clone)` now typecheck direct `.clone()` on concrete receivers (models and enums), matching behavior already allowed through unconstrained generics; builtin trait vocabulary stubs load method signatures from stdlib when needed (#193).
 - **Diagnostics**: Unknown symbol errors in f-string interpolations now point to the precise `{expr}` span (including nested interpolation expressions) instead of the full f-string ([RFC 011], #71).
 - **Compiler**: Fixed project root resolving to empty string when running `incan run src/main.incn` from the project directory, causing "No such file or directory" errors.
 - **Compiler**: Trait-typed values are now correctly assignable to supertrait return types in function returns and generic upcasts with compatible type arguments ([RFC 042], #184).


### PR DESCRIPTION
## Summary

Direct calls like `value.clone()` on concrete **models** and **enums** annotated with `@derive(Clone)` failed typechecking even though generic helpers using `T.clone()` still worked. This PR fixes that by (1) treating `@derive(...)` names as part of the trait set used for instance method lookup on models, classes, and enums, (2) recording **enum derives** end-to-end (`EnumInfo`, collection, library manifest `EnumExport`, staged exports), (3) substituting **`Self`** in resolved trait method return types using the call-site receiver, and (4) when builtin trait stubs in the symbol table have **empty `methods`**, falling back to the stdlib AST for traits mapped under `std.derives.*` (`stdlib_module_segments_for_trait_methods` + `trait_method_info_resolved`). Enums now run **`validate_derives`** like other user types. Release notes and agent learnings document the user-visible fix and the intentional limitation of the stdlib trait→module map.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics) *(typechecking behavior for derives / enums)*
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive) *(manifest + stdlib trait lookup)*
- [x] Documentation

## Key details

- **User-facing behavior**: `@derive(Clone)` (and other mapped derive traits) on models/classes/enums can be used for direct instance method calls such as `.clone()` with correct return typing. Invalid `@derive` on enums is diagnosed consistently with other declarations.
- **Internals**: `trait_names_for_type_methods` merges explicit `with Trait` lists and derives; `resolve_named_method` takes `receiver_ty` and substitutes `Self` in trait method signatures; `type_implements_trait` accounts for derives on enums; `EnumInfo` / `EnumExport` / `CheckedEnumExport` carry `derives`; narrow stdlib module map for empty-stub traits with documented extension path.
- **Risks**: Method resolution and trait satisfaction paths are broader for derived types; the stdlib fallback only covers traits under the mapped `std.derives.*` modules (documented in rustdoc and `.cursor/agents/learnings.md`). Other stdlib traits still need explicit design if similar empty-stub issues appear.

## Testing / verification

- [x] `make test` / `cargo test` *(per local gate before merge)*
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [ ] Manual verification described below

**Tests added** (typechecker):

- `test_derive_clone_allows_direct_clone_on_model`
- `test_derive_clone_allows_direct_clone_on_enum`

**Manual verification notes:**

- …

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

**If docs updated:**

- `workspaces/docs-site/docs/release_notes/0_2.md` — bugfix entry for #193
- `.cursor/agents/learnings.md` — builtin trait stubs / stdlib method lookup and map limitations

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #193