### PR TITLE
bugfix - allow pub from re-exports in src modules (#287)

### DIFF
--- a/crates/incan_syntax/src/diagnostics/catalog/errors/syntax.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/syntax.rs
@@ -82,15 +82,15 @@ pub fn pub_modifier_not_allowed_on_import(span: Span) -> CompileError {
         "The 'pub' modifier is only supported on `from ... import ...` re-exports".to_string(),
         span,
     )
-    .with_hint("Use `pub from module import Name` in `src/lib.incn`, or remove `pub`")
+    .with_hint("Use `pub from module import Name` in `src/`, or remove `pub`")
 }
 
-pub fn pub_reexport_only_allowed_in_library_entrypoint(span: Span) -> CompileError {
+pub fn pub_reexport_only_allowed_in_src_modules(span: Span) -> CompileError {
     CompileError::syntax(
-        "`pub from ... import ...` is only valid in `src/lib.incn`".to_string(),
+        "`pub from ... import ...` is only valid in modules under `src/`".to_string(),
         span,
     )
-    .with_hint("Move this re-export to `src/lib.incn`, or remove `pub` for an internal import")
+    .with_hint("Move this re-export into `src/`, or remove `pub` for an internal import")
 }
 
 pub fn decorator_path_expected(span: Span) -> CompileError {

--- a/crates/incan_syntax/src/parser/api.rs
+++ b/crates/incan_syntax/src/parser/api.rs
@@ -20,7 +20,7 @@ pub fn parse(tokens: &[Token]) -> Result<Program, Vec<CompileError>> {
 /// Parse a token stream into an AST [`Program`] with optional module-path context.
 ///
 /// The `module_path` is used for context-sensitive declaration diagnostics (for example,
-/// `pub from ... import ...` is only valid in `src/lib.incn`).
+/// `pub from ... import ...` is only valid in modules under `src/`).
 #[tracing::instrument(skip_all, fields(token_count = tokens.len(), has_module_path = module_path.is_some()))]
 pub fn parse_with_module_path(tokens: &[Token], module_path: Option<&str>) -> Result<Program, Vec<CompileError>> {
     parse_with_context(tokens, module_path, None)

--- a/crates/incan_syntax/src/parser/core.rs
+++ b/crates/incan_syntax/src/parser/core.rs
@@ -43,18 +43,18 @@ pub struct Parser<'a> {
     library_imported_vocab: ImportedLibraryVocab,
 }
 
-/// Compares the last path segment to an expected spelling for library entrypoint detection.
+/// Compares a path segment to an expected spelling for parser path-context checks.
 #[cfg(windows)]
-fn library_entrypoint_segment_eq(expected: &str, actual: &std::ffi::OsStr) -> bool {
+fn path_segment_eq(expected: &str, actual: &std::ffi::OsStr) -> bool {
     actual
         .to_str()
         .map(|value| value.eq_ignore_ascii_case(expected))
         .unwrap_or(false)
 }
 
-/// Compares the last path segment to an expected spelling for library entrypoint detection.
+/// Compares a path segment to an expected spelling for parser path-context checks.
 #[cfg(not(windows))]
-fn library_entrypoint_segment_eq(expected: &str, actual: &std::ffi::OsStr) -> bool {
+fn path_segment_eq(expected: &str, actual: &std::ffi::OsStr) -> bool {
     actual == std::ffi::OsStr::new(expected)
 }
 
@@ -198,31 +198,25 @@ impl<'a> Parser<'a> {
         Ok(Spanned::new(path, Span::new(start, end)))
     }
 
-    /// Whether the parser is currently parsing `src/lib.incn`.
+    /// Whether the parser is currently parsing a module under `src/`.
     ///
-    /// This gates [`Visibility::Public`] on `from ... import ...` (RFC 031). Callers must pass a
-    /// filesystem-style module path (as the CLI and LSP do) so the immediate parent directory is
-    /// `src` and the file name is `lib.incn`.
+    /// This gates [`Visibility::Public`] on `from ... import ...` (RFC 031). Callers must pass a filesystem-style module path (as the CLI and LSP do) so the parser can enforce that `pub from` appears only in source modules.
     ///
-    /// On Windows, the `src` / `lib.incn` segments are compared ASCII case-insensitively so editor
-    /// URIs that normalize path casing still match the library entrypoint rule.
-    fn is_library_entrypoint_module(&self) -> bool {
+    /// On Windows, path-segment checks are ASCII case-insensitive so editor URIs that normalize path casing still match.
+    fn is_src_module(&self) -> bool {
         let Some(module_path) = self.module_path.as_deref() else {
             return false;
         };
 
         let path = std::path::Path::new(module_path);
-        let Some(file_name) = path.file_name() else {
-            return false;
-        };
-        if !library_entrypoint_segment_eq("lib.incn", file_name) {
+        if path.file_name().is_none() {
             return false;
         }
 
-        let Some(parent_dir) = path.parent().and_then(std::path::Path::file_name) else {
-            return false;
-        };
-        library_entrypoint_segment_eq("src", parent_dir)
+        path.ancestors()
+            .skip(1)
+            .filter_map(std::path::Path::file_name)
+            .any(|segment| path_segment_eq("src", segment))
     }
 
     /// Activate soft keywords introduced by stdlib or library imports in this declaration.

--- a/crates/incan_syntax/src/parser/decl/entrypoints.rs
+++ b/crates/incan_syntax/src/parser/decl/entrypoints.rs
@@ -27,11 +27,8 @@ impl<'a> Parser<'a> {
         }
 
         let decl = if self.check_keyword(KeywordId::From) {
-            if visibility == Visibility::Public
-                && self.module_path.is_some()
-                && !self.is_library_entrypoint_module()
-            {
-                return Err(errors::pub_reexport_only_allowed_in_library_entrypoint(
+            if visibility == Visibility::Public && self.module_path.is_some() && !self.is_src_module() {
+                return Err(errors::pub_reexport_only_allowed_in_src_modules(
                     self.current_span(),
                 ));
             }

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -1045,13 +1045,60 @@ def add(a: int, b: int) -> int:
     }
 
     #[test]
-    fn test_parse_pub_from_outside_src_lib_is_error() {
+    fn test_parse_pub_from_in_src_main_is_public_reexport() -> Result<(), Vec<CompileError>> {
         let source = "pub from widgets import Widget\n";
-        let result = parse_str_with_module_path(source, Some("project/src/main.incn"));
-        assert!(result.is_err(), "Expected parser to reject `pub from` outside src/lib.incn");
+        let program = parse_str_with_module_path(source, Some("project/src/main.incn"))?;
+        assert_eq!(program.declarations.len(), 1);
+
+        let Declaration::Import(import) = &program.declarations[0].node else {
+            panic!("Expected import declaration");
+        };
+        assert!(matches!(import.visibility, Visibility::Public));
+        let ImportKind::From { module, items } = &import.kind else {
+            panic!("Expected from-import");
+        };
+        assert_eq!(module.segments, vec!["widgets".to_string()]);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "Widget");
+        assert_eq!(items[0].alias, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_pub_from_rust_in_src_module_is_public_reexport() -> Result<(), Vec<CompileError>> {
+        let source = "pub from rust::time import Instant\n";
+        let program = parse_str_with_module_path(source, Some("project/src/session/mod.incn"))?;
+        assert_eq!(program.declarations.len(), 1);
+
+        let Declaration::Import(import) = &program.declarations[0].node else {
+            panic!("Expected import declaration");
+        };
+        assert!(matches!(import.visibility, Visibility::Public));
+        let ImportKind::RustFrom {
+            crate_name,
+            path,
+            items,
+            ..
+        } = &import.kind
+        else {
+            panic!("Expected rust from-import");
+        };
+        assert_eq!(crate_name, "time");
+        assert!(path.is_empty());
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "Instant");
+        assert_eq!(items[0].alias, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_pub_from_outside_src_is_error() {
+        let source = "pub from widgets import Widget\n";
+        let result = parse_str_with_module_path(source, Some("project/tests/test_main.incn"));
+        assert!(result.is_err(), "Expected parser to reject `pub from` outside src/");
         let err = result.err().unwrap_or_default();
         assert!(
-            err[0].message.contains("only valid in `src/lib.incn`"),
+            err[0].message.contains("only valid in modules under `src/`"),
             "Unexpected error: {}",
             err[0].message
         );

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -126,10 +126,9 @@ impl IncanLanguageServer {
         // Step 2: Parse
         //
         // Pass the on-disk file path as `module_path` so context-sensitive syntax matches the CLI.
-        // In particular, `pub from ... import ...` is only accepted when this path resolves to a file
-        // named `lib.incn` whose parent directory is `src` (RFC 031 / `incan_syntax` parser).
-        // If `uri.to_file_path()` fails, `module_path` is omitted and those rules
-        // are skipped during parsing (prefer fixing the client URI scheme / workspace roots).
+        // In particular, `pub from ... import ...` is only accepted when this path resolves under `src/` (RFC 031 /
+        // `incan_syntax` parser). If `uri.to_file_path()` fails, `module_path` is omitted and those rules are
+        // skipped during parsing (prefer fixing the client URI scheme / workspace roots).
         let mut ast = match parser::parse_with_context(
             &tokens,
             module_path.as_deref().and_then(|path| path.to_str()),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3189,6 +3189,41 @@ pub def display[T](data: DataSet[T]) -> None:
     }
 
     #[test]
+    fn build_accepts_pub_from_reexport_in_src_submodule_facade() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project_root = tmp.path().join("session_facade_project");
+        std::fs::create_dir_all(project_root.join("src/session"))?;
+        std::fs::write(
+            project_root.join("incan.toml"),
+            "[project]\nname = \"session_facade\"\nversion = \"0.1.0\"\n",
+        )?;
+        std::fs::write(
+            project_root.join("src/session/types.incn"),
+            "pub class Session:\n  id: int\n",
+        )?;
+        std::fs::write(
+            project_root.join("src/session/mod.incn"),
+            "pub from crate.session.types import Session\n",
+        )?;
+        let main_path = project_root.join("src/main.incn");
+        std::fs::write(
+            &main_path,
+            "from session import Session\n\ndef main() -> None:\n  s = Session(id=1)\n  print(s.id)\n",
+        )?;
+
+        let out_dir = project_root.join("out");
+        let project_build = run_build(&main_path, &out_dir)?;
+        assert!(
+            project_build.status.success(),
+            "expected `build` to accept src submodule facade re-export.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&project_build.stdout),
+            String::from_utf8_lossy(&project_build.stderr)
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn build_lib_with_vocab_companion_embeds_vocab_payload() -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;
         let producer_root = tmp.path().join("widgets_vocab_project");

--- a/workspaces/docs-site/docs/language/reference/imports_and_modules.md
+++ b/workspaces/docs-site/docs/language/reference/imports_and_modules.md
@@ -355,9 +355,9 @@ Supported:
 - Parent navigation (`..` / `super`)
 - Root imports (`crate`)
 - Aliases (`as`)
+- Public re-exports in source modules: `pub from module import Item` (allowed in files under `src/`)
 
 Limitations (current):
 
 1. No wildcard imports (`from module import *`)
-2. No re-exports (cannot re-export imported items)
-3. No circular imports
+2. No circular imports

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -232,6 +232,7 @@ Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer globally
 
 ## Bugfixes
 
+- **Compiler**: `pub from ... import ...` now works in any module under `src/` (not just `src/lib.incn`), which unblocks package submodule facades that re-export symbols for parent imports like `from session import Session` (#287).
 - **Compiler**: Cyclic cross-module projects now resolve imported dependencies during per-module typechecking by import graph (not discovery order), so direct explicit call-site generic calls like `collect_with_active_session[T](...)` no longer fail with a false unsupported-call-form diagnostic in `incan run` / `incan --check` flows (#279).
 - **Tooling/Codegen**: Generated projects now resolve relative entry paths correctly and emit cleaner Rust for internal module calls and module statics, reducing false errors and compiler-noise in real project workflows.
 - **Compiler**: rust-inspect now recovers concrete borrowed function parameter pointee types from source when rust-analyzer degrades them to placeholders like `&?`, so imported Rust calls keep exact borrowed contracts during typechecking and generated-lock workspace interop paths (#259).


### PR DESCRIPTION
## Summary

This PR fixes #287 by expanding `pub from ... import ...` acceptance from only `src/lib.incn` to any module under `src/`, enabling folder-module facades like `src/session/mod.incn` to re-export symbols for imports such as `from session import Session`. It also updates parser diagnostics/comments, adds parser and integration regression coverage (including `RustFrom`), and updates language docs plus release notes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `pub from ... import ...` now works across source modules under `src/`, not just `src/lib.incn`.
- **Internals**: parser gating now checks `src` module scope; diagnostics and API/LSP comments were aligned with the new rule; tests cover both `From` and `RustFrom` paths.
- **Risks**: low; scope broadens parser acceptance intentionally, with explicit negative coverage retained for non-`src` paths.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan_syntax test_parse_pub_from_`
- `cargo test --test integration_tests build_accepts_pub_from_reexport_in_src_submodule_facade`
- `make pre-commit`
- `make smoke-test`
- `mkdocs build --strict`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/imports_and_modules.md`
- Link(s): `workspaces/docs-site/docs/release_notes/0_2.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #287