### PR TITLE
bugfix - typecheck: substitute Self at call sites for nominal methods (237)

### DIFF
--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -78,6 +78,9 @@ impl TypeChecker {
     ///
     /// Method return validation runs against the concrete owning type, not the abstract declaration surface, so
     /// containers like `List[Self]` must be concretized recursively before compatibility checks.
+    ///
+    /// **Call sites** use `substitute_self_in_resolved_type` in `check_expr/access.rs` instead: there `Self` is
+    /// resolved from the **instantiated** receiver expression (e.g. `Carrier[Order]` for `x.filter(...)`).
     fn concretize_self_type_in_annotation(ty: &ResolvedType, self_ty: &ResolvedType) -> ResolvedType {
         match ty {
             ResolvedType::SelfType => self_ty.clone(),

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -305,6 +305,11 @@ impl TypeChecker {
         }
     }
 
+    /// Replace every [`ResolvedType::SelfType`] in `ty` using the **call-site** receiver.
+    ///
+    /// For method **bodies**, `TypeChecker::concretize_self_type_in_annotation` in `check_decl.rs` maps `Self` to the
+    /// owner's `self_ty` while checking the implementation. At a **call site**, `Self` means the instantiated
+    /// receiver (for example `DataFrame[Order]` when calling on `x: DataFrame[Order]`).
     fn substitute_self_in_resolved_type(&self, ty: ResolvedType, receiver: &ResolvedType) -> ResolvedType {
         match ty {
             ResolvedType::SelfType => self.concrete_type_for_trait_self(receiver),
@@ -337,7 +342,33 @@ impl TypeChecker {
         }
     }
 
+    /// Build formal parameter types and return type for a call, replacing `Self` with `receiver_ty`.
+    ///
+    /// [`MethodInfo`] from collection stores `Self` literally; both inherent and trait dispatch must substitute using
+    /// the **instantiated** receiver before argument checking and before reporting the callee's result type.
+    fn method_types_substituting_call_site_self(
+        &self,
+        method_info: &MethodInfo,
+        receiver_ty: &ResolvedType,
+    ) -> (Vec<(String, ResolvedType)>, ResolvedType) {
+        let params = method_info
+            .params
+            .iter()
+            .map(|(name, ty)| {
+                (
+                    name.clone(),
+                    self.substitute_self_in_resolved_type(ty.clone(), receiver_ty),
+                )
+            })
+            .collect();
+        let return_type = self.substitute_self_in_resolved_type(method_info.return_type.clone(), receiver_ty);
+        (params, return_type)
+    }
+
     /// Resolve a method on a type's own methods or trait-adopted methods.
+    ///
+    /// Inherent methods and trait-provided methods both substitute `Self` in formal parameters and the return type
+    /// using the call-site receiver so generic carriers typecheck consistently (#237).
     #[allow(clippy::too_many_arguments)]
     fn resolve_named_method(
         &mut self,
@@ -350,17 +381,15 @@ impl TypeChecker {
         receiver_ty: &ResolvedType,
     ) -> Option<ResolvedType> {
         if let Some(method_info) = methods.get(method) {
-            let params = method_info.params.clone();
-            let return_type = method_info.return_type.clone();
+            let (params, return_type) = self.method_types_substituting_call_site_self(method_info, receiver_ty);
             self.validate_method_call_args(&params, args, arg_types);
             return Some(return_type);
         }
         if let Some(traits) = traits {
             for trait_name in traits {
                 if let Some(method_info) = self.trait_method_info_resolved(trait_name, method, call_site_span) {
-                    let params = method_info.params.clone();
-                    let return_type =
-                        self.substitute_self_in_resolved_type(method_info.return_type.clone(), receiver_ty);
+                    let (params, return_type) =
+                        self.method_types_substituting_call_site_self(&method_info, receiver_ty);
                     self.validate_method_call_args(&params, args, arg_types);
                     return Some(return_type);
                 }

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -2822,6 +2822,109 @@ model Order:
     Ok(())
 }
 
+/// Regression for #237: `-> Self` on a generic class method must type as the instantiated receiver at the call site,
+/// not bare `Self`, so annotations and chaining against `Carrier[Order]` succeed.
+#[test]
+fn test_issue_237_self_return_substituted_at_call_site() -> Result<(), Vec<CompileError>> {
+    let source = r#"
+class Carrier[T]:
+  _m: T
+
+  def filter(self, _p: bool) -> Self:
+    return self
+
+model Order:
+  id: int
+
+def use_filter(x: Carrier[Order]) -> Carrier[Order]:
+  return x.filter(true)
+
+def use_annotated_local(x: Carrier[Order]) -> Carrier[Order]:
+  y: Carrier[Order] = x.filter(true)
+  return y
+"#;
+    let tokens = lexer::lex(source)?;
+    let ast = parser::parse(&tokens)?;
+    let mut checker = TypeChecker::new();
+    checker.check_program(&ast)?;
+    Ok(())
+}
+
+/// `Self` in non-receiver parameters must use the same call-site substitution as the return type (#237 follow-up).
+#[test]
+fn test_self_param_substituted_at_call_site_for_method_args() -> Result<(), Vec<CompileError>> {
+    let source = r#"
+class Carrier[T]:
+  _m: T
+
+  def join(self, other: Self, cond: bool) -> Self:
+    return self
+
+model Order:
+  id: int
+
+def use_join(left: Carrier[Order], right: Carrier[Order]) -> Carrier[Order]:
+  return left.join(right, true)
+"#;
+    let tokens = lexer::lex(source)?;
+    let ast = parser::parse(&tokens)?;
+    let mut checker = TypeChecker::new();
+    checker.check_program(&ast)?;
+    Ok(())
+}
+
+/// Trait **default** methods are not copied into `ClassInfo.methods`; dispatch goes through the trait branch of
+/// `resolve_named_method`. Call-site `Self` substitution must still apply (#237).
+#[test]
+fn test_issue_237_self_substitution_trait_default_methods_not_on_class_map() -> Result<(), Vec<CompileError>> {
+    let source = r#"
+trait DataSet[T]:
+  def filter(self, _p: bool) -> Self:
+    return self
+
+  def join(self, other: Self, cond: bool) -> Self:
+    return self
+
+class Carrier[T] with DataSet:
+  _m: T
+
+model Order:
+  id: int
+
+def use_filter(x: Carrier[Order]) -> Carrier[Order]:
+  return x.filter(true)
+
+def use_annotated_local(x: Carrier[Order]) -> Carrier[Order]:
+  y: Carrier[Order] = x.filter(true)
+  return y
+
+def use_join(left: Carrier[Order], right: Carrier[Order]) -> Carrier[Order]:
+  return left.join(right, true)
+"#;
+    let tokens = lexer::lex(source)?;
+    let ast = parser::parse(&tokens)?;
+    let mut checker = TypeChecker::new();
+    checker.check_program(&ast)?;
+    Ok(())
+}
+
+/// `rusttype` inherent methods declared with `-> Self` must type as the surface newtype at the call site so
+/// `maybe_record_rusttype_return_coercion` and downstream checks see the substituted return (no bare `Self`).
+#[test]
+fn test_rusttype_method_returning_self_substitutes_at_call_site_without_metadata() {
+    let source = r#"
+from rust::acme import Widget as RustWidget
+
+type Widget = rusttype RustWidget:
+    def myself(self) -> Self:
+        ...
+
+def f(w: Widget) -> Widget:
+    return w.myself()
+"#;
+    assert_check_ok(source);
+}
+
 #[test]
 fn test_check_with_imports_concrete_and_supertrait_upcasts() -> Result<(), Box<dyn std::error::Error>> {
     let dependency_source = r#"

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -226,6 +226,7 @@ They are not intended as runtime function calls.
 
 ## Bugfixes
 
+- **Compiler**: Method dispatch on generic classes and models now substitutes `Self` in formal parameters and return types using the **instantiated** receiver at the call site, so carriers like `LazyFrame[Order]` no longer mis-type chained calls as bare `Self` (#237).
 - **Compiler**: Receiver-sensitive known-method lowering prevents non-string `.join(...)` calls from mis-emitting as `incan_stdlib::strings::str_join` (#236).
 - **Compiler**: `match` on `rusttype`-wrapped Rust enums and oneof-shaped values now binds variant payload names inside the arm body (same scoping rules as Incan enums), fixing unknown-symbol errors when inspecting imported protobuf-style types ([RFC 005], [RFC 041], #217).
 - **Compiler**: `await` is rejected when it appears outside an `async def` or async method body, matching async/await scoping rules (#210).


### PR DESCRIPTION
## Summary

Fixes incorrect typing when calling methods on concrete generic carriers (classes/models/newtypes) whose signatures use `Self` in the return type and/or in non-receiver parameters. The typechecker now substitutes `Self` using the **instantiated** receiver at the call site for both **inherent** methods and **trait** dispatch, matching the behavior users expect (e.g. `LazyFrame[Order]` after `filter`, and `other: Self` for `join`). Documentation clarifies the difference between decl-time `Self` concretization (method bodies) and call-site substitution. Adds focused regressions, including trait default methods (not present on the class method map) and `rusttype` methods returning `Self` without rust-metadata.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Chained calls and assignments that expect a concrete carrier type (e.g. `Carrier[Order]`) no longer fail with “expected `…`, found `Self`” when the method is declared with `-> Self` or parameters typed as `Self`. Same for calls resolved through adopted traits (including trait default methods).
- **Internals**: `resolve_named_method` routes both branches through `method_types_substituting_call_site_self`, which maps parameters and return through `substitute_self_in_resolved_type`. Rustdoc on `substitute_self_in_resolved_type` / `resolve_named_method` and a short note on `concretize_self_type_in_annotation` explain decl vs call-site `Self`.
- **Risks**: Low; behavior is a tightening/correction of method typing. Code that incorrectly relied on bare `Self` leaking as the expression type could see different (correct) typing; no syntax or codegen changes in this fix.

## Testing / verification

- [x] `make test` / `cargo test` (including `frontend::typechecker::tests` and full gate as run locally)
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (via `make fmt` / `make pre-commit-full`)
- [ ] Manual verification described below

Manual verification notes:

- Optional: `incan --check` on InQL or another package that uses generic carriers with `-> Self` (original #237 report).

**Tests added:**

- `test_issue_237_self_return_substituted_at_call_site`
- `test_self_param_substituted_at_call_site_for_method_args`
- `test_issue_237_self_substitution_trait_default_methods_not_on_class_map`
- `test_rusttype_method_returning_self_substitutes_at_call_site_without_metadata`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_2.md` (Bugfixes — #237); rustdoc in `src/frontend/typechecker/check_expr/access.rs` and `check_decl.rs`.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #237