### PR TITLE
chore - finalize 0.2 rc0 release readiness (#349)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,9 +188,11 @@ instead of calling `process::exit` directly. This makes commands testable.
 
 ### Prelude Status
 
-The stdlib prelude (`stdlib/`) contains trait definitions but is not yet integrated into
-compilation. Derives like `Debug`, `Clone` work through
-codegen heuristics rather than actual trait implementations.
+The stdlib surface now compiles through the normal pipeline under `crates/incan_stdlib/stdlib/`.
+Source declarations are the primary contract for `std.*` modules, including the prelude-facing
+trait definitions. Some behavior is still realized by backend lowering or runtime bridges
+(for example derive-backed Rust traits and host-backed stdlib leaves), but the compiler no longer
+treats the stdlib as documentation-only stubs.
 
 ### Property-Based Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "clap",
  "hex",
@@ -1471,14 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,14 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "axum",
  "incan_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["target/incan"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0-dev.9"
+version = "0.2.0-rc0"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.91"

--- a/crates/incan_derive/README.md
+++ b/crates/incan_derive/README.md
@@ -72,6 +72,7 @@ assert_eq!(config.__class__(), "Config");
 Generates convenience methods for JSON serialization (requires `serde` derives):
 
 ```rust
+fn demo() -> Result<(), Box<dyn std::error::Error>> {
 #[derive(Serialize, Deserialize, IncanJson)]
 struct ApiResponse {
     status: i64,
@@ -81,7 +82,11 @@ struct ApiResponse {
 let response = ApiResponse { status: 200, message: "OK".into() };
 let json = response.to_json();           // Compact JSON string
 let pretty = response.to_json_pretty();  // Pretty-printed JSON
-let parsed = ApiResponse::from_json(&json).unwrap();
+let parsed = ApiResponse::from_json(&json)?;
+# let _ = pretty;
+# let _ = parsed;
+# Ok(())
+}
 ```
 
 **Incan equivalent**: `@derive(Serialize, Deserialize)` (JSON methods added automatically)

--- a/crates/incan_stdlib/src/version.rs
+++ b/crates/incan_stdlib/src/version.rs
@@ -7,7 +7,7 @@
 //! This module prevents that by providing a macro that the compiler emits into every generated `main.rs`:
 //!
 //! ```rust,ignore
-//! incan_stdlib::__incan_stdlib_version_check!("0.2.0-dev.0");
+//! incan_stdlib::__incan_stdlib_version_check!("0.2.0");
 //! ```
 //!
 //! The macro expands into a `const` assertion that compares the compiler version (baked in as a string literal) against

--- a/crates/incan_syntax/src/lib.rs
+++ b/crates/incan_syntax/src/lib.rs
@@ -10,10 +10,13 @@
 //! ## Examples
 //! ```rust,no_run
 //! use incan_syntax::{lexer, parser};
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!
-//! let tokens = lexer::lex("pass\n").unwrap();
-//! let program = parser::parse(&tokens).unwrap();
+//! let tokens = lexer::lex("pass\n")?;
+//! let program = parser::parse(&tokens)?;
 //! assert_eq!(program.declarations.len(), 1);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## See also

--- a/crates/incan_syntax/src/parser/mod.rs
+++ b/crates/incan_syntax/src/parser/mod.rs
@@ -6,11 +6,14 @@
 //!
 //! ```rust,no_run
 //! use incan_syntax::{lexer, parser};
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!
 //! let source = "def foo() -> int:\n    return 42\n";
-//! let tokens = lexer::lex(source).unwrap();
-//! let ast = parser::parse(&tokens).unwrap();
+//! let tokens = lexer::lex(source)?;
+//! let ast = parser::parse(&tokens)?;
 //! assert_eq!(ast.declarations.len(), 1);
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::ast::*;

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -12,6 +12,13 @@ mod tests {
         parse(&tokens)
     }
 
+    fn parse_str_err(source: &str, context: &str) -> Vec<CompileError> {
+        match parse_str(source) {
+            Err(errs) => errs,
+            Ok(_) => panic!("{context}"),
+        }
+    }
+
     fn parse_str_with_module_path(source: &str, module_path: Option<&str>) -> Result<Program, Vec<CompileError>> {
         let tokens = lexer::lex(source).map_err(|_| vec![])?;
         parse_with_module_path(&tokens, module_path)
@@ -1472,8 +1479,7 @@ def add(a: int, b: int) -> int:
     #[test]
     fn test_parse_from_import_parenthesized_unclosed_error() {
         let source = "from db import (CategoryId, TagId\n";
-        let result = parse_str(source);
-        let err = result.expect_err("Unclosed import list should produce a parse error");
+        let err = parse_str_err(source, "Unclosed import list should produce a parse error");
         assert!(
             err[0].message.contains(')') || err[0].message.to_lowercase().contains("close"),
             "Expected error to mention ')'; got: {}",
@@ -1485,8 +1491,7 @@ def add(a: int, b: int) -> int:
     #[test]
     fn test_parse_from_import_empty_parens_error() {
         let source = "from db import ()\n";
-        let result = parse_str(source);
-        let err = result.expect_err("Empty import list should produce a parse error");
+        let err = parse_str_err(source, "Empty import list should produce a parse error");
         assert!(
             err[0].message.to_lowercase().contains("empty") || err[0].message.to_lowercase().contains("cannot"),
             "Expected 'empty' diagnostic; got: {}",

--- a/examples/pro/vocab_routekit/consumer/incan.lock
+++ b/examples/pro/vocab_routekit/consumer/incan.lock
@@ -3,8 +3,8 @@
 
 [incan]
 format = 1
-incan-version = "0.2.0-dev.4"
-generated = "2026-03-16T11:50:32.159374Z"
+incan-version = "0.2.0-rc0"
+generated = "2026-04-17T13:58:13.594617Z"
 deps-fingerprint = "sha256:316bf142e6f8ea3b5838746eabec99c7e77d0acbcca01f8890c489b63498a743"
 cargo-features = []
 cargo-no-default-features = false
@@ -18,11 +18,14 @@ version = 4
 
 [[package]]
 name = "incan_core"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "incan_derive"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -31,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
 dependencies = [
  "incan_core",
  "incan_derive",
@@ -57,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "routekit_consumer"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
 dependencies = [
  "incan_derive",
  "incan_stdlib",
@@ -66,10 +69,40 @@ dependencies = [
 
 [[package]]
 name = "routekit_core"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
 dependencies = [
  "incan_derive",
  "incan_stdlib",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/pro/vocab_routekit/producer/incan.lock
+++ b/examples/pro/vocab_routekit/producer/incan.lock
@@ -3,8 +3,8 @@
 
 [incan]
 format = 1
-incan-version = "0.2.0-dev.4"
-generated = "2026-03-16T11:43:18.530644Z"
+incan-version = "0.2.0-rc0"
+generated = "2026-04-17T13:57:17.628202Z"
 deps-fingerprint = "sha256:17f122844d2fa1c9756f9a1976d222f15255557e74d975b8d8ff46536ea82b87"
 cargo-features = []
 cargo-no-default-features = false
@@ -18,11 +18,14 @@ version = 4
 
 [[package]]
 name = "incan_core"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "incan_derive"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -31,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
 dependencies = [
  "incan_core",
  "incan_derive",
@@ -57,10 +60,40 @@ dependencies = [
 
 [[package]]
 name = "routekit_core"
-version = "0.2.0-dev.4"
+version = "0.2.0-rc0"
 dependencies = [
  "incan_derive",
  "incan_stdlib",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -44,10 +44,13 @@ pub enum FormatError {
 ///
 /// ```
 /// use incan::format_source;
+/// # fn main() -> Result<(), incan::FormatError> {
 ///
 /// let source = "def add(a: int, b: int) -> int:\n    return a + b\n";
-/// let formatted = format_source(source).unwrap();
+/// let formatted = format_source(source)?;
 /// assert!(formatted.contains("def add"));
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Errors
@@ -65,11 +68,14 @@ pub fn format_source(source: &str) -> Result<String, FormatError> {
 ///
 /// ```
 /// use incan::{FormatConfig, format_source_with_config};
+/// # fn main() -> Result<(), incan::FormatError> {
 ///
 /// let config = FormatConfig::default();
 /// let source = "def greet(name: str) -> str:\n    return name\n";
-/// let formatted = format_source_with_config(source, config).unwrap();
+/// let formatted = format_source_with_config(source, config)?;
 /// assert!(formatted.contains("def greet"));
+/// # Ok(())
+/// # }
 /// ```
 pub fn format_source_with_config(source: &str, config: FormatConfig) -> Result<String, FormatError> {
     // Parse the source - formatter requires valid syntax
@@ -373,12 +379,15 @@ fn trim_trailing_blank_comment_lines(lines: &[String]) -> Vec<String> {
 ///
 /// ```
 /// use incan::check_formatted;
+/// # fn main() -> Result<(), incan::FormatError> {
 ///
 /// // Check returns a boolean (true = already formatted)
 /// let source = "def foo() -> int:\n    return 42\n";
-/// let is_formatted = check_formatted(source).unwrap();
+/// let is_formatted = check_formatted(source)?;
 /// // Result depends on exact formatting rules
 /// assert!(is_formatted == true || is_formatted == false);
+/// # Ok(())
+/// # }
 /// ```
 pub fn check_formatted(source: &str) -> Result<bool, FormatError> {
     let formatted = format_source(source)?;

--- a/src/frontend/library_manifest_index.rs
+++ b/src/frontend/library_manifest_index.rs
@@ -1124,9 +1124,10 @@ analytics = { path = "deps/analytics-lib" }
         let parsed = ProjectManifest::from_str(manifest_content, &consumer_manifest_path)?;
         let index = LibraryManifestIndex::from_project_manifest(&parsed);
 
-        let error = index
-            .merged_provider_required_dependencies()
-            .expect_err("expected conflicting provider dependency requirements");
+        let error = match index.merged_provider_required_dependencies() {
+            Err(error) => error,
+            Ok(_) => panic!("expected conflicting provider dependency requirements"),
+        };
         assert!(
             matches!(error, ProviderRequirementError::DependencyConflict { ref crate_name, .. } if crate_name == "serde_json"),
             "unexpected error: {error}"

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -32,6 +32,13 @@ fn check_str(source: &str) -> Result<(), Vec<CompileError>> {
     check(&ast)
 }
 
+fn check_str_err(source: &str, context: &str) -> Vec<CompileError> {
+    match check_str(source) {
+        Err(errs) => errs,
+        Ok(()) => panic!("{context}"),
+    }
+}
+
 fn check_str_with_library_index(source: &str, library_index: LibraryManifestIndex) -> Result<(), Vec<CompileError>> {
     let tokens = lexer::lex(source)?;
     let ast = parser::parse(&tokens)?;
@@ -474,7 +481,7 @@ def accept(f: (int) -> int) -> int:
 def main() -> None:
   _ = accept(id)
 "#;
-    let err = check_str(source).expect_err("generic function name in value position should fail");
+    let err = check_str_err(source, "generic function name in value position should fail");
     assert!(
         err.iter()
             .any(|e| e.message.contains("generic function") && e.message.contains("'id'")),
@@ -1972,7 +1979,7 @@ from std.async.time import sleep
 def foo() -> None:
   await sleep(1.0)
 "#;
-    let errs = check_str(source).expect_err("await in sync function should fail");
+    let errs = check_str_err(source, "await in sync function should fail");
     assert!(
         errs.iter()
             .any(|e| e.message.contains("await") && e.message.contains("async")),
@@ -1991,7 +1998,7 @@ model Widget:
   def work(self) -> None:
     await sleep(1.0)
 "#;
-    let errs = check_str(source).expect_err("await in sync method should fail");
+    let errs = check_str_err(source, "await in sync method should fail");
     assert!(
         errs.iter()
             .any(|e| e.message.contains("await") && e.message.contains("async")),
@@ -3884,7 +3891,7 @@ def main() -> int:
   let _x = T()
   return 0
 "#;
-    let err = check_str(source).expect_err("trait constructor should be rejected");
+    let err = check_str_err(source, "trait constructor should be rejected");
     assert!(
         err.iter().any(|e| e.message.contains("Cannot construct trait")),
         "unexpected errors: {:?}",
@@ -6282,7 +6289,7 @@ def id[T](x: T) -> T:
 def run() -> int:
   return id[int, str](1)
 "#;
-    let errs = check_str(source).expect_err("expected explicit type arg arity error");
+    let errs = check_str_err(source, "expected explicit type arg arity error");
     assert!(
         errs.iter()
             .any(|e| e.message.contains("expects 1 explicit type argument(s), got 2")),
@@ -6316,7 +6323,7 @@ def run() -> int:
   let b = Box()
   return b.get[int](str("x"))
 "#;
-    let errs = check_str(source).expect_err("expected explicit method type arg mismatch");
+    let errs = check_str_err(source, "expected explicit method type arg mismatch");
     assert!(
         errs.iter().any(|e| e.message.contains("expected 'int', found 'str'")),
         "expected type mismatch after explicit method type specialization, got {errs:?}"
@@ -6358,7 +6365,7 @@ def mystery[T]() -> int:
 def run() -> int:
   return mystery[_]()
 "#;
-    let errs = check_str(source).expect_err("expected inference unresolved when no value args bind T");
+    let errs = check_str_err(source, "expected inference unresolved when no value args bind T");
     assert!(
         errs.iter()
             .any(|e| e.message.contains("Could not infer type parameter")),
@@ -6372,7 +6379,7 @@ fn explicit_call_type_args_rejected_on_builtin_callee() {
 def run() -> int:
   return len[int]([1, 2])
 "#;
-    let errs = check_str(source).expect_err("expected unsupported explicit type args on builtin");
+    let errs = check_str_err(source, "expected unsupported explicit type args on builtin");
     assert!(
         errs.iter()
             .any(|e| e.message.contains("not supported for this call form")),
@@ -6390,7 +6397,7 @@ def run() -> int:
   let f = id
   return f[int](1)
 "#;
-    let errs = check_str(source).expect_err("expected unsupported explicit type args on indirect call");
+    let errs = check_str_err(source, "expected unsupported explicit type args on indirect call");
     assert!(
         errs.iter()
             .any(|e| e.message.contains("not supported for this call form")),

--- a/src/frontend/vocab_desugar_pass/helper_bindings.rs
+++ b/src/frontend/vocab_desugar_pass/helper_bindings.rs
@@ -355,7 +355,10 @@ mod tests {
             },
         )]));
 
-        let err = resolve_helper_binding(&index, "demo", "filter").expect_err("expected missing export rejection");
+        let err = match resolve_helper_binding(&index, "demo", "filter") {
+            Err(err) => err,
+            Ok(_) => panic!("expected missing export rejection"),
+        };
         assert!(err.contains("missing export `filter`"), "unexpected error: {err}");
         Ok(())
     }

--- a/src/frontend/vocab_desugar_pass/runtime.rs
+++ b/src/frontend/vocab_desugar_pass/runtime.rs
@@ -789,8 +789,10 @@ mod tests {
     #[test]
     fn rejects_parent_directory_artifact_escape() -> Result<(), Box<dyn std::error::Error>> {
         let root = tempfile::tempdir()?;
-        let err = resolve_desugarer_artifact_path(root.path(), "../escape.wasm", "route")
-            .expect_err("expected path traversal rejection");
+        let err = match resolve_desugarer_artifact_path(root.path(), "../escape.wasm", "route") {
+            Err(err) => err,
+            Ok(_) => panic!("expected path traversal rejection"),
+        };
         assert!(
             matches!(err, VocabDesugarPassError::Resolution { .. }),
             "unexpected error: {err}"
@@ -801,8 +803,10 @@ mod tests {
     #[test]
     fn rejects_current_directory_artifact_prefix() -> Result<(), Box<dyn std::error::Error>> {
         let root = tempfile::tempdir()?;
-        let err = resolve_desugarer_artifact_path(root.path(), "./escape.wasm", "route")
-            .expect_err("expected non-normalized relative path rejection");
+        let err = match resolve_desugarer_artifact_path(root.path(), "./escape.wasm", "route") {
+            Err(err) => err,
+            Ok(_) => panic!("expected non-normalized relative path rejection"),
+        };
         assert!(
             matches!(err, VocabDesugarPassError::Resolution { .. }),
             "unexpected error: {err}"
@@ -821,8 +825,10 @@ mod tests {
             error_ptr: 64,
             error_len: 0,
         };
-        let err =
-            validate_runtime_layout_values(Path::new("mock.wasm"), 128, layout).expect_err("expected invalid layout");
+        let err = match validate_runtime_layout_values(Path::new("mock.wasm"), 128, layout) {
+            Err(err) => err,
+            Ok(_) => panic!("expected invalid layout"),
+        };
         assert!(
             matches!(err, VocabDesugarPassError::InvalidRuntimeLayout { .. }),
             "unexpected error: {err}"
@@ -841,8 +847,10 @@ mod tests {
             error_ptr: 64,
             error_len: 0,
         };
-        let err = validate_runtime_layout_values(Path::new("mock.wasm"), 128, layout)
-            .expect_err("expected out-of-bounds layout");
+        let err = match validate_runtime_layout_values(Path::new("mock.wasm"), 128, layout) {
+            Err(err) => err,
+            Ok(_) => panic!("expected out-of-bounds layout"),
+        };
         assert!(
             matches!(err, VocabDesugarPassError::InvalidRuntimeLayout { .. }),
             "unexpected error: {err}"

--- a/tests/semantic_core_parity.rs
+++ b/tests/semantic_core_parity.rs
@@ -98,7 +98,10 @@ pub const E: float = 7 / 2    # div => float
     let err_src = r#"
 pub const Z: int = 1 / 0
 "#;
-    let errs = run_const_eval_snippet(err_src).unwrap_err();
+    let errs = match run_const_eval_snippet(err_src) {
+        Err(errs) => errs,
+        Ok(_) => panic!("expected a const-eval error for division by zero"),
+    };
     // Accept any const-eval error for division by zero (message text may differ from runtime panic string)
     assert!(
         !errs.is_empty(),

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/023_compilable_stdlib_and_rust_module_binding.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/023_compilable_stdlib_and_rust_module_binding.md
@@ -825,7 +825,7 @@ Re-baselining note: this closure definition intentionally avoids smuggling unrel
 - [x] `std.web` response builders: pure Incan where possible, `@rust.extern` for framework I/O.
 - [x] All stdlib `.incn` files with `@rust.extern` carry `rust.module()` directives.
 - [x] `std.async.*` behavior is runtime-backed via narrow `@rust.extern` leaves (no broad `fail_t` placeholder surface).
-    > Note: remaining closeout is concentrated in `std.async.select`; follow-up language/library work is now tracked by RFC 038 and RFC 039 rather than being hand-waved inside RFC 023.
+    > Note: remaining closeout is concentrated in the wrapper-style async modules (`std.async.task`, `std.async.sync`, `std.async.channel`, and `std.async.prelude`); `std.async.time` and `std.async.select` are already direct-interoperability modules.
 - [x] `StdlibModuleInfo` fallback mapping removed (or marked deprecated).
 
 ### Diagnostics checklist

--- a/workspaces/docs-site/docs/contributing/explanation/readable-maintainable-rust.md
+++ b/workspaces/docs-site/docs/contributing/explanation/readable-maintainable-rust.md
@@ -253,11 +253,9 @@ Note: MSRV is enforced via CI running build/test with a pinned toolchain.
 
 ---
 
-## Common Pitfalls & Anti-Patterns
+## Common Pitfalls & Anti-Patterns {#common-pitfalls-anti-patterns}
 
 ### Quick-reference
-
-<!-- markdownlint-disable MD013 -->
 
 |                  Instead of                   |                 Prefer                 |                                Why                                |
 | --------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------- |
@@ -272,14 +270,11 @@ Note: MSRV is enforced via CI running build/test with a pinned toolchain.
 | `Result<T, String>` in public APIs            | A typed error enum (`thiserror`)       | Stringly-typed errors are hard to match on and evolve             |
 | `Rc<RefCell<T>>` everywhere                   | Restructure data / ownership           | Usually signals a design that fights the borrow checker           |
 
-<!-- markdownlint-enable MD013 -->
-
 ### Detailed guidance
 
 #### Panics on recoverable paths
 
-Reserve `.unwrap()` and `.expect()` for cases where you can **prove** the value is always `Some`/`Ok` — and add a
-comment explaining the invariant. Everywhere else, propagate with `?`:
+In this repository, do **not** use `.unwrap()` or `.expect()` in compiler code, tests, or examples. Even when an invariant feels obvious, prefer `?`, an explicit `match`, or a helper that turns the failure into a typed error with context. The only accepted exception is emitting `.unwrap()` / `.expect()` as literal strings in generated Rust when that is the intended runtime contract of the compiled program.
 
 ```rust
 // Bad — panics with no context if the file is missing

--- a/workspaces/docs-site/docs/release_notes/0_2.md
+++ b/workspaces/docs-site/docs/release_notes/0_2.md
@@ -1,22 +1,153 @@
 # Release 0.2
 
-Incan 0.2 introduces **namespaced stdlib imports** and **namespaced decorators** under the `std.*` module tree ([RFC 022]). This is a breaking change to import syntax — all stdlib imports and decorators must now use their fully qualified paths.
+Incan 0.2 is the release where the language surface becomes more explicit, more modular, and much more serious about Rust interop.
 
-This release lays the groundwork for a cleaner stdlib architecture where the compiler knows less about domain-specific modules (web, testing, async) and the stdlib can grow without polluting the global namespace.
+The headline breaking change is that stdlib imports and decorators now live under the `std.*` namespace. That affects everyday code immediately, but it is not cosmetic churn. It is the release boundary that moves Incan away from a compiler with lots of baked-in domain knowledge and toward a language where web, testing, async, derives, and trait surfaces are authored and imported as named library modules.
 
-## Project Manifest Changes
+If you already know Python and Rust, the point of `0.2` is not to hide Rust from you. It is to give you a Python-shaped language with a clearer path into Rust crates, Rust types, and Rust-backed capabilities, while still treating borrowing and most Rust-specific mechanics as compiler concerns rather than user-facing bookkeeping.
 
-Incan 0.2 introduces a distinction between **Incan Library dependencies** and **Rust crate dependencies**. As a result, the dependency tables in `incan.toml` have been renamed to clarify their purpose:
+That same theme shows up across the rest of the release:
 
-- `[dependencies]` is now reserved for **Incan Library** dependencies.
-- `[rust-dependencies]` is the new table for **Rust crate** dependencies.
-- `[dev-dependencies]` is now `[rust-dev-dependencies]`.
+- projects can now distinguish Incan library dependencies from Rust crate dependencies in `incan.toml`
+- Rust interop is no longer just an escape hatch; it has a clearer authoring model, stronger docs, and much better compiler/runtime support
+- library projects can export public APIs for other Incan projects to consume
+- modules can now own runtime state through `static`
+- generic calls can now spell explicit call-site type arguments
+- the stdlib/compiler boundary is much cleaner than it was in `0.1`
 
-Using `[dependencies]` for Rust crates will now emit a helpful migration error pointing you to the correct table name.
+If you are migrating from `0.1`, focus on the migration section first. If you want the short version, most existing projects need three concrete updates:
 
-## Incan Libraries (Experimental)
+1. move stdlib imports and decorators to `std.*`
+2. rename Rust dependency tables in `incan.toml`
+3. add explicit `std.async` / `std.testing` imports in files that use those language surfaces
 
-This release introduces the foundation for **Incan Libraries** ([RFC 031]). You can now build an Incan project as a library that exports functions, models, classes, and constants for other Incan projects to consume.
+For the core reference material, start with [Imports and modules](../language/reference/imports_and_modules.md), the [standard library reference](../language/reference/stdlib/index.md), and the [language reference index](../language/reference/index.md).
+
+## What 0.2 is about
+
+The `0.1` line proved out the compiler, core language, and early tooling. `0.2` turns that into a more coherent platform:
+
+- the stdlib is no longer presented as a bag of magical global names
+- compiler features that used to feel special-cased are pushed toward import-driven library surfaces
+- the Rust boundary is more explicit: crate dependencies, `rust::` imports, `rusttype`, `interop:` adapters, and trait/capability-oriented interop all fit together better than they did in `0.1`
+- projects now have a clearer dependency model and a first real story for sharing Incan code across repositories
+- the language picks up a few missing “this should just exist” capabilities such as `static`, list concatenation, list extension, and explicit call-site generic arguments
+
+This is still an incremental release rather than a final shape. Libraries are explicitly experimental, some runtime/library edges are still being refined, and `0.3` will continue improving ownership ergonomics and generated-runtime behavior. But `0.2` does make the language and tooling feel more coherent than `0.1`.
+
+If you want the broader conceptual backdrop, the best follow-up pages are [Imports and modules](../language/explanation/imports_and_modules.md), [Static storage](../language/explanation/static_storage.md), [Derives and traits](../language/explanation/derives_and_traits.md), and [How Incan works](../language/explanation/how_incan_works.md).
+
+## Migrating from 0.1
+
+Use this when moving a `0.1` codebase to `0.2`.
+
+### 1. Move stdlib imports to `std.*`
+
+All stdlib imports move from bare module names to the `std.*` namespace:
+
+```incan
+# Before (0.1)
+from web import App, Response, Json
+from testing import assert_eq, assert_ne
+
+# After (0.2)
+from std.web import App, Response, Json
+from std.testing import assert_eq, assert_ne
+```
+
+This also applies to async modules:
+
+```incan
+# Before (0.1)
+from async.time import sleep
+
+# After (0.2)
+from std.async.time import sleep
+```
+
+Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer implicitly available. Import them from `std.web` in each file that uses them.
+
+See also: [Imports and modules (reference)](../language/reference/imports_and_modules.md), [Stdlib index](../language/reference/stdlib/index.md)
+
+### 2. Move decorators onto their namespaced modules
+
+Decorators now resolve by module path rather than as ambient global names. The preferred style is to import the decorator and use the short local name:
+
+```incan
+from std.web.routing import route
+
+@route("/hello")
+async def hello() -> str:
+    return "Hello!"
+```
+
+The canonical fully qualified path also works:
+
+```incan
+@std.web.routing.route("/hello")
+async def hello() -> str:
+    return "Hello!"
+```
+
+The same rule applies to testing markers:
+
+```incan
+import std.testing as testing
+
+@testing.skip("not implemented")
+def test_future() -> None:
+    pass
+```
+
+`@skip`, `@xfail`, `@slow`, `@fixture`, and `@parametrize` are test-runner metadata from `std.testing`. They are not runtime function calls.
+
+See also: [std.testing (reference)](../language/reference/stdlib/testing.md), [Testing with the stdlib](../language/how-to/testing_stdlib.md)
+
+### 3. Split Incan dependencies from Rust dependencies
+
+`0.2` separates **Incan Library** dependencies from **Rust crate** dependencies in `incan.toml`:
+
+- `[dependencies]` is now for Incan libraries
+- `[rust-dependencies]` is for Rust crates
+- `[rust-dev-dependencies]` replaces `[dev-dependencies]` for Rust dev crates
+
+If you leave Rust crates under `[dependencies]`, the CLI emits a targeted migration error instead of silently accepting the old structure.
+
+This is also the release where the Rust boundary becomes easier to understand as a system: Rust crates belong in manifest-level Rust dependency tables, while Incan code imports them through `from rust import ...` / `from rust::... import ...` and can describe wrapped Rust types with `rusttype`.
+
+See also: [Rust interop](../language/how-to/rust_interop.md), [Understanding Rust types (coming from Python)](../language/how-to/rust_types_for_python_devs.md)
+
+### 4. Import `std.async` and `std.testing` in the files that use them
+
+`async` / `await` and `assert` are import-activated surfaces in `0.2`.
+
+If a file uses async syntax, import `std.async` or one of its submodules in that same file. If a file uses the `assert` statement or testing decorators, import `std.testing` in that file as well.
+
+See also: [Async programming](../language/how-to/async_programming.md), [std.async (reference)](../language/reference/stdlib/async.md)
+
+### 5. Avoid reserved namespace names
+
+`std` and `rust` are now reserved at module scope and can no longer be used as declaration names.
+
+## What 0.2 delivers
+
+### A namespaced, source-authored stdlib
+
+The most important architectural change in `0.2` is that stdlib features are now presented as explicit modules instead of ambient compiler surface. Web, testing, async, derives, traits, and related surfaces are increasingly defined through ordinary stdlib modules and metadata rather than bespoke compiler branches. That gives users a more readable import story and gives contributors a cleaner place to evolve the standard library.
+
+For the new stdlib surface, start with [std.* module reference](../language/reference/stdlib/index.md), [std.testing](../language/reference/stdlib/testing.md), [std.async](../language/reference/stdlib/async.md), [std.traits](../language/reference/stdlib/traits.md), and [std.derives](../language/reference/stdlib/derives.md).
+
+### A much stronger Rust interop story
+
+If `0.1` established that Incan could talk to Rust, `0.2` is the release where that boundary becomes much more usable in practice.
+
+You can now describe Rust-backed types more directly, declare Rust crate dependencies more clearly, import Rust items with better diagnostics, carry more borrowed-type information through the pipeline, and rely on much stronger docs for `rusttype`, `interop:` adapters, coercions, and capability-oriented generic bounds. That matters because Rust interop is not a niche escape hatch in Incan; it is part of the main workflow for real projects.
+
+For that part of the release, start with [Rust interop](../language/how-to/rust_interop.md), [Understanding Rust types (coming from Python)](../language/how-to/rust_types_for_python_devs.md), [Traits and derives reference](../language/reference/derives_and_traits.md), and [std.traits](../language/reference/stdlib/traits.md).
+
+### Incan Libraries (Experimental)
+
+`0.2` introduces the first cut of **Incan Libraries**. You can now build an Incan project as a library and consume its public API from another Incan project. The current scope is intentionally conservative, but it is the first real answer to “how do I share Incan code across projects?”
 
 ### Building a library
 
@@ -44,11 +175,13 @@ def main() -> None:
     my_function()
 ```
 
-This feature is in its early stages and currently supports local path dependencies. Further enhancements to the library system are planned for future releases.
+Library support is still early. The current release is built around local path dependencies and public API manifests, not a full package ecosystem.
+
+For adjacent docs, the best starting points are [Imports and modules](../language/reference/imports_and_modules.md) and [Build your first API](../language/tutorials/build_your_first_api.md), which show the project/module organization style `0.2` now leans into.
 
 ## Module Static Storage
 
-Incan 0.2 introduces a new top-level declaration form: `static` ([RFC 052], #242).
+`0.2` adds a new top-level declaration form: `static` ([RFC 052], #242).
 
 Use `static` when a module needs one live storage cell that persists across calls, for example counters, registries, caches, or shared mutable collections.
 
@@ -76,106 +209,19 @@ def main() -> None:
     println(hits)  # reads the current live value
 ```
 
+See also: [Static storage (reference)](../language/reference/static_storage.md), [Module state](../language/how-to/module_state.md), [Static storage (explanation)](../language/explanation/static_storage.md)
+
 ## Call-site type arguments ([RFC 054], #266) {#call-site-type-arguments}
 
-Calls and method calls may supply generic type arguments in brackets immediately before the value argument list, for example `id[int](1)` or `box.get[int](1)`. The `_` placeholder stands for a type parameter position that should still be inferred from value arguments (for example `pair_map[int, _](1, 2)`). If you use explicit brackets on a call form the compiler does not support, you now get a clear error instead of the arguments being ignored. See [Call-site type arguments](../language/reference/derives_and_traits.md#call-site-type-arguments) in the language reference for the normative rules and examples.
+Calls and method calls may now supply explicit generic type arguments in brackets immediately before the value argument list, for example `id[int](1)` or `box.get[int](1)`. The `_` placeholder still allows inference for selected positions, so forms like `pair_map[int, _](1, 2)` remain concise. Unsupported call forms now fail clearly instead of silently ignoring explicit brackets. See [Call-site type arguments](../language/reference/derives_and_traits.md#call-site-type-arguments) for the full rules and examples.
 
-## Migrating from 0.1
+## Other v0.2 features
 
-Use this checklist when moving a 0.1 codebase to 0.2.
-
-### Import paths
-
-All stdlib imports move from bare module names to the `std.*` namespace:
-
-```incan
-# Before (0.1)
-from web import App, Response, Json
-from testing import assert_eq, assert_ne
-
-# After (0.2)
-from std.web import App, Response, Json
-from std.testing import assert_eq, assert_ne
-```
-
-This also applies to async modules:
-
-```incan
-# Before (0.1)
-from async.time import sleep
-
-# After (0.2)
-from std.async.time import sleep
-```
-
-### Decorators
-
-Decorators are now resolved by their fully qualified module path. Use an explicit import or a canonical path:
-
-```incan
-# Import and use short name (preferred)
-from std.web.routing import route
-
-@route("/hello")
-async def hello() -> str:
-    return "Hello!"
-```
-
-```incan
-# Canonical path (also works)
-@std.web.routing.route("/hello")
-async def hello() -> str:
-    return "Hello!"
-```
-
-Testing decorators follow the same rule:
-
-```incan
-# Canonical path
-@std.testing.skip("not implemented")
-def test_future() -> None:
-    pass
-```
-
-Or with an alias:
-
-```incan
-import std.web.routing as routing
-
-@routing.route("/hello")
-async def hello() -> str:
-    return "Hello!"
-```
-
-and:
-
-```incan
-import std.testing as testing
-
-@testing.skip("not implemented")
-def test_future() -> None:
-    pass
-```
-
-### Soft keyword activation
-
-`async`/`await` keywords are activated per file through stdlib imports.
-
-If a file uses async syntax, import `std.async` (or a submodule like `std.async.time`) in that same file.
-
-### Stdlib types require explicit imports
-
-Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer globally available — import them from `std.web`. The compiler will suggest the correct import if you use a stdlib type without importing it.
-
-### Testing markers are runner metadata
-
-`@skip`, `@xfail`, `@slow`, `@fixture`, and `@parametrize` are consumed by `incan test` from `std.testing` metadata. They are not intended as runtime function calls.
-
-### Reserved names
-
-`std` and `rust` are now reserved at the module level and cannot be used as declaration names.
+Other `0.2` areas that are worth reading directly in the docs are [Rust interop](../language/how-to/rust_interop.md), [Reflection](../language/reference/stdlib/reflection.md), [Traits and derives](../language/reference/derives_and_traits.md), [book chapter: modules and imports](../language/tutorials/book/05_modules_and_imports.md), and [book chapter: traits and derives](../language/tutorials/book/11_traits_and_derives.md).
 
 ## Features and Enhancements
+
+The sections above are the release story. The list below is the detailed inventory of language, compiler, runtime, tooling, and docs changes that shipped in `0.2`.
 
 - **Compiler**: Namespaced stdlib imports under `std.*` — all stdlib modules use qualified paths ([RFC 022]).
 - **Compiler**: New `static` keyword for module-owned runtime state, plus `pub static` exports through library manifests and `pub::` imports ([RFC 052], #242). See [Module Static Storage](#module-static-storage).
@@ -190,7 +236,7 @@ Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer globally
 - **Compiler**: Namespaced decorator resolution — decorators resolved by module path (e.g., `from std.web.routing import route` enables `@route(...)`) with alias support ([RFC 022]).
 - **Compiler**: `@rust.extern` marker for Rust-backed function stubs, replacing the internal `@std.builtin` decorator ([RFC 022], [RFC 023]).
 - **Compiler**: `@staticmethod` decorator for type-scoped methods with no `self` receiver, available on `class`, `model`, and `newtype` declarations. Required for `@rust.extern` methods on types (instance delegation is not supported).
-- **Testing**: `std.testing` is now surface-first: assertion and marker-facing API is declared in `crates/incan_stdlib/stdlib/testing.incn`; runtime-backed helpers are kept only where required for semantics. `fail_t` remains the panic host boundary, marker functions keep metadata-backed runtime entry points, and `assert_raises` is tracked as a known blocker until parser-level `assert ... raises ...` support is available. (#302)
+- **Testing**: `std.testing` is now surface-first: assertion and marker-facing API is defined in ordinary stdlib source, while runtime-backed helpers are kept only where required for semantics. `fail_t` remains the panic host boundary, marker functions keep metadata-backed runtime entry points, and `assert_raises` is tracked as a known blocker until parser-level `assert <expr> raises <Type>` support and panic payload capture are both implemented. (#302)
 - **Runtime / Compiler**: `std.serde.json.Serialize` now provides a source-defined default `to_json()` path for explicit `with Serialize` adopters, while lowering forwards that trait adoption into the matching Rust `serde::Serialize` derive so the direct-interop body compiles honestly. `Deserialize.from_json()` remains the irreducible host boundary for now. (#303)
 - **Compiler / Stdlib**: `std.reflection` now typechecks `__class_name__()` and `__fields__()` against their real surface types (`str` and `FrozenList[FieldInfo]`) instead of backend-only unknown fallbacks. Plain reflection use no longer requires importing `FieldInfo`; explicit type annotations still do. (#304)
 - **Compiler / Stdlib**: `std.derives.{comparison,copying,string}` no longer model derive-provided methods as `rust.module()` helper shims. These traits now live as source-defined capability contracts, while codegen continues to realize `@derive(...)` through ordinary Rust derive attributes on the adopting type. (#305)
@@ -226,7 +272,7 @@ Types like `App`, `Response`, `Html`, `Json`, and `Query` are no longer globally
 - **Tooling**: `incan init` scaffolds a full project: `src/main.incn`, `tests/test_main.incn`, and `incan.toml` with `[project.scripts] main` set ([RFC 015]).
 - **Tooling**: `incan lock` generates `incan.lock` for reproducible builds; `--locked` and `--frozen` flags enforce lock freshness in CI ([RFC 013]).
 - **Tooling**: Test runner resolves imports against the project source root, enabling tests to import directly from source modules (e.g., `from greet import greet`) without duplication ([RFC 015]).
-- **Tooling**: Test marker semantics (`@skip`, `@xfail`, `@slow`, `@fixture`, `@parametrize`) are derived from `std.testing` metadata in `crates/incan_stdlib/stdlib/testing.incn` instead of brittle string/path hardcoding ([RFC 023]).
+- **Tooling**: Test marker semantics (`@skip`, `@xfail`, `@slow`, `@fixture`, `@parametrize`) are derived from `std.testing` metadata instead of brittle string/path hardcoding ([RFC 023]).
 - **Parser**: `async` is allowed as a module path segment in imports (e.g., `from std.async.time import sleep`).
 - **Diagnostics**: Clearer error messages for unknown decorators and reserved namespace violations.
 - **Diagnostics**: Enhanced lock-out-of-date error with expected vs actual fingerprint for easier debugging.


### PR DESCRIPTION
## Summary

This PR turns `#349` into a real `0.2` release-readiness sweep. It tightens contributor-facing panic-policy docs and examples, removes remaining `expect_err` / `unwrap_err` drift from tests, rewrites the `0.2` release notes into a coherent narrative with clearer migration guidance and stronger Rust-interop emphasis, and bumps the workspace from `0.2.0-dev.9` to `0.2.0-rc0` while refreshing the committed example lockfiles to match.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: The visible release change is the `0.2.0-rc0` version bump and a much clearer `0.2` release note that now explains the release story, migration path, docs map, and Rust-interop emphasis instead of reading like a stitched changelog. The committed example `incan.lock` files also now reflect the current compiler version.
- **Internals**: Contributor-facing docs now align with the repo-wide no-`unwrap` / no-`expect` rule for compiler code, tests, and examples. Remaining `expect_err` / `unwrap_err` test call sites were rewritten to explicit `match`-based error assertions. The RFC 023 closeout note and stale prelude wording in `CONTRIBUTING.md` were corrected to match the current codebase.
- **Risks**: This PR is intentionally broad but shallow: docs, tests, and version surfaces move together. The main risk is release-surface drift, especially around versioning or lockfiles, which is why the branch includes the version bump, example lock regeneration, and full release gate verification together.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Ran `make pre-commit` successfully on the final `0.2.0-rc0` tree.
- Verified the full gate passed, including tests, clippy, cargo-deny, examples, and `smoke-test-fast`.
- Ran `mkdocs build --strict` successfully after the release-note rewrite and docs consistency changes.
- Verified `cargo run --quiet --bin incan -- --version` reports `incan 0.2.0-rc0`.
- Rebuilt and relocked the committed `vocab_routekit` example manifests so they no longer drift from the workspace version.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_2.md`
- Link(s): `workspaces/docs-site/docs/contributing/explanation/readable-maintainable-rust.md`
- Link(s): `workspaces/docs-site/docs/RFCs/closed/implemented/023_compilable_stdlib_and_rust_module_binding.md`
- Link(s): `CONTRIBUTING.md`
- Link(s): `crates/incan_derive/README.md`
- Link(s): `crates/incan_syntax/src/lib.rs`
- Link(s): `crates/incan_syntax/src/parser/mod.rs`
- Link(s): `src/format/mod.rs`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #349
