### PR TITLE
bugfix - preserve list literal typing for empty lists and List[Self] returns (#229, #230)

### DIFF
--- a/src/backend/ir/conversions.rs
+++ b/src/backend/ir/conversions.rs
@@ -485,7 +485,10 @@ pub fn determine_conversion(expr: &IrExpr, target_ty: Option<&IrType>, context: 
                 // Vec<&str> to Vec<String> - check before generic variable handling
                 (_, Some(IrType::List(elem))) if matches!(elem.as_ref(), IrType::String) => {
                     if matches!(expr.ty, IrType::List(_)) {
-                        Conversion::VecStringConversion
+                        match &expr.kind {
+                            IrExprKind::List(items) if items.is_empty() => Conversion::None,
+                            _ => Conversion::VecStringConversion,
+                        }
                     } else {
                         Conversion::None
                     }
@@ -667,6 +670,15 @@ mod tests {
 
         let conv = determine_conversion(&expr, Some(&target), ConversionContext::IncanFunctionArg);
         assert_eq!(conv, Conversion::VecStringConversion);
+    }
+
+    #[test]
+    fn test_incan_function_empty_list_to_string_list_skips_collect_conversion() {
+        let expr = IrExpr::new(IrExprKind::List(Vec::new()), IrType::List(Box::new(IrType::String)));
+        let target = IrType::List(Box::new(IrType::String));
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::IncanFunctionArg);
+        assert_eq!(conv, Conversion::None);
     }
 
     #[test]

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -74,6 +74,49 @@ struct InteropAdapterSig {
 }
 
 impl TypeChecker {
+    /// Replace every nested `Self` occurrence in an annotation with the concrete owner type used for this method body.
+    ///
+    /// Method return validation runs against the concrete owning type, not the abstract declaration surface, so
+    /// containers like `List[Self]` must be concretized recursively before compatibility checks.
+    fn concretize_self_type_in_annotation(ty: &ResolvedType, self_ty: &ResolvedType) -> ResolvedType {
+        match ty {
+            ResolvedType::SelfType => self_ty.clone(),
+            ResolvedType::Generic(name, args) => ResolvedType::Generic(
+                name.clone(),
+                args.iter()
+                    .map(|arg| Self::concretize_self_type_in_annotation(arg, self_ty))
+                    .collect(),
+            ),
+            ResolvedType::Tuple(items) => ResolvedType::Tuple(
+                items
+                    .iter()
+                    .map(|item| Self::concretize_self_type_in_annotation(item, self_ty))
+                    .collect(),
+            ),
+            ResolvedType::Function(params, ret) => ResolvedType::Function(
+                params
+                    .iter()
+                    .map(|param| Self::concretize_self_type_in_annotation(param, self_ty))
+                    .collect(),
+                Box::new(Self::concretize_self_type_in_annotation(ret, self_ty)),
+            ),
+            ResolvedType::FrozenList(inner) => {
+                ResolvedType::FrozenList(Box::new(Self::concretize_self_type_in_annotation(inner, self_ty)))
+            }
+            ResolvedType::FrozenSet(inner) => {
+                ResolvedType::FrozenSet(Box::new(Self::concretize_self_type_in_annotation(inner, self_ty)))
+            }
+            ResolvedType::FrozenDict(key, value) => ResolvedType::FrozenDict(
+                Box::new(Self::concretize_self_type_in_annotation(key, self_ty)),
+                Box::new(Self::concretize_self_type_in_annotation(value, self_ty)),
+            ),
+            ResolvedType::Ref(inner) => {
+                ResolvedType::Ref(Box::new(Self::concretize_self_type_in_annotation(inner, self_ty)))
+            }
+            _ => ty.clone(),
+        }
+    }
+
     /// Build the resolved surface type that represents `nt` in interop signature validation.
     ///
     /// Generic rusttypes are represented as `Generic(Name, TypeVar...)` so adapter checks compare against the
@@ -1314,17 +1357,7 @@ impl TypeChecker {
         }
 
         let return_type = self.resolve_type_checked(&method.return_type);
-        let effective_return_type =
-            if matches!(return_type, ResolvedType::SelfType) && !matches!(self_ty, ResolvedType::SelfType) {
-                match &self_ty {
-                    ResolvedType::Named(name) if !owner_type_params.is_empty() => {
-                        ResolvedType::Generic(name.clone(), vec![ResolvedType::Unknown; owner_type_params.len()])
-                    }
-                    _ => self_ty.clone(),
-                }
-            } else {
-                return_type.clone()
-            };
+        let effective_return_type = Self::concretize_self_type_in_annotation(&return_type, &self_ty);
         self.symbols.set_return_type(effective_return_type);
 
         // Set error type for ? checking

--- a/src/frontend/typechecker/check_expr/calls.rs
+++ b/src/frontend/typechecker/check_expr/calls.rs
@@ -343,32 +343,33 @@ impl TypeChecker {
         fields: &std::collections::HashMap<String, FieldInfo>,
         args: &[CallArg],
         call_span: Span,
-    ) {
+    ) -> ResolvedType {
         // v0.1: only named args for model/class constructors (stable field ordering not guaranteed).
         if args.iter().any(|a| matches!(a, CallArg::Positional(_))) {
             // Typecheck argument expressions regardless, so type errors in expressions still show up.
             self.check_call_args(args);
             self.errors
                 .push(errors::positional_constructor_args_not_supported(type_name, call_span));
-            return;
+            return self.constructor_result_type(type_name);
         }
 
         // Track provided fields and validate existence/duplicates/type compatibility.
         let mut provided: std::collections::HashMap<String, Span> = std::collections::HashMap::new();
+        let mut type_bindings: std::collections::HashMap<String, ResolvedType> = std::collections::HashMap::new();
         for arg in args {
             let CallArg::Named(field_name, expr) = arg else {
                 continue;
             };
 
-            // Always typecheck the expression exactly once, even if the key is invalid/duplicate.
-            // This avoids double-reporting while still surfacing expression errors.
-            let value_ty = self.check_expr(expr);
-
             let Some((canonical_name, field_info)) = self.resolve_field_info(fields, field_name, true, true) else {
+                // Still typecheck the expression exactly once so nested diagnostics are preserved.
+                self.check_expr(expr);
                 self.errors
                     .push(errors::missing_field(type_name, field_name, expr.span));
                 continue;
             };
+
+            let value_ty = self.check_expr_with_expected(expr, Some(&field_info.ty));
 
             if provided.contains_key(&canonical_name) {
                 self.errors.push(errors::duplicate_field_in_call(
@@ -379,6 +380,7 @@ impl TypeChecker {
                 continue;
             }
             provided.insert(canonical_name.clone(), expr.span);
+            self.infer_type_param_bindings(&field_info.ty, &value_ty, &mut type_bindings);
 
             if !self.types_compatible(&value_ty, &field_info.ty) {
                 self.errors.push(errors::field_type_mismatch(
@@ -398,6 +400,8 @@ impl TypeChecker {
                 ));
             }
         }
+
+        self.constructor_result_type_with_bindings(type_name, &type_bindings)
     }
 
     /// Extract the expression from a call argument (positional or named).
@@ -477,24 +481,80 @@ impl TypeChecker {
             .collect()
     }
 
+    /// Type-check call arguments while threading parameter types into contextual-expression checks when available.
+    fn check_call_arg_types_for_params(
+        &mut self,
+        args: &[CallArg],
+        params: &[(String, ResolvedType)],
+    ) -> Vec<ResolvedType> {
+        let mut positional_index = 0usize;
+
+        args.iter()
+            .map(|arg| {
+                let expected = match arg {
+                    CallArg::Positional(_) => {
+                        let expected = params.get(positional_index).map(|(_, ty)| ty);
+                        positional_index += 1;
+                        expected
+                    }
+                    CallArg::Named(name, _) => params
+                        .iter()
+                        .find(|(param_name, _)| param_name == name)
+                        .map(|(_, ty)| ty),
+                };
+                self.check_expr_with_expected(Self::call_arg_expr(arg), expected)
+            })
+            .collect()
+    }
+
     /// Compute the constructor result surface type for a known type symbol.
     ///
     /// Generic constructors return a placeholder `Generic(Name, Unknown...)` so call sites can continue
     /// typechecking while inference refines arguments.
     fn constructor_result_type(&self, name: &str) -> ResolvedType {
+        self.constructor_result_type_with_bindings(name, &std::collections::HashMap::new())
+    }
+
+    /// Compute the constructor result surface type, substituting any generic bindings inferred from constructor fields.
+    ///
+    /// Unbound type parameters remain `Unknown` so callers can continue typechecking even when inference is partial.
+    fn constructor_result_type_with_bindings(
+        &self,
+        name: &str,
+        bindings: &std::collections::HashMap<String, ResolvedType>,
+    ) -> ResolvedType {
         match self.lookup_type_info(name) {
-            Some(TypeInfo::Model(model)) if !model.type_params.is_empty() => {
-                ResolvedType::Generic(name.to_string(), vec![ResolvedType::Unknown; model.type_params.len()])
-            }
-            Some(TypeInfo::Class(class)) if !class.type_params.is_empty() => {
-                ResolvedType::Generic(name.to_string(), vec![ResolvedType::Unknown; class.type_params.len()])
-            }
-            Some(TypeInfo::Newtype(newtype)) if !newtype.type_params.is_empty() => {
-                ResolvedType::Generic(name.to_string(), vec![ResolvedType::Unknown; newtype.type_params.len()])
-            }
+            Some(TypeInfo::Model(model)) if !model.type_params.is_empty() => ResolvedType::Generic(
+                name.to_string(),
+                model
+                    .type_params
+                    .iter()
+                    .map(|type_param| bindings.get(type_param).cloned().unwrap_or(ResolvedType::Unknown))
+                    .collect(),
+            ),
+            Some(TypeInfo::Class(class)) if !class.type_params.is_empty() => ResolvedType::Generic(
+                name.to_string(),
+                class
+                    .type_params
+                    .iter()
+                    .map(|type_param| bindings.get(type_param).cloned().unwrap_or(ResolvedType::Unknown))
+                    .collect(),
+            ),
+            Some(TypeInfo::Newtype(newtype)) if !newtype.type_params.is_empty() => ResolvedType::Generic(
+                name.to_string(),
+                newtype
+                    .type_params
+                    .iter()
+                    .map(|type_param| bindings.get(type_param).cloned().unwrap_or(ResolvedType::Unknown))
+                    .collect(),
+            ),
             Some(TypeInfo::Enum(enum_info)) if !enum_info.type_params.is_empty() => ResolvedType::Generic(
                 name.to_string(),
-                vec![ResolvedType::Unknown; enum_info.type_params.len()],
+                enum_info
+                    .type_params
+                    .iter()
+                    .map(|type_param| bindings.get(type_param).cloned().unwrap_or(ResolvedType::Unknown))
+                    .collect(),
             ),
             _ => ResolvedType::Named(name.to_string()),
         }
@@ -508,7 +568,7 @@ impl TypeChecker {
         args: &[CallArg],
         call_span: Span,
     ) -> ResolvedType {
-        let arg_types = self.check_call_arg_types(args);
+        let arg_types = self.check_call_arg_types_for_params(args, &info.params);
         let mut positional: Vec<(ResolvedType, Span)> = Vec::new();
         let mut named: std::collections::HashMap<&str, (ResolvedType, Span)> = std::collections::HashMap::new();
 
@@ -552,6 +612,9 @@ impl TypeChecker {
     }
 
     /// Infer concrete type bindings for generic type parameters from a parameter/argument type pair.
+    ///
+    /// This walks matching container structure recursively so constructor field checks and function calls can recover
+    /// bindings such as `T -> String` from shapes like `Boxed[T]` versus `Boxed[String]`.
     fn infer_type_param_bindings(
         &self,
         expected: &ResolvedType,
@@ -1454,7 +1517,7 @@ impl TypeChecker {
                     _ => None,
                 });
             if let Some(fields) = ctor_fields {
-                self.check_model_or_class_constructor_call(name, &fields, args, span);
+                let constructor_ty = self.check_model_or_class_constructor_call(name, &fields, args, span);
                 if in_scope && let Some(tid) = surface_types::from_str(name) {
                     if matches!(tid, SurfaceTypeId::Json | SurfaceTypeId::Query) {
                         return self.check_json_query_constructor_call(tid, args, span);
@@ -1463,7 +1526,7 @@ impl TypeChecker {
                         return ResolvedType::Named(surface_types::as_str(tid).to_string());
                     }
                 }
-                return self.constructor_result_type(name);
+                return constructor_ty;
             }
         }
 
@@ -1510,7 +1573,19 @@ impl TypeChecker {
         }
 
         match self.lookup_symbol(name).map(|s| &s.kind) {
-            Some(SymbolKind::Type(_)) => self.constructor_result_type(name),
+            Some(SymbolKind::Type(_)) => {
+                let ctor_fields: Option<std::collections::HashMap<String, FieldInfo>> =
+                    self.lookup_type_info(name).and_then(|info| match info {
+                        TypeInfo::Model(m) => Some(m.fields.clone()),
+                        TypeInfo::Class(c) => Some(c.fields.clone()),
+                        _ => None,
+                    });
+                if let Some(fields) = ctor_fields {
+                    self.check_model_or_class_constructor_call(name, &fields, args, span)
+                } else {
+                    self.constructor_result_type(name)
+                }
+            }
             Some(SymbolKind::Variant(info)) => ResolvedType::Named(info.enum_name.clone()),
             Some(_) => ResolvedType::Unknown,
             None => {

--- a/src/frontend/typechecker/check_expr/collections.rs
+++ b/src/frontend/typechecker/check_expr/collections.rs
@@ -4,12 +4,66 @@
 //! checker's compatibility rules.
 
 use crate::frontend::ast::*;
+use crate::frontend::diagnostics::errors;
 use crate::frontend::symbols::ResolvedType;
-use crate::frontend::typechecker::helpers::{dict_ty, list_ty, set_ty};
+use crate::frontend::typechecker::helpers::{collection_type_id, dict_ty, list_ty, set_ty};
+use incan_core::lang::types::collections::CollectionTypeId;
 
 use super::TypeChecker;
 
 impl TypeChecker {
+    /// Extract the element type from an expected `List[T]` destination, if one is already known.
+    fn list_expected_element_type(expected: Option<&ResolvedType>) -> Option<ResolvedType> {
+        match expected {
+            Some(ResolvedType::Generic(name, args))
+                if collection_type_id(name.as_str()) == Some(CollectionTypeId::List) && args.len() == 1 =>
+            {
+                Some(args[0].clone())
+            }
+            _ => None,
+        }
+    }
+
+    /// Type-check a list literal with an optional destination-type hint.
+    ///
+    /// When a surrounding context already expects `List[T]`, empty lists adopt `T` directly and non-empty lists
+    /// validate each element against that hinted type. Without a hint, the first element still seeds the candidate
+    /// element type, but later elements must remain compatible instead of being ignored.
+    pub(in crate::frontend::typechecker::check_expr) fn check_list_with_expected(
+        &mut self,
+        elems: &[Spanned<Expr>],
+        expected: Option<&ResolvedType>,
+    ) -> ResolvedType {
+        let hinted_elem_ty = Self::list_expected_element_type(expected);
+        let mut elem_ty = hinted_elem_ty.clone().unwrap_or(ResolvedType::Unknown);
+
+        for (index, elem) in elems.iter().enumerate() {
+            let value_ty = self.check_expr_with_expected(elem, hinted_elem_ty.as_ref());
+
+            if index == 0 && hinted_elem_ty.is_none() {
+                elem_ty = value_ty.clone();
+                continue;
+            }
+
+            if self.types_compatible(&value_ty, &elem_ty) {
+                continue;
+            }
+
+            if self.types_compatible(&elem_ty, &value_ty) {
+                elem_ty = value_ty;
+                continue;
+            }
+
+            self.errors.push(errors::type_mismatch(
+                &elem_ty.to_string(),
+                &value_ty.to_string(),
+                elem.span,
+            ));
+        }
+
+        list_ty(elem_ty)
+    }
+
     /// Type-check a tuple literal.
     pub(in crate::frontend::typechecker::check_expr) fn check_tuple(
         &mut self,
@@ -21,17 +75,7 @@ impl TypeChecker {
 
     /// Type-check a list literal.
     pub(in crate::frontend::typechecker::check_expr) fn check_list(&mut self, elems: &[Spanned<Expr>]) -> ResolvedType {
-        let elem_ty = if let Some(first) = elems.first() {
-            self.check_expr(first)
-        } else {
-            ResolvedType::Unknown
-        };
-
-        for elem in elems.iter().skip(1) {
-            self.check_expr(elem);
-        }
-
-        list_ty(elem_ty)
+        self.check_list_with_expected(elems, None)
     }
 
     /// Type-check a dict literal.

--- a/src/frontend/typechecker/check_expr/mod.rs
+++ b/src/frontend/typechecker/check_expr/mod.rs
@@ -113,6 +113,25 @@ impl TypeChecker {
         ty
     }
 
+    /// Type-check an expression with an expected destination type when one is already known.
+    ///
+    /// This is intentionally narrow: only expression forms that benefit from contextual typing without broad inference
+    /// changes should use the hint.
+    pub(crate) fn check_expr_with_expected(
+        &mut self,
+        expr: &Spanned<Expr>,
+        expected: Option<&ResolvedType>,
+    ) -> ResolvedType {
+        let ty = match (&expr.node, expected) {
+            (Expr::Paren(inner), Some(expected_ty)) => self.check_expr_with_expected(inner, Some(expected_ty)),
+            (Expr::List(elems), expected_ty) => self.check_list_with_expected(elems, expected_ty),
+            _ => return self.check_expr(expr),
+        };
+
+        self.record_expr_type(expr.span, ty.clone());
+        ty
+    }
+
     /// Typecheck a surface expression via the semantics registry.
     fn check_surface_expr(&mut self, expr: &SurfaceExpr, span: Span) -> ResolvedType {
         use crate::semantics_registry::semantics_registry;

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -234,8 +234,6 @@ impl TypeChecker {
     fn check_field_assignment(&mut self, field_assign: &FieldAssignmentStmt, span: Span) {
         // Check the object expression
         let obj_ty = self.check_expr(&field_assign.object);
-        // Check the value expression
-        let value_ty = self.check_expr(&field_assign.value);
         let field = &field_assign.field;
 
         // Tuples are immutable - disallow field assignment on tuples
@@ -247,15 +245,16 @@ impl TypeChecker {
         // Verify field exists on object and value type matches field type
         match &obj_ty {
             ResolvedType::SelfType => {
-                if let Some(expected_ty) = self.trait_required_field_type(field, field_assign.target_span)
-                    && !self.types_compatible(&value_ty, &expected_ty)
-                {
-                    self.errors.push(errors::field_type_mismatch(
-                        field,
-                        &expected_ty.to_string(),
-                        &value_ty.to_string(),
-                        field_assign.value.span,
-                    ));
+                if let Some(expected_ty) = self.trait_required_field_type(field, field_assign.target_span) {
+                    let value_ty = self.check_expr_with_expected(&field_assign.value, Some(&expected_ty));
+                    if !self.types_compatible(&value_ty, &expected_ty) {
+                        self.errors.push(errors::field_type_mismatch(
+                            field,
+                            &expected_ty.to_string(),
+                            &value_ty.to_string(),
+                            field_assign.value.span,
+                        ));
+                    }
                 }
             }
             ResolvedType::Named(type_name) => {
@@ -272,6 +271,7 @@ impl TypeChecker {
 
                 match field_type {
                     Some(expected_ty) => {
+                        let value_ty = self.check_expr_with_expected(&field_assign.value, Some(&expected_ty));
                         if !self.types_compatible(&value_ty, &expected_ty) {
                             self.errors.push(errors::field_type_mismatch(
                                 field,
@@ -370,7 +370,15 @@ impl TypeChecker {
     }
 
     fn check_assignment(&mut self, assign: &AssignmentStmt, span: Span) {
-        let value_ty = self.check_expr(&assign.value);
+        let annotated_ty = assign.ty.as_ref().map(|ty_ann| self.resolve_type_checked(ty_ann));
+        let reassignment_ty = self
+            .lookup_local_variable_info(&assign.name)
+            .map(|var_info| var_info.ty.clone());
+        let value_ty = if let Some(var_ty) = reassignment_ty.as_ref() {
+            self.check_expr_with_expected(&assign.value, Some(var_ty))
+        } else {
+            self.check_expr_with_expected(&assign.value, annotated_ty.as_ref())
+        };
 
         // Check if it's a re-assignment
         if let Some(var_info) = self.lookup_local_variable_info(&assign.name) {
@@ -403,7 +411,7 @@ impl TypeChecker {
         }
 
         let ty = if let Some(ty_ann) = &assign.ty {
-            let ann_ty = self.resolve_type_checked(ty_ann);
+            let ann_ty = annotated_ty.unwrap_or_else(|| self.resolve_type_checked(ty_ann));
             // Check value matches annotation
             if !self.types_compatible(&value_ty, &ann_ty) {
                 self.errors.push(errors::type_mismatch(
@@ -431,7 +439,8 @@ impl TypeChecker {
 
     fn check_return(&mut self, expr: Option<&Spanned<Expr>>, span: Span) {
         let return_ty = if let Some(e) = expr {
-            self.check_expr(e)
+            let expected_return_ty = self.symbols.current_return_type().cloned();
+            self.check_expr_with_expected(e, expected_return_ty.as_ref())
         } else {
             ResolvedType::Unit
         };

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3199,6 +3199,30 @@ def foo() -> List[int]:
     assert!(check_str(source).is_ok());
 }
 
+#[test]
+fn test_empty_list_matches_typed_call_parameter() {
+    let source = r#"
+def takes_names(names: List[str]) -> int:
+  return len(names)
+
+def foo() -> int:
+  return takes_names([])
+"#;
+    assert!(check_str(source).is_ok());
+}
+
+#[test]
+fn test_list_self_accepts_explicit_owner_instances() {
+    let source = r#"
+pub class Boxed[T]:
+  pub value: T
+
+  def pair(self) -> List[Self]:
+    return [Boxed(value=self.value), Boxed(value=self.value)]
+"#;
+    assert!(check_str(source).is_ok());
+}
+
 // ========================================
 // Model tests
 // ========================================

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1289,6 +1289,68 @@ def test_nested_dataset_modules() -> None:
     }
 
     #[test]
+    fn e2e_empty_list_arguments_in_tests_preserve_string_element_type() {
+        let dir = write_test_project(
+            "incan.toml",
+            r#"[project]
+name = "empty_list_test"
+version = "0.1.0"
+"#,
+        );
+        let src_dir = dir.join("src");
+        let tests_dir = dir.join("tests");
+
+        if let Err(err) = std::fs::create_dir_all(&src_dir) {
+            panic!("failed to create src dir: {}", err);
+        }
+        if let Err(err) = std::fs::create_dir_all(&tests_dir) {
+            panic!("failed to create tests dir: {}", err);
+        }
+        if let Err(err) = std::fs::write(
+            src_dir.join("helpers.incn"),
+            r#"
+pub def count_names(names: List[str]) -> int:
+    return len(names)
+"#,
+        ) {
+            panic!("failed to write helper source: {}", err);
+        }
+        if let Err(err) = std::fs::write(
+            tests_dir.join("test_empty_names.incn"),
+            r#"
+from std.testing import assert_eq
+from helpers import count_names
+
+def test_empty_names() -> None:
+    assert_eq(count_names([]), 0)
+"#,
+        ) {
+            panic!("failed to write test source: {}", err);
+        }
+
+        let output = run_incan_test(&dir);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "expected empty list string arg test to succeed.\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr,
+        );
+        assert!(
+            !stderr.contains("type annotations needed"),
+            "expected no Rust inference failure for empty string list.\nstderr:\n{}",
+            stderr,
+        );
+        assert!(
+            !stderr.contains("vec![].into_iter().map(|s| s.to_string()).collect()"),
+            "expected no untyped empty string-list conversion in generated Rust.\nstderr:\n{}",
+            stderr,
+        );
+    }
+
+    #[test]
     fn e2e_assert_statement_with_module_import_succeeds() {
         let dir = write_test_project(
             "test_assert_stmt.incn",

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -192,6 +192,8 @@ They are not intended as runtime function calls.
   version validation (semver), and lock files for reproducible builds ([RFC 013]).
 - **Compiler**: RFC 041 first-class Rust interop authoring surface: `rusttype` declarations, `interop:` edge blocks, and `std.rust` capability markers used in generic `with` bounds ([RFC 041], #175).
 - **Compiler/LSP**: Imported prost `oneof` payloads now keep their concrete field/variant typing through CLI and editor analysis, so matches like `Some(RelType.Read(read))` on imported Rust-backed fields resolve `read` reliably instead of degrading to placeholder `T` (#218).
+- **Compiler**: Empty list literals now preserve destination element typing in typed call, assignment, and test-runner codegen paths, avoiding generated Rust inference failures for cases like `List[str]` parameters receiving `[]` (#229).
+- **Compiler**: `List[Self]` method returns now accept list literals containing explicit instances of the enclosing class when those constructor arguments determine the same owner type, instead of degrading to `List[Owner[?]]` mismatches (#230).
 - **Tooling**: LSP document symbols, hover, and completions now include `newtype`/`rusttype` and `type` alias declarations. Hovering over a `rusttype` shows the canonical Rust path of the underlying type ([RFC 041]).
 - **Compiler**: Convention-based source root resolution — the compiler and test runner resolve user module imports
   against `src/` (or an explicit `[build] source-root`) so imports are uniform across source and test files ([RFC 015]).


### PR DESCRIPTION
## Summary

This PR fixes two list-typing bugs that shared the same underlying weakness: list literals were losing too much type information between typechecking and lowering. Empty list literals now preserve destination element typing in typed contexts such as returns, assignments, constructor fields, and call arguments, and `List[Self]` method returns now accept list literals containing explicit instances of the enclosing generic owner when those constructor arguments determine the same concrete type.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `[]` now typechecks and lowers correctly in typed `List[T]` positions, including `List[str]` arguments that previously generated Rust requiring type annotations. Methods returning `List[Self]` also now accept list literals containing explicit same-owner constructor calls instead of rejecting them as `List[Owner[?]]`.
- **Internals**: The typechecker now has a narrow contextual-expression path for list literals, constructor checking infers generic bindings from field arguments, and nested `Self` annotations are concretized before method-body return validation. On the lowering side, empty string-list conversions no longer emit the untyped `vec![].into_iter().map(|s| s.to_string()).collect()` path.
- **Risks**: The main risk is broader list-literal contextual typing changing edge-case inference behavior outside the two reported bugs. The implementation keeps that scope intentionally narrow, but it still touches shared typechecker paths.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Added typechecker regressions for typed empty-list call arguments and `List[Self]` returns with explicit owner instances.
- Added a backend conversion regression to ensure empty `List[String]` arguments skip the string-collection conversion path.
- Added an end-to-end `incan test` regression covering `List[str]` parameters receiving `[]`.
- Ran `make fmt`, `make pre-commit-full`, and `make smoke-test`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_2.md`

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #229
Closes #230
