### PR TITLE
bugfix - enforce nominal trait conformance for explicit generic bounds (#299)

### DIFF
--- a/src/frontend/typechecker/check_expr/calls.rs
+++ b/src/frontend/typechecker/check_expr/calls.rs
@@ -920,6 +920,12 @@ impl TypeChecker {
         if is_rust_capability_bound(bound) {
             return true;
         }
+        // For non-builtin traits, apply nominal trait/supertrait compatibility (RFC 042) directly.
+        //
+        // This keeps capability checks language-general and avoids ad hoc receiver-category gating.
+        if builtin_traits::from_str(bound).is_none() && self.lookup_semantic_trait_info(bound).is_some() {
+            return self.type_satisfies_nominal_trait_bound(ty, bound);
+        }
         match ty {
             // Unknown / still-generic types are kept permissive to avoid cascading errors.
             ResolvedType::Unknown
@@ -959,6 +965,54 @@ impl TypeChecker {
             ResolvedType::Named(type_name) => self.named_type_satisfies_bound(type_name, bound),
             ResolvedType::Ref(inner) | ResolvedType::RefMut(inner) => self.type_satisfies_explicit_bound(inner, bound),
             ResolvedType::Function(_, _) | ResolvedType::SelfType => false,
+        }
+    }
+
+    /// Check whether `ty` satisfies a nominal trait bound `bound_trait` under RFC 042 semantics.
+    ///
+    /// This path is used for non-builtin traits. It intentionally reuses existing trait compatibility helpers:
+    /// - concrete adopters satisfy direct and transitive supertraits via `type_implements_trait`
+    /// - trait-typed values satisfy broader traits via `trait_is_supertrait_of`
+    fn type_satisfies_nominal_trait_bound(&self, ty: &ResolvedType, bound_trait: &str) -> bool {
+        match ty {
+            // Keep unknown / generic placeholders permissive to avoid cascading diagnostics.
+            ResolvedType::Unknown
+            | ResolvedType::TypeVar(_)
+            | ResolvedType::RustPath(_)
+            | ResolvedType::CallSiteInfer => true,
+            ResolvedType::Named(type_name) => {
+                if self.lookup_semantic_trait_info(type_name).is_some() {
+                    self.trait_is_supertrait_of(type_name, bound_trait)
+                } else {
+                    self.type_implements_trait(type_name, bound_trait)
+                }
+            }
+            ResolvedType::Generic(type_name, _args) => {
+                if self.lookup_semantic_trait_info(type_name).is_some() {
+                    self.trait_is_supertrait_of(type_name, bound_trait)
+                } else if self.lookup_semantic_type_info(type_name).is_some() {
+                    self.type_implements_trait(type_name, bound_trait)
+                } else {
+                    false
+                }
+            }
+            ResolvedType::Ref(inner) | ResolvedType::RefMut(inner) => {
+                self.type_satisfies_nominal_trait_bound(inner, bound_trait)
+            }
+            ResolvedType::Int
+            | ResolvedType::Float
+            | ResolvedType::Bool
+            | ResolvedType::Str
+            | ResolvedType::Bytes
+            | ResolvedType::FrozenStr
+            | ResolvedType::FrozenBytes
+            | ResolvedType::Unit
+            | ResolvedType::Tuple(_)
+            | ResolvedType::FrozenList(_)
+            | ResolvedType::FrozenSet(_)
+            | ResolvedType::FrozenDict(_, _)
+            | ResolvedType::Function(_, _)
+            | ResolvedType::SelfType => false,
         }
     }
 

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -5497,6 +5497,124 @@ def main() -> float:
 }
 
 #[test]
+fn test_explicit_trait_bound_accepts_transitive_supertrait_adopter() {
+    let source = r#"
+trait Capability:
+  def capability(self) -> int: ...
+
+trait Ordered with Capability:
+  def ordered(self) -> int: ...
+
+model Carrier with Ordered:
+  value: int
+
+  def capability(self) -> int:
+    return self.value
+
+  def ordered(self) -> int:
+    return self.value
+
+def require_capability[T with Capability](value: T) -> T:
+  return value
+
+def main() -> Carrier:
+  return require_capability(Carrier(value=1))
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_explicit_trait_bound_accepts_trait_typed_arguments() {
+    let source = r#"
+trait Capability:
+  def capability(self) -> int: ...
+
+trait Ordered with Capability:
+  def ordered(self) -> int: ...
+
+model Carrier with Ordered:
+  value: int
+
+  def capability(self) -> int:
+    return self.value
+
+  def ordered(self) -> int:
+    return self.value
+
+def as_ordered(value: Carrier) -> Ordered:
+  return value
+
+def require_capability[T with Capability](value: T) -> T:
+  return value
+
+def main() -> Ordered:
+  ordered = as_ordered(Carrier(value=1))
+  return require_capability(ordered)
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_method_generic_bound_accepts_transitive_capability_adopter() {
+    let source = r#"
+trait Capability:
+  def capability(self) -> int: ...
+
+trait Ordered with Capability:
+  def ordered(self) -> int: ...
+
+model Carrier with Ordered:
+  value: int
+
+  def capability(self) -> int:
+    return self.value
+
+  def ordered(self) -> int:
+    return self.value
+
+class Helpers:
+  @staticmethod
+  def require_capability[T with Capability](value: T) -> T:
+    return value
+
+def main() -> Carrier:
+  return Helpers.require_capability(Carrier(value=1))
+"#;
+    assert_check_ok(source);
+}
+
+#[test]
+fn test_explicit_trait_bound_rejects_missing_capability() {
+    let source = r#"
+trait Capability:
+  def capability(self) -> int: ...
+
+trait Other:
+  def other(self) -> int: ...
+
+model Plain with Other:
+  value: int
+
+  def other(self) -> int:
+    return self.value
+
+def require_capability[T with Capability](value: T) -> T:
+  return value
+
+def main() -> Plain:
+  return require_capability(Plain(value=1))
+"#;
+    let Err(errs) = check_str(source) else {
+        panic!("missing capability should fail explicit trait bound");
+    };
+    assert!(
+        errs.iter().any(|e| e.message.contains("violates generic bound")),
+        "Expected explicit generic bound error; got: {:?}",
+        errs.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_static_initializer_requires_earlier_static() {
     let source = r#"
 static SECOND: int = FIRST

--- a/tests/fixtures/invalid/capability_bound_missing.incn
+++ b/tests/fixtures/invalid/capability_bound_missing.incn
@@ -1,0 +1,21 @@
+trait Capability:
+    def capability(self) -> int: ...
+
+
+trait Other:
+    def other(self) -> int: ...
+
+
+model Plain with Other:
+    value: int
+
+    def other(self) -> int:
+        return self.value
+
+
+def require_capability[T with Capability](value: T) -> T:
+    return value
+
+
+def main() -> Plain:
+    return require_capability(Plain(value=1))

--- a/tests/fixtures/valid/capability_bound_transitive.incn
+++ b/tests/fixtures/valid/capability_bound_transitive.incn
@@ -1,0 +1,35 @@
+trait Capability:
+    def capability(self) -> int: ...
+
+
+trait Ordered with Capability:
+    def ordered(self) -> int: ...
+
+
+model Carrier with Ordered:
+    value: int
+
+    def capability(self) -> int:
+        return self.value
+
+    def ordered(self) -> int:
+        return self.value
+
+
+def require_capability[T with Capability](value: T) -> T:
+    return value
+
+
+class Helpers:
+    @staticmethod
+    def require_capability[T with Capability](value: T) -> T:
+        return value
+
+
+def as_ordered(value: Carrier) -> Ordered:
+    return value
+
+
+def main() -> Ordered:
+    ordered = as_ordered(Carrier(value=1))
+    return Helpers.require_capability(require_capability(ordered))

--- a/workspaces/docs-site/docs/language/reference/derives_and_traits.md
+++ b/workspaces/docs-site/docs/language/reference/derives_and_traits.md
@@ -311,6 +311,15 @@ Rules to keep in mind:
 - A value annotated as `Collection[int]` may be any concrete adopter of that trait instantiation.
 - Supertrait relationships are transitive: if `OrderedCollection[T]` adopts `Collection[T]`, adopters of `OrderedCollection[T]` also satisfy `Collection[T]`.
 
+When an operation should only be available for values with specific capabilities, express that constraint in the type system with generic bounds instead of selectively hiding inherited trait methods:
+
+```incan
+def require_ordering[T with OrderedCollection[int]](values: T) -> T:
+    return values
+```
+
+The compiler enforces these bounds at call sites using nominal trait conformance, including transitive supertrait relationships.
+
 ### `@requires(...)` (adopter contract)
 
 `@requires(...)` is a decorator you can put on a `trait` to declare **which adopter fields must exist** (and what types

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -230,6 +230,7 @@ Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer globally
 - **Codegen**: String literals passed to external Rust type methods now emit `.into()` instead of `.to_string()`, letting the Rust compiler resolve custom string types (e.g. Polars' `PlSmallStr`) via the `Into` trait.
 - **Compiler**: MSRV bumped from 1.85 to 1.91 (required by the current compiler/runtime/tooling dependency set, including `wasmtime` 40.x and rust-analyzer metadata crates).
 - **Compiler/Tooling**: AST expression traversal for serde runtime detection and test-fixture teardown discovery is now centralized through a shared walker, closing false-negative gaps in contexts like `elif` branches and loop condition/iterator expressions (#123).
+- **Compiler**: Explicit generic `with` bounds now use nominal trait conformance (including transitive supertraits and trait-typed arguments) for non-builtin trait capabilities, so capability-constrained APIs are enforced without receiver-name special-casing (#299).
 
 ## Bugfixes
 


### PR DESCRIPTION
## Summary

This PR fixes explicit generic `with` bound checking so non-builtin trait bounds are enforced using nominal trait conformance rather than direct name matching. This correctly accepts transitive supertrait adopters and trait-typed arguments while still rejecting missing-capability cases.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Capability-constrained APIs via explicit generic bounds now accept valid transitive/trait-typed cases and reject invalid adopters consistently.
- **Internals**: Typechecker bound validation now routes non-builtin trait checks through nominal trait compatibility helpers (`type_implements_trait` / `trait_is_supertrait_of`).
- **Risks**: Bound validation behavior changes at call sites; mitigated by new unit + integration fixtures.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Ran targeted tests for explicit and method-level generic bounds.
- Ran integration fixture suites (`test_valid_fixtures`, `test_invalid_fixtures`).
- Ran `make pre-commit` (tests, clippy, deny, smoke) with all green.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/derives_and_traits.md`, `workspaces/docs-site/docs/release_notes/0_2.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #299


