### PR TITLE
bugfix - reject await outside async callables (#210)

### DIFF
--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -202,6 +202,17 @@ pub fn try_on_non_result(found: &str, span: Span) -> CompileError {
     })
 }
 
+/// `await` appeared outside an `async def`, outside an async method, or inside a closure body (closures are never
+/// async).
+pub fn await_outside_async(span: Span) -> CompileError {
+    CompileError::type_error(
+        "Cannot use 'await' outside of an async function or async method".to_string(),
+        span,
+    )
+    .with_note("'await' is only valid inside `async def` and async method bodies")
+    .with_hint("Declare the enclosing function or method with the `async` keyword (after importing `std.async`)")
+}
+
 // -- Mutability --------------------------------------------------------------
 
 pub fn mutation_without_mut(name: &str, span: Span) -> CompileError {

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -1202,8 +1202,8 @@ impl TypeChecker {
         self.symbols.enter_scope(ScopeKind::Function);
 
         self.validate_decorators(&func.decorators);
-        // TODO(#146): add async-specific validation here (await-outside-async, return-type constraints) via the
-        // surface semantics registry — not hardcoded KeywordId checks.
+        // TODO(#146): add async return-type and related validation here via the surface semantics registry — not
+        // hardcoded KeywordId checks.
 
         // Define type parameters so explicit generic bounds are visible in function-level type resolution.
         for param in &func.type_params {
@@ -1236,11 +1236,15 @@ impl TypeChecker {
         // Set error type for ? checking
         self.current_return_error_type = return_type.result_err_type().cloned();
 
+        let prev_in_async_body = self.in_async_body;
+        self.in_async_body = func.is_async();
+
         // Check body
         for stmt in &func.body {
             self.check_statement(stmt);
         }
 
+        self.in_async_body = prev_in_async_body;
         self.current_return_error_type = None;
         self.symbols.exit_scope();
     }
@@ -1264,7 +1268,7 @@ impl TypeChecker {
         self.symbols.enter_scope(ScopeKind::Method {
             receiver: method.receiver,
         });
-        // TODO(#146): add async-specific validation for methods via the surface semantics registry.
+        // TODO(#146): add async return-type and related validation for methods via the surface semantics registry.
 
         // Define owner type parameters so generic wrappers can use them in bodies and annotations.
         for type_param in owner_type_params {
@@ -1328,9 +1332,12 @@ impl TypeChecker {
 
         // Check body
         if let Some(body) = &method.body {
+            let prev_in_async_body = self.in_async_body;
+            self.in_async_body = method.is_async();
             for stmt in body {
                 self.check_statement(stmt);
             }
+            self.in_async_body = prev_in_async_body;
         }
 
         self.current_return_error_type = None;

--- a/src/frontend/typechecker/check_expr/comps.rs
+++ b/src/frontend/typechecker/check_expr/comps.rs
@@ -82,6 +82,9 @@ impl TypeChecker {
     ) -> ResolvedType {
         self.symbols.enter_scope(ScopeKind::Function);
 
+        let prev_in_async_body = self.in_async_body;
+        self.in_async_body = false;
+
         let param_types: Vec<_> = params
             .iter()
             .map(|p| {
@@ -101,6 +104,7 @@ impl TypeChecker {
             .collect();
 
         let return_ty = self.check_expr(body);
+        self.in_async_body = prev_in_async_body;
         self.symbols.exit_scope();
 
         ResolvedType::Function(param_types, Box::new(return_ty))

--- a/src/frontend/typechecker/check_expr/control_flow.rs
+++ b/src/frontend/typechecker/check_expr/control_flow.rs
@@ -15,12 +15,19 @@ impl TypeChecker {
     /// Type-check an `await` expression.
     ///
     /// By the time we reach this method the registry has already confirmed that the `await` feature is active (via
-    /// `typecheck_surface_expr_action`), so no additional feature-gate check is needed here.
+    /// `typecheck_surface_expr_action`), so no additional feature-gate check is needed here. The enclosing callable
+    /// must be `async` (`in_async_body`). Closure bodies are not async contexts: `check_closure` clears
+    /// `in_async_body` while typechecking the body.
     pub(in crate::frontend::typechecker::check_expr) fn check_await(
         &mut self,
         inner: &Spanned<Expr>,
-        _span: Span,
+        span: Span,
     ) -> ResolvedType {
+        if !self.in_async_body {
+            self.errors.push(errors::await_outside_async(span));
+            return ResolvedType::Unknown;
+        }
+
         let inner_ty = self.check_expr(inner);
 
         if let ResolvedType::Generic(name, args) = &inner_ty

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -214,6 +214,8 @@ pub struct TypeChecker {
     pub(crate) mutable_bindings: HashSet<String>,
     /// Current function's error type for `?` operator compatibility.
     pub(crate) current_return_error_type: Option<ResolvedType>,
+    /// Whether the body currently being checked belongs to an `async def` or async method.
+    pub(crate) in_async_body: bool,
     /// Active trait @requires context for default method bodies.
     pub(crate) current_trait_requires: Option<HashMap<String, ResolvedType>>,
     /// Active trait name for default method diagnostics.
@@ -284,6 +286,7 @@ impl TypeChecker {
             warnings: Vec::new(),
             mutable_bindings: HashSet::new(),
             current_return_error_type: None,
+            in_async_body: false,
             current_trait_requires: None,
             current_trait_name: None,
             current_trait_missing_requires_emitted: None,

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -946,6 +946,41 @@ async def foo() -> None:
 }
 
 #[test]
+fn test_await_outside_async_function() {
+    let source = r#"
+from std.async.time import sleep
+
+def foo() -> None:
+  await sleep(1.0)
+"#;
+    let errs = check_str(source).expect_err("await in sync function should fail");
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("await") && e.message.contains("async")),
+        "expected await-outside-async diagnostic, got: {errs:?}"
+    );
+}
+
+#[test]
+fn test_await_outside_async_method() {
+    let source = r#"
+from std.async.time import sleep
+
+model Widget:
+  id: int
+
+  def work(self) -> None:
+    await sleep(1.0)
+"#;
+    let errs = check_str(source).expect_err("await in sync method should fail");
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("await") && e.message.contains("async")),
+        "expected await-outside-async diagnostic, got: {errs:?}"
+    );
+}
+
+#[test]
 fn test_await_join_handle_returns_result_task_join_error() {
     let source = r#"
 from std.async.task import JoinHandle, TaskJoinError

--- a/workspaces/docs-site/docs/language/how-to/async_programming.md
+++ b/workspaces/docs-site/docs/language/how-to/async_programming.md
@@ -55,6 +55,11 @@ async def process() -> str:
     return result
 ```
 
+`await` is only valid inside `async def` bodies and **async** methods Using `await` in an ordinary `def` or sync method is a type error.
+
+!!! info "Coming from Python?"
+    Incan's `await` follows the same rules as in Python: it is disallowed outside an `async` scope.
+
 ## Time Primitives
 
 ### sleep

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -222,6 +222,7 @@ They are not intended as runtime function calls.
 
 ## Bugfixes
 
+- **Compiler**: `await` is rejected when it appears outside an `async def` or async method body, matching async/await scoping rules (#210).
 - **Compiler**: `for ... in` over a variable-bound `list` of enums now iterates with owned enum values in generated Rust, so comparisons such as `item == some_enum` compile without comparing `&E` to `E` (#195).
 - **Compiler**: `list.pop()` no longer lowers to `Vec::pop().unwrap_or_default()`, so element types do not need `Default` (e.g. Clone-only models). Popping an empty list now raises `IndexError: pop from empty list`, matching Python (#194).
 - **Compiler**: Types with `@derive(Clone)` now typecheck direct `.clone()` on concrete receivers (models and enums), matching behavior already allowed through unconstrained generics; builtin trait vocabulary stubs load method signatures from stdlib when needed (#193).


### PR DESCRIPTION
## Summary

The typechecker now rejects `await` when it is not in an async context: `await` is only allowed inside `async def` bodies and async methods. This matches the intent of issue #210 and avoids invalid programs slipping through to confusing Rust errors.

Implementation adds `TypeChecker::in_async_body`, set while checking function and method bodies from `FunctionDecl::is_async()` / `MethodDecl::is_async()`, and cleared while typechecking closure bodies (`check_closure`) so `await` is not treated as valid inside `=>` closures nested under `async def`. `check_await` emits a new catalog diagnostic (`errors::await_outside_async`) and returns `ResolvedType::Unknown` after the error to limit follow-on noise.

The existing `TODO(#146)` comments in `check_decl.rs` are narrowed to **future** async validation (return-type / registry-driven work deferred to a later release); they are **not** resolved by this PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Code that uses `await` in a plain `def`, a non-async method, or a closure body now fails typechecking with a clear Incan diagnostic. The async programming how-to notes that `await` is only valid in `async def` and async methods. Release notes (`0_2.md`) include a bugfix line for #210.
- **Internals**: New field `in_async_body` on `TypeChecker`; `check_function`, `check_method_with_self_ty`, and `check_closure` manage it; `check_await` consults it. New diagnostic constructor in `crates/incan_syntax/src/diagnostics/catalog/errors/types.rs`.
- **Risks**: Any code that incorrectly relied on `await` outside async contexts will now error at typecheck time (intended). Legitimate `async def` / async method code should be unchanged.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [ ] Manual verification described below

**Suggested commands:** `make fmt && make pre-commit-full` from the Incan repo root; optionally `mkdocs build --strict` from `workspaces/docs-site`.

**Tests added:**

- `test_await_outside_async_function` — sync top-level `def` with `await sleep(...)` → typecheck error
- `test_await_outside_async_method` — sync model method with `await` → typecheck error

Manual verification notes:

- …

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

**Links:**

- `workspaces/docs-site/docs/language/how-to/async_programming.md` — short note under **Await**
- `workspaces/docs-site/docs/release_notes/0_2.md` — Bugfixes bullet for #210

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions

Closes #210