### PR TITLE
bugfix - preserve method result types for locals bound from calls (#252, #255)

### DIFF
--- a/.agents/skills/write-commit-message/SKILL.md
+++ b/.agents/skills/write-commit-message/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: write-commit-message
+description: Draft commit titles and optional commit bodies using the workspace commit naming convention. Use when the user asks for a commit message, commit text, commit title, or wants commit wording in the format `chore|bugfix|feature - <issue_id(s)> <short description>`.
+---
+
+# Write Commit Message
+
+## Workflow
+
+1. Identify the repository and inspect the actual change set before drafting anything.
+2. Infer the change type from the diff:
+   - `bugfix` for correctness fixes and regressions
+   - `feature` for new behavior or newly implemented surface area
+   - `chore` for maintenance, docs-only changes, refactors without new behavior, or repository housekeeping
+3. Infer issue ids from the branch name first, then from explicit issue references in the current task context if needed.
+4. Write the title in exactly this format:
+
+```text
+<type> - <short description> (<#issue_id(s)>)
+```
+
+5. Keep the short description concrete:
+   - specific to the actual diff
+   - no trailing punctuation
+   - no vague filler like `updates` or `misc fixes`
+6. If the user also wants a commit body, write:
+   - one short sentence on what changed
+   - one short sentence on why
+   - optional flat bullets only if there are multiple distinct changes worth calling out
+
+## Issue Id Rules
+
+- Use numeric ids joined by commas when there are multiple issues:
+
+```text
+bugfix - preserve method result types for locals bound from calls (#252, #255) 
+```
+
+- Do not prepend `#` unless the user explicitly asks for that style.
+- If no issue id is discoverable, say so instead of inventing one.
+
+## Output Rules
+
+- If the user asks for a commit message or commit text, return the commit title by itself unless they also asked for a body.
+- If the user asks for both, return the title first and then the body.
+- Do not wrap the final title in commentary.
+- If the requested type conflicts with the actual diff, follow the diff and say so.
+
+## Examples
+
+```text
+bugfix - preserve something important for locals bound from calls (#42)
+```
+
+```text
+feature - add Session builder and DataFusion backend seam (#5)
+```
+
+```text
+chore - tighten RFC 008 optimizer boundary wording (#18)
+```

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -134,7 +134,7 @@ impl TypeChecker {
     /// Register a model declaration with its fields, methods, and derived traits.
     fn collect_model(&mut self, model: &ModelDecl, span: Span) {
         let fields = collect_fields(&model.fields, self);
-        let mut methods = collect_methods(&model.methods, self);
+        let mut methods = collect_methods(&model.methods, self, Some(&model.name), &model.type_params);
 
         // Inject JSON methods based on derives
         let derives = self.extract_derive_names(&model.decorators);
@@ -164,7 +164,12 @@ impl TypeChecker {
         fields.extend(collect_fields(&class.fields, self));
 
         // Add own methods (can override inherited ones)
-        methods.extend(collect_methods(&class.methods, self));
+        methods.extend(collect_methods(
+            &class.methods,
+            self,
+            Some(&class.name),
+            &class.type_params,
+        ));
 
         // Inject JSON methods based on derives
         let derives = self.extract_derive_names(&class.decorators);
@@ -201,7 +206,7 @@ impl TypeChecker {
 
     /// Register a trait declaration with its method signatures, supertraits, and requirements.
     fn collect_trait(&mut self, tr: &TraitDecl, span: Span) {
-        let methods = collect_methods(&tr.methods, self);
+        let methods = collect_methods(&tr.methods, self, None, &tr.type_params);
         let requires = self.extract_requires(&tr.decorators);
         if !tr.traits.is_empty() {
             self.pending_trait_supertraits
@@ -446,7 +451,7 @@ impl TypeChecker {
         });
 
         // Now collect methods - they can reference the newtype name
-        let methods = collect_methods(&nt.methods, self);
+        let methods = collect_methods(&nt.methods, self, Some(&nt.name), &nt.type_params);
 
         // Update the symbol with the collected methods
         if let Some(sym_id) = self.symbols.lookup(&nt.name)

--- a/src/frontend/typechecker/collect/decl_helpers.rs
+++ b/src/frontend/typechecker/collect/decl_helpers.rs
@@ -7,11 +7,103 @@ use crate::frontend::symbols::{FieldInfo, MethodInfo, ResolvedType, TypeBoundInf
 use crate::frontend::typechecker::TypeChecker;
 use incan_core::lang::derives::{self, DeriveId};
 
+/// Build the resolved surface type for a declaration owner while that owner is still being collected.
+///
+/// During first-pass collection the owner type symbol is not yet registered, so simple self-references like `->
+/// Session` would otherwise fall back to `TypeVar("Session")`.
+fn owner_resolved_type(owner_name: &str, owner_type_params: &[TypeParam]) -> ResolvedType {
+    if owner_type_params.is_empty() {
+        return ResolvedType::Named(owner_name.to_string());
+    }
+    ResolvedType::Generic(
+        owner_name.to_string(),
+        owner_type_params
+            .iter()
+            .map(|tp| ResolvedType::TypeVar(tp.name.clone()))
+            .collect(),
+    )
+}
+
+/// Replace unresolved simple self-references with the concrete owner type during declaration collection.
+///
+/// This is intentionally narrow: only `TypeVar(owner_name)` is rewritten. Other unknown names must keep flowing as
+/// unresolved placeholders so forward references do not silently become owner-self references.
+fn resolve_owner_self_reference(
+    ty: ResolvedType,
+    owner_name: Option<&str>,
+    owner_self_ty: Option<&ResolvedType>,
+) -> ResolvedType {
+    let Some(owner_name) = owner_name else {
+        return ty;
+    };
+    let Some(owner_self_ty) = owner_self_ty else {
+        return ty;
+    };
+
+    match ty {
+        ResolvedType::TypeVar(name) if name == owner_name => owner_self_ty.clone(),
+        ResolvedType::Generic(name, args) => ResolvedType::Generic(
+            name,
+            args.into_iter()
+                .map(|arg| resolve_owner_self_reference(arg, Some(owner_name), Some(owner_self_ty)))
+                .collect(),
+        ),
+        ResolvedType::Function(params, ret) => ResolvedType::Function(
+            params
+                .into_iter()
+                .map(|param| resolve_owner_self_reference(param, Some(owner_name), Some(owner_self_ty)))
+                .collect(),
+            Box::new(resolve_owner_self_reference(
+                *ret,
+                Some(owner_name),
+                Some(owner_self_ty),
+            )),
+        ),
+        ResolvedType::Tuple(items) => ResolvedType::Tuple(
+            items
+                .into_iter()
+                .map(|item| resolve_owner_self_reference(item, Some(owner_name), Some(owner_self_ty)))
+                .collect(),
+        ),
+        ResolvedType::FrozenList(inner) => ResolvedType::FrozenList(Box::new(resolve_owner_self_reference(
+            *inner,
+            Some(owner_name),
+            Some(owner_self_ty),
+        ))),
+        ResolvedType::FrozenSet(inner) => ResolvedType::FrozenSet(Box::new(resolve_owner_self_reference(
+            *inner,
+            Some(owner_name),
+            Some(owner_self_ty),
+        ))),
+        ResolvedType::FrozenDict(key, value) => ResolvedType::FrozenDict(
+            Box::new(resolve_owner_self_reference(
+                *key,
+                Some(owner_name),
+                Some(owner_self_ty),
+            )),
+            Box::new(resolve_owner_self_reference(
+                *value,
+                Some(owner_name),
+                Some(owner_self_ty),
+            )),
+        ),
+        ResolvedType::Ref(inner) => ResolvedType::Ref(Box::new(resolve_owner_self_reference(
+            *inner,
+            Some(owner_name),
+            Some(owner_self_ty),
+        ))),
+        other => other,
+    }
+}
+
 /// Collect methods from method declarations into a `HashMap`.
 pub(super) fn collect_methods(
     methods: &[Spanned<MethodDecl>],
     checker: &mut TypeChecker,
+    owner_name: Option<&str>,
+    owner_type_params: &[TypeParam],
 ) -> HashMap<String, MethodInfo> {
+    let owner_self_ty = owner_name.map(|name| owner_resolved_type(name, owner_type_params));
     methods
         .iter()
         .map(|m| {
@@ -41,7 +133,13 @@ pub(super) fn collect_methods(
                                 type_args: bound
                                     .type_args
                                     .iter()
-                                    .map(|type_arg| checker.resolve_type_checked(type_arg))
+                                    .map(|type_arg| {
+                                        resolve_owner_self_reference(
+                                            checker.resolve_type_checked(type_arg),
+                                            owner_name,
+                                            owner_self_ty.as_ref(),
+                                        )
+                                    })
                                     .collect(),
                             })
                             .collect(),
@@ -52,9 +150,22 @@ pub(super) fn collect_methods(
                 .node
                 .params
                 .iter()
-                .map(|p| (p.node.name.clone(), checker.resolve_type_checked(&p.node.ty)))
+                .map(|p| {
+                    (
+                        p.node.name.clone(),
+                        resolve_owner_self_reference(
+                            checker.resolve_type_checked(&p.node.ty),
+                            owner_name,
+                            owner_self_ty.as_ref(),
+                        ),
+                    )
+                })
                 .collect();
-            let return_type = checker.resolve_type_checked(&m.node.return_type);
+            let return_type = resolve_owner_self_reference(
+                checker.resolve_type_checked(&m.node.return_type),
+                owner_name,
+                owner_self_ty.as_ref(),
+            );
             (
                 m.node.name.clone(),
                 MethodInfo {

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -4959,3 +4959,141 @@ def main() -> None:
         "expected imported static mutation to typecheck"
     );
 }
+
+#[test]
+fn test_local_inference_preserves_method_result_field_access_after_factory_call() {
+    let source = r#"
+class Backend:
+  enable_optimizer: bool
+
+class Session:
+  @staticmethod
+  def default() -> Session:
+    return Session()
+
+  def backend(self) -> Backend:
+    return Backend(enable_optimizer=True)
+
+def main() -> None:
+  let session = Session.default()
+  let backend = session.backend()
+  let enabled = backend.enable_optimizer
+  let _ = enabled
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_local_inference_preserves_result_match_after_factory_call() {
+    let source = r#"
+@derive(Clone)
+class Source:
+  value: str
+
+model SessionError:
+  kind: str
+
+class Session:
+  regs: list[Source]
+
+  @staticmethod
+  def default() -> Session:
+    return Session(regs=[])
+
+  def register(mut self, logical_name: str, source: Source) -> Result[None, SessionError]:
+    self.regs.append(source)
+    return Ok(None)
+
+def main() -> None:
+  mut session = Session.default()
+  match session.register("x", Source(value="y")):
+    Ok(_) => pass
+    Err(err) => pass
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_local_inference_preserves_generic_result_match_after_factory_call() {
+    let source = r#"
+model SessionError:
+  kind: str
+
+class Session:
+  @staticmethod
+  def default() -> Session:
+    return Session()
+
+  def table[T with Clone](self, logical_name: str, marker: T) -> Result[T, SessionError]:
+    return Ok(marker)
+
+def main() -> None:
+  let session = Session.default()
+  match session.table("x", 1):
+    Ok(value) => pass
+    Err(err) => pass
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_local_inference_annotation_control_still_typechecks() {
+    let source = r#"
+class Backend:
+  enable_optimizer: bool
+
+class Session:
+  @staticmethod
+  def default() -> Session:
+    return Session()
+
+  def backend(self) -> Backend:
+    return Backend(enable_optimizer=True)
+
+def main() -> None:
+  let session: Session = Session.default()
+  let backend: Backend = session.backend()
+  let _ = backend.enable_optimizer
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_direct_construction_method_result_field_access_control_typechecks() {
+    let source = r#"
+class Backend:
+  enable_optimizer: bool
+
+class Session:
+  def backend(self) -> Backend:
+    return Backend(enable_optimizer=True)
+
+def main() -> None:
+  let session = Session()
+  let backend = session.backend()
+  let _ = backend.enable_optimizer
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_direct_construction_with_static_factory_present_still_typechecks() {
+    let source = r#"
+class Backend:
+  enable_optimizer: bool
+
+class Session:
+  @staticmethod
+  def default() -> Session:
+    return Session()
+
+  def backend(self) -> Backend:
+    return Backend(enable_optimizer=True)
+
+def main() -> None:
+  let session = Session()
+  let backend = session.backend()
+  let _ = backend.enable_optimizer
+"#;
+    assert_check_ok(source);
+}

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -261,6 +261,7 @@ They are not intended as runtime function calls.
 ## Bugfixes
 
 - **Compiler**: Generic instance methods on classes, traits, models, and newtypes now parse and flow through formatting, typechecking, lowering, and library export metadata correctly (#253).
+- **Compiler**: Locals initialized from call expressions now preserve the callee's declared result type through later field access, method chaining, and `match` scrutinees. This fixes false receiver-typed errors after static factory calls such as `Session.default()` and the related local-inference family regressions (#252, #255).
 - **Tooling**: `incan fmt` keeps qualified enum/constructor match patterns in the dot form (`Type.Variant`), instead of rewriting them to `Type::Variant`, which the parser does not accept in pattern position (#235).
 - **Tooling**: `incan fmt` re-emits numeric literals using their source spelling (integer and float, including `_` separators and `E`/`e` in float exponents), avoiding `Display` normalization such as `120.0` → `120` or `1_000` → `1000`, so comment reattachment keeps standalone `#` lines next to the right statements instead of moving them to the end of a block (#250).
 - **Tooling**: `incan fmt` preserves a single blank line between statements in indented blocks (functions, control flow, match arms, vocab bodies, and similar) and collapses two or more consecutive empty lines down to one.


### PR DESCRIPTION
## Summary

This PR fixes a typechecker bug family where locals initialized from call expressions could lose their real inferred type, causing later method calls, field access, and `match` scrutinees to collapse back to the receiver type. In practice this showed up as false receiver-typed errors after static factory calls such as `Session.default()`. The fix also covers the related local-inference regression tracked in #252 by correcting self-referential owner type resolution during first-pass method collection instead of papering over the downstream symptoms.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: unannotated locals initialized from call expressions now preserve the callee's declared result type through later field access, method chaining, and `match` scrutinees. This fixes false diagnostics in patterns like `let session = Session.default()` followed by `session.backend()` or `match session.register(...)`.
- **Internals**: method collection now resolves simple self-references to the concrete owner type while the owner declaration is still being collected, instead of letting `-> Session` degrade to `TypeVar("Session")`. Regression tests cover both issue shapes and control cases, and release notes now document the fix.
- **Risks**: this changes first-pass type collection for owner self-references in methods. The fix is intentionally narrow, but it touches shared typechecker collection code, so regressions would most likely show up in method signature collection for models, classes, or newtypes.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Ran `cargo test test_local_inference_`
- Ran `cargo test generic_instance_method_full_pipeline`
- Ran `make fmt`
- Ran `make pre-commit-full`
- Ran `make smoke-test`
- `mkdocs build --strict` was not run because `mkdocs` is not installed in the current environment

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_2.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #252
Closes #255
