### PR TITLE
bugfix - fix rc2 const-static reads and std.math overflow (#359)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "clap",
  "hex",
@@ -1471,14 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,14 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "axum",
  "incan_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["target/incan"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.91"

--- a/crates/incan_core/src/lang/stdlib.rs
+++ b/crates/incan_core/src/lang/stdlib.rs
@@ -150,16 +150,10 @@ pub const STDLIB_NAMESPACES: &[StdlibNamespace] = &[
     StdlibNamespace {
         name: "math",
         feature: None,
-        extra_crate_deps: &[
-            StdlibExtraCrateDep {
-                crate_name: "libm",
-                source: StdlibExtraCrateSource::Version("0.2"),
-            },
-            StdlibExtraCrateDep {
-                crate_name: "num-integer",
-                source: StdlibExtraCrateSource::Version("0.1"),
-            },
-        ],
+        extra_crate_deps: &[StdlibExtraCrateDep {
+            crate_name: "libm",
+            source: StdlibExtraCrateSource::Version("0.2"),
+        }],
         submodules: &[],
         typechecker_only: false,
     },

--- a/crates/incan_stdlib/src/num.rs
+++ b/crates/incan_stdlib/src/num.rs
@@ -34,7 +34,7 @@
 /// assert_eq!(py_floor_div_i64(7, -3), -3); // Rust would give -2
 /// assert_eq!(py_floor_div_i64(-7, -3), 2);
 /// ```
-use crate::errors::raise_zero_division;
+use crate::errors::{raise_value_error, raise_zero_division};
 
 // --- Numeric kernels (hot) ---------------------------------------------------------------------
 //
@@ -85,6 +85,38 @@ fn py_mod_f64_impl(a: f64, b: f64) -> f64 {
         r + b
     } else {
         r
+    }
+}
+
+#[inline]
+fn gcd_u64_impl(mut m: u64, mut n: u64) -> u64 {
+    if m == 0 || n == 0 {
+        return m | n;
+    }
+
+    let shift = (m | n).trailing_zeros();
+
+    m >>= m.trailing_zeros();
+    n >>= n.trailing_zeros();
+
+    while m != n {
+        if m > n {
+            m -= n;
+            m >>= m.trailing_zeros();
+        } else {
+            n -= m;
+            n >>= n.trailing_zeros();
+        }
+    }
+
+    m << shift
+}
+
+#[inline]
+fn non_negative_i64_or_overflow(value: u64, fn_name: &str) -> i64 {
+    match i64::try_from(value) {
+        Ok(value) => value,
+        Err(_) => raise_value_error(&format!("{fn_name} result overflows Incan int")),
     }
 }
 
@@ -441,6 +473,38 @@ pub fn py_mod_f64(a: f64, b: f64) -> f64 {
     py_mod_f64_impl(a, b)
 }
 
+/// Greatest common divisor for signed 64-bit integers.
+///
+/// The result is always non-negative and matches Python's `math.gcd` behavior for `int` when it
+/// fits in Incan's signed 64-bit `int`.
+///
+/// ## Panics
+///
+/// Raises `ValueError` if the mathematical result exceeds `i64::MAX`.
+#[inline]
+pub fn gcd_i64(a: i64, b: i64) -> i64 {
+    non_negative_i64_or_overflow(gcd_u64_impl(a.unsigned_abs(), b.unsigned_abs()), "math.gcd")
+}
+
+/// Lowest common multiple for signed 64-bit integers.
+///
+/// Returns `0` if either input is `0`.
+///
+/// ## Panics
+///
+/// Raises `ValueError` if the mathematical result exceeds `i64::MAX`.
+#[inline]
+pub fn lcm_i64(a: i64, b: i64) -> i64 {
+    if a == 0 || b == 0 {
+        return 0;
+    }
+    let gcd = gcd_u64_impl(a.unsigned_abs(), b.unsigned_abs());
+    let lcm = (a.unsigned_abs() / gcd)
+        .checked_mul(b.unsigned_abs())
+        .unwrap_or_else(|| raise_value_error("math.lcm result overflows Incan int"));
+    non_negative_i64_or_overflow(lcm, "math.lcm")
+}
+
 // --- Tests -------------------------------------------------------------------------------------
 
 #[cfg(test)]
@@ -517,6 +581,60 @@ mod tests {
         assert!(approx_eq(py_mod(7_i64, 3.0_f64), 1.0));
         assert!(approx_eq(py_mod(7.0_f64, 3_i64), 1.0));
         assert!(approx_eq(py_mod(7.0_f64, 3.0_f64), 1.0));
+    }
+
+    #[test]
+    fn test_gcd_i64_matches_python_shape() {
+        assert_eq!(gcd_i64(54, 24), 6);
+        assert_eq!(gcd_i64(-54, 24), 6);
+        assert_eq!(gcd_i64(54, -24), 6);
+        assert_eq!(gcd_i64(0, 24), 24);
+        assert_eq!(gcd_i64(0, 0), 0);
+    }
+
+    #[test]
+    fn test_lcm_i64_matches_python_shape() {
+        assert_eq!(lcm_i64(6, 8), 24);
+        assert_eq!(lcm_i64(-6, 8), 24);
+        assert_eq!(lcm_i64(6, -8), 24);
+        assert_eq!(lcm_i64(0, 8), 0);
+        assert_eq!(lcm_i64(0, 0), 0);
+    }
+
+    #[test]
+    fn test_gcd_i64_reports_unrepresentable_result() {
+        let result = std::panic::catch_unwind(|| gcd_i64(i64::MIN, 0));
+        let panic = match result {
+            Ok(_) => panic!("expected overflow panic"),
+            Err(panic) => panic,
+        };
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&'static str>().copied())
+            .unwrap_or("<non-string panic>");
+        assert!(
+            message.contains("ValueError: math.gcd result overflows Incan int"),
+            "unexpected panic message: {message}"
+        );
+    }
+
+    #[test]
+    fn test_lcm_i64_reports_unrepresentable_result() {
+        let result = std::panic::catch_unwind(|| lcm_i64(i64::MIN, 1));
+        let panic = match result {
+            Ok(_) => panic!("expected overflow panic"),
+            Err(panic) => panic,
+        };
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&'static str>().copied())
+            .unwrap_or("<non-string panic>");
+        assert!(
+            message.contains("ValueError: math.lcm result overflows Incan int"),
+            "unexpected panic message: {message}"
+        );
     }
 
     #[test]

--- a/crates/incan_stdlib/stdlib/math.incn
+++ b/crates/incan_stdlib/stdlib/math.incn
@@ -21,6 +21,9 @@ Integer:
   math.gcd(a, b)  - Greatest common divisor
   math.lcm(a, b)  - Lowest common multiple
 
+Integer notes:
+  gcd/lcm raise ValueError if the mathematical result exceeds Incan's signed 64-bit int range
+
 Basic:
   math.sqrt(x)    - Square root
   math.abs(x)     - Absolute value
@@ -54,7 +57,7 @@ Geometry:
 
 from rust::std::f64::consts import PI as RUST_PI, E as RUST_E, TAU as RUST_TAU
 from rust::std::f64 import INFINITY as RUST_INFINITY, NAN as RUST_NAN
-from rust::num_integer import gcd as rust_gcd, lcm as rust_lcm
+from rust::incan_stdlib::num import gcd_i64 as rust_gcd, lcm_i64 as rust_lcm
 from rust::libm import (
     sqrt as rust_sqrt,
     fabs as rust_abs,

--- a/examples/pro/vocab_routekit/consumer/incan.lock
+++ b/examples/pro/vocab_routekit/consumer/incan.lock
@@ -3,7 +3,7 @@
 
 [incan]
 format = 1
-incan-version = "0.2.0-rc1"
+incan-version = "0.2.0-rc2"
 generated = "2026-04-17T13:58:13.594617Z"
 deps-fingerprint = "sha256:316bf142e6f8ea3b5838746eabec99c7e77d0acbcca01f8890c489b63498a743"
 cargo-features = []
@@ -18,14 +18,14 @@ version = 4
 
 [[package]]
 name = "incan_core"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "incan_core",
  "incan_derive",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "routekit_consumer"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "incan_derive",
  "incan_stdlib",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "routekit_core"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "incan_derive",
  "incan_stdlib",

--- a/examples/pro/vocab_routekit/producer/incan.lock
+++ b/examples/pro/vocab_routekit/producer/incan.lock
@@ -3,7 +3,7 @@
 
 [incan]
 format = 1
-incan-version = "0.2.0-rc1"
+incan-version = "0.2.0-rc2"
 generated = "2026-04-17T13:57:17.628202Z"
 deps-fingerprint = "sha256:17f122844d2fa1c9756f9a1976d222f15255557e74d975b8d8ff46536ea82b87"
 cargo-features = []
@@ -18,14 +18,14 @@ version = 4
 
 [[package]]
 name = "incan_core"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "incan_core",
  "incan_derive",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "routekit_core"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 dependencies = [
  "incan_derive",
  "incan_stdlib",

--- a/src/backend/ir/conversions.rs
+++ b/src/backend/ir/conversions.rs
@@ -309,7 +309,7 @@ fn emit_binop_token(op: &BinOp) -> TokenStream {
 /// Determine a BinOpPlan: conversions + emit strategy in one place.
 pub fn determine_binop_plan(op: &BinOp, left: &TypedExpr, right: &TypedExpr) -> BinOpPlan {
     let is_stringish = |ty: &IrType| match ty {
-        IrType::String => true,
+        IrType::String | IrType::StaticStr | IrType::StrRef | IrType::FrozenStr => true,
         IrType::Ref(inner) | IrType::RefMut(inner) => matches!(inner.as_ref(), IrType::String),
         _ => false,
     };
@@ -492,11 +492,25 @@ pub fn determine_conversion(expr: &IrExpr, target_ty: Option<&IrType>, context: 
             match (&expr.kind, target_ty) {
                 // String literal to String param → .to_string()
                 (IrExprKind::String(_), Some(IrType::String)) => Conversion::ToString,
+                // Static const reads still represent Incan `str` at ordinary call sites.
+                (IrExprKind::StaticRead { .. }, Some(IrType::String | IrType::Generic(_)))
+                    if matches!(expr.ty, IrType::StaticStr) =>
+                {
+                    Conversion::ToString
+                }
+                (IrExprKind::StaticRead { .. }, None) if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
+                // Const `str` values lower as `&'static str` but still follow Incan owned-string semantics at call
+                // sites.
+                (_, Some(IrType::String)) if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
                 // String literal to generic type param (e.g. assert_eq[T]) → owned String.
                 // Typechecker constrains `T`; this keeps Incan `str` semantics in generic calls.
                 (IrExprKind::String(_), Some(IrType::Generic(_))) => Conversion::ToString,
+                // Generic `T` instantiated with Incan `str` must still materialize to owned `String`.
+                (_, Some(IrType::Generic(_))) if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
                 // String literal with unknown target (enum variants, etc.) → .to_string()
                 (IrExprKind::String(_), None) => Conversion::ToString,
+                // Const `str` values need the same owned-string materialization when the target is inferred.
+                (_, None) if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
 
                 // Vec<&str> to Vec<String> - check before generic variable handling
                 (_, Some(IrType::List(elem))) if matches!(elem.as_ref(), IrType::String) => {
@@ -541,6 +555,9 @@ pub fn determine_conversion(expr: &IrExpr, target_ty: Option<&IrType>, context: 
             match (&expr.kind, target_ty) {
                 // String literal → .to_string()
                 (IrExprKind::String(_), _) => Conversion::ToString,
+                (IrExprKind::StaticRead { .. }, _) if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
+                // Const `str` values remain owned `str` at the Incan surface even inside return-context calls.
+                (_, _) if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
 
                 // String variable to String param:
                 // - last-use read can move ownership directly
@@ -578,6 +595,8 @@ pub fn determine_conversion(expr: &IrExpr, target_ty: Option<&IrType>, context: 
             match &expr.kind {
                 // String literals → .into() (works for String, &str, PlSmallStr, and any From<&str>)
                 IrExprKind::String(_) => Conversion::Into, // String variables → borrow for external calls (&str param)
+                IrExprKind::StaticRead { .. } if matches!(expr.ty, IrType::StaticStr) => Conversion::Into,
+                IrExprKind::Var { .. } if matches!(expr.ty, IrType::StaticStr) => Conversion::Into,
                 IrExprKind::Var { .. } if matches!(expr.ty, IrType::String) => Conversion::Borrow,
                 // Rust adapter leaves commonly accept borrowed handles (`&Sender<T>`, `&Mutex<T>`, ...).
                 // When the frontend cannot surface an explicit `&T` parameter type for inline Rust imports,
@@ -594,6 +613,7 @@ pub fn determine_conversion(expr: &IrExpr, target_ty: Option<&IrType>, context: 
             // Struct fields are always owned
             match &expr.kind {
                 IrExprKind::String(_) => Conversion::ToString,
+                _ if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
                 _ => Conversion::None,
             }
         }
@@ -608,6 +628,12 @@ pub fn determine_conversion(expr: &IrExpr, target_ty: Option<&IrType>, context: 
             match (&expr.kind, target_ty) {
                 // String literal assigned to String variable → .to_string()
                 (IrExprKind::String(_), Some(IrType::String)) => Conversion::ToString,
+                (IrExprKind::StaticRead { .. }, Some(IrType::String | IrType::Generic(_)))
+                    if matches!(expr.ty, IrType::StaticStr) =>
+                {
+                    Conversion::ToString
+                }
+                (_, Some(IrType::String)) if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
                 _ => Conversion::None,
             }
         }
@@ -617,6 +643,10 @@ pub fn determine_conversion(expr: &IrExpr, target_ty: Option<&IrType>, context: 
             match (&expr.kind, target_ty) {
                 // String literal returned when function returns String → .to_string()
                 (IrExprKind::String(_), Some(IrType::String)) => Conversion::ToString,
+                (IrExprKind::StaticRead { .. }, Some(IrType::String)) if matches!(expr.ty, IrType::StaticStr) => {
+                    Conversion::ToString
+                }
+                (_, Some(IrType::String)) if matches!(expr.ty, IrType::StaticStr) => Conversion::ToString,
                 // Other cases: as-is
                 _ => Conversion::None,
             }
@@ -771,6 +801,66 @@ mod tests {
     }
 
     #[test]
+    fn test_incan_function_static_str_var_to_string() {
+        let expr = IrExpr::new(
+            IrExprKind::Var {
+                name: "s".to_string(),
+                access: VarAccess::Read,
+                ref_kind: VarRefKind::StaticBinding,
+            },
+            IrType::StaticStr,
+        );
+        let target = IrType::String;
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::IncanFunctionArg);
+        assert_eq!(conv, Conversion::ToString);
+    }
+
+    #[test]
+    fn test_incan_function_static_str_var_to_generic() {
+        let expr = IrExpr::new(
+            IrExprKind::Var {
+                name: "s".to_string(),
+                access: VarAccess::Read,
+                ref_kind: VarRefKind::StaticBinding,
+            },
+            IrType::StaticStr,
+        );
+        let target = IrType::Generic("T".to_string());
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::IncanFunctionArg);
+        assert_eq!(conv, Conversion::ToString);
+    }
+
+    #[test]
+    fn test_incan_function_static_read_to_string() {
+        let expr = IrExpr::new(
+            IrExprKind::StaticRead {
+                name: "PREFIX".to_string(),
+            },
+            IrType::StaticStr,
+        );
+        let target = IrType::String;
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::IncanFunctionArg);
+        assert_eq!(conv, Conversion::ToString);
+    }
+
+    #[test]
+    fn test_incan_function_static_read_int_to_generic_stays_as_is() {
+        let expr = IrExpr::new(
+            IrExprKind::StaticRead {
+                name: "MARKER".to_string(),
+            },
+            IrType::Int,
+        );
+        let target = IrType::Generic("T".to_string());
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::IncanFunctionArg);
+        assert_eq!(conv, Conversion::None);
+    }
+
+    #[test]
     fn test_incan_function_vec_string_conversion() {
         let expr = IrExpr::new(
             IrExprKind::Var {
@@ -855,6 +945,66 @@ mod tests {
 
         let conv = determine_conversion(&expr, Some(&target), ConversionContext::IncanFunctionArg);
         assert_eq!(conv, Conversion::Clone);
+    }
+
+    #[test]
+    fn test_assignment_static_str_to_string() {
+        let expr = IrExpr::new(
+            IrExprKind::Var {
+                name: "prefix".to_string(),
+                access: VarAccess::Read,
+                ref_kind: VarRefKind::StaticBinding,
+            },
+            IrType::StaticStr,
+        );
+        let target = IrType::String;
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::Assignment);
+        assert_eq!(conv, Conversion::ToString);
+    }
+
+    #[test]
+    fn test_assignment_static_read_int_stays_as_is() {
+        let expr = IrExpr::new(
+            IrExprKind::StaticRead {
+                name: "MARKER".to_string(),
+            },
+            IrType::Int,
+        );
+        let target = IrType::Int;
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::Assignment);
+        assert_eq!(conv, Conversion::None);
+    }
+
+    #[test]
+    fn test_return_static_str_to_string() {
+        let expr = IrExpr::new(
+            IrExprKind::Var {
+                name: "prefix".to_string(),
+                access: VarAccess::Read,
+                ref_kind: VarRefKind::StaticBinding,
+            },
+            IrType::StaticStr,
+        );
+        let target = IrType::String;
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::ReturnValue);
+        assert_eq!(conv, Conversion::ToString);
+    }
+
+    #[test]
+    fn test_return_static_read_to_string() {
+        let expr = IrExpr::new(
+            IrExprKind::StaticRead {
+                name: "PREFIX".to_string(),
+            },
+            IrType::StaticStr,
+        );
+        let target = IrType::String;
+
+        let conv = determine_conversion(&expr, Some(&target), ConversionContext::ReturnValue);
+        assert_eq!(conv, Conversion::ToString);
     }
 
     // === ExternalFunctionArg Tests ===

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -70,10 +70,16 @@ impl AstLowering {
                 //
                 // The frontend type system does not model references, so `expr_type` typically returns `T` where
                 // lowering may have already marked the same binding as `Ref(T)`/`RefMut(T)`.
+                //
+                // Likewise, RFC-008 const lowering may have already refined `str`/`bytes` to their static IR forms.
+                // Keep those backend-specific const representations intact so later emission can materialize owned
+                // values only when required.
                 let inner = self.lower_resolved_type(res_ty);
                 lowered.ty = match &lowered.ty {
                     IrType::Ref(_) => IrType::Ref(Box::new(inner)),
                     IrType::RefMut(_) => IrType::RefMut(Box::new(inner)),
+                    IrType::StaticStr => IrType::StaticStr,
+                    IrType::StaticBytes => IrType::StaticBytes,
                     _ => inner,
                 };
             }

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -503,7 +503,7 @@ impl AstLowering {
         for decl in &program.declarations {
             if let ast::Declaration::Const(ref c) = decl.node {
                 let ty = if let Some(ann) = &c.ty {
-                    self.lower_type(&ann.node)
+                    self.lower_const_annotation_type(&ann.node)
                 } else {
                     IrType::Unknown
                 };

--- a/src/dependency_resolver.rs
+++ b/src/dependency_resolver.rs
@@ -538,30 +538,24 @@ fn known_good_spec(crate_name: &str) -> Option<DependencySpec> {
 fn known_good_spec_from_stdlib(crate_name: &str) -> Option<DependencySpec> {
     for ns in STDLIB_NAMESPACES {
         for dep in ns.extra_crate_deps {
-            let matches_declared_name = dep.crate_name == crate_name
-                || dep.crate_name.replace('-', "_") == crate_name
-                || dep.crate_name.replace('_', "-") == crate_name;
-            if !matches_declared_name {
-                continue;
+            if dep.crate_name == crate_name {
+                let StdlibExtraCrateSource::Version(version) = dep.source else {
+                    // Path dependencies are not registry crates; skip.
+                    continue;
+                };
+                return Some(
+                    DependencySpec {
+                        crate_name: crate_name.to_string(),
+                        version: Some(version.to_string()),
+                        features: vec![],
+                        default_features: true,
+                        source: DependencySource::Registry,
+                        optional: false,
+                        package: None,
+                    }
+                    .normalized(),
+                );
             }
-
-            let StdlibExtraCrateSource::Version(version) = dep.source else {
-                // Path dependencies are not registry crates; skip.
-                continue;
-            };
-            let package = (dep.crate_name != crate_name).then(|| dep.crate_name.to_string());
-            return Some(
-                DependencySpec {
-                    crate_name: crate_name.to_string(),
-                    version: Some(version.to_string()),
-                    features: vec![],
-                    default_features: true,
-                    source: DependencySource::Registry,
-                    optional: false,
-                    package,
-                }
-                .normalized(),
-            );
         }
     }
     None
@@ -663,17 +657,6 @@ mod tests {
         let err = first_error(&err)?;
         let msg = &err.error.message;
         assert!(msg.contains("conflicting"), "expected conflict error, got: {msg}");
-        Ok(())
-    }
-
-    #[test]
-    fn stdlib_hyphenated_known_good_dep_resolves_with_package_alias() -> TestResult {
-        let imports = vec![inline("num_integer", None, &[], false)];
-
-        let resolved = resolve_ok(None, &imports, false, &default_cargo_features())?;
-        let dep = dependency(&resolved.dependencies, "num_integer")?;
-        assert_eq!(dep.version.as_deref(), Some("0.1"));
-        assert_eq!(dep.package.as_deref(), Some("num-integer"));
         Ok(())
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1850,6 +1850,50 @@ def main() -> None:
     }
 
     #[test]
+    fn test_const_str_materializes_to_owned_str_at_runtime_sites() {
+        let Ok(output) = Command::new(incan_debug_binary())
+            .args([
+                "run",
+                "-c",
+                r#"
+const PREFIX: str = "target/"
+
+def echo(value: str) -> str:
+    return value
+
+def direct() -> str:
+    return PREFIX
+
+def join(name: str) -> str:
+    return PREFIX + name
+
+def main() -> None:
+    local = PREFIX
+    println(direct())
+    println(echo(PREFIX))
+    println(echo(local))
+    println(join("orders.csv"))
+"#,
+            ])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()
+        else {
+            panic!("failed to run incan");
+        };
+
+        assert!(
+            output.status.success(),
+            "const str materialization test failed: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(lines, vec!["target/", "target/", "target/", "target/orders.csv"]);
+    }
+
+    #[test]
     fn test_rfc041_rusttype_interop_typechecks_end_to_end() {
         let source = r#"
 from rust::std::string import String as RustString

--- a/workspaces/docs-site/docs/language/reference/stdlib/math.md
+++ b/workspaces/docs-site/docs/language/reference/stdlib/math.md
@@ -53,4 +53,5 @@ Access values through the `math` namespace, for example `math.PI` or `math.sqrt(
 
 - `math.gcd` returns the greatest common divisor of two integers.
 - `math.lcm` returns the lowest common multiple of two integers.
+- `math.gcd` and `math.lcm` raise `ValueError` if the mathematical result does not fit Incan's signed 64-bit `int`.
 - The floating-point helpers remain thin wrappers over Rust math facilities.


### PR DESCRIPTION
## Summary

This PR fixes the `#359` release-candidate regression where const `str` lowering overreached and broke imported pub static scalar reads in generated test runners, and it hardens the new `std.math.gcd` / `std.math.lcm` helpers against signed 64-bit overflow edge cases. It also bumps the branch from `0.2.0-rc1` to `0.2.0-rc2` and refreshes the committed example lockfiles to match.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `const ...: str` values once again materialize correctly to owned `str` at normal Incan runtime sites without corrupting non-string imported pub statics in tests. `std.math.gcd` and `std.math.lcm` now raise `ValueError` when the mathematical result exceeds Incan’s signed 64-bit `int` range instead of panicking through `i64::MIN` overflow. The release candidate version is now `0.2.0-rc2`.
- **Internals**: Lowering now preserves static const IR types more precisely, conversion logic only materializes `StaticRead` values as strings when the IR type is actually `StaticStr`, and the stdlib math runtime uses unsigned-magnitude kernels for `gcd` / `lcm` with explicit overflow-to-`ValueError` handling. The stdlib math namespace no longer depends on `num-integer`; it uses the in-tree runtime helper path instead.
- **Risks**: The main risk is conversion-policy drift around `StaticRead` / `StaticStr`, because that logic affects ordinary calls, returns, assignments, and test-runner generation. The math change also tightens overflow behavior for extreme integer inputs, which is correct, but it is still worth keeping under regression coverage because it sits in runtime helpers used by generated code.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Ran targeted integration coverage for:
  - const `str` materialization at return/call/assignment/concat sites
  - imported pub static scalar reads in generated tests
  - `std.math` end-to-end module execution
- Ran targeted stdlib tests for:
  - `gcd_i64` / `lcm_i64` normal behavior
  - overflow edge cases such as `i64::MIN`
- Ran `cargo clippy --all-targets --all-features --quiet`
- Ran `mkdocs build --strict`
- Ran `make -C <incan-checkout> pre-commit` successfully, including:
  - full tests
  - clippy
  - cargo-deny
  - smoke-test-fast
  - examples
  - benchmark build checks

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/stdlib/math.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #359
