### PR TITLE
fix: improve light theme contrast for code blocks

### DIFF
--- a/workspaces/docs-site/docs/stylesheets/pygments.css
+++ b/workspaces/docs-site/docs/stylesheets/pygments.css
@@ -182,13 +182,13 @@ body[data-md-color-scheme="slate"] .highlight .il { color: #AE81FF } /* Literal.
 
 /* Fix: Light theme code block contrast - by Muhammad Zain */
 [data-md-color-scheme="default"] .highlight {
-  background-color: #f6f8fa !important;
-  color: #1f2328 !important;
+  background-color: #282c34 !important;
+  color: #abb2bf !important;
   border: 1px solid #d0d7de !important;
   border-radius: 6px !important;
 }
 
 [data-md-color-scheme="default"] .highlight code {
   background: transparent !important;
-  color: #1f2328 !important;
+  color: #abb2bf !important;
 }

--- a/workspaces/docs-site/docs/stylesheets/pygments.css
+++ b/workspaces/docs-site/docs/stylesheets/pygments.css
@@ -178,3 +178,17 @@ body[data-md-color-scheme="slate"] .highlight .il { color: #AE81FF } /* Literal.
 .md-typeset .highlight span {
   text-decoration: none;
 }
+
+
+/* Fix: Light theme code block contrast - by Muhammad Zain */
+[data-md-color-scheme="default"] .highlight {
+  background-color: #f6f8fa !important;
+  color: #1f2328 !important;
+  border: 1px solid #d0d7de !important;
+  border-radius: 6px !important;
+}
+
+[data-md-color-scheme="default"] .highlight code {
+  background: transparent !important;
+  color: #1f2328 !important;
+}


### PR DESCRIPTION


## What
Improves light theme contrast for code blocks by setting dark gray background (#282c34) and off-white text (#abb2bf).

## Why
Previous light theme had poor readability in code blocks. This matches industry standard One Dark palette and improves accessibility.

## Type of change
- [x] Bug fix
- [x] Documentation

## Area(s)
- [x] Tooling (CLI/formatter/test runner)

Part of Phase 1 roadmap for premium docs theme.

cc @DannyMeijer