### PR TITLE
chore - centralize AST expression traversal for serde and fixture teardown detection (#123)

### DIFF
--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -966,6 +966,14 @@ mod tests {
         must_ok(parser::parse(&tokens))
     }
 
+    /// Parse and scan a source snippet to determine whether serde runtime support is required.
+    fn detects_serde(source: &str) -> bool {
+        let ast = parse_program(source);
+        let mut codegen = IrCodegen::new();
+        codegen.update_serde_requirement(&ast);
+        codegen.needs_serde()
+    }
+
     #[cfg(feature = "rust_inspect")]
     fn seeded_rust_inspect_workspace() -> Result<tempfile::TempDir, Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;
@@ -1114,11 +1122,7 @@ model User:
 model Config:
   name: str
 "#;
-        let tokens = must_ok(lexer::lex(source));
-        let ast = must_ok(parser::parse(&tokens));
-        let mut codegen = IrCodegen::new();
-        codegen.update_serde_requirement(&ast);
-        assert!(codegen.needs_serde());
+        assert!(detects_serde(source));
     }
 
     #[test]
@@ -1128,11 +1132,7 @@ model Config:
 model User:
   id: int
 "#;
-        let tokens = must_ok(lexer::lex(source));
-        let ast = must_ok(parser::parse(&tokens));
-        let mut codegen = IrCodegen::new();
-        codegen.update_serde_requirement(&ast);
-        assert!(codegen.needs_serde());
+        assert!(detects_serde(source));
     }
 
     #[test]
@@ -1142,11 +1142,7 @@ model User:
 model User:
   id: int
 "#;
-        let tokens = must_ok(lexer::lex(source));
-        let ast = must_ok(parser::parse(&tokens));
-        let mut codegen = IrCodegen::new();
-        codegen.update_serde_requirement(&ast);
-        assert!(!codegen.needs_serde());
+        assert!(!detects_serde(source));
     }
 
     #[test]
@@ -1155,11 +1151,49 @@ model User:
 def main() -> None:
   _ = json_stringify(123)
 "#;
-        let tokens = must_ok(lexer::lex(source));
-        let ast = must_ok(parser::parse(&tokens));
-        let mut codegen = IrCodegen::new();
-        codegen.update_serde_requirement(&ast);
-        assert!(codegen.needs_serde());
+        assert!(detects_serde(source));
+    }
+
+    #[test]
+    fn test_serde_detection_json_stringify_in_if_condition() {
+        let source = r#"
+def main() -> None:
+  if json_stringify(1) == "1":
+    pass
+"#;
+        assert!(detects_serde(source));
+    }
+
+    #[test]
+    fn test_serde_detection_json_stringify_in_elif_body() {
+        let source = r#"
+def main() -> None:
+  if true:
+    pass
+  elif false:
+    _ = json_stringify(1)
+"#;
+        assert!(detects_serde(source));
+    }
+
+    #[test]
+    fn test_serde_detection_json_stringify_in_while_condition() {
+        let source = r#"
+def main() -> None:
+  while json_stringify(1) == "1":
+    break
+"#;
+        assert!(detects_serde(source));
+    }
+
+    #[test]
+    fn test_serde_detection_json_stringify_in_for_iterator() {
+        let source = r#"
+def main() -> None:
+  for item in [json_stringify(1)]:
+    _ = item
+"#;
+        assert!(detects_serde(source));
     }
 
     #[test]

--- a/src/backend/ir/scanners/serde.rs
+++ b/src/backend/ir/scanners/serde.rs
@@ -8,7 +8,8 @@
 //! Once `json_stringify` is behind `from std.serde.json import json_stringify`, the
 //! builtin fallback here can be removed entirely.
 
-use crate::frontend::ast::{CallArg, Declaration, DecoratorArg, Expr, Program, Spanned, Statement};
+use crate::frontend::ast::{Declaration, DecoratorArg, Expr, Program};
+use crate::frontend::ast_walk::any_expr_in_program;
 use incan_core::lang::builtins::{self, BuiltinFnId};
 use incan_core::lang::decorators::DecoratorId;
 use incan_core::lang::derives::{self, DeriveId};
@@ -81,124 +82,13 @@ fn has_serde_derive(program: &Program) -> bool {
 // ---------------------------------------------------------------------------
 
 fn program_has_json_stringify(program: &Program) -> bool {
-    for decl in &program.declarations {
-        let bodies: Vec<&[Spanned<Statement>]> = match &decl.node {
-            Declaration::Function(f) => vec![&f.body],
-            Declaration::Model(m) => m.methods.iter().filter_map(|m| m.node.body.as_deref()).collect(),
-            Declaration::Class(c) => c.methods.iter().filter_map(|m| m.node.body.as_deref()).collect(),
-            _ => continue,
+    any_expr_in_program(program, |expr| {
+        let Expr::Call(callee, _type_args, _args) = expr else {
+            return false;
         };
-        for body in bodies {
-            if body_has_call_named(body, BuiltinFnId::JsonStringify) {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-fn body_has_call_named(body: &[Spanned<Statement>], target: BuiltinFnId) -> bool {
-    body.iter().any(|s| stmt_has_call(s, target))
-}
-
-fn stmt_has_call(stmt: &Spanned<Statement>, target: BuiltinFnId) -> bool {
-    match &stmt.node {
-        Statement::Expr(e) | Statement::Return(Some(e)) => expr_has_call(&e.node, target),
-        Statement::Assignment(a) => expr_has_call(&a.value.node, target),
-        Statement::CompoundAssignment(a) => expr_has_call(&a.value.node, target),
-        Statement::FieldAssignment(a) => expr_has_call(&a.value.node, target),
-        Statement::IndexAssignment(a) => expr_has_call(&a.value.node, target),
-        Statement::TupleUnpack(u) => expr_has_call(&u.value.node, target),
-        Statement::TupleAssign(a) => expr_has_call(&a.value.node, target),
-        Statement::Surface(surface_stmt) => match &surface_stmt.payload {
-            crate::frontend::ast::SurfaceStmtPayload::KeywordArgs(args) => {
-                args.iter().any(|arg| expr_has_call(&arg.node, target))
-            }
-        },
-        Statement::VocabBlock(block) => {
-            block.header_args.iter().any(|arg| expr_has_call(&arg.node, target))
-                || body_has_call_named(&block.body, target)
-        }
-        Statement::If(s) => {
-            body_has_call_named(&s.then_body, target)
-                || s.else_body.as_ref().is_some_and(|b| body_has_call_named(b, target))
-        }
-        Statement::While(s) => body_has_call_named(&s.body, target),
-        Statement::For(s) => body_has_call_named(&s.body, target),
-        _ => false,
-    }
-}
-
-/// Compact recursive expression check — does any sub-expression call the target builtin?
-fn expr_has_call(expr: &Expr, target: BuiltinFnId) -> bool {
-    match expr {
-        Expr::Call(f, _type_args, args) => {
-            if let Expr::Ident(name) = &f.node
-                && builtins::from_str(name.as_str()) == Some(target)
-            {
-                return true;
-            }
-            expr_has_call(&f.node, target) || args.iter().any(|a| call_arg_has(a, target))
-        }
-        Expr::MethodCall(base, _, _type_args, args) => {
-            expr_has_call(&base.node, target) || args.iter().any(|a| call_arg_has(a, target))
-        }
-        Expr::Constructor(_, args) => args.iter().any(|a| call_arg_has(a, target)),
-        Expr::Binary(l, _, r) | Expr::Index(l, r) => expr_has_call(&l.node, target) || expr_has_call(&r.node, target),
-        Expr::Range { start, end, .. } => expr_has_call(&start.node, target) || expr_has_call(&end.node, target),
-        Expr::Unary(_, e) | Expr::Try(e) | Expr::Paren(e) | Expr::Field(e, _) => expr_has_call(&e.node, target),
-        Expr::Surface(surface_expr) => match &surface_expr.payload {
-            crate::frontend::ast::SurfaceExprPayload::PrefixUnary(inner) => expr_has_call(&inner.node, target),
-        },
-        Expr::Closure(_, body) => expr_has_call(&body.node, target),
-        Expr::Yield(Some(e)) => expr_has_call(&e.node, target),
-        Expr::List(items) | Expr::Tuple(items) | Expr::Set(items) => {
-            items.iter().any(|i| expr_has_call(&i.node, target))
-        }
-        Expr::Dict(pairs) => pairs
-            .iter()
-            .any(|(k, v)| expr_has_call(&k.node, target) || expr_has_call(&v.node, target)),
-        Expr::If(if_expr) => {
-            body_has_call_named(&if_expr.then_body, target)
-                || if_expr
-                    .else_body
-                    .as_ref()
-                    .is_some_and(|b| body_has_call_named(b, target))
-        }
-        Expr::Match(scrutinee, arms) => {
-            expr_has_call(&scrutinee.node, target)
-                || arms.iter().any(|arm| match &arm.node.body {
-                    crate::frontend::ast::MatchBody::Expr(e) => expr_has_call(&e.node, target),
-                    crate::frontend::ast::MatchBody::Block(stmts) => body_has_call_named(stmts, target),
-                })
-        }
-        Expr::Slice(base, slice) => {
-            expr_has_call(&base.node, target)
-                || slice.start.as_ref().is_some_and(|e| expr_has_call(&e.node, target))
-                || slice.end.as_ref().is_some_and(|e| expr_has_call(&e.node, target))
-                || slice.step.as_ref().is_some_and(|e| expr_has_call(&e.node, target))
-        }
-        Expr::ListComp(c) => {
-            expr_has_call(&c.expr.node, target)
-                || expr_has_call(&c.iter.node, target)
-                || c.filter.as_ref().is_some_and(|f| expr_has_call(&f.node, target))
-        }
-        Expr::DictComp(c) => {
-            expr_has_call(&c.key.node, target)
-                || expr_has_call(&c.value.node, target)
-                || expr_has_call(&c.iter.node, target)
-                || c.filter.as_ref().is_some_and(|f| expr_has_call(&f.node, target))
-        }
-        Expr::FString(parts) => parts.iter().any(|p| match p {
-            crate::frontend::ast::FStringPart::Literal(_) => false,
-            crate::frontend::ast::FStringPart::Expr(e) => expr_has_call(&e.node, target),
-        }),
-        _ => false,
-    }
-}
-
-fn call_arg_has(arg: &CallArg, target: BuiltinFnId) -> bool {
-    match arg {
-        CallArg::Positional(e) | CallArg::Named(_, e) => expr_has_call(&e.node, target),
-    }
+        let Expr::Ident(name) = &callee.node else {
+            return false;
+        };
+        builtins::from_str(name.as_str()) == Some(BuiltinFnId::JsonStringify)
+    })
 }

--- a/src/cli/test_runner/discovery.rs
+++ b/src/cli/test_runner/discovery.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::frontend::ast::{DecoratorArg, DecoratorArgValue, Expr, Literal, Statement};
+use crate::frontend::ast::{DecoratorArg, DecoratorArgValue, Expr, Literal};
+use crate::frontend::ast_walk::any_expr_in_body;
 use crate::frontend::testing_markers::{
     TestingMarkerKind, TestingMarkerSemantics, load_testing_marker_semantics, resolve_testing_marker_kind,
 };
@@ -165,48 +166,7 @@ fn extract_fixture_dependencies(
 
 /// Check if a function has a yield statement.
 fn function_has_yield(body: &[crate::frontend::ast::Spanned<crate::frontend::ast::Statement>]) -> bool {
-    for stmt in body {
-        if statement_has_yield(&stmt.node) {
-            return true;
-        }
-    }
-    false
-}
-
-/// Check if a statement has a yield expression.
-fn statement_has_yield(stmt: &Statement) -> bool {
-    match stmt {
-        Statement::Expr(expr) => expr_has_yield(&expr.node),
-        Statement::Return(Some(expr)) => expr_has_yield(&expr.node),
-        Statement::If(if_stmt) => {
-            if_stmt.then_body.iter().any(|s| statement_has_yield(&s.node))
-                || if_stmt
-                    .else_body
-                    .as_ref()
-                    .is_some_and(|b| b.iter().any(|s| statement_has_yield(&s.node)))
-        }
-        Statement::While(while_stmt) => while_stmt.body.iter().any(|s| statement_has_yield(&s.node)),
-        Statement::For(for_stmt) => for_stmt.body.iter().any(|s| statement_has_yield(&s.node)),
-        _ => false,
-    }
-}
-
-/// Check if an expression has a yield expression.
-fn expr_has_yield(expr: &Expr) -> bool {
-    match expr {
-        Expr::Yield(_) => true,
-        Expr::Binary(left, _, right) => expr_has_yield(&left.node) || expr_has_yield(&right.node),
-        Expr::Unary(_, operand) => expr_has_yield(&operand.node),
-        Expr::Call(callee, _type_args, args) => {
-            expr_has_yield(&callee.node)
-                || args.iter().any(|a| match a {
-                    crate::frontend::ast::CallArg::Positional(e) => expr_has_yield(&e.node),
-                    crate::frontend::ast::CallArg::Named(_, e) => expr_has_yield(&e.node),
-                })
-        }
-        Expr::Paren(inner) => expr_has_yield(&inner.node),
-        _ => false,
-    }
+    any_expr_in_body(body, |expr| matches!(expr, Expr::Yield(_)))
 }
 
 /// Get autouse fixtures for a given scope.
@@ -612,6 +572,27 @@ def temp_file() -> str:
 
         assert_eq!(result.fixtures.len(), 1);
         assert!(result.fixtures[0].has_teardown, "yield should be detected as teardown");
+        Ok(())
+    }
+
+    #[test]
+    fn discover_fixture_with_teardown_in_assignment_expression() -> Result<(), Box<dyn std::error::Error>> {
+        let source = r#"
+from std.testing import fixture
+
+@fixture
+def temp_file() -> str:
+    path = (yield "tmp.txt")
+    return path
+"#;
+        let file = write_test_file(source)?;
+        let result = discover_tests_and_fixtures(file.path())?;
+
+        assert_eq!(result.fixtures.len(), 1);
+        assert!(
+            result.fixtures[0].has_teardown,
+            "yield used in assignment expression should still be detected as teardown"
+        );
         Ok(())
     }
 

--- a/src/frontend/ast_walk.rs
+++ b/src/frontend/ast_walk.rs
@@ -1,0 +1,331 @@
+//! Shared expression traversal over the frontend AST.
+//!
+//! This module is the canonical place to recurse through expression-bearing AST slots.
+//! Callers provide a predicate and receive `true` on the first match.
+//!
+//! ## Traversal semantics
+//! - Source-order traversal.
+//! - Deterministic behavior (same AST + predicate => same visit order/result).
+//! - Short-circuit evaluation: traversal stops at the first `true`.
+//!
+//! ## Coverage contract
+//! The traversal visits expression slots in declarations, statements, and expressions, including:
+//! - declaration values/defaults (`const`/`static`, field defaults, parameter defaults)
+//! - decorator args (positional and expression-valued named args)
+//! - control-flow conditions and bodies (`if`/`elif`/`else`, `while`, `for`)
+//! - assignment RHS and lvalue expressions where applicable (for example tuple/index/field forms)
+//! - call/constructor args, match guards and bodies, comprehensions, and f-string interpolations
+//! - newtype rebinding/interop adapter expressions
+//!
+//! ## Non-goals
+//! - type traversal (for example type annotations and type arguments)
+//! - pattern traversal
+//! - import-path traversal
+
+use crate::frontend::ast::{
+    CallArg, Declaration, DecoratorArg, DecoratorArgValue, Expr, MatchBody, Program, Spanned, Statement,
+};
+
+/// Returns `true` if any expression in `program` satisfies `pred`.
+///
+/// This entry point walks expression-bearing declaration content and then descends into contained statement/expression
+/// trees using the same ordering and early-exit semantics documented at the module level.
+pub(crate) fn any_expr_in_program<F>(program: &Program, mut pred: F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    program
+        .declarations
+        .iter()
+        .any(|decl| declaration_has_expr(decl, &mut pred))
+}
+
+/// Returns `true` if any expression reachable from `body` satisfies `pred`.
+///
+/// Use this when a caller already has a statement slice (for example function/method bodies) and does not need to walk
+/// top-level declarations.
+pub(crate) fn any_expr_in_body<F>(body: &[Spanned<Statement>], mut pred: F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    any_expr_in_body_impl(body, &mut pred)
+}
+
+/// Checks whether a top-level declaration contains any matching expression.
+///
+/// This helper is responsible for declaration-specific expression slots (for example defaults, decorators, and
+/// method/function bodies).
+fn declaration_has_expr<F>(decl: &Spanned<Declaration>, pred: &mut F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    match &decl.node {
+        Declaration::Import(_) | Declaration::TypeAlias(_) | Declaration::Docstring(_) => false,
+        Declaration::Const(c) => expr_has(&c.value.node, pred),
+        Declaration::Static(s) => expr_has(&s.value.node, pred),
+        Declaration::Model(m) => {
+            decorators_have_expr(&m.decorators, pred)
+                || m.fields.iter().any(|field| {
+                    field
+                        .node
+                        .default
+                        .as_ref()
+                        .is_some_and(|value| expr_has(&value.node, pred))
+                })
+                || m.methods.iter().any(|method| method_has_expr(&method.node, pred))
+        }
+        Declaration::Class(c) => {
+            decorators_have_expr(&c.decorators, pred)
+                || c.fields.iter().any(|field| {
+                    field
+                        .node
+                        .default
+                        .as_ref()
+                        .is_some_and(|value| expr_has(&value.node, pred))
+                })
+                || c.methods.iter().any(|method| method_has_expr(&method.node, pred))
+        }
+        Declaration::Trait(t) => {
+            decorators_have_expr(&t.decorators, pred)
+                || t.methods.iter().any(|method| method_has_expr(&method.node, pred))
+        }
+        Declaration::Newtype(n) => {
+            decorators_have_expr(&n.decorators, pred)
+                || n.rebindings
+                    .iter()
+                    .any(|rebinding| expr_has(&rebinding.node.target.node, pred))
+                || n.interop_edges
+                    .iter()
+                    .any(|edge| expr_has(&edge.node.adapter.node, pred))
+                || n.methods.iter().any(|method| method_has_expr(&method.node, pred))
+        }
+        Declaration::Enum(e) => decorators_have_expr(&e.decorators, pred),
+        Declaration::Function(f) => {
+            decorators_have_expr(&f.decorators, pred)
+                || params_have_expr(&f.params, pred)
+                || any_expr_in_body_impl(&f.body, pred)
+        }
+    }
+}
+
+/// Checks whether a method declaration contains any matching expression.
+///
+/// Abstract methods (`body: None`) only contribute via decorators/parameter defaults.
+fn method_has_expr<F>(method: &crate::frontend::ast::MethodDecl, pred: &mut F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    decorators_have_expr(&method.decorators, pred)
+        || params_have_expr(&method.params, pred)
+        || method
+            .body
+            .as_ref()
+            .is_some_and(|body| any_expr_in_body_impl(body, pred))
+}
+
+/// Checks parameter default expressions for a match.
+fn params_have_expr<F>(params: &[Spanned<crate::frontend::ast::Param>], pred: &mut F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    params.iter().any(|param| {
+        param
+            .node
+            .default
+            .as_ref()
+            .is_some_and(|value| expr_has(&value.node, pred))
+    })
+}
+
+/// Checks decorator argument expressions for a match.
+///
+/// Type-valued named decorator args are intentionally excluded.
+fn decorators_have_expr<F>(decorators: &[Spanned<crate::frontend::ast::Decorator>], pred: &mut F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    decorators.iter().any(|decorator| {
+        decorator.node.args.iter().any(|arg| match arg {
+            DecoratorArg::Positional(value) => expr_has(&value.node, pred),
+            DecoratorArg::Named(_, value) => match value {
+                DecoratorArgValue::Type(_) => false,
+                DecoratorArgValue::Expr(value) => expr_has(&value.node, pred),
+            },
+        })
+    })
+}
+
+/// Checks a statement slice in source order, short-circuiting on first match.
+fn any_expr_in_body_impl<F>(body: &[Spanned<Statement>], pred: &mut F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    body.iter().any(|stmt| statement_has_expr(&stmt.node, pred))
+}
+
+/// Checks a single statement and all expression-bearing descendants for a match.
+fn statement_has_expr<F>(stmt: &Statement, pred: &mut F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    // ---- Context: direct expression-bearing statement forms ----
+    match stmt {
+        Statement::Assignment(a) => expr_has(&a.value.node, pred),
+        Statement::FieldAssignment(a) => expr_has(&a.object.node, pred) || expr_has(&a.value.node, pred),
+        Statement::IndexAssignment(a) => {
+            expr_has(&a.object.node, pred) || expr_has(&a.index.node, pred) || expr_has(&a.value.node, pred)
+        }
+        Statement::Return(Some(expr)) => expr_has(&expr.node, pred),
+        Statement::Expr(expr) => expr_has(&expr.node, pred),
+        Statement::CompoundAssignment(a) => expr_has(&a.value.node, pred),
+        Statement::TupleUnpack(u) => expr_has(&u.value.node, pred),
+        Statement::TupleAssign(a) => {
+            a.targets.iter().any(|target| expr_has(&target.node, pred)) || expr_has(&a.value.node, pred)
+        }
+        Statement::ChainedAssignment(a) => expr_has(&a.value.node, pred),
+        Statement::Surface(surface_stmt) => match &surface_stmt.payload {
+            crate::frontend::ast::SurfaceStmtPayload::KeywordArgs(args) => {
+                args.iter().any(|arg| expr_has(&arg.node, pred))
+            }
+        },
+        Statement::VocabBlock(block) => {
+            decorators_have_expr(&block.decorators, pred)
+                || block.header_args.iter().any(|arg| expr_has(&arg.node, pred))
+                || any_expr_in_body_impl(&block.body, pred)
+        }
+
+        // ---- Context: control-flow statements ----
+        Statement::If(s) => {
+            if expr_has(&s.condition.node, pred) || any_expr_in_body_impl(&s.then_body, pred) {
+                return true;
+            }
+
+            for (condition, body) in &s.elif_branches {
+                if expr_has(&condition.node, pred) || any_expr_in_body_impl(body, pred) {
+                    return true;
+                }
+            }
+
+            s.else_body
+                .as_ref()
+                .is_some_and(|else_body| any_expr_in_body_impl(else_body, pred))
+        }
+        Statement::While(s) => expr_has(&s.condition.node, pred) || any_expr_in_body_impl(&s.body, pred),
+        Statement::For(s) => expr_has(&s.iter.node, pred) || any_expr_in_body_impl(&s.body, pred),
+
+        Statement::Return(None) | Statement::Pass | Statement::Break | Statement::Continue => false,
+    }
+}
+
+/// Recursive expression walker used by all traversal entry points.
+///
+/// Visits `expr` first (pre-order) and then descends into child expressions in source order until `pred` returns
+/// `true`.
+fn expr_has<F>(expr: &Expr, pred: &mut F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    if pred(expr) {
+        return true;
+    }
+
+    // ---- Context: literal / leaf expressions ----
+    match expr {
+        Expr::Ident(_) | Expr::Literal(_) | Expr::SelfExpr => false,
+
+        // ---- Context: unary / binary / call-like expressions ----
+        Expr::Binary(left, _, right) | Expr::Index(left, right) => {
+            expr_has(&left.node, pred) || expr_has(&right.node, pred)
+        }
+        Expr::Unary(_, operand) | Expr::Try(operand) | Expr::Paren(operand) | Expr::Field(operand, _) => {
+            expr_has(&operand.node, pred)
+        }
+        Expr::Call(callee, _type_args, args) => {
+            expr_has(&callee.node, pred) || args.iter().any(|arg| call_arg_has_expr(arg, pred))
+        }
+        Expr::MethodCall(base, _, _type_args, args) => {
+            expr_has(&base.node, pred) || args.iter().any(|arg| call_arg_has_expr(arg, pred))
+        }
+        Expr::Constructor(_, args) => args.iter().any(|arg| call_arg_has_expr(arg, pred)),
+
+        // ---- Context: structured / control-flow expressions ----
+        Expr::Slice(base, slice) => {
+            expr_has(&base.node, pred)
+                || slice.start.as_ref().is_some_and(|expr| expr_has(&expr.node, pred))
+                || slice.end.as_ref().is_some_and(|expr| expr_has(&expr.node, pred))
+                || slice.step.as_ref().is_some_and(|expr| expr_has(&expr.node, pred))
+        }
+        Expr::Match(scrutinee, arms) => {
+            if expr_has(&scrutinee.node, pred) {
+                return true;
+            }
+
+            for arm in arms {
+                if arm.node.guard.as_ref().is_some_and(|guard| expr_has(&guard.node, pred)) {
+                    return true;
+                }
+                match &arm.node.body {
+                    MatchBody::Expr(value) => {
+                        if expr_has(&value.node, pred) {
+                            return true;
+                        }
+                    }
+                    MatchBody::Block(body) => {
+                        if any_expr_in_body_impl(body, pred) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            false
+        }
+        Expr::If(if_expr) => {
+            expr_has(&if_expr.condition.node, pred)
+                || any_expr_in_body_impl(&if_expr.then_body, pred)
+                || if_expr
+                    .else_body
+                    .as_ref()
+                    .is_some_and(|else_body| any_expr_in_body_impl(else_body, pred))
+        }
+        Expr::ListComp(comp) => {
+            expr_has(&comp.expr.node, pred)
+                || expr_has(&comp.iter.node, pred)
+                || comp.filter.as_ref().is_some_and(|filter| expr_has(&filter.node, pred))
+        }
+        Expr::DictComp(comp) => {
+            expr_has(&comp.key.node, pred)
+                || expr_has(&comp.value.node, pred)
+                || expr_has(&comp.iter.node, pred)
+                || comp.filter.as_ref().is_some_and(|filter| expr_has(&filter.node, pred))
+        }
+        Expr::Closure(params, body) => params_have_expr(params, pred) || expr_has(&body.node, pred),
+        Expr::Range { start, end, .. } => expr_has(&start.node, pred) || expr_has(&end.node, pred),
+        Expr::Surface(surface_expr) => match &surface_expr.payload {
+            crate::frontend::ast::SurfaceExprPayload::PrefixUnary(expr) => expr_has(&expr.node, pred),
+        },
+
+        // ---- Context: collection / interpolation expressions ----
+        Expr::Tuple(items) | Expr::List(items) | Expr::Set(items) => {
+            items.iter().any(|item| expr_has(&item.node, pred))
+        }
+        Expr::Dict(entries) => entries
+            .iter()
+            .any(|(key, value)| expr_has(&key.node, pred) || expr_has(&value.node, pred)),
+        Expr::FString(parts) => parts.iter().any(|part| match part {
+            crate::frontend::ast::FStringPart::Literal(_) => false,
+            crate::frontend::ast::FStringPart::Expr(expr) => expr_has(&expr.node, pred),
+        }),
+        Expr::Yield(Some(expr)) => expr_has(&expr.node, pred),
+        Expr::Yield(None) => false,
+    }
+}
+
+/// Checks a call argument expression for a match.
+fn call_arg_has_expr<F>(arg: &CallArg, pred: &mut F) -> bool
+where
+    F: FnMut(&Expr) -> bool,
+{
+    match arg {
+        CallArg::Positional(expr) | CallArg::Named(_, expr) => expr_has(&expr.node, pred),
+    }
+}

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -13,6 +13,7 @@
 pub use incan_syntax::{ast, diagnostics, lexer, parser};
 
 // Compiler-specific pieces remain local.
+pub(crate) mod ast_walk;
 pub mod decorator_resolution;
 pub mod library_exports;
 pub mod library_manifest_index;

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -229,6 +229,7 @@ Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer globally
 - **Docs**: Contributor docs now describe the registry-driven keyword path, including `incan-vocab`, parser `Ident` keyword handling, and generated VS Code grammar synchronization ([RFC 027]).
 - **Codegen**: String literals passed to external Rust type methods now emit `.into()` instead of `.to_string()`, letting the Rust compiler resolve custom string types (e.g. Polars' `PlSmallStr`) via the `Into` trait.
 - **Compiler**: MSRV bumped from 1.85 to 1.91 (required by the current compiler/runtime/tooling dependency set, including `wasmtime` 40.x and rust-analyzer metadata crates).
+- **Compiler/Tooling**: AST expression traversal for serde runtime detection and test-fixture teardown discovery is now centralized through a shared walker, closing false-negative gaps in contexts like `elif` branches and loop condition/iterator expressions (#123).
 
 ## Bugfixes
 


### PR DESCRIPTION
## Summary

This PR centralizes expression traversal into a shared frontend AST walker and refactors two drift-prone call sites to use it: serde runtime detection and fixture teardown (`yield`) discovery. The goal is to prevent silent false negatives when AST shape evolves, while keeping scope constrained to issue #123.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: serde requirement detection and fixture teardown detection now correctly catch expression placements that were previously missed (e.g., `if` conditions, `elif` bodies, `while` conditions, `for` iterators, and nested assignment-expression `yield`).
- **Internals**: adds `frontend::ast_walk::{any_expr_in_program, any_expr_in_body}` as the canonical traversal path, then removes ad-hoc recursion from `backend::ir::scanners::serde` and `cli::test_runner::discovery`.
- **Risks**: traversal centralization changes one shared path; regressions would affect multiple detectors. Added targeted tests to pin known missed contexts.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test serde_detection`
- `cargo test discover_fixture_with_teardown`
- `make fmt`
- `make pre-commit`
- `make smoke-test`
- `cd workspaces/docs-site && mkdocs build --strict`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_2.md` (bugfix bullet for centralized traversal and false-negative reduction)

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #123
