### PR TITLE
bugfix - isolate single-file test harness outcomes and reduce cold-path rust-inspect churn (#288)

### DIFF
--- a/crates/rust_inspect/src/cache.rs
+++ b/crates/rust_inspect/src/cache.rs
@@ -5,6 +5,8 @@ use std::collections::hash_map::Entry;
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+#[cfg(not(test))]
+use std::sync::OnceLock;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -28,7 +30,7 @@ const INSPECTOR_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The entire cache is protected by one mutex so `RustWorkspace` (which is not `Sync` because of the retained `Vfs`)
 /// never has to live inside `Arc` for cross-thread sharing.
 pub struct RustMetadataCache {
-    inner: Mutex<CacheInner>,
+    inner: Arc<Mutex<CacheInner>>,
 }
 
 #[derive(Default)]
@@ -554,10 +556,22 @@ fn extract_in_workspace_set(
 }
 
 impl RustMetadataCache {
+    #[cfg(not(test))]
+    fn shared_inner() -> Arc<Mutex<CacheInner>> {
+        static SHARED_INNER: OnceLock<Arc<Mutex<CacheInner>>> = OnceLock::new();
+        Arc::clone(SHARED_INNER.get_or_init(|| Arc::new(Mutex::new(CacheInner::default()))))
+    }
+
+    #[cfg(test)]
+    fn shared_inner() -> Arc<Mutex<CacheInner>> {
+        // Keep unit tests isolated by default so assertions remain deterministic.
+        Arc::new(Mutex::new(CacheInner::default()))
+    }
+
     /// Create an empty cache.
     pub fn new() -> Self {
         Self {
-            inner: Mutex::new(CacheInner::default()),
+            inner: Self::shared_inner(),
         }
     }
 

--- a/src/cli/test_runner/discovery.rs
+++ b/src/cli/test_runner/discovery.rs
@@ -800,4 +800,18 @@ def test_len(input: str, expected: int) -> None:
         assert!(names.contains(&"math_test.incn".to_string()));
         Ok(())
     }
+
+    #[test]
+    fn discover_single_file_input_returns_only_that_file() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let first = dir.path().join("test_alpha.incn");
+        let second = dir.path().join("test_beta.incn");
+        std::fs::write(&first, "def test_alpha() -> None:\n    pass\n")?;
+        std::fs::write(&second, "def test_beta() -> None:\n    pass\n")?;
+
+        let files = discover_test_files(&first);
+        assert_eq!(files.len(), 1, "single-file input should not recurse the directory");
+        assert_eq!(files[0], first);
+        Ok(())
+    }
 }

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -29,10 +29,16 @@ use super::types::{TestInfo, TestResult};
 /// Generated `#[cfg(test)]` module that wraps Incan test functions as Rust `#[test]` cases, one `cargo test` per file.
 const INCAN_FILE_TEST_MOD: &str = "__incan_file_tests";
 
-/// Shared Cargo `target/` directory for all generated test crates in a package (`target/incan_test_runner`).
+fn parse_isolated_target_env(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1" | "true" | "yes" | "on"))
+}
+
+/// Shared Cargo `target/` directory for generated test crates in a package.
 ///
-/// Every harness still gets its own generated tree under `target/incan_tests/`, but dependency crates are built once
-/// into this directory so repeated `cargo test` / `cargo run` invocations reuse artifacts.
+/// By default this reuses the project's main `target/` so existing dependency artifacts are shared across regular
+/// builds and `incan test` runs for better DX.
+///
+/// Set `INCAN_TEST_ISOLATED_TARGET_DIR` to one of `1|true|yes|on` to use `target/incan_test_runner` instead.
 fn shared_cargo_target_dir(project_root: &Path) -> PathBuf {
     let absolute_project_root = if project_root.is_absolute() {
         project_root.to_path_buf()
@@ -42,7 +48,11 @@ fn shared_cargo_target_dir(project_root: &Path) -> PathBuf {
         project_root.to_path_buf()
     };
 
-    absolute_project_root.join("target").join("incan_test_runner")
+    if parse_isolated_target_env(std::env::var("INCAN_TEST_ISOLATED_TARGET_DIR").ok().as_deref()) {
+        absolute_project_root.join("target").join("incan_test_runner")
+    } else {
+        absolute_project_root.join("target")
+    }
 }
 
 /// Shared front-end + dependency work for one test file, reused across parametrized variants and multiple tests in the
@@ -118,12 +128,57 @@ fn compute_test_prep_cache_key(
     format!("v1:{}", hex::encode(hasher.finalize()))
 }
 
+/// Merge stdlib feature flags from previously prepared files with the current file requirements.
+///
+/// The rust-inspect workspace lives under one shared `target/incan_lock` directory per package. If files in a single
+/// `incan test` session require different stdlib features, a non-monotonic feature set can cause workspace
+/// fingerprint churn and expensive mid-run rewrites. Keeping a session-local feature union avoids that churn.
+fn merge_rust_inspect_stdlib_features<'a>(
+    existing_feature_sets: impl Iterator<Item = &'a [String]>,
+    current_features: &[String],
+) -> Vec<String> {
+    let mut merged: BTreeSet<String> = current_features.iter().cloned().collect();
+    for features in existing_feature_sets {
+        merged.extend(features.iter().cloned());
+    }
+    merged.into_iter().collect()
+}
+
 fn file_batch_dir_suffix(file_path: &Path) -> String {
     let p = fs::canonicalize(file_path).unwrap_or_else(|_| file_path.to_path_buf());
     let mut hasher = Sha256::new();
     hasher.update(p.to_string_lossy().as_bytes());
     let digest = hex::encode(hasher.finalize());
     format!("batch_{}", &digest[..16])
+}
+
+/// Stable Rust crate name for one generated per-file test runner crate.
+///
+/// We derive this from the per-file batch suffix so shared `CARGO_TARGET_DIR` reuse does not alias crate identities
+/// across different `.incn` files.
+fn runner_crate_name_for_batch_suffix(batch_suffix: &str) -> String {
+    let normalized = batch_suffix
+        .strip_prefix("batch_")
+        .unwrap_or(batch_suffix)
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect::<String>();
+    format!("test_runner_{}", normalized)
+}
+
+/// Normalize a libtest test name by stripping any leading crate/module qualifiers before
+/// [`INCAN_FILE_TEST_MOD`].
+///
+/// Examples:
+/// - `__incan_file_tests::incan_harness_0_case` (unchanged)
+/// - `test_runner::__incan_file_tests::incan_harness_0_case` (crate prefix removed)
+fn normalize_libtest_test_name(name: &str) -> String {
+    let trimmed = name.trim();
+    if let Some(pos) = trimmed.find(INCAN_FILE_TEST_MOD) {
+        trimmed[pos..].to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 /// Stable `#[test]` function name inside [`INCAN_FILE_TEST_MOD`] (indexed for guaranteed uniqueness).
@@ -188,7 +243,7 @@ fn parse_libtest_outcomes(combined: &str) -> HashMap<String, bool> {
         let passed = status.starts_with("ok");
         let failed = status.starts_with("FAILED");
         if passed || failed {
-            map.insert(name.to_string(), passed);
+            map.insert(normalize_libtest_test_name(name), passed);
         }
     }
     map
@@ -203,27 +258,22 @@ fn libtest_qualified_name(fn_name: &str) -> String {
 ///
 /// Looks for libtest `---- <qualified> stdout ----` sections, then falls back to panic/assertion heuristics or the
 /// full trimmed output.
-fn extract_libtest_failure_detail(combined: &str, fn_name: &str) -> String {
-    let needle = libtest_qualified_name(fn_name);
-    let header = format!("---- {needle} stdout ----");
-    if let Some(pos) = combined.find(&header) {
-        let after = &combined[pos + header.len()..];
-        let end = after
-            .find("\n---- ")
-            .unwrap_or_else(|| after.find("\nfailures:").unwrap_or(after.len()));
-        let body = after[..end].trim();
-        if !body.is_empty() {
-            return body.to_string();
-        }
-    }
-    let crate_needle = format!("test_runner::{needle}");
-    let header2 = format!("---- {crate_needle} stdout ----");
-    if let Some(pos) = combined.find(&header2) {
-        let after = &combined[pos + header2.len()..];
-        let end = after.find("\n---- ").unwrap_or(after.len());
-        let body = after[..end].trim();
-        if !body.is_empty() {
-            return body.to_string();
+fn extract_libtest_failure_detail(combined: &str, full_name: &str) -> String {
+    for line in combined.lines() {
+        let line = line.trim();
+        if line.starts_with("---- ")
+            && line.ends_with(" stdout ----")
+            && normalize_libtest_test_name(line).contains(full_name)
+            && let Some(pos) = combined.find(line)
+        {
+            let after = &combined[pos + line.len()..];
+            let end = after
+                .find("\n---- ")
+                .unwrap_or_else(|| after.find("\nfailures:").unwrap_or(after.len()));
+            let body = after[..end].trim();
+            if !body.is_empty() {
+                return body.to_string();
+            }
         }
     }
     if combined.contains("panicked at") {
@@ -245,6 +295,8 @@ fn map_batch_results(
     elapsed: std::time::Duration,
     compile_failed: bool,
     compile_message: &str,
+    manifest_path: &Path,
+    crate_name: &str,
 ) -> Vec<(TestInfo, TestResult)> {
     if compile_failed {
         let msg = compile_message.to_string();
@@ -266,14 +318,22 @@ fn map_batch_results(
             let result = match outcomes.get(&full) {
                 Some(true) => TestResult::Passed(std::time::Duration::from_millis(per_test_ms as u64)),
                 Some(false) => {
-                    let detail = extract_libtest_failure_detail(combined_output, &fname);
+                    let detail = extract_libtest_failure_detail(combined_output, &full);
                     TestResult::Failed(std::time::Duration::from_millis(per_test_ms as u64), detail)
                 }
                 None => TestResult::Failed(
                     elapsed,
-                    format!(
-                        "Test runner did not report outcome for `{full}` (see cargo output below)\n{combined_output}"
-                    ),
+                    if combined_output.contains(INCAN_FILE_TEST_MOD) {
+                        format!(
+                            "Test runner did not report outcome for `{full}`.\nmanifest=`{}` crate=`{}`\nThis may indicate stale/shared test-runner artifacts.\n{combined_output}",
+                            manifest_path.display(),
+                            crate_name,
+                        )
+                    } else {
+                        format!(
+                            "Test runner did not report outcome for `{full}` (see cargo output below)\n{combined_output}"
+                        )
+                    },
                 ),
             };
             (t.clone(), result)
@@ -530,6 +590,13 @@ pub(super) fn run_file_tests_batch(
         #[cfg(feature = "rust_inspect")]
         let rust_inspect_manifest_dir = {
             let metadata_query_paths = collect_rust_inspect_query_paths(&dependency_modules);
+            let mut rust_inspect_requirements = project_requirements.clone();
+            rust_inspect_requirements.stdlib_features = merge_rust_inspect_stdlib_features(
+                prep_cache
+                    .values()
+                    .map(|prepared| prepared.project_requirements.stdlib_features.as_slice()),
+                &project_requirements.stdlib_features,
+            );
             let rust_inspect_manifest_dir = match ensure_rust_inspect_workspace(
                 &project_root,
                 &project_name,
@@ -537,7 +604,7 @@ pub(super) fn run_file_tests_batch(
                     .as_ref()
                     .and_then(|m| m.build.as_ref().and_then(|build| build.rust_edition.clone())),
                 &resolved,
-                &project_requirements,
+                &rust_inspect_requirements,
                 lock_payload.clone(),
             ) {
                 Ok(dir) => dir,
@@ -586,9 +653,18 @@ pub(super) fn run_file_tests_batch(
     }
 
     let dir_suffix = file_batch_dir_suffix(&first.file_path);
+    let runner_crate_name = runner_crate_name_for_batch_suffix(&dir_suffix);
     let temp_dir = format!("target/incan_tests/{}", dir_suffix);
+    let temp_dir_path = PathBuf::from(&temp_dir);
+    let manifest_path = if temp_dir_path.is_absolute() {
+        temp_dir_path.join("Cargo.toml")
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(&temp_dir).join("Cargo.toml")
+    } else {
+        temp_dir_path.join("Cargo.toml")
+    };
 
-    let mut generator = ProjectGenerator::new(&temp_dir, "test_runner", false);
+    let mut generator = ProjectGenerator::new(&temp_dir, &runner_crate_name, false);
     generator.set_stdlib_features(prepared.project_requirements.stdlib_features.clone());
     generator.set_include_dev_dependencies(true);
     generator.set_dependencies(prepared.resolved.dependencies.clone());
@@ -631,6 +707,8 @@ pub(super) fn run_file_tests_batch(
     let shared_target_dir = shared_cargo_target_dir(&prepared.project_root);
     let mut command = std::process::Command::new("cargo");
     command.arg("test");
+    command.arg("--manifest-path");
+    command.arg(&manifest_path);
     for flag in common::cargo_command_flags(locked, frozen, &cargo_feature_selection) {
         command.arg(flag);
     }
@@ -674,10 +752,18 @@ pub(super) fn run_file_tests_batch(
             || combined.contains("error: aborting due to"));
 
     if compile_failed {
-        return map_batch_results(tests, &combined, elapsed, true, &combined);
+        return map_batch_results(
+            tests,
+            &combined,
+            elapsed,
+            true,
+            &combined,
+            &manifest_path,
+            &runner_crate_name,
+        );
     }
 
-    map_batch_results(tests, &combined, elapsed, false, "")
+    map_batch_results(tests, &combined, elapsed, false, "", &manifest_path, &runner_crate_name)
 }
 
 /// Inject a `fn main()` into generated Rust code that calls the test function (legacy single-case `cargo run` path).
@@ -737,7 +823,20 @@ mod tests {
     #[test]
     fn shared_target_dir_stays_under_project_target() {
         let target_dir = shared_cargo_target_dir(Path::new("/tmp/incan_project"));
-        assert_eq!(target_dir, PathBuf::from("/tmp/incan_project/target/incan_test_runner"));
+        assert_eq!(target_dir, PathBuf::from("/tmp/incan_project/target"));
+    }
+
+    #[test]
+    fn parse_isolated_target_env_requires_truthy_values() {
+        assert!(parse_isolated_target_env(Some("1")));
+        assert!(parse_isolated_target_env(Some("true")));
+        assert!(parse_isolated_target_env(Some(" yes ")));
+        assert!(parse_isolated_target_env(Some("on")));
+        assert!(!parse_isolated_target_env(None));
+        assert!(!parse_isolated_target_env(Some("0")));
+        assert!(!parse_isolated_target_env(Some("false")));
+        assert!(!parse_isolated_target_env(Some("off")));
+        assert!(!parse_isolated_target_env(Some("")));
     }
 
     #[test]
@@ -839,6 +938,27 @@ mod tests {
     }
 
     #[test]
+    fn merge_rust_inspect_stdlib_features_unions_and_sorts() {
+        let existing = [
+            vec!["json".to_string(), "async".to_string()],
+            vec!["web".to_string(), "async".to_string()],
+        ];
+        let merged = merge_rust_inspect_stdlib_features(
+            existing.iter().map(|set| set.as_slice()),
+            &["serde".to_string(), "json".to_string()],
+        );
+        assert_eq!(
+            merged,
+            vec![
+                "async".to_string(),
+                "json".to_string(),
+                "serde".to_string(),
+                "web".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn parse_libtest_outcomes_detects_ok_and_failed() {
         let out = r#"
 test __incan_file_tests::incan_harness_0_a ... ok
@@ -848,6 +968,23 @@ test result: FAILED. 1 passed; 1 failed
         let m = parse_libtest_outcomes(out);
         assert_eq!(m.get("__incan_file_tests::incan_harness_0_a"), Some(&true));
         assert_eq!(m.get("__incan_file_tests::incan_harness_1_b"), Some(&false));
+    }
+
+    #[test]
+    fn parse_libtest_outcomes_normalizes_prefixed_names() {
+        let out = r#"
+test test_runner_76001490ba86f677::__incan_file_tests::incan_harness_0_a ... ok
+test test_runner_76001490ba86f677::__incan_file_tests::incan_harness_1_b ... FAILED
+"#;
+        let m = parse_libtest_outcomes(out);
+        assert_eq!(m.get("__incan_file_tests::incan_harness_0_a"), Some(&true));
+        assert_eq!(m.get("__incan_file_tests::incan_harness_1_b"), Some(&false));
+    }
+
+    #[test]
+    fn runner_crate_name_is_derived_from_batch_suffix() {
+        let name = runner_crate_name_for_batch_suffix("batch_76001490ba86f677");
+        assert_eq!(name, "test_runner_76001490ba86f677");
     }
 
     #[test]

--- a/src/cli/test_runner/mod.rs
+++ b/src/cli/test_runner/mod.rs
@@ -1,6 +1,7 @@
 //! Test runner implementation (pytest-style).
 
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
@@ -245,6 +246,15 @@ pub fn run_tests(config: TestRunConfig<'_>) -> CliResult<ExitCode> {
         }
 
         let batch = &filtered_tests[batch_start..idx];
+        println!(
+            "{}",
+            style(
+                format!("running {} ({} item(s))", file_path.display(), batch.len()),
+                "2",
+                use_color
+            )
+        );
+        let _ = std::io::stdout().flush();
         let batch_results = run_file_tests_batch(
             batch,
             &mut prep_cache,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1546,6 +1546,7 @@ def main() -> None:
 /// expansion that unit tests cannot detect.
 mod test_runner_e2e {
     use super::incan_debug_binary;
+    use std::path::Path;
     use std::process::Command;
 
     /// Create a temp directory with a single test file and return the directory path.
@@ -1567,17 +1568,22 @@ mod test_runner_e2e {
         dir
     }
 
-    /// Run `incan test` on a directory and return the combined output.
-    fn run_incan_test(dir: &std::path::Path) -> std::process::Output {
+    /// Run `incan test` for the given path argument (file or directory).
+    fn run_incan_test_path(path: &Path) -> std::process::Output {
         Command::new(incan_debug_binary())
-            .args(["test", dir.to_string_lossy().as_ref()])
+            .args(["test", path.to_string_lossy().as_ref()])
             .env("CARGO_NET_OFFLINE", "true")
             .output()
             .unwrap_or_else(|e| panic!("failed to run `incan test`: {}", e))
     }
 
+    /// Run `incan test` on a directory and return the combined output.
+    fn run_incan_test(dir: &Path) -> std::process::Output {
+        run_incan_test_path(dir)
+    }
+
     /// Run `incan test` with extra flags.
-    fn run_incan_test_with_args(dir: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    fn run_incan_test_with_args(dir: &Path, extra: &[&str]) -> std::process::Output {
         let mut cmd = Command::new(incan_debug_binary());
         cmd.arg("test");
         for arg in extra {
@@ -1587,6 +1593,17 @@ mod test_runner_e2e {
         cmd.env("CARGO_NET_OFFLINE", "true");
         cmd.output()
             .unwrap_or_else(|e| panic!("failed to run `incan test`: {}", e))
+    }
+
+    /// Run `incan test` with `cwd` and a relative path argument.
+    fn run_incan_test_relative(cwd: &Path, relative_path: &str) -> std::process::Output {
+        Command::new(incan_debug_binary())
+            .arg("test")
+            .arg(relative_path)
+            .env("CARGO_NET_OFFLINE", "true")
+            .current_dir(cwd)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run `incan test {relative_path}`: {}", e))
     }
 
     // ---- Passing test ----
@@ -1654,6 +1671,158 @@ def test_two() -> None:
             stdout.match_indices("PASSED").count() >= 2,
             "expected two passing results (per-test PASSED lines).\nstdout:\n{}",
             stdout,
+        );
+    }
+
+    #[test]
+    fn e2e_sequential_single_file_runs_do_not_cross_wire_relative_paths() {
+        let dir = write_test_project(
+            "incan.toml",
+            r#"[project]
+name = "session_isolation_relative"
+version = "0.1.0"
+"#,
+        );
+        let tests_dir = dir.join("tests");
+        if let Err(err) = std::fs::create_dir_all(&tests_dir) {
+            panic!("failed to create tests dir: {}", err);
+        }
+        if let Err(err) = std::fs::write(
+            tests_dir.join("test_alpha.incn"),
+            r#"
+from std.testing import assert_eq
+
+def test_alpha_one() -> None:
+    assert_eq(1, 1)
+
+def test_alpha_two() -> None:
+    assert_eq(2, 2)
+"#,
+        ) {
+            panic!("failed to write test_alpha.incn: {}", err);
+        }
+        if let Err(err) = std::fs::write(
+            tests_dir.join("test_beta.incn"),
+            r#"
+from std.testing import assert_eq
+
+def test_beta_only() -> None:
+    assert_eq(3, 3)
+"#,
+        ) {
+            panic!("failed to write test_beta.incn: {}", err);
+        }
+
+        let first = run_incan_test_relative(&dir, "tests/test_alpha.incn");
+        let first_stdout = String::from_utf8_lossy(&first.stdout);
+        let first_stderr = String::from_utf8_lossy(&first.stderr);
+        assert!(
+            first.status.success(),
+            "expected first single-file run to succeed.\nstdout:\n{}\nstderr:\n{}",
+            first_stdout,
+            first_stderr,
+        );
+
+        let second = run_incan_test_relative(&dir, "tests/test_beta.incn");
+        let second_stdout = String::from_utf8_lossy(&second.stdout);
+        let second_stderr = String::from_utf8_lossy(&second.stderr);
+        let second_combined = format!("{second_stdout}\n{second_stderr}");
+        assert!(
+            second.status.success(),
+            "expected second single-file run to succeed.\nstdout:\n{}\nstderr:\n{}",
+            second_stdout,
+            second_stderr,
+        );
+        assert!(
+            second_combined.contains("test_beta.incn::test_beta_only"),
+            "expected the requested beta test to run.\noutput:\n{}",
+            second_combined,
+        );
+        assert!(
+            !second_combined.contains("test_alpha.incn::test_alpha_one")
+                && !second_combined.contains("test_alpha.incn::test_alpha_two"),
+            "expected no alpha tests in second single-file run.\noutput:\n{}",
+            second_combined,
+        );
+        assert!(
+            !second_combined.contains("Test runner did not report outcome"),
+            "expected no missing-outcome diagnostic in second run.\noutput:\n{}",
+            second_combined,
+        );
+    }
+
+    #[test]
+    fn e2e_sequential_single_file_runs_do_not_cross_wire_absolute_paths() {
+        let dir = write_test_project(
+            "incan.toml",
+            r#"[project]
+name = "session_isolation_absolute"
+version = "0.1.0"
+"#,
+        );
+        let tests_dir = dir.join("tests");
+        if let Err(err) = std::fs::create_dir_all(&tests_dir) {
+            panic!("failed to create tests dir: {}", err);
+        }
+        let alpha_path = tests_dir.join("test_alpha_abs.incn");
+        let beta_path = tests_dir.join("test_beta_abs.incn");
+        if let Err(err) = std::fs::write(
+            &alpha_path,
+            r#"
+from std.testing import assert_eq
+
+def test_alpha_abs_one() -> None:
+    assert_eq(10, 10)
+"#,
+        ) {
+            panic!("failed to write test_alpha_abs.incn: {}", err);
+        }
+        if let Err(err) = std::fs::write(
+            &beta_path,
+            r#"
+from std.testing import assert_eq
+
+def test_beta_abs_only() -> None:
+    assert_eq(20, 20)
+"#,
+        ) {
+            panic!("failed to write test_beta_abs.incn: {}", err);
+        }
+
+        let first = run_incan_test_path(&alpha_path);
+        let first_stdout = String::from_utf8_lossy(&first.stdout);
+        let first_stderr = String::from_utf8_lossy(&first.stderr);
+        assert!(
+            first.status.success(),
+            "expected first absolute-path run to succeed.\nstdout:\n{}\nstderr:\n{}",
+            first_stdout,
+            first_stderr,
+        );
+
+        let second = run_incan_test_path(&beta_path);
+        let second_stdout = String::from_utf8_lossy(&second.stdout);
+        let second_stderr = String::from_utf8_lossy(&second.stderr);
+        let second_combined = format!("{second_stdout}\n{second_stderr}");
+        assert!(
+            second.status.success(),
+            "expected second absolute-path run to succeed.\nstdout:\n{}\nstderr:\n{}",
+            second_stdout,
+            second_stderr,
+        );
+        assert!(
+            second_combined.contains("test_beta_abs.incn::test_beta_abs_only"),
+            "expected the requested absolute-path beta test to run.\noutput:\n{}",
+            second_combined,
+        );
+        assert!(
+            !second_combined.contains("test_alpha_abs.incn::test_alpha_abs_one"),
+            "expected no alpha absolute-path tests in second run.\noutput:\n{}",
+            second_combined,
+        );
+        assert!(
+            !second_combined.contains("Test runner did not report outcome"),
+            "expected no missing-outcome diagnostic in second absolute-path run.\noutput:\n{}",
+            second_combined,
         );
     }
 

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -233,6 +233,8 @@ Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer globally
 ## Bugfixes
 
 - **Compiler**: `pub from ... import ...` now works in any module under `src/` (not just `src/lib.incn`), which unblocks package submodule facades that re-export symbols for parent imports like `from session import Session` (#287).
+- **Tooling**: `incan test <single-file>` now isolates generated per-file harness crates and resolves outcomes against the requested file only, fixing cross-wired runs that could report `Test runner did not report outcome` for unrelated tests (#288).
+- **Tooling/Performance**: `incan test` now reuses shared build and rust-inspect metadata caches more aggressively, reducing repeated cold-start overhead between runs, especially across multi-file test sessions (#288).
 - **Compiler**: Cyclic cross-module projects now resolve imported dependencies during per-module typechecking by import graph (not discovery order), so direct explicit call-site generic calls like `collect_with_active_session[T](...)` no longer fail with a false unsupported-call-form diagnostic in `incan run` / `incan --check` flows (#279).
 - **Tooling/Codegen**: Generated projects now resolve relative entry paths correctly and emit cleaner Rust for internal module calls and module statics, reducing false errors and compiler-noise in real project workflows.
 - **Compiler**: rust-inspect now recovers concrete borrowed function parameter pointee types from source when rust-analyzer degrades them to placeholders like `&?`, so imported Rust calls keep exact borrowed contracts during typechecking and generated-lock workspace interop paths (#259).


### PR DESCRIPTION
## Summary

This PR fixes `incan test <single-file>` cross-wiring by isolating generated per-file harness crates, resolving outcomes only against the requested file, and making cargo invocation deterministic via explicit manifest paths. It also improves cold-path behavior by reusing cache/workspace state more effectively (including process-shared rust-inspect metadata cache and session-level rust-inspect feature-union stabilization), plus adds progress output and regression coverage. Release notes for `0.2` are updated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan test <single-file>` no longer reports outcomes for unrelated files or emits false “Test runner did not report outcome” errors due to stale/shared harness identity. Test runs now print per-file progress lines and default to reusing project `target/` artifacts for better DX.
- **Internals**:
  - Per-file crate names are now derived from stable file batch suffixes.
  - `cargo test` uses explicit `--manifest-path` for the generated harness crate.
  - Libtest name parsing normalizes crate-prefixed test names.
  - rust-inspect workspace prep now uses a monotonic stdlib-feature union within a run.
  - `RustMetadataCache` now uses a process-shared inner cache (non-test builds) via `OnceLock`.
  - Added discovery unit test + e2e sequential single-file tests (relative and absolute path variants).
- **Risks**:
  - Shared caches can increase process memory footprint in very long-lived sessions.
  - Reusing project `target/` by default may surface environment-specific cargo artifact interactions; opt-out remains available via `INCAN_TEST_ISOLATED_TARGET_DIR=1`.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Ran:
  - `cargo fmt --all`
  - `cargo clippy --all-targets --all-features --quiet`
  - `cargo test -p rust_inspect --quiet`
  - `cargo test -p incan test_runner_e2e::e2e_sequential_single_file_runs_do_not_cross_wire_relative_paths --quiet`
  - `cargo test -p incan test_runner_e2e::e2e_sequential_single_file_runs_do_not_cross_wire_absolute_paths --quiet`
- Reproduction/perf check in InQL:
  - Prior baseline observed: `59 passed in 320.13s` (cold path in failing setup)
  - Current branch observed: `59 passed in 102.66s` (`~105.49s real`) on clean cold run
  - Warm follow-up run observed: `~50.88s real`, subsequent rerun `~2.28s real`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_2.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #288
