### PR TITLE
bugfix - 388 support generic type-owned factories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "clap",
  "hex",
@@ -1471,14 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,14 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "axum",
  "incan_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["target/incan"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.10"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.91"

--- a/crates/incan_core/src/lang/highlighting.rs
+++ b/crates/incan_core/src/lang/highlighting.rs
@@ -66,7 +66,7 @@ const LOGICAL_OPERATOR_KEYWORDS: &[KeywordId] = &[
 const TRUE_KEYWORDS: &[KeywordId] = &[KeywordId::True];
 const FALSE_KEYWORDS: &[KeywordId] = &[KeywordId::False];
 const NONE_KEYWORDS: &[KeywordId] = &[KeywordId::None];
-const SELF_KEYWORDS: &[KeywordId] = &[KeywordId::SelfKw];
+const SELF_KEYWORDS: &[KeywordId] = &[KeywordId::SelfKw, KeywordId::Cls];
 
 /// Registry-backed regex buckets for VS Code/TextMate grammar generation.
 pub const VSCODE_KEYWORD_BUCKETS: &[VscodeKeywordBucket] = &[

--- a/crates/incan_core/src/lang/keywords.rs
+++ b/crates/incan_core/src/lang/keywords.rs
@@ -83,6 +83,7 @@ pub enum KeywordId {
     Let,
     Mut,
     SelfKw,
+    Cls,
 
     // Literals
     True,
@@ -523,6 +524,15 @@ pub const KEYWORDS: &[KeywordDescriptor] = &[
         RFC::_000,
         Since(0, 1),
     ),
+    info_contextual_binding(
+        KeywordId::Cls,
+        "cls",
+        KeywordCategory::Binding,
+        &[KeywordUsage::ReceiverOnly],
+        RFC::_000,
+        Since(0, 2),
+        Stability::Stable,
+    ),
     // Literals
     info_with_aliases(
         KeywordId::True,
@@ -845,6 +855,32 @@ const fn info_contextual(
     }
 }
 
+#[allow(clippy::too_many_arguments)] // const table constructor mirrors the keyword metadata shape
+/// Build metadata for an always-available contextual keyword with no parser surface handoff.
+const fn info_contextual_binding(
+    id: KeywordId,
+    canonical: &'static str,
+    category: KeywordCategory,
+    usage: &'static [KeywordUsage],
+    introduced_in_rfc: RfcId,
+    since: Since,
+    stability: Stability,
+) -> KeywordDescriptor {
+    KeywordDescriptor {
+        id,
+        canonical,
+        aliases: &[],
+        activation: KeywordActivation::Contextual,
+        surface_kind: None,
+        category,
+        usage,
+        introduced_in_rfc,
+        since,
+        stability,
+        examples: &[],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -861,5 +897,12 @@ mod tests {
     fn hard_only_lookup_excludes_contextual_assert() {
         assert_eq!(from_str("assert"), Some(KeywordId::Assert));
         assert_eq!(from_str_hard_only("assert"), None);
+    }
+
+    #[test]
+    fn hard_only_lookup_excludes_contextual_cls() {
+        assert_eq!(from_str("cls"), Some(KeywordId::Cls));
+        assert_eq!(activation_kind(KeywordId::Cls), KeywordActivation::Contextual);
+        assert_eq!(from_str_hard_only("cls"), None);
     }
 }

--- a/crates/incan_syntax/src/parser/decl/functions.rs
+++ b/crates/incan_syntax/src/parser/decl/functions.rs
@@ -128,7 +128,7 @@ impl<'a> Parser<'a> {
                 self.skip_newlines();
             }
             Some(Receiver::Immutable)
-        } else if is_classmethod && self.peek_ident_text("cls") {
+        } else if is_classmethod && self.peek_ident_text(incan_core::lang::keywords::as_str(KeywordId::Cls)) {
             self.advance();
             self.skip_newlines();
             if self.check(&TokenKind::Punctuation(PunctuationId::Comma)) {

--- a/editors/vscode/incan.tmLanguage.json
+++ b/editors/vscode/incan.tmLanguage.json
@@ -974,7 +974,7 @@
     "variables": {
       "patterns": [
         {
-          "match": "\\b(self)\\b",
+          "match": "\\b(cls|self)\\b",
           "name": "variable.language.self.incan"
         },
         {

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -225,6 +225,13 @@ impl<'a> IrEmitter<'a> {
             // This avoids capitalization heuristics that can mis-emit runtime variables named `TitleCase`.
             if Self::expr_is_type_like(receiver) {
                 let type_ident = format_ident!("{}", name);
+                let type_path = match &receiver.ty {
+                    IrType::NamedGeneric(type_name, type_args) if type_name == name => {
+                        let emitted: Vec<TokenStream> = type_args.iter().map(|ty| self.emit_type(ty)).collect();
+                        quote! { #type_ident :: <#(#emitted),*> }
+                    }
+                    _ => quote! { #type_ident },
+                };
                 let m = format_ident!("{}", method);
                 let in_return = *self.in_return_context.borrow();
                 let receiver_ref_kind = match &receiver.kind {
@@ -265,7 +272,7 @@ impl<'a> IrEmitter<'a> {
                     .iter()
                     .map(|a| self.emit_expr_for_use(a, use_site))
                     .collect::<Result<_, _>>()?;
-                return Ok(quote! { #type_ident::#m #method_turbofish (#(#arg_tokens),*) });
+                return Ok(quote! { #type_path::#m #method_turbofish (#(#arg_tokens),*) });
             }
         }
 

--- a/src/backend/ir/lower/decl/methods.rs
+++ b/src/backend/ir/lower/decl/methods.rs
@@ -10,9 +10,18 @@ use super::super::errors::LoweringError;
 use crate::frontend::ast::{self, Spanned};
 use crate::frontend::resolved_type_subst::{substitute_resolved_type, type_param_subst_map};
 use crate::frontend::symbols::ResolvedType;
+use incan_core::lang::decorators::{self, DecoratorId};
 use incan_core::lang::keywords::{self, KeywordId};
 
 impl AstLowering {
+    /// Return whether a method carries a resolved builtin decorator.
+    fn method_has_decorator(method: &ast::MethodDecl, id: DecoratorId) -> bool {
+        method
+            .decorators
+            .iter()
+            .any(|decorator| decorators::from_segments(&decorator.node.path.segments) == Some(id))
+    }
+
     /// Trait type-parameter names from either local AST declarations or typechecker metadata.
     fn trait_type_param_names(&self, trait_name: &str) -> Option<Vec<String>> {
         if let Some(decl) = self.trait_decls.get(trait_name) {
@@ -151,65 +160,71 @@ impl AstLowering {
         impl_methods: &[Spanned<ast::MethodDecl>],
     ) -> Result<IrImpl, LoweringError> {
         let type_param_names: std::collections::HashSet<&str> = type_params.iter().map(|tp| tp.name.as_str()).collect();
-        // Avoid holding an immutable borrow of `self` across lowering calls.
-        //
-        // In multi-module lowering, imported trait declarations may live in a different module AST and therefore not be
-        // present in `self.trait_decls` for this module. Typechecker already validates trait conformance, so lowering
-        // should stay permissive and emit an impl block from the methods we do have instead of hard-failing.
-        let Some(trait_decl) = self.trait_decls.get(trait_name).cloned() else {
+        let prev = self.current_impl_type.replace(type_name.to_string());
+        let lowered_result = (|| {
+            // Avoid holding an immutable borrow of `self` across lowering calls.
+            //
+            // In multi-module lowering, imported trait declarations may live in a different module AST and therefore
+            // not be present in `self.trait_decls` for this module. Typechecker already validates trait
+            // conformance, so lowering should stay permissive and emit an impl block from the methods we do
+            // have instead of hard-failing.
+            let Some(trait_decl) = self.trait_decls.get(trait_name).cloned() else {
+                let mut methods: Vec<IrFunction> = Vec::new();
+                for method in impl_methods {
+                    methods.push(self.lower_impl_method_for_trait(&method.node, Some(&type_param_names))?);
+                }
+                return Ok(IrImpl {
+                    target_type: type_name.to_string(),
+                    type_params: Self::lower_type_params(type_params),
+                    trait_name: Some(trait_name.to_string()),
+                    trait_type_args,
+                    methods,
+                });
+            };
+            let trait_methods = trait_decl.methods;
+
             let mut methods: Vec<IrFunction> = Vec::new();
-            for method in impl_methods {
-                methods.push(self.lower_impl_method_for_trait(&method.node, Some(&type_param_names))?);
+            for trait_method in &trait_methods {
+                let method_name = trait_method.node.name.as_str();
+
+                // Prefer the implementing type's override, if present.
+                let mut found_override: Option<&ast::MethodDecl> = None;
+                for m in impl_methods {
+                    if m.node.name == method_name {
+                        found_override = Some(&m.node);
+                        break;
+                    }
+                }
+                if let Some(m) = found_override {
+                    methods.push(self.lower_impl_method_for_trait(m, Some(&type_param_names))?);
+                    continue;
+                }
+
+                // Otherwise, expand a default method body into the impl (RFC 000: defaults may assume adopter fields).
+                if trait_method.node.body.is_some() {
+                    methods.push(self.lower_impl_method_for_trait(&trait_method.node, Some(&type_param_names))?);
+                    continue;
+                }
+
+                // Required trait method with no default implementation.
+                return Err(LoweringError {
+                    message: format!(
+                        "Type '{type_name}' does not implement required method '{method_name}' for trait '{trait_name}'"
+                    ),
+                    span: IrSpan::default(),
+                });
             }
-            return Ok(IrImpl {
+
+            Ok(IrImpl {
                 target_type: type_name.to_string(),
                 type_params: Self::lower_type_params(type_params),
                 trait_name: Some(trait_name.to_string()),
                 trait_type_args,
                 methods,
-            });
-        };
-        let trait_methods = trait_decl.methods;
-
-        let mut methods: Vec<IrFunction> = Vec::new();
-        for trait_method in &trait_methods {
-            let method_name = trait_method.node.name.as_str();
-
-            // Prefer the implementing type's override, if present.
-            let mut found_override: Option<&ast::MethodDecl> = None;
-            for m in impl_methods {
-                if m.node.name == method_name {
-                    found_override = Some(&m.node);
-                    break;
-                }
-            }
-            if let Some(m) = found_override {
-                methods.push(self.lower_impl_method_for_trait(m, Some(&type_param_names))?);
-                continue;
-            }
-
-            // Otherwise, expand a default method body into the impl (RFC 000: defaults may assume adopter fields).
-            if trait_method.node.body.is_some() {
-                methods.push(self.lower_impl_method_for_trait(&trait_method.node, Some(&type_param_names))?);
-                continue;
-            }
-
-            // Required trait method with no default implementation.
-            return Err(LoweringError {
-                message: format!(
-                    "Type '{type_name}' does not implement required method '{method_name}' for trait '{trait_name}'"
-                ),
-                span: IrSpan::default(),
-            });
-        }
-
-        Ok(IrImpl {
-            target_type: type_name.to_string(),
-            type_params: Self::lower_type_params(type_params),
-            trait_name: Some(trait_name.to_string()),
-            trait_type_args,
-            methods,
-        })
+            })
+        })();
+        self.current_impl_type = prev;
+        lowered_result
     }
 
     fn lower_impl_method_for_trait(
@@ -332,6 +347,11 @@ impl AstLowering {
         })
     }
 
+    /// Lower an inherent method while preserving owner and method generic parameters in signatures and bodies.
+    ///
+    /// During `@classmethod` bodies this also exposes the current impl target as the lowering target for source
+    /// `cls(...)` constructor calls. The marker is scoped to the body lowering so ordinary methods and local `cls`
+    /// bindings keep their normal value-call behavior.
     fn lower_method_with_type_params(
         &mut self,
         m: &ast::MethodDecl,
@@ -412,12 +432,20 @@ impl AstLowering {
         params.extend(other_params);
 
         let return_type = self.lower_callable_return_type(&m.return_type.node, Some(&combined_type_param_names));
-        let body = if let Some(ref body_stmts) = m.body {
-            self.lower_statements(body_stmts)?
+        let previous_classmethod_constructor = self.current_classmethod_constructor.take();
+        if Self::method_has_decorator(m, DecoratorId::ClassMethod)
+            && let Some(type_name) = self.current_impl_type.clone()
+        {
+            self.current_classmethod_constructor = Some(type_name);
+        }
+        let body_result = if let Some(ref body_stmts) = m.body {
+            self.lower_statements(body_stmts)
         } else {
             // Abstract method with no body
-            vec![]
+            Ok(vec![])
         };
+        self.current_classmethod_constructor = previous_classmethod_constructor;
+        let body = body_result?;
         self.pop_scope();
 
         // Incan methods are part of the type's public surface. Trait-impl methods are handled separately in

--- a/src/backend/ir/lower/expr/calls.rs
+++ b/src/backend/ir/lower/expr/calls.rs
@@ -11,6 +11,7 @@ use super::super::AstLowering;
 use super::super::errors::LoweringError;
 use crate::frontend::ast;
 use crate::frontend::typechecker::RustArgCoercionKind;
+use incan_core::lang::keywords::{self, KeywordId};
 use incan_core::lang::surface::constructors::{self, ConstructorId};
 
 pub(crate) const INTERNAL_PANIC_FN: &str = "__incan_internal_panic";
@@ -182,6 +183,13 @@ impl AstLowering {
     ) -> Result<(IrExprKind, IrType), LoweringError> {
         // Check if this is a struct/model/class constructor call
         if let ast::Expr::Ident(name) = &f.node {
+            if keywords::from_str(name.as_str()) == Some(KeywordId::Cls)
+                && matches!(self.lookup_var(name), IrType::Unknown)
+                && let Some(owner_name) = self.current_classmethod_constructor.clone()
+            {
+                return self.lower_constructor_call(&owner_name, args);
+            }
+
             // Use two strategies for constructor detection:
             // 1. Known struct from current file (in struct_names map)
             // 2. Uppercase identifier heuristic (works cross-file like old codegen)

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -268,7 +268,28 @@ impl AstLowering {
 
             // ---- Method calls ----
             ast::Expr::MethodCall(o, m, type_args, args) => {
-                let receiver = self.lower_expr_spanned(o)?;
+                let receiver = if let ast::Expr::Index(base, _) = &o.node
+                    && let ast::Expr::Ident(name) = &base.node
+                    && self.type_info.as_ref().is_some_and(|info| {
+                        matches!(info.ident_kind(base.span), Some(IdentKind::TypeName | IdentKind::Trait))
+                    }) {
+                    let ty = self
+                        .type_info
+                        .as_ref()
+                        .and_then(|info| info.expr_type(o.span))
+                        .map(|ty| self.lower_resolved_type(ty))
+                        .unwrap_or_else(|| self.struct_names.get(name).cloned().unwrap_or(IrType::Unknown));
+                    TypedExpr::new(
+                        IrExprKind::Var {
+                            name: name.clone(),
+                            access: VarAccess::Copy,
+                            ref_kind: VarRefKind::TypeName,
+                        },
+                        ty,
+                    )
+                } else {
+                    self.lower_expr_spanned(o)?
+                };
                 let mut args_ir = self.lower_call_args(args)?;
                 let lowered_type_args = self.lower_call_site_type_args(expr_span, type_args);
                 for (arg_ir, arg_ast) in args_ir.iter_mut().zip(args.iter()) {

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -90,6 +90,8 @@ pub struct AstLowering {
     /// When lowering methods inside an impl block, this tracks the current target type name.
     /// Used to avoid rewriting `T(x)` inside `impl T` bodies (e.g. inside `T.from_underlying`).
     pub(super) current_impl_type: Option<String>,
+    /// Current classmethod constructor target exposed by source `cls(...)` calls.
+    pub(super) current_classmethod_constructor: Option<String>,
     /// RFC 021: Map from (struct_name, alias) -> canonical_field_name for alias-aware resolution.
     ///
     /// Populated during model/class lowering; used to translate alias field names in:
@@ -206,6 +208,7 @@ impl AstLowering {
             type_info: None,
             newtype_checked_ctor: HashMap::new(),
             current_impl_type: None,
+            current_classmethod_constructor: None,
             struct_field_aliases: HashMap::new(),
             remaining_ident_reads: Vec::new(),
             non_linear_context_depth: 0,

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -7,6 +7,7 @@ use crate::frontend::symbols::*;
 
 use super::TypeChecker;
 use incan_core::interop::RustItemKind;
+use incan_core::lang::decorators::{self, DecoratorId};
 use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::magic_methods;
 use incan_core::lang::traits::{self, TraitId};
@@ -74,6 +75,14 @@ struct InteropAdapterSig {
 }
 
 impl TypeChecker {
+    /// Return whether a method carries a resolved builtin decorator.
+    fn method_has_decorator(method: &MethodDecl, id: DecoratorId) -> bool {
+        method
+            .decorators
+            .iter()
+            .any(|decorator| decorators::from_segments(&decorator.node.path.segments) == Some(id))
+    }
+
     /// Replace every nested `Self` occurrence in an annotation with the concrete owner type used for this method body.
     ///
     /// Method return validation runs against the concrete owning type, not the abstract declaration surface, so
@@ -1612,10 +1621,26 @@ impl TypeChecker {
             })
             .unwrap_or_default();
         let previous_owner = self.current_method_owner.replace(owner.to_string());
-        self.check_method_with_self_ty(method, ResolvedType::Named(owner.to_string()), &owner_type_params);
+        let owner_self_ty = if owner_type_params.is_empty() {
+            ResolvedType::Named(owner.to_string())
+        } else {
+            ResolvedType::Generic(
+                owner.to_string(),
+                owner_type_params
+                    .iter()
+                    .map(|type_param| ResolvedType::TypeVar(type_param.clone()))
+                    .collect(),
+            )
+        };
+        self.check_method_with_self_ty(method, owner_self_ty, &owner_type_params);
         self.current_method_owner = previous_owner;
     }
 
+    /// Check a method body with the concrete owner type used for `Self` in annotations and classmethod constructors.
+    ///
+    /// Generic owners pass `Owner[T, ...]` here so return checking and `cls(...)` constructor calls see the same
+    /// generic surface that call sites use. Trait default methods may still pass bare `Self` because their eventual
+    /// adopter is resolved later during trait conformance and method-call substitution.
     fn check_method_with_self_ty(&mut self, method: &MethodDecl, self_ty: ResolvedType, owner_type_params: &[String]) {
         self.symbols.enter_scope(ScopeKind::Method {
             receiver: method.receiver,
@@ -1659,6 +1684,11 @@ impl TypeChecker {
                 scope: 0,
             });
         }
+        let is_classmethod = Self::method_has_decorator(method, DecoratorId::ClassMethod);
+        let previous_classmethod_self_ty = self.current_classmethod_self_ty.take();
+        if is_classmethod {
+            self.current_classmethod_self_ty = Some(self_ty.clone());
+        }
 
         // Define parameters
         for param in &method.params {
@@ -1693,6 +1723,7 @@ impl TypeChecker {
         }
 
         self.current_return_error_type = None;
+        self.current_classmethod_self_ty = previous_classmethod_self_ty;
         self.mutable_bindings.remove("self");
         self.symbols.exit_scope();
     }

--- a/src/frontend/typechecker/check_expr/calls.rs
+++ b/src/frontend/typechecker/check_expr/calls.rs
@@ -20,6 +20,7 @@ use crate::frontend::typechecker::helpers::{collection_type_id, dict_ty, list_ty
 use incan_core::interop::{CoercionPolicy, RustFunctionSig, admitted_builtin_coercion, is_rust_capability_bound};
 use incan_core::lang::builtins::{self, BuiltinFnId};
 use incan_core::lang::derives::{self, DeriveId};
+use incan_core::lang::keywords::{self, KeywordId};
 use incan_core::lang::surface::constructors::{self, ConstructorId};
 use incan_core::lang::surface::functions::{self as surface_functions, SurfaceFnId};
 use incan_core::lang::surface::types::{self as surface_types, SurfaceTypeId};
@@ -1818,6 +1819,29 @@ impl TypeChecker {
         }
 
         if let Expr::Ident(name) = &callee.node {
+            if keywords::from_str(name.as_str()) == Some(KeywordId::Cls)
+                && self.symbols.lookup(name).is_none()
+                && let (Some(owner_name), Some(self_ty)) = (
+                    self.current_method_owner.clone(),
+                    self.current_classmethod_self_ty.clone(),
+                )
+            {
+                let ctor_fields: Option<std::collections::HashMap<String, FieldInfo>> =
+                    self.lookup_type_info(&owner_name).and_then(|info| match info {
+                        TypeInfo::Model(m) => Some(m.fields.clone()),
+                        TypeInfo::Class(c) => Some(c.fields.clone()),
+                        _ => None,
+                    });
+                if let Some(fields) = ctor_fields {
+                    self.record_expr_type(callee.span, self_ty.clone());
+                    self.type_info
+                        .ident_kinds
+                        .insert((callee.span.start, callee.span.end), IdentKind::TypeName);
+                    self.check_model_or_class_constructor_call(&owner_name, &fields, args, span);
+                    return self_ty;
+                }
+            }
+
             let marker_binding_in_scope = self
                 .symbols
                 .lookup(name)

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -301,6 +301,8 @@ pub struct TypeChecker {
     pub(crate) current_trait_name: Option<String>,
     /// Active nominal owner while checking a method body.
     pub(crate) current_method_owner: Option<String>,
+    /// Active `@classmethod` owner type exposed to the method body as `cls`.
+    pub(crate) current_classmethod_self_ty: Option<ResolvedType>,
     /// Deduplicate missing-`@requires` diagnostics within a single trait default method body.
     pub(crate) current_trait_missing_requires_emitted: Option<HashSet<String>>,
     /// Collected module-level const declarations (for rich const-eval + cycle detection).
@@ -393,6 +395,7 @@ impl TypeChecker {
             current_trait_requires: None,
             current_trait_name: None,
             current_method_owner: None,
+            current_classmethod_self_ty: None,
             current_trait_missing_requires_emitted: None,
             const_decls: HashMap::new(),
             static_decls: Vec::new(),

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3806,6 +3806,21 @@ def use_join(left: Carrier[Order], right: Carrier[Order]) -> Carrier[Order]:
     Ok(())
 }
 
+#[test]
+fn test_issue_388_generic_classmethod_cls_constructor_typechecks() {
+    let source = r#"
+@derive(Clone)
+class Box[T with Clone]:
+  value: T
+
+  @classmethod
+  def make(cls, value: T) -> Self:
+    return cls(value=value)
+"#;
+
+    assert_check_ok(source);
+}
+
 /// Trait **default** methods are not copied into `ClassInfo.methods`; dispatch goes through the trait branch of
 /// `resolve_named_method`. Call-site `Self` substitution must still apply (#237).
 #[test]

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -26,7 +26,7 @@ use crate::cli::commands::common::{
 use crate::cli::prelude::ParsedModule;
 #[cfg(feature = "rust_inspect")]
 use crate::dependency_resolver::{ResolvedDependencies, resolve_dependencies};
-use crate::frontend::ast::{Declaration, Program, Span, Type};
+use crate::frontend::ast::{Declaration, MethodDecl, Program, Span, Type, TypeParam};
 use crate::frontend::diagnostics::CompileError;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::module::resolve_import_path;
@@ -66,6 +66,11 @@ struct RustOriginSymbol {
     local_name: String,
     span: Span,
     info: crate::frontend::symbols::RustItemInfo,
+}
+
+#[derive(Debug, Clone)]
+struct ClassmethodContext {
+    owner_type: String,
 }
 
 /// Incan Language Server
@@ -924,6 +929,60 @@ def bind(input_columns: list[str]) -> list[str]:
     }
 }
 
+#[cfg(test)]
+mod lsp_classmethod_tests {
+    use std::collections::HashMap;
+
+    use super::{classmethod_cls_detail, classmethod_context_at_offset, identifier_at_offset};
+    use crate::frontend::{lexer, parser};
+
+    fn parse_source(source: &str) -> crate::frontend::ast::Program {
+        let tokens = lexer::lex(source).unwrap_or_else(|errors| panic!("lexer failed: {errors:?}"));
+        parser::parse_with_context(&tokens, Some("src/main.incn"), Some(&HashMap::new()))
+            .unwrap_or_else(|errors| panic!("parser failed: {errors:?}"))
+    }
+
+    #[test]
+    fn classmethod_context_surfaces_cls_receiver_for_lsp() {
+        let source = r#"
+class Box[T with Clone]:
+    value: T
+
+    @classmethod
+    def make(cls, value: T) -> Self:
+        return cls(value=value)
+"#;
+        let ast = parse_source(source);
+        let offset = source.find("cls(value").expect("expected cls call");
+        let aliases = HashMap::new();
+
+        let context = classmethod_context_at_offset(&ast, offset, &aliases).expect("expected classmethod context");
+        assert_eq!(context.owner_type, "Box[T]");
+        assert_eq!(classmethod_cls_detail(&context), "cls: type[Box[T]]");
+
+        let (ident, span) = identifier_at_offset(source, offset).expect("expected identifier at cls call");
+        assert_eq!(ident, "cls");
+        assert_eq!(&source[span.start..span.end], "cls");
+    }
+
+    #[test]
+    fn staticmethod_body_does_not_surface_cls_receiver_for_lsp() {
+        let source = r#"
+class Box[T with Clone]:
+    value: T
+
+    @staticmethod
+    def make(value: T) -> Self:
+        return Box(value=value)
+"#;
+        let ast = parse_source(source);
+        let offset = source.find("return Box").expect("expected static factory body");
+        let aliases = HashMap::new();
+
+        assert!(classmethod_context_at_offset(&ast, offset, &aliases).is_none());
+    }
+}
+
 /// Symbol information for hover/goto
 #[derive(Debug, Clone)]
 pub struct SymbolInfo {
@@ -992,6 +1051,153 @@ fn resolve_decorator_path(
     aliases: &HashMap<String, Vec<String>>,
 ) -> Vec<String> {
     crate::frontend::decorator_resolution::resolve_decorator_path(dec, aliases)
+}
+
+/// Return whether a method has the requested decorator after resolving import aliases.
+fn method_has_decorator(
+    method: &MethodDecl,
+    id: decorators::DecoratorId,
+    aliases: &HashMap<String, Vec<String>>,
+) -> bool {
+    method
+        .decorators
+        .iter()
+        .any(|decorator| decorators::from_segments(&resolve_decorator_path(&decorator.node, aliases)) == Some(id))
+}
+
+/// Format the owner type as it should appear in LSP details.
+fn owner_type_display(owner_name: &str, type_params: &[TypeParam]) -> String {
+    if type_params.is_empty() {
+        owner_name.to_string()
+    } else {
+        let params: Vec<&str> = type_params.iter().map(|param| param.name.as_str()).collect();
+        format!("{owner_name}[{}]", params.join(", "))
+    }
+}
+
+/// Return whether an offset falls inside a method body rather than its signature.
+fn method_body_contains_offset(method: &MethodDecl, method_span: Span, offset: usize) -> bool {
+    let Some(body) = &method.body else {
+        return false;
+    };
+    let Some(first) = body.first() else {
+        return false;
+    };
+    first.span.start <= offset && offset < method_span.end
+}
+
+/// Build contextual classmethod receiver metadata when the offset is inside a classmethod body.
+fn classmethod_context_for_method(
+    owner_name: &str,
+    owner_type_params: &[TypeParam],
+    method: &crate::frontend::ast::Spanned<MethodDecl>,
+    offset: usize,
+    aliases: &HashMap<String, Vec<String>>,
+) -> Option<ClassmethodContext> {
+    if !method_body_contains_offset(&method.node, method.span, offset) {
+        return None;
+    }
+    if !method_has_decorator(&method.node, decorators::DecoratorId::ClassMethod, aliases) {
+        return None;
+    }
+    Some(ClassmethodContext {
+        owner_type: owner_type_display(owner_name, owner_type_params),
+    })
+}
+
+/// Find the active classmethod receiver context for an offset in a parsed program.
+fn classmethod_context_at_offset(
+    ast: &Program,
+    offset: usize,
+    aliases: &HashMap<String, Vec<String>>,
+) -> Option<ClassmethodContext> {
+    for decl in &ast.declarations {
+        match &decl.node {
+            Declaration::Model(model) => {
+                for method in &model.methods {
+                    if let Some(context) =
+                        classmethod_context_for_method(&model.name, &model.type_params, method, offset, aliases)
+                    {
+                        return Some(context);
+                    }
+                }
+            }
+            Declaration::Class(class) => {
+                for method in &class.methods {
+                    if let Some(context) =
+                        classmethod_context_for_method(&class.name, &class.type_params, method, offset, aliases)
+                    {
+                        return Some(context);
+                    }
+                }
+            }
+            Declaration::Newtype(newtype) => {
+                for method in &newtype.methods {
+                    if let Some(context) =
+                        classmethod_context_for_method(&newtype.name, &newtype.type_params, method, offset, aliases)
+                    {
+                        return Some(context);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Return the identifier containing or immediately preceding an offset.
+fn identifier_at_offset(source: &str, offset: usize) -> Option<(String, Span)> {
+    if source.is_empty() {
+        return None;
+    }
+    let mut cursor = offset.min(source.len().saturating_sub(1));
+    if !source
+        .as_bytes()
+        .get(cursor)
+        .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_')
+    {
+        if cursor == 0 {
+            return None;
+        }
+        cursor -= 1;
+        if !source
+            .as_bytes()
+            .get(cursor)
+            .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_')
+        {
+            return None;
+        }
+    }
+
+    let mut start = cursor;
+    while start > 0 {
+        let prev = source.as_bytes()[start - 1];
+        if !(prev.is_ascii_alphanumeric() || prev == b'_') {
+            break;
+        }
+        start -= 1;
+    }
+
+    let mut end = cursor + 1;
+    while end < source.len() {
+        let next = source.as_bytes()[end];
+        if !(next.is_ascii_alphanumeric() || next == b'_') {
+            break;
+        }
+        end += 1;
+    }
+
+    Some((source[start..end].to_string(), Span::new(start, end)))
+}
+
+/// Format the LSP detail string for the contextual `cls` receiver binding.
+fn classmethod_cls_detail(context: &ClassmethodContext) -> String {
+    format!(
+        "{}: type[{}]",
+        keywords::as_str(keywords::KeywordId::Cls),
+        context.owner_type
+    )
 }
 
 fn stdlib_location_for_path(path: &[String]) -> Option<Location> {
@@ -1411,6 +1617,7 @@ impl LanguageServer for IncanLanguageServer {
         self.client.publish_diagnostics(uri, vec![], None).await;
     }
 
+    /// Provide hover text for symbols, call-site type arguments, Rust imports, and contextual receiver bindings.
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
         let uri = &params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
@@ -1486,6 +1693,24 @@ impl LanguageServer for IncanLanguageServer {
                         value: markdown,
                     }),
                     range: Some(span_to_range(&doc.source, rust_symbol.span.start, rust_symbol.span.end)),
+                }));
+            }
+
+            if let Some((ident, span)) = identifier_at_offset(&doc.source, offset)
+                && keywords::from_str(ident.as_str()) == Some(keywords::KeywordId::Cls)
+                && let Some(context) = classmethod_context_at_offset(ast, offset, &aliases)
+            {
+                let detail = classmethod_cls_detail(&context);
+                let markdown = format!(
+                    "```incan\n{detail}\n```\n\n*classmethod receiver* — callable constructor for `{}`.",
+                    context.owner_type
+                );
+                return Ok(Some(Hover {
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: markdown,
+                    }),
+                    range: Some(span_to_range(&doc.source, span.start, span.end)),
                 }));
             }
 
@@ -1632,6 +1857,7 @@ impl LanguageServer for IncanLanguageServer {
         Ok(None)
     }
 
+    /// Provide context-aware completions for decorators, imports, type arguments, symbols, and receiver bindings.
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
         let uri = &params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
@@ -1672,6 +1898,25 @@ impl LanguageServer for IncanLanguageServer {
         }
 
         // ---- General completions (not in a specific context) ----
+
+        if let Some(ast) = &doc.ast {
+            let aliases = collect_import_aliases(ast);
+            if let Some(off) = position_to_offset(&doc.source, position)
+                && let Some(context) = classmethod_context_at_offset(ast, off, &aliases)
+            {
+                push_completion(
+                    &mut items,
+                    &mut seen,
+                    keywords::as_str(keywords::KeywordId::Cls),
+                    CompletionItemKind::VARIABLE,
+                    Some(format!(
+                        "{} — classmethod receiver constructor",
+                        classmethod_cls_detail(&context)
+                    )),
+                    Some("0_cls".to_string()),
+                );
+            }
+        }
 
         // Add keywords from the registry (canonical + aliases).
         for info in keywords::KEYWORDS {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4578,6 +4578,49 @@ def main() -> None:
     }
 
     #[test]
+    fn test_issue388_generic_type_owned_factories_run() -> Result<(), Box<dyn std::error::Error>> {
+        let source = r#"
+@derive(Clone)
+class FactoryBox[T with Clone]:
+  value: T
+
+  @classmethod
+  def make(cls, value: T) -> Self:
+    return cls(value=value)
+
+  @staticmethod
+  def make_static(value: T) -> Self:
+    return FactoryBox(value=value)
+
+def main() -> None:
+  from_classmethod = FactoryBox[int].make(1)
+  from_staticmethod = FactoryBox[int].make_static(2)
+  println(str(from_classmethod.value))
+  println(str(from_staticmethod.value))
+"#;
+        let output = std::process::Command::new(super::incan_debug_binary())
+            .args(["run", "-c", source])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "expected generic type-owned factories to run.\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            lines,
+            vec!["1", "2"],
+            "unexpected generic type-owned factory output:\n{stdout}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_match_with_case() {
         let source = r#"
 def foo(x: Option[int]) -> int:

--- a/workspaces/docs-site/docs/_snippets/language/decorators/staticmethod.md
+++ b/workspaces/docs-site/docs/_snippets/language/decorators/staticmethod.md
@@ -19,6 +19,7 @@ Rules:
 
 - A `@staticmethod` method **must not** have a `self` or `mut self` parameter. The compiler rejects this.
 - Call static methods via the type name: `TypeName.method_name(...)`.
+- Generic static factory methods can return `Self`; call them with explicit type arguments when inference needs the owner type, such as `Box[int].make(...)`.
 - `@staticmethod` can be combined with `@rust.extern` for Rust-backed static methods on types.
 
 Use cases:
@@ -26,3 +27,18 @@ Use cases:
 - **Factory methods**: alternative constructors (`from_fahrenheit`, `from_json`, `parse`).
 - **Utility functions**: logic scoped to a type that doesn't need instance state.
 - **Rust interop**: `@rust.extern` on type methods requires `@staticmethod` (instance delegation is not supported).
+
+Generic static factories can use the declaring type constructor directly:
+
+```incan
+class Box[T with Clone]:
+    value: T
+
+    @staticmethod
+    def make(value: T) -> Self:
+        return Box(value=value)
+
+def main() -> None:
+    boxed = Box[int].make(1)
+    println(str(boxed.value))
+```

--- a/workspaces/docs-site/docs/language/explanation/scopes_and_name_resolution.md
+++ b/workspaces/docs-site/docs/language/explanation/scopes_and_name_resolution.md
@@ -86,7 +86,11 @@ In this example, the names `sqrt`, `PI`, `area`, and `Circle` are all resolved f
 
 Each `def ...:` body is a **function scope**.
 
-Methods also have a function-like scope and define `self` (and `mut self`) for the method body.
+Methods also have a function-like scope and define receiver names for the method body:
+
+- Instance methods define `self` or `mut self`.
+- Class methods define their explicit first parameter, conventionally `cls`. Inside a `@classmethod`, calling
+  `cls(...)` constructs the declaring type.
 
 For example:
 
@@ -102,13 +106,17 @@ model Circle:
 
     def area(self) -> float:
         return PI * self.radius * self.radius  # self: method scope, PI: module scope
+
+    @classmethod
+    def unit(cls) -> Self:
+        return cls(radius=1.0)                  # cls: classmethod scope, constructor for Circle
 ```
 
 In these examples:
 
 - **Module-scope names**: `PI`, `Circle`, `area_scaled`
 - **Function-scope names**: parameters like `r` and `scale`, plus locals like `base`
-- **Method-scope names**: `self` (and anything you bind inside the method body)
+- **Method-scope names**: `self`, `cls`, and anything you bind inside the method body
 
 ### Block scope
 

--- a/workspaces/docs-site/docs/language/reference/derives_and_traits.md
+++ b/workspaces/docs-site/docs/language/reference/derives_and_traits.md
@@ -178,10 +178,25 @@ model UserId:
 
     @classmethod
     def from(cls, value: str) -> Self:
-        return UserId(value=int(value))
+        return cls(value=int(value))
 ```
 
-Unlike an instance method, a class method does not take `self`. Unlike a static method, it is written as a type-associated constructor-style hook and returns `Self` naturally.
+Unlike an instance method, a class method does not take `self`. Its first parameter is conventionally named `cls` and can be called like a constructor for the declaring type. Unlike a static method, it is written as a type-associated constructor-style hook and returns `Self` naturally.
+
+For generic types, `Self` keeps the active type arguments at the call site:
+
+```incan
+class Box[T with Clone]:
+    value: T
+
+    @classmethod
+    def make(cls, value: T) -> Self:
+        return cls(value=value)
+
+def main() -> None:
+    boxed = Box[int].make(1)
+    println(str(boxed.value))
+```
 
 ### `@requires(...)`
 

--- a/workspaces/docs-site/docs/language/reference/language.md
+++ b/workspaces/docs-site/docs/language/reference/language.md
@@ -69,6 +69,7 @@ Reservation describes how a spelling is reserved: `Hard` keywords are always res
 | Let | `let` |  | Hard | - | Binding | Statement | RFC 000 | 0.1 | Stable |
 | Mut | `mut` |  | Hard | - | Binding | Modifier | RFC 000 | 0.1 | Stable |
 | SelfKw | `self` |  | Hard | - | Binding | ReceiverOnly | RFC 000 | 0.1 | Stable |
+| Cls | `cls` |  | Contextual | - | Binding | ReceiverOnly | RFC 000 | 0.2 | Stable |
 | True | `true` | `True` | Hard | - | Literal | Expression | RFC 000 | 0.1 | Stable |
 | False | `false` | `False` | Hard | - | Literal | Expression | RFC 000 | 0.1 | Stable |
 | None | `None` |  | Hard | - | Literal | Expression | RFC 000 | 0.1 | Stable |

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -117,6 +117,7 @@ The sections above are the release story. The list below is the detailed invento
 ### Compiler and code generation
 
 - **Compiler/Codegen**: Duckborrowing ownership planning is now centralized around typed value-use sites, covering Incan call arguments, Rust interop arguments, struct fields, collection and tuple elements, assignments, returns, match scrutinees, mutable aggregate parameters, collection lookup probes, loop/comprehension traversal, and backend-inserted generic `Clone` bounds. This removes several classes of generated-Rust borrow/move failures and reduces the need for user-authored `.clone()`, `.as_ref()`, `str(...)`, and `.into()` workarounds (#121).
+- **Compiler/Codegen**: Generic class type-owned factories can now construct and return `Self` from `@classmethod` and `@staticmethod` bodies. The compiler binds `cls(...)` inside classmethods, lowers `Type[T].factory(...)` as a Rust associated call instead of a value-position index expression, and the LSP surfaces `cls` hover/completion inside classmethod bodies (#388).
 - **Compiler/Codegen**: RFC 032 value enums now lower their raw-value metadata into IR and generate `value()`, `from_value(...)`, display, string parsing, and serde implementations that use the canonical raw representation while keeping `message()` variant-name based (#317, RFC 032).
 - **Compiler/Runtime**: Generated Rust now routes the in-scope panic-backed collection and JSON extraction paths, plus proc-macro decorator misuse stubs, through named stdlib helpers instead of open-coded fallback or `panic!` shims. The narrow checked-newtype construction panic remains tracked separately (#351).
 - **Compiler/Codegen**: `@rust.allow(...)` now emits targeted Rust `#[allow(...)]` metadata for specific generated Rust items when an Incan declaration intentionally accepts a narrow rustc or Clippy lint. The decorator supports functions, methods, models, classes, enums, and newtypes, rejects module-level directives, and blocks broad lint groups such as `warnings`, `unused`, and the common Clippy group lints (#337, RFC 057).
@@ -138,7 +139,7 @@ The sections above are the release story. The list below is the detailed invento
 ### Versioning and release track
 
 - **Project lifecycle tooling**: Added lifecycle commands for interactive `incan new` / `incan init`, `incan version`, and `incan env`, plus project lifecycle documentation and `incan.toml` environment metadata support (#73).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.9`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.10`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

This PR fixes issue #388 by making generic class type-owned factories work across both `@classmethod` and `@staticmethod` paths. Classmethod bodies can now use the conventional contextual receiver `cls(...)` to construct `Self` for generic owners, and generic static factories like `FactoryBox[int].make(...)` lower as associated type-owned calls instead of invalid value-position indexing. The change also documents the behavior in stable language docs, adds `cls` to the generated language reference as a contextual receiver binding, and teaches the LSP/VS Code surfaces about that binding.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Generic class factories can now return `Self` from `@classmethod` bodies using `cls(...)`, and generic type-owned static factories can be called as `Box[int].make(...)`. Users also get reference/explanation docs for the behavior plus contextual LSP hover/completion for `cls` inside classmethod bodies.
- **Internals**: The parser, typechecker, lowering, and LSP now refer to the shared `KeywordId::Cls` registry entry instead of independently string-coding `cls`. Typechecking tracks the active classmethod owner type, lowering preserves generic type-owned receivers as associated calls, and the generated reference/VS Code grammar are regenerated from the registry.
- **Risks**: The affected paths are constructor-call resolution, generic `Self` handling in classmethod bodies, type-owned method lowering, and contextual LSP completions. Shadowing is intentionally preserved: an ordinary local or parameter named `cls` remains a normal value binding.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed end to end, including formatting, rustdoc coverage, 1610 tests, clippy, cargo-deny, smoke-test-fast, examples, and benchmark build checks.
- Added `test_issue_388_generic_classmethod_cls_constructor_typechecks` for generic `@classmethod cls(...) -> Self` typechecking.
- Added `test_issue388_generic_type_owned_factories_run` for runtime/codegen coverage of generic classmethod and staticmethod factory calls.
- Added feature-gated LSP tests for contextual `cls` hover/completion inside classmethod bodies and absence inside staticmethod bodies.
- Regenerated the language reference and VS Code grammar from the shared keyword registry.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/language.md`
- Link(s): `workspaces/docs-site/docs/language/reference/derives_and_traits.md`
- Link(s): `workspaces/docs-site/docs/language/explanation/scopes_and_name_resolution.md`
- Link(s): `workspaces/docs-site/docs/_snippets/language/decorators/staticmethod.md`
- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #388