### PR TITLE
bugfix - reuse workspace lockfile for vocab extraction helper (#211)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "clap",
  "hex",
@@ -1471,14 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,14 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "axum",
  "incan_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["target/incan"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.91"

--- a/src/cli/commands/vocab_extraction.rs
+++ b/src/cli/commands/vocab_extraction.rs
@@ -311,6 +311,7 @@ fn create_extraction_workspace_dir() -> CliResult<PathBuf> {
     Ok(dir)
 }
 
+/// Write the temporary Cargo package that calls the companion crate's `library_vocab()` entrypoint.
 fn write_extraction_runner_manifest(
     helper_root: &Path,
     companion_crate_root: &Path,
@@ -327,9 +328,29 @@ fn write_extraction_runner_manifest(
             "failed to write vocab extraction helper manifest {}: {err}",
             helper_manifest.display()
         ))
-    })
+    })?;
+    copy_workspace_lockfile_to_extraction_runner(helper_root)
 }
 
+/// Seed the temporary helper with the repo lockfile so path-only vocab tests do not re-resolve crates.io.
+fn copy_workspace_lockfile_to_extraction_runner(helper_root: &Path) -> CliResult<()> {
+    let workspace_lockfile = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock");
+    if !workspace_lockfile.is_file() {
+        return Ok(());
+    }
+
+    let helper_lockfile = helper_root.join("Cargo.lock");
+    fs::copy(&workspace_lockfile, &helper_lockfile).map_err(|err| {
+        CliError::failure(format!(
+            "failed to copy workspace lockfile {} to vocab extraction helper {}: {err}",
+            workspace_lockfile.display(),
+            helper_lockfile.display()
+        ))
+    })?;
+    Ok(())
+}
+
+/// Write the Rust entrypoint for the temporary Cargo package that prints serialized vocab metadata.
 fn write_extraction_runner_source(helper_root: &Path) -> CliResult<()> {
     let source_path = helper_root.join("src").join("main.rs");
     let source = "fn main() {\n    let registration = companion::library_vocab();\n    let metadata = registration.metadata();\n    let text = match serde_json::to_string_pretty(&metadata) {\n        Ok(text) => text,\n        Err(err) => {\n            eprintln!(\"failed to serialize registration metadata: {err}\");\n            std::process::exit(1);\n        }\n    };\n    print!(\"{text}\");\n}\n";
@@ -674,6 +695,25 @@ mod tests {
             incan_vocab::KeywordActivation::OnImport {
                 namespace: "widgets.dsl".to_string()
             }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn extraction_runner_manifest_reuses_workspace_lockfile() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let helper_root = temp.path().join("runner");
+        let companion_root = temp.path().join("vocab_companion");
+        fs::create_dir_all(helper_root.join("src"))?;
+        fs::create_dir_all(&companion_root)?;
+
+        write_extraction_runner_manifest(&helper_root, &companion_root, "widgets_vocab_companion")?;
+
+        let manifest = fs::read_to_string(helper_root.join("Cargo.toml"))?;
+        assert!(manifest.contains("serde_json = \"1.0\""));
+        assert!(
+            helper_root.join("Cargo.lock").is_file(),
+            "helper runner should inherit the workspace lockfile"
         );
         Ok(())
     }

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -125,6 +125,7 @@ The sections above are the release story. The list below is the detailed invento
 
 - **Compiler/Tooling**: RFC 053’s vertical-spacing contract is now reflected in `incan fmt`: top-level `def` / `model` / `type`-like declarations keep two blank lines around them, adjacent constants/statics stay grouped unless they border one of those declarations, trait abstract methods stay tight until a following body-bearing member, docstring indentation is normalized while actual blank-line runs collapse to one blank line, single readability gaps between statement groups survive nested suites, short single-statement `match` arms stay inline, blank lines after suite headers and match-arm arrows are normalized, trailing EOF blank lines are removed, two consecutive blank lines are allowed only at root level, and stand-alone comments attach as leading/trailing bundles even when the formatter wraps the target statement (#336, RFC 053).
 - **Compiler/Tooling**: `incan fmt` now wraps overflowing call and constructor argument lists across multiple lines, with trailing commas controlled by the existing formatter setting (#336).
+- **Tooling**: Vocab extraction helper tests now reuse the workspace lockfile when resolving helper dependencies, so focused vocab extraction coverage can run in restricted-network environments once local workspace dependencies are present (#211).
 
 ### Parser and syntax
 
@@ -138,7 +139,7 @@ The sections above are the release story. The list below is the detailed invento
 ### Versioning and release track
 
 - **Project lifecycle tooling**: Added lifecycle commands for interactive `incan new` / `incan init`, `incan version`, and `incan env`, plus project lifecycle documentation and `incan.toml` environment metadata support (#73).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.9`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.10`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

This PR fixes vocab extraction test hermeticity by copying the workspace `Cargo.lock` into the generated extraction helper before invoking Cargo. That lets focused vocab extraction coverage run in restricted-network environments once local workspace dependencies are present.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Focused vocab extraction tests no longer require live crates.io resolution when workspace dependencies are already local.
- **Internals**: The temporary helper runner now inherits the repository lockfile before `cargo run`.
- **Risks**: Low; this only affects the generated helper workspace used to call `library_vocab()`.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] Example/smoke coverage via `make pre-commit`
- [x] `incan fmt --check .`
- [x] Manual verification described below

Manual verification notes:

- Reproduced the original restricted-network failure before the fix.
- Verified `cargo test -q cli::commands::vocab_extraction --lib`.
- Verified `make pre-commit`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #211