### PR TITLE
bugfix - fix cyclic module dependency resolution for explicit call-site generics (#279)

### DIFF
--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 use crate::backend::{IrCodegen, ProjectGenerator};
 use crate::cli::{CliError, CliResult, ExitCode};
 use crate::dependency_resolver::resolve_dependencies;
-use crate::frontend::ast::Program;
 use crate::frontend::ast::{Declaration, Decorator, ImportKind, Span, Spanned};
 use crate::frontend::library_exports::{CheckedExportKind, CheckedNamedExport, collect_checked_public_exports};
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
@@ -23,7 +22,8 @@ use std::collections::{HashMap, HashSet};
 
 use super::common::{
     build_source_map, cargo_command_flags, collect_inline_rust_imports, collect_modules, collect_project_requirements,
-    format_dependency_error, merge_project_requirement_dependencies, resolve_project_root, validate_output_dir,
+    format_dependency_error, imported_module_deps_for_with_index, merge_project_requirement_dependencies,
+    module_key_index, resolve_project_root, validate_output_dir,
 };
 #[cfg(feature = "rust_inspect")]
 use super::common::{collect_rust_inspect_query_paths, ensure_rust_inspect_workspace, prewarm_rust_inspect_workspace};
@@ -370,9 +370,9 @@ fn prepare_project(
     // Type check all modules (dependencies + stdlib first), so diagnostics are associated with the correct file.
     let declared = manifest.as_ref().map(|m| m.declared_rust_crate_names());
     let mut all_errors: String = String::new();
+    let module_idx_by_key = module_key_index(&modules);
     for (idx, module) in modules.iter().enumerate() {
-        let deps_for_module: Vec<(&str, &Program)> = modules[..idx].iter().map(|m| (m.name.as_str(), &m.ast)).collect();
-
+        let deps_for_module = imported_module_deps_for_with_index(&modules, idx, &module_idx_by_key);
         let mut checker = typechecker::TypeChecker::new();
         if let Some(names) = declared.clone() {
             checker.set_declared_crate_names(names);
@@ -679,10 +679,10 @@ pub fn build_library(
 
     let mut all_errors = String::new();
     let mut checked_exports_by_module: HashMap<String, HashMap<String, CheckedNamedExport>> = HashMap::new();
+    let module_idx_by_key = module_key_index(&modules);
 
     for (idx, module) in modules.iter().enumerate() {
-        let deps_for_module: Vec<(&str, &Program)> = modules[..idx].iter().map(|m| (m.name.as_str(), &m.ast)).collect();
-
+        let deps_for_module = imported_module_deps_for_with_index(&modules, idx, &module_idx_by_key);
         let mut checker = typechecker::TypeChecker::new();
         checker.set_declared_crate_names(declared.clone());
         checker.set_library_manifest_index(library_manifest_index.clone());

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -14,9 +14,9 @@ use crate::cli::prelude::ParsedModule;
 use crate::cli::{CliError, CliResult};
 use crate::dependency_resolver::ResolvedDependencies;
 use crate::dependency_resolver::{DependencyError, InlineRustImport};
-use crate::frontend::ast::{ImportKind, Span};
+use crate::frontend::ast::{ImportKind, Program, Span};
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
-use crate::frontend::module::resolve_source_module_from_base;
+use crate::frontend::module::{canonicalize_source_module_segments, resolve_source_module_from_base};
 use crate::frontend::{diagnostics, lexer, parser, vocab_desugar_pass};
 use crate::lockfile::CargoFeatureSelection;
 use crate::manifest::ProjectManifest;
@@ -1193,6 +1193,78 @@ pub(crate) fn cargo_command_flags(locked: bool, frozen: bool, cargo_features: &C
     flags
 }
 
+/// Build a lookup map from canonical module key (`a_b_c`) to module index in `collect_modules` output.
+pub(crate) fn module_key_index(modules: &[ParsedModule]) -> HashMap<String, usize> {
+    let mut module_idx_by_key: HashMap<String, usize> = HashMap::new();
+    for (idx, module) in modules.iter().enumerate() {
+        let key = canonicalize_source_module_segments(&module.path_segments).join("_");
+        module_idx_by_key.insert(key, idx);
+    }
+    module_idx_by_key
+}
+
+/// Resolve imported source-module dependencies for one collected module using a precomputed module key index.
+///
+/// Use this variant inside per-module loops to avoid rebuilding the module key map on every iteration.
+pub(crate) fn imported_module_deps_for_with_index<'m>(
+    modules: &'m [ParsedModule],
+    module_index: usize,
+    module_idx_by_key: &HashMap<String, usize>,
+) -> Vec<(&'m str, &'m Program)> {
+    // ---- Context: bounds and setup ----
+    if module_index >= modules.len() {
+        return Vec::new();
+    }
+
+    // ---- Context: collect dependency module indexes from import declarations ----
+    let mut dep_indexes: BTreeSet<usize> = BTreeSet::new();
+    for decl in &modules[module_index].ast.declarations {
+        let crate::frontend::ast::Declaration::Import(import) = &decl.node else {
+            continue;
+        };
+        match &import.kind {
+            ImportKind::From { module, .. } => {
+                if module.parent_levels > 0 || module.is_absolute || module.segments.is_empty() {
+                    continue;
+                }
+                let key = canonicalize_source_module_segments(&module.segments).join("_");
+                if let Some(dep_idx) = module_idx_by_key.get(&key).copied()
+                    && dep_idx != module_index
+                {
+                    dep_indexes.insert(dep_idx);
+                }
+            }
+            ImportKind::Module(path) => {
+                if path.parent_levels > 0 || path.is_absolute || path.segments.is_empty() {
+                    continue;
+                }
+                let full_key = canonicalize_source_module_segments(&path.segments).join("_");
+                if let Some(dep_idx) = module_idx_by_key.get(&full_key).copied()
+                    && dep_idx != module_index
+                {
+                    dep_indexes.insert(dep_idx);
+                }
+                if path.segments.len() > 1 {
+                    let parent_key =
+                        canonicalize_source_module_segments(&path.segments[..path.segments.len() - 1]).join("_");
+                    if let Some(dep_idx) = module_idx_by_key.get(&parent_key).copied()
+                        && dep_idx != module_index
+                    {
+                        dep_indexes.insert(dep_idx);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // ---- Context: materialize dependency pairs for typechecker.check_with_imports ----
+    dep_indexes
+        .into_iter()
+        .map(|idx| (modules[idx].name.as_str(), &modules[idx].ast))
+        .collect()
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -1632,9 +1704,9 @@ pub def probe() -> SubstraitPlan:
         )?;
 
         let modules = collect_modules(entry.to_string_lossy().as_ref())?;
+        let module_idx_by_key = module_key_index(&modules);
         for (idx, module) in modules.iter().enumerate() {
-            let deps: Vec<(&str, &crate::frontend::ast::Program)> =
-                modules[..idx].iter().map(|m| (m.name.as_str(), &m.ast)).collect();
+            let deps = imported_module_deps_for_with_index(&modules, idx, &module_idx_by_key);
             let mut checker = typechecker::TypeChecker::new();
             if let Err(errs) = checker.check_with_imports(&module.ast, &deps) {
                 return Err(format!(
@@ -1645,6 +1717,62 @@ pub def probe() -> SubstraitPlan:
                 .into());
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn imported_module_deps_for_includes_forward_edge_in_cycle() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project_root = tmp.path();
+        std::fs::write(
+            project_root.join("incan.toml"),
+            r#"[project]
+name = "cycle_dep_resolver_demo"
+version = "0.1.0"
+"#,
+        )?;
+        let src_dir = project_root.join("src");
+        std::fs::create_dir_all(&src_dir)?;
+        std::fs::write(
+            src_dir.join("a.incn"),
+            r#"from b import pong
+
+pub def ping() -> int:
+    return pong()
+"#,
+        )?;
+        std::fs::write(
+            src_dir.join("b.incn"),
+            r#"from a import ping
+
+pub def pong() -> int:
+    return 1
+"#,
+        )?;
+        let entry = src_dir.join("main.incn");
+        std::fs::write(
+            &entry,
+            r#"from a import ping
+
+pub def main() -> int:
+    return ping()
+"#,
+        )?;
+
+        let modules = collect_modules(entry.to_string_lossy().as_ref())?;
+        let Some(b_index) = modules
+            .iter()
+            .position(|module| module.file_path.ends_with("src/b.incn"))
+        else {
+            panic!("expected src/b.incn module");
+        };
+        let module_idx_by_key = module_key_index(&modules);
+        let deps = imported_module_deps_for_with_index(&modules, b_index, &module_idx_by_key);
+        assert!(
+            deps.iter().any(|(name, _)| *name == "a"),
+            "expected cyclic forward dependency `b -> a` to be resolved, got: {:?}",
+            deps.iter().map(|(name, _)| (*name).to_string()).collect::<Vec<_>>()
+        );
         Ok(())
     }
 

--- a/src/cli/commands/debug.rs
+++ b/src/cli/commands/debug.rs
@@ -4,13 +4,14 @@
 
 use crate::backend::IrCodegen;
 use crate::cli::{CliError, CliResult, ExitCode};
-use crate::frontend::ast::Program;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::{diagnostics, lexer, parser, typechecker};
 use crate::manifest::ProjectManifest;
 use std::path::Path;
 
-use super::common::{collect_modules, read_source, resolve_project_root};
+use super::common::{
+    collect_modules, imported_module_deps_for_with_index, module_key_index, read_source, resolve_project_root,
+};
 
 /// Lex and display tokens.
 pub fn lex_file(file_path: &str) -> CliResult<ExitCode> {
@@ -74,8 +75,9 @@ pub fn check_file(file_path: &str) -> CliResult<ExitCode> {
         .unwrap_or_default();
 
     let mut all_errors: String = String::new();
+    let module_idx_by_key = module_key_index(&modules);
     for (idx, module) in modules.iter().enumerate() {
-        let deps_for_module: Vec<(&str, &Program)> = modules[..idx].iter().map(|m| (m.name.as_str(), &m.ast)).collect();
+        let deps_for_module = imported_module_deps_for_with_index(&modules, idx, &module_idx_by_key);
 
         let mut checker = typechecker::TypeChecker::new();
         if let Some(names) = declared.clone() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the Incan compiler frontend
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -78,6 +78,48 @@ fn make_temp_test_dir() -> std::path::PathBuf {
         panic!("failed to create temp test dir");
     };
     dir
+}
+
+fn write_cycle_explicit_call_site_generics_project(dir: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let src_dir = dir.join("src");
+    std::fs::create_dir_all(&src_dir)?;
+    std::fs::write(
+        dir.join("incan.toml"),
+        r#"[project]
+name = "cycle_explicit_call_site_generics"
+version = "0.1.0"
+"#,
+    )?;
+    std::fs::write(
+        src_dir.join("dataset.incn"),
+        r#"from session import collect_with_active_session
+
+pub model DataSet[T]:
+  value: T
+
+pub def collect_with_dataset[T](dataset: DataSet[T]) -> T:
+  return collect_with_active_session[T](dataset)
+"#,
+    )?;
+    std::fs::write(
+        src_dir.join("session.incn"),
+        r#"from dataset import DataSet
+
+pub def collect_with_active_session[T](dataset: DataSet[T]) -> T:
+  return dataset.value
+"#,
+    )?;
+    let main_path = src_dir.join("main.incn");
+    std::fs::write(
+        &main_path,
+        r#"from dataset import DataSet, collect_with_dataset
+
+def main() -> None:
+  let ds = DataSet(value=1)
+  println(collect_with_dataset[int](ds))
+"#,
+    )?;
+    Ok(main_path)
 }
 
 /// Regression (GitHub #247): `incan fmt` on disk must preserve body docstrings for all public block-like type
@@ -1149,6 +1191,53 @@ async def main() -> None:
             "expected child field in __fields__; got:\n{}",
             stdout
         );
+    }
+
+    #[test]
+    fn test_check_cyclic_explicit_call_site_generics_cross_module_succeeds() -> Result<(), Box<dyn std::error::Error>> {
+        let project_dir = make_temp_dir("incan_cycle_explicit_call_site_check");
+        let main_path = super::write_cycle_explicit_call_site_generics_project(&project_dir)?;
+
+        let output = Command::new(incan_debug_binary())
+            .arg("--check")
+            .arg(main_path)
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+
+        assert!(
+            output.status.success(),
+            "incan --check cyclic explicit call-site generics failed: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_run_cyclic_explicit_call_site_generics_cross_module_succeeds() -> Result<(), Box<dyn std::error::Error>> {
+        let project_dir = make_temp_dir("incan_cycle_explicit_call_site_run");
+        let main_path = super::write_cycle_explicit_call_site_generics_project(&project_dir)?;
+
+        let output = Command::new(incan_debug_binary())
+            .arg("run")
+            .arg(main_path)
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+
+        assert!(
+            output.status.success(),
+            "incan run cyclic explicit call-site generics failed: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains('1'),
+            "expected runtime output to contain 1, got:\n{}",
+            stdout
+        );
+        Ok(())
     }
 
     #[test]

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -232,6 +232,7 @@ Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer globally
 
 ## Bugfixes
 
+- **Compiler**: Cyclic cross-module projects now resolve imported dependencies during per-module typechecking by import graph (not discovery order), so direct explicit call-site generic calls like `collect_with_active_session[T](...)` no longer fail with a false unsupported-call-form diagnostic in `incan run` / `incan --check` flows (#279).
 - **Compiler**: rust-inspect now recovers concrete borrowed function parameter pointee types from source when rust-analyzer degrades them to placeholders like `&?`, so imported Rust calls keep exact borrowed contracts during typechecking and generated-lock workspace interop paths (#259).
 - **Compiler**: Generic instance methods on classes, traits, models, and newtypes now parse and flow through formatting, typechecking, lowering, and library export metadata correctly (#253).
 - **Compiler**: Locals initialized from call expressions now preserve the callee's declared result type through later field access, method chaining, and `match` scrutinees. This fixes false receiver-typed errors after static factory calls such as `Session.default()` and the related local-inference family regressions (#252, #255).


### PR DESCRIPTION
## Summary

This PR fixes issue #279 where explicit call-site generics could fail in cyclic cross-module graphs with a false diagnostic (`Explicit call-site type arguments are not supported for this call form`) during CLI typecheck flows.

The fix replaces order-sensitive per-module dependency selection (`modules[..idx]`) with import-aware dependency resolution in CLI typecheck loops, including cyclic forward edges.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Cyclic cross-module projects can now use direct explicit call-site generics (for supported call forms) without false rejection in `incan run` / `incan --check`.
- **Internals**: Added `imported_module_deps_for` in CLI common utilities and replaced order-based dependency slicing in build/check paths.
- **Risks**: Dependency selection now depends on import declarations; behavior should be more accurate in cycles, but import-shape edge cases remain the main risk area.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Added regression tests:
  - `test_check_cyclic_explicit_call_site_generics_cross_module_succeeds`
  - `test_run_cyclic_explicit_call_site_generics_cross_module_succeeds`
  - `imported_module_deps_for_includes_forward_edge_in_cycle`
- Ran focused tests for the new regressions.
- Ran `make pre-commit` (full gate, including smoke-test-fast).
- Ran docs build strict: `mkdocs build --strict`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_2.md` (Bugfixes entry for #279)

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #279