### PR TITLE
bugfix - prost oneof introspection fix (#218)

### DIFF
--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -66,18 +66,69 @@ pub struct RustMethodSig {
     pub signature: RustFunctionSig,
 }
 
+/// Structured Rust type information used by Incan interop consumers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RustTypeShape {
+    /// Any Rust `bool`.
+    Bool,
+    /// Any floating-point scalar. Width is intentionally erased at this layer.
+    Float,
+    /// Any signed or unsigned integer scalar. Width is intentionally erased at this layer.
+    Int,
+    /// UTF-8 string data such as `str` or `String`.
+    Str,
+    /// Byte buffers such as `Vec<u8>` or `&[u8]`.
+    Bytes,
+    /// The unit type `()`.
+    Unit,
+    /// An `Option<T>`-like wrapper.
+    Option(Box<RustTypeShape>),
+    /// A `Result<T, E>`-like wrapper.
+    Result(Box<RustTypeShape>, Box<RustTypeShape>),
+    /// A tuple shape with one entry per element.
+    Tuple(Vec<RustTypeShape>),
+    /// A shared or mutable reference.
+    Ref(Box<RustTypeShape>),
+    /// A concrete Rust path plus any generic arguments preserved by the extractor.
+    RustPath { path: String, args: Vec<RustTypeShape> },
+    /// A generic type parameter such as `T`.
+    TypeParam(String),
+    /// Metadata recovery could not determine a stable semantic shape.
+    Unknown,
+}
+
 /// A public field surfaced on a Rust struct/union-like type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustFieldInfo {
+    /// Field name as it appears in Rust.
     pub name: String,
+    /// Pretty-printed type for diagnostics and debug output.
     pub type_display: String,
+    /// Semantic type shape used by the typechecker for field access and pattern payload binding.
+    pub type_shape: RustTypeShape,
 }
 
-/// Method and associated-fn surface for a Rust ADT or builtin type.
+/// One enum variant and its payload field types.
+///
+/// Payload shapes are normalized for matching. For example, prost-style `Box<T>` payloads are recorded as `T` because
+/// that is what Incan binds in constructor patterns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RustVariantInfo {
+    /// Variant name as it appears in Rust.
+    pub name: String,
+    /// Positional payload field shapes in declaration order.
+    pub fields: Vec<RustTypeShape>,
+}
+
+/// Method, field, and variant surface for a Rust ADT or builtin type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustTypeInfo {
+    /// Public inherent methods and associated functions.
     pub methods: Vec<RustMethodSig>,
+    /// Public fields for struct/union-like types.
     pub fields: Vec<RustFieldInfo>,
+    /// Enum variants when the type is an enum; empty for non-enums.
+    pub variants: Vec<RustVariantInfo>,
 }
 
 /// One exported name inside a module (lightweight summary for namespace resolution).

--- a/crates/incan_core/src/interop/mod.rs
+++ b/crates/incan_core/src/interop/mod.rs
@@ -11,5 +11,6 @@ pub use capabilities::{RUST_CAPABILITY_BOUNDS, is_rust_capability_bound};
 pub use coercions::{CoercionPolicy, admitted_builtin_coercion};
 pub use metadata::{
     RustFieldInfo, RustFunctionSig, RustItemKind, RustItemMetadata, RustMethodSig, RustModuleChild,
-    RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo, RustVisibility,
+    RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo, RustTypeShape,
+    RustVariantInfo, RustVisibility,
 };

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -529,7 +529,7 @@ impl TypeChecker {
                     if let RustItemKind::Type(info) = &meta.kind
                         && let Some(rust_field) = info.fields.iter().find(|f| f.name == field)
                     {
-                        return self.resolved_type_from_rust_display(rust_field.type_display.as_str());
+                        return self.resolved_type_from_rust_shape(&rust_field.type_shape);
                     }
                     // Metadata may still be missing constants, type aliases, trait-provided items, or private fields.
                     // Stay permissive when no exact field surface is available.
@@ -597,8 +597,7 @@ impl TypeChecker {
                                         && let RustItemKind::Type(info) = &meta.kind
                                         && let Some(rust_field) = info.fields.iter().find(|f| f.name == field)
                                     {
-                                        return checker
-                                            .resolved_type_from_rust_display(rust_field.type_display.as_str());
+                                        return checker.resolved_type_from_rust_shape(&rust_field.type_shape);
                                     }
                                 }
                             }

--- a/src/frontend/typechecker/check_expr/match_.rs
+++ b/src/frontend/typechecker/check_expr/match_.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use crate::frontend::ast::*;
 use crate::frontend::diagnostics::errors;
 use crate::frontend::symbols::*;
+use incan_core::interop::RustItemKind;
 use incan_core::lang::surface::constructors;
 use incan_core::lang::surface::constructors::ConstructorId;
 use incan_core::lang::types::collections::{self, CollectionTypeId};
@@ -380,6 +381,18 @@ impl TypeChecker {
             ResolvedType::RustPath(p) => p.clone(),
             _ => return None,
         };
+
+        if let Some(meta) = self.rust_item_metadata_for_path(base_rust_path.as_str())
+            && let RustItemKind::Type(info) = meta.kind
+            && let Some(variant) = info.variants.iter().find(|variant| variant.name == variant_segment)
+        {
+            let fields: Vec<ResolvedType> = variant
+                .fields
+                .iter()
+                .map(|field| self.resolved_type_from_rust_shape(field))
+                .collect();
+            return Some(RustEnumPatternResolution::payloads(fields));
+        }
 
         Some(RustEnumPatternResolution::payloads(match positional_count {
             0 => vec![],

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -905,7 +905,7 @@ impl TypeChecker {
 
     /// Define a symbol for a Rust crate import, skipping if a real definition exists.
     fn define_rust_import_symbol(&mut self, name: Ident, info: RustItemInfo, span: Span) {
-        if self.has_real_definition(&name) {
+        if self.has_non_builtin_real_definition(&name) {
             return;
         }
         self.symbols.define(Symbol {
@@ -937,6 +937,21 @@ impl TypeChecker {
                 sym.kind,
                 SymbolKind::Type(_) | SymbolKind::Function(_) | SymbolKind::Trait(_) | SymbolKind::Variant(_)
             )
+        })
+    }
+
+    /// Returns `true` when `name` resolves to a real definition that is not one of the implicit root builtins.
+    ///
+    /// Explicit Rust imports should shadow implicit builtins such as `HashMap` or `Some`, but they must not overwrite
+    /// user-defined or previously imported names.
+    fn has_non_builtin_real_definition(&self, name: &str) -> bool {
+        self.lookup_symbol(name).is_some_and(|sym| {
+            let is_real = matches!(
+                sym.kind,
+                SymbolKind::Type(_) | SymbolKind::Function(_) | SymbolKind::Trait(_) | SymbolKind::Variant(_)
+            );
+            let is_implicit_builtin = sym.scope == 0 && sym.span == Span::default();
+            is_real && !is_implicit_builtin
         })
     }
 }

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -69,7 +69,7 @@ use crate::frontend::symbols::*;
 #[cfg(feature = "rust-metadata")]
 use crate::rust_metadata::RustMetadataCache;
 use helpers::{collection_type_id, stringlike_type_id};
-use incan_core::interop::{CoercionPolicy, RustFunctionSig, RustItemKind, RustItemMetadata, RustParam};
+use incan_core::interop::{CoercionPolicy, RustFunctionSig, RustItemKind, RustItemMetadata, RustParam, RustTypeShape};
 use incan_core::lang::surface::types as surface_types;
 use incan_core::lang::surface::types::SurfaceTypeKind;
 use incan_core::lang::types::collections::CollectionTypeId;
@@ -365,6 +365,83 @@ impl TypeChecker {
             .collect();
         let ret = self.resolved_type_from_rust_display(sig.return_type.as_str());
         ResolvedType::Function(params, Box::new(ret))
+    }
+
+    /// Render `path` with generic arguments as `path<A, B, ...>` for embedding in [`ResolvedType::RustPath`].
+    ///
+    /// When `args` is empty, returns `path` unchanged (no angle brackets).
+    fn render_rust_shape_path(path: &str, args: &[RustTypeShape]) -> String {
+        if args.is_empty() {
+            return path.to_string();
+        }
+        let rendered_args: Vec<String> = args.iter().map(Self::render_rust_shape_type).collect();
+        format!("{path}<{}>", rendered_args.join(", "))
+    }
+
+    /// Pretty-print a [`RustTypeShape`] as a stable Rust-like type string.
+    ///
+    /// Feeds [`ResolvedType::RustPath`] strings. Scalar widths are normalized (`f64`, `i64`, `String`, `Vec<u8>`) to
+    /// match [`Self::resolved_type_from_rust_shape`], not to recover the exact original Rust spelling from metadata.
+    fn render_rust_shape_type(shape: &RustTypeShape) -> String {
+        match shape {
+            RustTypeShape::Bool => "bool".to_string(),
+            RustTypeShape::Float => "f64".to_string(),
+            RustTypeShape::Int => "i64".to_string(),
+            RustTypeShape::Str => "String".to_string(),
+            RustTypeShape::Bytes => "Vec<u8>".to_string(),
+            RustTypeShape::Unit => "()".to_string(),
+            RustTypeShape::Option(inner) => format!("Option<{}>", Self::render_rust_shape_type(inner)),
+            RustTypeShape::Result(ok, err) => {
+                format!(
+                    "Result<{}, {}>",
+                    Self::render_rust_shape_type(ok),
+                    Self::render_rust_shape_type(err)
+                )
+            }
+            RustTypeShape::Tuple(items) => {
+                let rendered: Vec<String> = items.iter().map(Self::render_rust_shape_type).collect();
+                format!("({})", rendered.join(", "))
+            }
+            RustTypeShape::Ref(inner) => format!("&{}", Self::render_rust_shape_type(inner)),
+            RustTypeShape::RustPath { path, args } => Self::render_rust_shape_path(path, args),
+            RustTypeShape::TypeParam(name) => name.clone(),
+            RustTypeShape::Unknown => "?".to_string(),
+        }
+    }
+
+    /// Map structured rust-metadata [`RustTypeShape`] into a [`ResolvedType`] for field access and pattern typing.
+    ///
+    /// `Option`/`Result` become [`ResolvedType::Generic`] with constructor names `Option` and `Result`. Concrete paths
+    /// use [`Self::render_rust_shape_path`] so generic arguments stay attached to [`ResolvedType::RustPath`].
+    pub(crate) fn resolved_type_from_rust_shape(&self, shape: &RustTypeShape) -> ResolvedType {
+        match shape {
+            RustTypeShape::Bool => ResolvedType::Bool,
+            RustTypeShape::Float => ResolvedType::Float,
+            RustTypeShape::Int => ResolvedType::Int,
+            RustTypeShape::Str => ResolvedType::Str,
+            RustTypeShape::Bytes => ResolvedType::Bytes,
+            RustTypeShape::Unit => ResolvedType::Unit,
+            RustTypeShape::Option(inner) => {
+                ResolvedType::Generic("Option".to_string(), vec![self.resolved_type_from_rust_shape(inner)])
+            }
+            RustTypeShape::Result(ok, err) => ResolvedType::Generic(
+                "Result".to_string(),
+                vec![
+                    self.resolved_type_from_rust_shape(ok),
+                    self.resolved_type_from_rust_shape(err),
+                ],
+            ),
+            RustTypeShape::Tuple(items) => ResolvedType::Tuple(
+                items
+                    .iter()
+                    .map(|item| self.resolved_type_from_rust_shape(item))
+                    .collect(),
+            ),
+            RustTypeShape::Ref(inner) => ResolvedType::Ref(Box::new(self.resolved_type_from_rust_shape(inner))),
+            RustTypeShape::RustPath { path, args } => ResolvedType::RustPath(Self::render_rust_shape_path(path, args)),
+            RustTypeShape::TypeParam(name) => ResolvedType::TypeVar(name.clone()),
+            RustTypeShape::Unknown => ResolvedType::Unknown,
+        }
     }
 
     /// Resolve a Rust-origin method signature from cached metadata.

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -11,11 +11,15 @@ use crate::library_manifest::{
     ParamExport, TraitExport, TypeParamExport, TypeRef,
 };
 #[cfg(feature = "rust-metadata")]
+use crate::rust_metadata::write_substrait_probe_crate;
+#[cfg(feature = "rust-metadata")]
 use incan_core::interop::{
     RustFieldInfo, RustFunctionSig, RustItemKind, RustItemMetadata, RustMethodSig, RustParam, RustTypeInfo,
-    RustVisibility,
+    RustTypeShape, RustVariantInfo, RustVisibility,
 };
 use std::collections::HashMap;
+#[cfg(feature = "rust-metadata")]
+use std::fs;
 use std::path::PathBuf;
 
 fn check_str(source: &str) -> Result<(), Vec<CompileError>> {
@@ -38,6 +42,51 @@ fn synthetic_artifact_root(name: &str) -> PathBuf {
     root.push("target");
     root.push("lib");
     root
+}
+
+#[cfg(feature = "rust-metadata")]
+fn write_rust_metadata_probe_crate(root: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    fs::create_dir_all(root.join("src"))?;
+    fs::create_dir_all(root.join("demo").join("src"))?;
+    fs::write(
+        root.join("Cargo.toml"),
+        r#"[package]
+name = "ra_frontend_probe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+demo = { path = "demo" }
+"#,
+    )?;
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn touch() { let _ = demo::Builder::new(); }\n",
+    )?;
+    fs::write(
+        root.join("demo").join("Cargo.toml"),
+        r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        root.join("demo").join("src/lib.rs"),
+        r#"pub struct Builder;
+
+impl Builder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+pub enum Choice {
+    Some(i32),
+}
+"#,
+    )?;
+    Ok(())
 }
 
 fn assert_check_ok(source: &str) {
@@ -702,15 +751,18 @@ def f() -> None:
 #[test]
 fn test_rust_metadata_resolves_type_associated_function_field_access() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
-from rust::std::collections import HashMap
+from rust::demo import Builder
 
 def f() -> None:
-  make = HashMap.new
+  make = Builder.new
   _ = make
 "#;
     let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
     let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
     let mut checker = TypeChecker::new();
+    let tmp = tempfile::tempdir()?;
+    write_rust_metadata_probe_crate(tmp.path())?;
+    checker.set_rust_metadata_manifest_dir(tmp.path().to_path_buf());
     checker.check_program(&ast).map_err(|errs| {
         std::io::Error::other(format!(
             "expected associated function field access to typecheck: {errs:?}"
@@ -729,33 +781,46 @@ def f() -> None:
 
 #[cfg(feature = "rust-metadata")]
 #[test]
-fn test_rust_metadata_validates_associated_function_arguments() {
+fn test_rust_metadata_validates_associated_function_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
-from rust::std::string import String
+from rust::demo import Builder
 
 def f() -> None:
-  _ = String.new("x")
+  _ = Builder.new("x")
 "#;
-    let Err(errs) = check_str(source) else {
-        panic!("expected arity error for String.new with an argument");
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
+    let tmp = tempfile::tempdir()?;
+    write_rust_metadata_probe_crate(tmp.path())?;
+    let mut checker = TypeChecker::new();
+    checker.set_rust_metadata_manifest_dir(tmp.path().to_path_buf());
+    let Err(errs) = checker.check_program(&ast) else {
+        panic!("expected arity error for Builder.new with an argument");
     };
     assert!(
         errs.iter()
-            .any(|e| e.message.contains("String.new() expects 0 argument") && e.message.contains("got 1")),
+            .any(|e| e.message.contains("Builder.new() expects 0 argument") && e.message.contains("got 1")),
         "expected associated-function arity diagnostic, got {errs:?}"
     );
+    Ok(())
 }
 
 #[cfg(feature = "rust-metadata")]
 #[test]
-fn test_rust_metadata_reports_unsupported_rust_item_shape() {
+fn test_rust_metadata_reports_unsupported_rust_item_shape() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
-from rust::std::option::Option import Some
+from rust::demo::Choice import Some
 
 def f() -> None:
   _ = Some
 "#;
-    let Err(errs) = check_str(source) else {
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
+    let tmp = tempfile::tempdir()?;
+    write_rust_metadata_probe_crate(tmp.path())?;
+    let mut checker = TypeChecker::new();
+    checker.set_rust_metadata_manifest_dir(tmp.path().to_path_buf());
+    let Err(errs) = checker.check_program(&ast) else {
         panic!("expected unsupported Rust item shape diagnostic");
     };
     assert!(
@@ -763,6 +828,7 @@ def f() -> None:
             .any(|e| e.message.contains("unsupported shape") && e.message.contains("enum variant")),
         "expected unsupported-shape diagnostic, got {errs:?}"
     );
+    Ok(())
 }
 
 /// Field access on a Rust type that isn't a known inherent associated function should be permissive
@@ -929,6 +995,7 @@ def render[T](value: Label[T]) -> str:
                         },
                     }],
                     fields: vec![],
+                    variants: vec![],
                 }),
             },
         )
@@ -989,7 +1056,12 @@ def f(x: Envelope) -> None:
                     fields: vec![RustFieldInfo {
                         name: "kind".to_string(),
                         type_display: "Option<demo::Kind>".to_string(),
+                        type_shape: RustTypeShape::Option(Box::new(RustTypeShape::RustPath {
+                            path: "demo::Kind".to_string(),
+                            args: vec![],
+                        })),
                     }],
+                    variants: vec![],
                 }),
             },
         )
@@ -1004,6 +1076,7 @@ def f(x: Envelope) -> None:
                 kind: RustItemKind::Type(RustTypeInfo {
                     methods: vec![],
                     fields: vec![],
+                    variants: vec![],
                 }),
             },
         )
@@ -1050,7 +1123,12 @@ def f(x: Envelope) -> None:
                     fields: vec![RustFieldInfo {
                         name: "kind".to_string(),
                         type_display: "Option<demo::Kind>".to_string(),
+                        type_shape: RustTypeShape::Option(Box::new(RustTypeShape::RustPath {
+                            path: "demo::Kind".to_string(),
+                            args: vec![],
+                        })),
                     }],
+                    variants: vec![],
                 }),
             },
         )
@@ -1065,6 +1143,7 @@ def f(x: Envelope) -> None:
                 kind: RustItemKind::Type(RustTypeInfo {
                     methods: vec![],
                     fields: vec![],
+                    variants: vec![],
                 }),
             },
         )
@@ -1072,6 +1151,158 @@ def f(x: Envelope) -> None:
     checker.check_program(&ast).map_err(|errs| {
         std::io::Error::other(format!(
             "expected rust path field access + nested match binding to typecheck: {errs:?}"
+        ))
+    })?;
+    Ok(())
+}
+
+#[cfg(feature = "rust-metadata")]
+#[test]
+fn test_imported_prost_oneof_field_match_uses_concrete_variant_payload_types() -> Result<(), Box<dyn std::error::Error>>
+{
+    let source = r#"
+from rust::demo import Rel
+from rust::demo::rel import RelType
+from rust::demo::read_rel import ReadType
+
+def inspect(rel: Rel) -> None:
+  match rel.rel_type:
+    Some(RelType.Read(read)) =>
+      match read.read_type:
+        Some(ReadType.NamedTable(_)) =>
+          _ = 0
+        _ =>
+          _ = 1
+    _ =>
+      _ = 2
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
+    let mut checker = TypeChecker::new();
+    let manifest_dir = std::env::current_dir()?;
+    checker.set_rust_metadata_manifest_dir(manifest_dir.clone());
+    checker
+        .rust_metadata_cache
+        .insert_test_item(
+            &manifest_dir,
+            RustItemMetadata {
+                canonical_path: "demo::Rel".to_string(),
+                visibility: RustVisibility::Public,
+                kind: RustItemKind::Type(RustTypeInfo {
+                    methods: vec![],
+                    fields: vec![RustFieldInfo {
+                        name: "rel_type".to_string(),
+                        type_display: "Option<demo::rel::RelType>".to_string(),
+                        type_shape: RustTypeShape::Option(Box::new(RustTypeShape::RustPath {
+                            path: "demo::rel::RelType".to_string(),
+                            args: vec![],
+                        })),
+                    }],
+                    variants: vec![],
+                }),
+            },
+        )
+        .map_err(|e| std::io::Error::other(format!("seed rust metadata rel: {e}")))?;
+    checker
+        .rust_metadata_cache
+        .insert_test_item(
+            &manifest_dir,
+            RustItemMetadata {
+                canonical_path: "demo::rel::RelType".to_string(),
+                visibility: RustVisibility::Public,
+                kind: RustItemKind::Type(RustTypeInfo {
+                    methods: vec![],
+                    fields: vec![],
+                    variants: vec![RustVariantInfo {
+                        name: "Read".to_string(),
+                        fields: vec![RustTypeShape::RustPath {
+                            path: "demo::ReadRel".to_string(),
+                            args: vec![],
+                        }],
+                    }],
+                }),
+            },
+        )
+        .map_err(|e| std::io::Error::other(format!("seed rust metadata rel type: {e}")))?;
+    checker
+        .rust_metadata_cache
+        .insert_test_item(
+            &manifest_dir,
+            RustItemMetadata {
+                canonical_path: "demo::ReadRel".to_string(),
+                visibility: RustVisibility::Public,
+                kind: RustItemKind::Type(RustTypeInfo {
+                    methods: vec![],
+                    fields: vec![RustFieldInfo {
+                        name: "read_type".to_string(),
+                        type_display: "Option<demo::read_rel::ReadType>".to_string(),
+                        type_shape: RustTypeShape::Option(Box::new(RustTypeShape::RustPath {
+                            path: "demo::read_rel::ReadType".to_string(),
+                            args: vec![],
+                        })),
+                    }],
+                    variants: vec![],
+                }),
+            },
+        )
+        .map_err(|e| std::io::Error::other(format!("seed rust metadata read rel: {e}")))?;
+    checker
+        .rust_metadata_cache
+        .insert_test_item(
+            &manifest_dir,
+            RustItemMetadata {
+                canonical_path: "demo::read_rel::ReadType".to_string(),
+                visibility: RustVisibility::Public,
+                kind: RustItemKind::Type(RustTypeInfo {
+                    methods: vec![],
+                    fields: vec![],
+                    variants: vec![RustVariantInfo {
+                        name: "NamedTable".to_string(),
+                        fields: vec![RustTypeShape::RustPath {
+                            path: "demo::NamedTable".to_string(),
+                            args: vec![],
+                        }],
+                    }],
+                }),
+            },
+        )
+        .map_err(|e| std::io::Error::other(format!("seed rust metadata read type: {e}")))?;
+    checker.check_program(&ast).map_err(|errs| {
+        std::io::Error::other(format!(
+            "expected imported prost oneof field match to typecheck: {errs:?}"
+        ))
+    })?;
+    Ok(())
+}
+
+#[cfg(feature = "rust-metadata")]
+#[test]
+fn test_real_rust_metadata_allows_imported_prost_oneof_field_match() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    write_substrait_probe_crate(tmp.path())?;
+    let source = r#"
+from rust::substrait::proto import Rel
+from rust::substrait::proto::rel import RelType
+from rust::substrait::proto::read_rel import ReadType
+
+def inspect(rel: Rel) -> None:
+  match rel.rel_type:
+    Some(RelType.Read(read)) =>
+      match read.read_type:
+        Some(ReadType.NamedTable(_)) =>
+          _ = 0
+        _ =>
+          _ = 1
+    _ =>
+      _ = 2
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
+    let mut checker = TypeChecker::new();
+    checker.set_rust_metadata_manifest_dir(tmp.path().to_path_buf());
+    checker.check_program(&ast).map_err(|errs| {
+        std::io::Error::other(format!(
+            "expected extracted prost oneof field metadata to typecheck end-to-end: {errs:?}"
         ))
     })?;
     Ok(())

--- a/src/rust_metadata/cache.rs
+++ b/src/rust_metadata/cache.rs
@@ -80,6 +80,84 @@ fn dependency_manifest_dir_for_crate(root: &Path, crate_name: &str) -> Option<Pa
         .and_then(|pkg| pkg.manifest_path.parent().map(Path::to_path_buf))
 }
 
+fn canonical_path_aliases(canonical_path: &str) -> Vec<String> {
+    let mut aliases = Vec::new();
+
+    for (prefix, replacement) in [
+        ("std::option::", "core::option::"),
+        ("std::result::", "core::result::"),
+        ("std::string::", "alloc::string::"),
+        ("std::vec::", "alloc::vec::"),
+        ("std::boxed::", "alloc::boxed::"),
+    ] {
+        if let Some(rest) = canonical_path.strip_prefix(prefix) {
+            aliases.push(format!("{replacement}{rest}"));
+        }
+    }
+
+    if canonical_path == "std::collections::HashMap" {
+        aliases.push("hashbrown::HashMap".to_string());
+    } else if let Some(rest) = canonical_path.strip_prefix("std::collections::HashMap::") {
+        aliases.push(format!("hashbrown::HashMap::{rest}"));
+    }
+
+    aliases
+}
+
+fn canonical_path_candidates(canonical_path: &str) -> Vec<String> {
+    let aliases = canonical_path_aliases(canonical_path);
+    if canonical_path.starts_with("std::") && !aliases.is_empty() {
+        aliases
+            .into_iter()
+            .chain(std::iter::once(canonical_path.to_string()))
+            .collect()
+    } else {
+        std::iter::once(canonical_path.to_string()).chain(aliases).collect()
+    }
+}
+
+fn crate_name_for_path(canonical_path: &str) -> &str {
+    canonical_path.split("::").next().unwrap_or(canonical_path)
+}
+
+fn extract_in_workspace_set(
+    inner: &mut CacheInner,
+    root: &Path,
+    canonical_path: &str,
+    progress: &(dyn Fn(String) + Sync),
+) -> Result<RustItemMetadata, RustMetadataError> {
+    let workspace = match inner.workspaces.entry((root.to_path_buf(), false)) {
+        Entry::Occupied(o) => o.into_mut(),
+        Entry::Vacant(v) => v.insert(RustWorkspace::load(root, progress)?),
+    };
+    match extract_rust_item(workspace.db(), canonical_path) {
+        Ok(meta) => return Ok(meta),
+        Err(RustMetadataError::CrateNotFound(_)) | Err(RustMetadataError::PathNotResolved(_)) => {}
+        Err(err) => return Err(err),
+    }
+
+    let root_outdir_workspace = match inner.workspaces.entry((root.to_path_buf(), true)) {
+        Entry::Occupied(o) => o.into_mut(),
+        Entry::Vacant(v) => v.insert(RustWorkspace::load_with_options(root, progress, true)?),
+    };
+    match extract_rust_item(root_outdir_workspace.db(), canonical_path) {
+        Ok(meta) => return Ok(meta),
+        Err(RustMetadataError::CrateNotFound(_)) | Err(RustMetadataError::PathNotResolved(_)) => {}
+        Err(err) => return Err(err),
+    }
+
+    let crate_name = crate_name_for_path(canonical_path);
+    if let Some(dep_root) = dependency_manifest_dir_for_crate(root, crate_name) {
+        let dep_workspace = match inner.workspaces.entry((dep_root.clone(), true)) {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(v) => v.insert(RustWorkspace::load_with_options(&dep_root, progress, true)?),
+        };
+        return extract_rust_item(dep_workspace.db(), canonical_path);
+    }
+
+    Err(RustMetadataError::CrateNotFound(crate_name.to_string()))
+}
+
 impl RustMetadataCache {
     /// Create an empty cache.
     pub fn new() -> Self {
@@ -107,33 +185,22 @@ impl RustMetadataCache {
             return Ok(Arc::clone(hit));
         }
 
-        let workspace = match inner.workspaces.entry((root.clone(), false)) {
-            Entry::Occupied(o) => o.into_mut(),
-            Entry::Vacant(v) => v.insert(RustWorkspace::load(&root, progress)?),
-        };
-
-        let meta = match extract_rust_item(workspace.db(), canonical_path) {
-            Ok(meta) => meta,
-            Err(RustMetadataError::CrateNotFound(crate_name)) => {
-                let root_outdir_workspace = match inner.workspaces.entry((root.clone(), true)) {
-                    Entry::Occupied(o) => o.into_mut(),
-                    Entry::Vacant(v) => v.insert(RustWorkspace::load_with_options(&root, progress, true)?),
-                };
-                if let Ok(meta) = extract_rust_item(root_outdir_workspace.db(), canonical_path) {
-                    meta
-                } else {
-                    let Some(dep_root) = dependency_manifest_dir_for_crate(&root, crate_name.as_str()) else {
-                        return Err(RustMetadataError::CrateNotFound(crate_name));
-                    };
-                    let dep_workspace = match inner.workspaces.entry((dep_root.clone(), true)) {
-                        Entry::Occupied(o) => o.into_mut(),
-                        Entry::Vacant(v) => v.insert(RustWorkspace::load_with_options(&dep_root, progress, true)?),
-                    };
-                    extract_rust_item(dep_workspace.db(), canonical_path)?
+        let mut last_err = None;
+        let mut meta = None;
+        for candidate in canonical_path_candidates(canonical_path) {
+            match extract_in_workspace_set(&mut inner, &root, candidate.as_str(), progress) {
+                Ok(found) => {
+                    meta = Some(found);
+                    break;
                 }
+                Err(err) => last_err = Some(err),
             }
-            Err(err) => return Err(err),
-        };
+        }
+        let mut meta = meta.ok_or_else(|| {
+            last_err
+                .unwrap_or_else(|| RustMetadataError::CrateNotFound(crate_name_for_path(canonical_path).to_string()))
+        })?;
+        meta.canonical_path = canonical_path.to_owned();
         let arc = Arc::new(meta);
         inner.items.insert(key_item, Arc::clone(&arc));
         Ok(arc)

--- a/src/rust_metadata/extractor.rs
+++ b/src/rust_metadata/extractor.rs
@@ -4,11 +4,12 @@ use std::collections::BTreeMap;
 
 use incan_core::interop::{
     RustFieldInfo, RustFunctionSig, RustItemKind, RustItemMetadata, RustMethodSig, RustModuleChild,
-    RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo, RustVisibility,
+    RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo, RustTypeShape,
+    RustVariantInfo, RustVisibility,
 };
 use ra_ap_hir::{
-    Adt, AssocItem, Crate, DisplayTarget, Function, HasVisibility, HirDisplay, ItemInNs, Module, ModuleDef, Name,
-    ScopeDef, Trait, Type, VariantDef, Visibility, attach_db,
+    Adt, AssocItem, Crate, DisplayTarget, Enum, FieldSource, Function, HasSource, HasVisibility, HirDisplay, ItemInNs,
+    Module, ModuleDef, Name, ScopeDef, Trait, Type, Variant, VariantDef, Visibility, attach_db,
 };
 use ra_ap_ide_db::RootDatabase;
 
@@ -27,6 +28,336 @@ fn is_exported_rust_api(vis: Visibility) -> bool {
 
 fn format_ty(ty: &Type<'_>, db: &RootDatabase, dt: DisplayTarget) -> String {
     format!("{}", ty.display(db, dt))
+}
+
+fn normalize_display_path(display: &str) -> String {
+    display.trim().trim_start_matches("::").to_string()
+}
+
+fn split_display_base(display: &str) -> &str {
+    display.split('<').next().unwrap_or(display)
+}
+
+fn display_looks_like_type_param(display: &str) -> bool {
+    !display.is_empty()
+        && !display.contains("::")
+        && !display.contains(['<', '>', '(', ')', '[', ']', '&', ' '])
+        && display.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn module_path_segments(module: Module, db: &RootDatabase) -> Vec<String> {
+    module
+        .path_to_root(db)
+        .into_iter()
+        .rev()
+        .filter_map(|module| module.name(db).map(|name| name.as_str().to_owned()))
+        .collect()
+}
+
+fn field_module(field: &ra_ap_hir::Field, db: &RootDatabase) -> Module {
+    match field.parent_def(db) {
+        VariantDef::Struct(strukt) => strukt.module(db),
+        VariantDef::Union(union) => union.module(db),
+        VariantDef::Variant(variant) => variant.module(db),
+    }
+}
+
+fn resolve_relative_source_path(text: &str, crate_name: &str, module: Module, db: &RootDatabase) -> Option<String> {
+    let mut text = text.trim().trim_start_matches("::");
+    if text.is_empty() {
+        return None;
+    }
+
+    let mut module_segments = module_path_segments(module, db);
+    if let Some(rest) = text.strip_prefix("crate::") {
+        text = rest;
+        module_segments.clear();
+    } else if let Some(rest) = text.strip_prefix("self::") {
+        text = rest;
+    } else {
+        while let Some(rest) = text.strip_prefix("super::") {
+            text = rest;
+            module_segments.pop();
+        }
+    }
+
+    let mut canonical = vec![crate_name.to_string()];
+    canonical.extend(module_segments);
+    canonical.extend(
+        text.split("::")
+            .filter(|segment| !segment.is_empty())
+            .map(ToOwned::to_owned),
+    );
+    Some(canonical.join("::"))
+}
+
+fn canonical_module_def_path(def: ModuleDef, db: &RootDatabase) -> Option<String> {
+    let local_path = match def {
+        ModuleDef::BuiltinType(builtin) => builtin.name().as_str().to_owned(),
+        _ => def.canonical_path(db, def.module(db)?.krate(db).edition(db))?,
+    };
+    let crate_name = def
+        .module(db)
+        .and_then(|module| module.krate(db).display_name(db))
+        .map(|name| name.canonical_name().as_str().to_owned());
+
+    match crate_name {
+        Some(crate_name) if !local_path.starts_with(crate_name.as_str()) => Some(format!("{crate_name}::{local_path}")),
+        Some(_) | None => Some(local_path),
+    }
+}
+
+fn resolve_source_path(text: &str, crate_name: &str, module: Module, db: &RootDatabase) -> Option<String> {
+    let text = text.trim().replace(' ', "");
+    if text.is_empty() {
+        return None;
+    }
+
+    if text.starts_with("::")
+        || text.starts_with("crate::")
+        || text.starts_with("self::")
+        || text.starts_with("super::")
+    {
+        return resolve_relative_source_path(text.as_str(), crate_name, module, db);
+    }
+
+    let segments: Vec<Name> = text
+        .split("::")
+        .filter(|segment| !segment.is_empty())
+        .map(Name::new_root)
+        .collect();
+    if !segments.is_empty()
+        && let Some(mut resolved) = module.resolve_mod_path(db, segments)
+        && let Some(item) = resolved.next()
+        && let Some(path) = canonical_module_def_path(item.into_module_def(), db)
+    {
+        return Some(path);
+    }
+
+    if text.contains("::") {
+        return Some(text);
+    }
+
+    None
+}
+
+fn split_top_level_args(text: &str) -> Vec<&str> {
+    let mut args = Vec::new();
+    let mut start = 0usize;
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '<' => angle += 1,
+            '>' => angle = angle.saturating_sub(1),
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            ',' if angle == 0 && paren == 0 && bracket == 0 => {
+                args.push(text[start..idx].trim());
+                start = idx + 1;
+            }
+            _ => {}
+        }
+    }
+    let tail = text[start..].trim();
+    if !tail.is_empty() {
+        args.push(tail);
+    }
+    args
+}
+
+fn source_type_shape(text: &str, crate_name: &str, module: Module, db: &RootDatabase) -> RustTypeShape {
+    let text = text.trim().replace(' ', "");
+    if text.is_empty() {
+        return RustTypeShape::Unknown;
+    }
+    match text.as_str() {
+        "bool" => return RustTypeShape::Bool,
+        "f32" | "f64" => return RustTypeShape::Float,
+        "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
+            return RustTypeShape::Int;
+        }
+        "str" | "String" | "std::string::String" | "alloc::string::String" => return RustTypeShape::Str,
+        "()" => return RustTypeShape::Unit,
+        _ => {}
+    }
+
+    if let Some(inner) = text.strip_prefix('&') {
+        let inner = inner.strip_prefix("mut").unwrap_or(inner).trim();
+        return RustTypeShape::Ref(Box::new(source_type_shape(inner, crate_name, module, db)));
+    }
+
+    if text == "[u8]" || text == "&[u8]" {
+        return RustTypeShape::Bytes;
+    }
+
+    if text.starts_with('(') && text.ends_with(')') {
+        let inner = &text[1..text.len() - 1];
+        if inner.is_empty() {
+            return RustTypeShape::Unit;
+        }
+        return RustTypeShape::Tuple(
+            split_top_level_args(inner)
+                .into_iter()
+                .map(|arg| source_type_shape(arg, crate_name, module, db))
+                .collect(),
+        );
+    }
+
+    if let Some(start) = text.find('<')
+        && text.ends_with('>')
+    {
+        let base =
+            resolve_source_path(&text[..start], crate_name, module, db).unwrap_or_else(|| text[..start].to_string());
+        let inner = &text[start + 1..text.len() - 1];
+        let args: Vec<RustTypeShape> = split_top_level_args(inner)
+            .into_iter()
+            .map(|arg| source_type_shape(arg, crate_name, module, db))
+            .collect();
+        match base.as_str() {
+            "Option" | "std::option::Option" | "core::option::Option" => {
+                return RustTypeShape::Option(Box::new(args.into_iter().next().unwrap_or(RustTypeShape::Unknown)));
+            }
+            "Result" | "std::result::Result" | "core::result::Result" => {
+                let mut it = args.into_iter();
+                return RustTypeShape::Result(
+                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
+                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
+                );
+            }
+            "Vec" | "std::vec::Vec" | "alloc::vec::Vec"
+                if matches!(args.first(), Some(RustTypeShape::Int)) && text.ends_with("<u8>") =>
+            {
+                return RustTypeShape::Bytes;
+            }
+            _ => {}
+        }
+        return RustTypeShape::RustPath { path: base, args };
+    }
+
+    if let Some(path) = resolve_source_path(text.as_str(), crate_name, module, db) {
+        return RustTypeShape::RustPath { path, args: Vec::new() };
+    }
+
+    if display_looks_like_type_param(text.as_str()) {
+        return RustTypeShape::TypeParam(text);
+    }
+
+    RustTypeShape::Unknown
+}
+
+fn source_field_type_shape(field: &ra_ap_hir::Field, db: &RootDatabase, crate_name: &str) -> Option<RustTypeShape> {
+    let source = field.source(db)?;
+    let text = match source.value {
+        FieldSource::Named(field) => field.ty()?.to_string(),
+        FieldSource::Pos(field) => field.ty()?.to_string(),
+    };
+    let module = field_module(field, db);
+    Some(source_type_shape(text.as_str(), crate_name, module, db))
+}
+
+fn normalize_variant_payload_shape(shape: RustTypeShape) -> RustTypeShape {
+    match shape {
+        RustTypeShape::RustPath { path, args }
+            if matches!(path.as_str(), "Box" | "std::boxed::Box" | "alloc::boxed::Box") =>
+        {
+            args.into_iter().next().unwrap_or(RustTypeShape::Unknown)
+        }
+        other => other,
+    }
+}
+
+fn rust_type_shape(ty: &Type<'_>, db: &RootDatabase, dt: DisplayTarget) -> RustTypeShape {
+    if ty.is_bool() {
+        return RustTypeShape::Bool;
+    }
+    if ty.is_float() {
+        return RustTypeShape::Float;
+    }
+    if ty.is_int_or_uint() {
+        return RustTypeShape::Int;
+    }
+    if ty.is_str() {
+        return RustTypeShape::Str;
+    }
+    if ty.is_unit() {
+        return RustTypeShape::Unit;
+    }
+    if let Some((inner, _)) = ty.as_reference() {
+        if let Some(slice_inner) = inner.as_slice() {
+            let slice_display = normalize_display_path(format_ty(&slice_inner, db, dt).as_str());
+            if slice_display == "u8" {
+                return RustTypeShape::Bytes;
+            }
+        }
+        return RustTypeShape::Ref(Box::new(rust_type_shape(&inner, db, dt)));
+    }
+    if let Some(slice_inner) = ty.as_slice() {
+        let slice_display = normalize_display_path(format_ty(&slice_inner, db, dt).as_str());
+        if slice_display == "u8" {
+            return RustTypeShape::Bytes;
+        }
+    }
+    if ty.is_tuple() {
+        return RustTypeShape::Tuple(ty.tuple_fields(db).iter().map(|t| rust_type_shape(t, db, dt)).collect());
+    }
+
+    let display = normalize_display_path(format_ty(ty, db, dt).as_str());
+    if matches!(
+        display.as_str(),
+        "String" | "std::string::String" | "alloc::string::String"
+    ) {
+        return RustTypeShape::Str;
+    }
+
+    if let Some((_adt, args)) = ty.as_adt_with_args() {
+        let base = split_display_base(display.as_str()).to_string();
+        let arg_shapes: Vec<RustTypeShape> = args
+            .into_iter()
+            .map(|arg| {
+                arg.map(|ty| rust_type_shape(&ty, db, dt))
+                    .unwrap_or(RustTypeShape::Unknown)
+            })
+            .collect();
+        match base.as_str() {
+            "Option" | "std::option::Option" | "core::option::Option" => {
+                return RustTypeShape::Option(Box::new(
+                    arg_shapes.into_iter().next().unwrap_or(RustTypeShape::Unknown),
+                ));
+            }
+            "Result" | "std::result::Result" | "core::result::Result" => {
+                let mut it = arg_shapes.into_iter();
+                return RustTypeShape::Result(
+                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
+                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
+                );
+            }
+            "Vec" | "std::vec::Vec" | "alloc::vec::Vec" if display.ends_with("<u8>") => {
+                return RustTypeShape::Bytes;
+            }
+            _ => {}
+        }
+        return RustTypeShape::RustPath {
+            path: base,
+            args: arg_shapes,
+        };
+    }
+
+    if display_looks_like_type_param(display.as_str()) {
+        return RustTypeShape::TypeParam(display);
+    }
+
+    if !display.is_empty() && display.contains("::") {
+        return RustTypeShape::RustPath {
+            path: display,
+            args: Vec::new(),
+        };
+    }
+
+    RustTypeShape::Unknown
 }
 
 fn extract_function_sig(f: Function, db: &RootDatabase, dt: DisplayTarget) -> RustFunctionSig {
@@ -64,34 +395,92 @@ fn collect_inherent_methods(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget) 
     by_name.into_values().collect()
 }
 
-fn collect_public_fields_from_variant_def(
-    variant_def: VariantDef,
-    db: &RootDatabase,
-    dt: DisplayTarget,
-) -> Vec<RustFieldInfo> {
+fn collect_public_fields(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget, crate_name: &str) -> Vec<RustFieldInfo> {
+    if let Some(adt) = ty.as_adt() {
+        let type_args: Vec<Type<'_>> = ty.type_arguments().collect();
+        let fields = match adt {
+            Adt::Struct(strukt) => strukt.fields(db),
+            Adt::Union(union) => union.fields(db),
+            Adt::Enum(_) => Vec::new(),
+        };
+        let mut collected = Vec::new();
+        for field in fields {
+            if !is_exported_rust_api(field.visibility(db)) {
+                continue;
+            }
+            let field_ty = field.ty_with_args(db, type_args.iter().cloned());
+            let mut type_shape = rust_type_shape(&field_ty, db, dt);
+            if matches!(type_shape, RustTypeShape::Unknown) || field_ty.contains_unknown() {
+                type_shape = source_field_type_shape(&field, db, crate_name).unwrap_or(type_shape);
+            }
+            collected.push(RustFieldInfo {
+                name: field.name(db).as_str().to_owned(),
+                type_display: format_ty(&field_ty, db, dt),
+                type_shape,
+            });
+        }
+        collected.sort_by(|a, b| a.name.cmp(&b.name));
+        return collected;
+    }
+
     let mut fields = Vec::new();
-    for field in variant_def.fields(db) {
+    for (field, field_ty) in ty.fields(db) {
         if !is_exported_rust_api(field.visibility(db)) {
             continue;
         }
+        let mut type_shape = rust_type_shape(&field_ty, db, dt);
+        if matches!(type_shape, RustTypeShape::Unknown) || field_ty.contains_unknown() {
+            type_shape = source_field_type_shape(&field, db, crate_name).unwrap_or(type_shape);
+        }
         fields.push(RustFieldInfo {
             name: field.name(db).as_str().to_owned(),
-            type_display: format_ty(&field.ty(db).to_type(db), db, dt),
+            type_display: format_ty(&field_ty, db, dt),
+            type_shape,
         });
     }
     fields.sort_by(|a, b| a.name.cmp(&b.name));
     fields
 }
 
-fn collect_public_fields(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget) -> Vec<RustFieldInfo> {
-    let Some((adt, _args)) = ty.as_adt_with_args() else {
-        return Vec::new();
-    };
-    match adt {
-        Adt::Struct(s) => collect_public_fields_from_variant_def(VariantDef::Struct(s), db, dt),
-        Adt::Union(u) => collect_public_fields_from_variant_def(VariantDef::Union(u), db, dt),
-        Adt::Enum(_) => Vec::new(),
+fn collect_enum_variant_payloads(
+    enum_: Enum,
+    ty: Type<'_>,
+    db: &RootDatabase,
+    dt: DisplayTarget,
+    crate_name: &str,
+) -> Vec<RustVariantInfo> {
+    let type_args: Vec<Type<'_>> = ty.type_arguments().collect();
+    let mut variants = Vec::new();
+    for variant in enum_.variants(db) {
+        variants.push(RustVariantInfo {
+            name: variant.name(db).as_str().to_owned(),
+            fields: collect_variant_payload_shapes(variant, &type_args, db, dt, crate_name),
+        });
     }
+    variants.sort_by(|a, b| a.name.cmp(&b.name));
+    variants
+}
+
+fn collect_variant_payload_shapes(
+    variant: Variant,
+    type_args: &[Type<'_>],
+    db: &RootDatabase,
+    dt: DisplayTarget,
+    crate_name: &str,
+) -> Vec<RustTypeShape> {
+    variant
+        .fields(db)
+        .iter()
+        .filter(|field| is_exported_rust_api(field.visibility(db)))
+        .map(|field| {
+            let field_ty = field.ty_with_args(db, type_args.iter().cloned());
+            let mut shape = rust_type_shape(&field_ty, db, dt);
+            if matches!(shape, RustTypeShape::Unknown) || field_ty.contains_unknown() {
+                shape = source_field_type_shape(field, db, crate_name).unwrap_or(shape);
+            }
+            normalize_variant_payload_shape(shape)
+        })
+        .collect()
 }
 
 fn module_children(module: Module, db: &RootDatabase) -> RustModuleInfo {
@@ -251,14 +640,19 @@ fn extract_rust_item_inner(db: &RootDatabase, canonical_path: &str) -> Result<Ru
             let ty = adt.ty(db);
             RustItemKind::Type(RustTypeInfo {
                 methods: collect_inherent_methods(ty.clone(), db, dt),
-                fields: collect_public_fields(ty, db, dt),
+                fields: collect_public_fields(ty.clone(), db, dt, crate_name),
+                variants: match adt {
+                    Adt::Enum(enum_) => collect_enum_variant_payloads(enum_, ty, db, dt, crate_name),
+                    _ => Vec::new(),
+                },
             })
         }
         ModuleDef::BuiltinType(b) => {
             let ty = b.ty(db);
             RustItemKind::Type(RustTypeInfo {
                 methods: collect_inherent_methods(ty.clone(), db, dt),
-                fields: collect_public_fields(ty, db, dt),
+                fields: collect_public_fields(ty, db, dt, crate_name),
+                variants: Vec::new(),
             })
         }
         ModuleDef::Const(c) => RustItemKind::Constant {
@@ -272,7 +666,8 @@ fn extract_rust_item_inner(db: &RootDatabase, canonical_path: &str) -> Result<Ru
             let ty = a.ty(db);
             RustItemKind::Type(RustTypeInfo {
                 methods: collect_inherent_methods(ty.clone(), db, dt),
-                fields: collect_public_fields(ty, db, dt),
+                fields: collect_public_fields(ty, db, dt, crate_name),
+                variants: Vec::new(),
             })
         }
         ModuleDef::Variant(_) => RustItemKind::Unsupported {

--- a/src/rust_metadata/mod.rs
+++ b/src/rust_metadata/mod.rs
@@ -8,6 +8,12 @@ mod error;
 mod extractor;
 mod loader;
 
+#[cfg(test)]
+mod test_fixtures;
+
+#[cfg(test)]
+pub(crate) use test_fixtures::write_substrait_probe_crate;
+
 pub use cache::RustMetadataCache;
 pub use error::RustMetadataError;
 pub use extractor::extract_rust_item;
@@ -20,6 +26,11 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use incan_core::interop::{RustItemKind, RustTypeShape};
+
+    fn type_mismatch(msg: impl std::fmt::Display) -> Box<dyn std::error::Error> {
+        std::io::Error::other(msg.to_string()).into()
+    }
 
     fn write_probe_crate(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
         fs::create_dir_all(root.join("src"))?;
@@ -90,6 +101,89 @@ hashbrown = "0.15"
         let a = cache.get_or_extract(tmp.path(), "regex::Regex", &|_| ())?;
         let b = cache.get_or_extract(tmp.path(), "regex::Regex", &|_| ())?;
         assert!(Arc::ptr_eq(&a, &b));
+        Ok(())
+    }
+
+    #[test]
+    fn substrait_rel_field_preserves_concrete_oneof_payload_type() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        write_substrait_probe_crate(tmp.path())?;
+        let cache = RustMetadataCache::new();
+        let meta = cache.get_or_extract(tmp.path(), "substrait::proto::Rel", &|_| ())?;
+        let info = match &meta.kind {
+            RustItemKind::Type(info) => info,
+            other => {
+                return Err(type_mismatch(format!(
+                    "expected `substrait::proto::Rel` metadata to be a type, got {other:?}"
+                )));
+            }
+        };
+        let rel_type = info
+            .fields
+            .iter()
+            .find(|field| field.name == "rel_type")
+            .ok_or_else(|| {
+                type_mismatch(format!(
+                    "expected `rel_type` field on substrait::proto::Rel, got {:?}",
+                    info.fields
+                ))
+            })?;
+        assert_eq!(
+            rel_type.type_shape,
+            RustTypeShape::Option(Box::new(RustTypeShape::RustPath {
+                path: "substrait::proto::rel::RelType".to_string(),
+                args: vec![],
+            })),
+            "expected concrete oneof payload type for Rel.rel_type, got {:?} (display: {})",
+            rel_type.type_shape,
+            rel_type.type_display
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn substrait_relative_variant_payloads_preserve_canonical_paths() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        write_substrait_probe_crate(tmp.path())?;
+        let cache = RustMetadataCache::new();
+
+        let rel_type_meta = cache.get_or_extract(tmp.path(), "substrait::proto::rel::RelType", &|_| ())?;
+        let rel_type_info = match &rel_type_meta.kind {
+            RustItemKind::Type(info) => info,
+            other => {
+                return Err(type_mismatch(format!(
+                    "expected `substrait::proto::rel::RelType` metadata to be a type, got {other:?}"
+                )));
+            }
+        };
+        assert_eq!(
+            rel_type_info.variants[0].fields,
+            vec![RustTypeShape::RustPath {
+                path: "substrait::proto::ReadRel".to_string(),
+                args: vec![],
+            }],
+            "expected `super::ReadRel` payload to normalize to the canonical path, got {:?}",
+            rel_type_info.variants[0].fields
+        );
+
+        let read_type_meta = cache.get_or_extract(tmp.path(), "substrait::proto::read_rel::ReadType", &|_| ())?;
+        let read_type_info = match &read_type_meta.kind {
+            RustItemKind::Type(info) => info,
+            other => {
+                return Err(type_mismatch(format!(
+                    "expected `substrait::proto::read_rel::ReadType` metadata to be a type, got {other:?}"
+                )));
+            }
+        };
+        assert_eq!(
+            read_type_info.variants[0].fields,
+            vec![RustTypeShape::RustPath {
+                path: "substrait::proto::read_rel::NamedTable".to_string(),
+                args: vec![],
+            }],
+            "expected bare `NamedTable` payload to normalize to the canonical path, got {:?}",
+            read_type_info.variants[0].fields
+        );
         Ok(())
     }
 }

--- a/src/rust_metadata/test_fixtures.rs
+++ b/src/rust_metadata/test_fixtures.rs
@@ -1,0 +1,63 @@
+//! Shared on-disk fixtures for `rust-metadata` tests (typechecker + extractor).
+
+use std::fs;
+use std::path::Path;
+
+/// Minimal “prost-style” crate mirroring oneof/enum shapes used by Substrait protos.
+pub(crate) fn write_substrait_probe_crate(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    fs::create_dir_all(root.join("src"))?;
+    fs::create_dir_all(root.join("substrait").join("src"))?;
+    fs::write(
+        root.join("Cargo.toml"),
+        r#"[package]
+name = "ra_substrait_probe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+substrait = { path = "substrait" }
+"#,
+    )?;
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn touch() { let _ = substrait::proto::PlanRel; }\n",
+    )?;
+    fs::write(
+        root.join("substrait").join("Cargo.toml"),
+        r#"[package]
+name = "substrait"
+version = "0.63.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        root.join("substrait").join("src/lib.rs"),
+        r#"pub mod proto {
+    pub struct PlanRel;
+
+    pub struct Rel {
+        pub rel_type: std::option::Option<rel::RelType>,
+    }
+
+    pub struct ReadRel {
+        pub read_type: std::option::Option<read_rel::ReadType>,
+    }
+
+    pub mod rel {
+        pub enum RelType {
+            Read(Box<super::ReadRel>),
+        }
+    }
+
+    pub mod read_rel {
+        pub struct NamedTable;
+
+        pub enum ReadType {
+            NamedTable(Box<NamedTable>),
+        }
+    }
+}
+"#,
+    )?;
+    Ok(())
+}

--- a/workspaces/docs-site/docs/language/how-to/rust_interop.md
+++ b/workspaces/docs-site/docs/language/how-to/rust_interop.md
@@ -383,7 +383,7 @@ Incan types map to canonical Rust types:
 
 ### Matching on Rust-backed enums and oneofs
 
-When you wrap an imported Rust enum (or a prost-style `oneof`) in a `rusttype`, `match` uses the same qualified constructor patterns as for Incan enums (`Type.Variant(...)` in source; the compiler normalizes this to `Type::Variant` internally). Names you bind in those patterns are in scope in the arm body, so you can nest `Option` / `Result` matches the same way you would for native types.
+When you wrap an imported Rust enum (or a prost-style `oneof`) in a `rusttype`, `match` uses the same qualified constructor patterns as for Incan enums (`Type.Variant(...)` in source; the compiler normalizes this to `Type::Variant` internally). Names you bind in those patterns are in scope in the arm body, so you can nest `Option` / `Result` matches the same way you would for native types. The same payload typing now applies when you match through imported Rust/prost fields in normal CLI builds and editor/tooling analysis, so helpers like `match rel.rel_type: Some(RelType.Read(read)) => ...` resolve `read` to the concrete payload type instead of degrading to a placeholder `T`.
 
 ```incan
 type PlanRel = rusttype rust::my_crate::proto::PlanRel:

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -191,6 +191,7 @@ They are not intended as runtime function calls.
 - **Compiler**: Rust crate dependency management with inline version annotations, manifest-based configuration,
   version validation (semver), and lock files for reproducible builds ([RFC 013]).
 - **Compiler**: RFC 041 first-class Rust interop authoring surface: `rusttype` declarations, `interop:` edge blocks, and `std.rust` capability markers used in generic `with` bounds ([RFC 041], #175).
+- **Compiler/LSP**: Imported prost `oneof` payloads now keep their concrete field/variant typing through CLI and editor analysis, so matches like `Some(RelType.Read(read))` on imported Rust-backed fields resolve `read` reliably instead of degrading to placeholder `T` (#218).
 - **Tooling**: LSP document symbols, hover, and completions now include `newtype`/`rusttype` and `type` alias declarations. Hovering over a `rusttype` shows the canonical Rust path of the underlying type ([RFC 041]).
 - **Compiler**: Convention-based source root resolution — the compiler and test runner resolve user module imports
   against `src/` (or an explicit `[build] source-root`) so imports are uniform across source and test files ([RFC 015]).


### PR DESCRIPTION
## Summary

This PR fixes **imported prost-style `oneof` / generated-Rust** typing so nested `match` patterns keep **concrete** payload types (e.g. `Some(RelType.Read(read))` → `read` is the real message type) instead of degrading to placeholders. It does so by enriching **RFC 041 rust-metadata** with a small **`RustTypeShape`** model, **enum variant payload** shapes, **source-based** type recovery when rust-analyzer’s HIR is opaque, and **`Box<…>`** normalization for variant payloads. The typechecker uses shapes for **Rust field access** and **`match`** arm bindings when metadata is available.

Related fixes bundled for reliable analysis: **Rust import symbols** may shadow **implicit builtins** (`Some`, `HashMap`, …) without being skipped as “already defined,” and the **metadata cache** tries **`std` → `core`/`alloc` path aliases**, loads **out-dir** and **dependency** workspaces, and resolves paths more robustly for extracted crates.

Release notes and docs-site pages (RFC cross-links / rust interop how-to) are updated where this behavior is user-visible.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension) — same typechecker paths as CLI
- [x] Runtime / Core crates (stdlib/core/derive) — `incan_core::interop` metadata surface
- [x] Documentation

## Key details

- **User-facing behavior**: Imported Rust-backed fields that wrap prost `oneof`-style enums (`Option<ConcreteEnum>`, nested matches) typecheck with **accurate inner bindings** in CLI/LSP. Rust imports can **shadow builtins** where appropriate.
- **Internals**: `RustFieldInfo` gains `type_shape`; `RustTypeInfo` gains `variants` (`RustVariantInfo`); extractor builds shapes from HIR plus **source** fallback and collects **variant payload** shapes; `resolved_type_from_rust_shape` in the typechecker; `match_.rs` prefers metadata-backed payload lists; cache gains **path alias** and **multi-workspace** extraction helpers; shared test fixture **`test_fixtures.rs`** for Substrait-style probe crates (ensure it is **committed** if not already).
- **Risks**: **Breaking** for any out-of-tree code constructing `RustFieldInfo` / `RustTypeInfo` manually (new required fields). Shape recovery remains **best-effort** where source/HIR cannot recover types. Integer/float **width** is still erased in `RustTypeShape` (by design for this layer).

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [ ] Manual verification described below

**Suggested commands**

- `cargo test -p incan --features rust-metadata substrait`
- `cargo test -p incan --features rust-metadata prost_oneof`
- `cargo clippy --all-targets --all-features -- -D warnings`

**Tests added/extended (representative)**

- Typechecker: synthetic metadata + end-to-end extraction for prost-like nested `match` (`test_imported_prost_oneof_field_match_*`, `test_real_rust_metadata_allows_imported_prost_oneof_field_match`).
- `rust_metadata`: Substrait-style probe crate — `rel_type` shape and variant payload canonical paths.

Manual verification notes:

- Open a project that imports generated protos and exercise nested `match` on `Option` + enum + inner `read` field; confirm LSP hover / diagnostics match CLI.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- `workspaces/docs-site/docs/release_notes/0_2.md` — #218 oneof / concrete typing note
- `workspaces/docs-site/docs/language/how-to/rust_interop.md` — minor touch

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions

Closes #218