### PR TITLE
bugfix - qualify imported default argument helpers (#395)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "clap",
  "hex",
@@ -1471,14 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,14 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "axum",
  "incan_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["target/incan"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0-dev.10"
+version = "0.3.0-dev.11"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.91"

--- a/examples/pro/vocab_routekit/consumer/incan.lock
+++ b/examples/pro/vocab_routekit/consumer/incan.lock
@@ -3,7 +3,7 @@
 
 [incan]
 format = 1
-incan-version = "0.3.0-dev.9"
+incan-version = "0.3.0-dev.11"
 generated = "2026-04-24T18:59:21.913351Z"
 deps-fingerprint = "sha256:316bf142e6f8ea3b5838746eabec99c7e77d0acbcca01f8890c489b63498a743"
 cargo-features = []
@@ -18,14 +18,14 @@ version = 4
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "incan_core",
  "incan_derive",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "routekit_consumer"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "incan_derive",
  "incan_stdlib",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "routekit_core"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "incan_derive",
  "incan_stdlib",

--- a/examples/pro/vocab_routekit/producer/incan.lock
+++ b/examples/pro/vocab_routekit/producer/incan.lock
@@ -3,7 +3,7 @@
 
 [incan]
 format = 1
-incan-version = "0.3.0-dev.9"
+incan-version = "0.3.0-dev.11"
 generated = "2026-04-26T18:31:59.106418Z"
 deps-fingerprint = "sha256:17f122844d2fa1c9756f9a1976d222f15255557e74d975b8d8ff46536ea82b87"
 cargo-features = []
@@ -18,14 +18,14 @@ version = 4
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "incan_core",
  "incan_derive",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "routekit_core"
-version = "0.3.0-dev.9"
+version = "0.3.0-dev.11"
 dependencies = [
  "incan_derive",
  "incan_stdlib",

--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -332,7 +332,7 @@ impl<'a> IrEmitter<'a> {
         // Order arguments only when keyword args are present (positional-only calls preserve previous behavior,
         // which is important for snapshots + for default-arg lowering work that happens elsewhere).
         let has_named_args = args.iter().any(|a| a.name.is_some());
-        let ordered_args: Vec<TypedExpr> = if has_named_args {
+        let ordered_args: Vec<(TypedExpr, bool)> = if has_named_args {
             if let Some(sig) = function_sig {
                 let mut positional: Vec<TypedExpr> = Vec::new();
                 let mut named: std::collections::HashMap<&str, TypedExpr> = std::collections::HashMap::new();
@@ -345,27 +345,27 @@ impl<'a> IrEmitter<'a> {
                 }
 
                 let mut pos_idx = 0usize;
-                let mut out: Vec<TypedExpr> = Vec::new();
+                let mut out: Vec<(TypedExpr, bool)> = Vec::new();
                 for p in &sig.params {
                     if let Some(v) = named.get(p.name.as_str()) {
-                        out.push(v.clone());
+                        out.push((v.clone(), false));
                     } else if pos_idx < positional.len() {
-                        out.push(positional[pos_idx].clone());
+                        out.push((positional[pos_idx].clone(), false));
                         pos_idx += 1;
                     } else if let Some(default_arg) = &p.default {
-                        out.push(default_arg.clone());
+                        out.push((default_arg.clone(), true));
                     }
                 }
                 out
             } else {
-                args.iter().map(|a| a.expr.clone()).collect()
+                args.iter().map(|a| (a.expr.clone(), false)).collect()
             }
         } else {
-            let mut out: Vec<TypedExpr> = args.iter().map(|a| a.expr.clone()).collect();
+            let mut out: Vec<(TypedExpr, bool)> = args.iter().map(|a| (a.expr.clone(), false)).collect();
             if let Some(sig) = function_sig {
                 for p in sig.params.iter().skip(out.len()) {
                     if let Some(default_arg) = &p.default {
-                        out.push(default_arg.clone());
+                        out.push((default_arg.clone(), true));
                     } else {
                         break;
                     }
@@ -378,7 +378,7 @@ impl<'a> IrEmitter<'a> {
         let arg_tokens: Vec<TokenStream> = ordered_args
             .iter()
             .enumerate()
-            .map(|(idx, a)| {
+            .map(|(idx, (a, from_default))| {
                 let target_ty = function_sig
                     .and_then(|sig| sig.params.get(idx))
                     .map(|param| &param.ty)
@@ -386,29 +386,41 @@ impl<'a> IrEmitter<'a> {
                         IrType::Function { params, .. } => params.get(idx),
                         _ => None,
                     });
-                let emitted = if let Some(target_ty) = target_ty {
-                    if let Some(seed) = self.emit_inference_seeded_literal_arg(a, target_ty)? {
-                        seed
-                    } else if Self::is_unresolved_call_seed_type(target_ty) {
-                        // Signature exists but leaves generics unresolved: fallback to the argument's own inferred IR
-                        // type to seed constructor literals.
+                let previous_qualify = if *from_default {
+                    Some(self.qualify_internal_canonical_paths.replace(true))
+                } else {
+                    None
+                };
+                let emitted = (|| {
+                    let emitted = if let Some(target_ty) = target_ty {
+                        if let Some(seed) = self.emit_inference_seeded_literal_arg(a, target_ty)? {
+                            seed
+                        } else if Self::is_unresolved_call_seed_type(target_ty) {
+                            // Signature exists but leaves generics unresolved: fallback to the argument's own inferred
+                            // IR type to seed constructor literals.
+                            if let Some(seed) = self.emit_inference_seeded_literal_arg(a, &a.ty)? {
+                                seed
+                            } else {
+                                self.emit_expr(a)?
+                            }
+                        } else {
+                            self.emit_expr(a)?
+                        }
+                    } else {
+                        // No parameter type available (e.g. heavily generic paths): use the argument's own type as a
+                        // best-effort inference seed source.
                         if let Some(seed) = self.emit_inference_seeded_literal_arg(a, &a.ty)? {
                             seed
                         } else {
                             self.emit_expr(a)?
                         }
-                    } else {
-                        self.emit_expr(a)?
-                    }
-                } else {
-                    // No parameter type available (e.g. heavily generic paths): use the argument's own type as a
-                    // best-effort inference seed source.
-                    if let Some(seed) = self.emit_inference_seeded_literal_arg(a, &a.ty)? {
-                        seed
-                    } else {
-                        self.emit_expr(a)?
-                    }
-                };
+                    };
+                    Ok::<TokenStream, EmitError>(emitted)
+                })();
+                if let Some(previous) = previous_qualify {
+                    self.qualify_internal_canonical_paths.replace(previous);
+                }
+                let emitted = emitted?;
 
                 // Check VarAccess for explicit borrow requirements
                 if let IrExprKind::Var { access, .. } = &a.kind {
@@ -787,8 +799,14 @@ impl<'a> IrEmitter<'a> {
         }})
     }
 
+    /// Emit a canonical callee path when the compiler knows how to materialize that namespace at the current call
+    /// site.
+    ///
+    /// Canonical stdlib calls route through the generated `crate::__incan_std` module. Canonical calls to internal
+    /// source modules route through an explicit `crate::...` path so imported helper calls remain valid when default
+    /// argument expressions are expanded outside the defining module.
     fn emit_canonical_callee_path(&self, canonical_path: &[String]) -> Result<Option<TokenStream>, EmitError> {
-        if canonical_path.len() < 3 || canonical_path.first().map(String::as_str) != Some(stdlib::STDLIB_ROOT) {
+        if canonical_path.len() < 2 {
             return Ok(None);
         }
 
@@ -796,17 +814,28 @@ impl<'a> IrEmitter<'a> {
         let Some(function_name) = canonical_path.last() else {
             return Ok(None);
         };
-        if !stdlib::is_known_stdlib_module(&module_path) {
+        let mut segments: Vec<TokenStream> = if module_path.first().map(String::as_str) == Some(stdlib::STDLIB_ROOT) {
+            if canonical_path.len() < 3 || !stdlib::is_known_stdlib_module(&module_path) {
+                return Ok(None);
+            }
+            let ns = Self::rust_ident(stdlib::INCAN_STD_NAMESPACE);
+            let mut segments = vec![quote! { crate }, quote! { #ns }];
+            for seg in module_path.iter().skip(1) {
+                let ident = Self::rust_ident(seg);
+                segments.push(quote! { #ident });
+            }
+            segments
+        } else if *self.qualify_internal_canonical_paths.borrow() && self.is_internal_module_path(&module_path) {
+            let mut segments = vec![quote! { crate }];
+            for seg in &module_path {
+                let ident = Self::rust_ident(seg);
+                segments.push(quote! { #ident });
+            }
+            segments
+        } else {
             return Ok(None);
-        }
+        };
 
-        let ns = Self::rust_ident(stdlib::INCAN_STD_NAMESPACE);
-        let mut segments: Vec<TokenStream> = vec![quote! { crate }, quote! { #ns }];
-
-        for seg in module_path.iter().skip(1) {
-            let ident = Self::rust_ident(seg);
-            segments.push(quote! { #ident });
-        }
         let fn_ident = Self::rust_ident(function_name);
         segments.push(quote! { #fn_ident });
 
@@ -942,6 +971,77 @@ mod tests {
 
     fn canonical_testing_path(name: &str) -> Vec<String> {
         vec!["std".to_string(), "testing".to_string(), name.to_string()]
+    }
+
+    #[test]
+    fn emit_internal_canonical_call_preserves_local_binding_without_default_context()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let registry = FunctionRegistry::new();
+        let mut emitter = IrEmitter::new(&registry);
+        emitter.set_internal_module_roots(std::collections::HashSet::from(["defaults".to_string()]));
+        let func = rust_call_target("fallback");
+        let path = vec!["defaults".to_string(), "fallback".to_string()];
+        let tokens = emitter
+            .emit_call_expr(&func, &[], &[], Some(&path))
+            .map_err(|err| std::io::Error::other(format!("canonical internal call should emit: {err:?}")))?;
+        assert_eq!(render(tokens), "fallback()");
+        Ok(())
+    }
+
+    #[test]
+    fn emit_default_arg_internal_canonical_call_uses_crate_qualified_path() -> Result<(), Box<dyn std::error::Error>> {
+        let default_expr = TypedExpr::new(
+            IrExprKind::Call {
+                func: Box::new(rust_call_target("fallback")),
+                type_args: Vec::new(),
+                args: Vec::new(),
+                canonical_path: Some(vec!["defaults".to_string(), "fallback".to_string()]),
+            },
+            IrType::Int,
+        );
+        let mut registry = FunctionRegistry::new();
+        registry.register(
+            "combine".to_string(),
+            vec![
+                FunctionParam {
+                    name: "left".to_string(),
+                    ty: IrType::Int,
+                    mutability: Mutability::Immutable,
+                    is_self: false,
+                    default: None,
+                },
+                FunctionParam {
+                    name: "middle".to_string(),
+                    ty: IrType::Int,
+                    mutability: Mutability::Immutable,
+                    is_self: false,
+                    default: Some(default_expr),
+                },
+            ],
+            IrType::Int,
+        );
+        let mut emitter = IrEmitter::new(&registry);
+        emitter.set_internal_module_roots(std::collections::HashSet::from(["defaults".to_string()]));
+        let func = local_arg(
+            "combine",
+            IrType::Function {
+                params: vec![IrType::Int, IrType::Int],
+                ret: Box::new(IrType::Int),
+            },
+        );
+        let tokens = emitter
+            .emit_call_expr(
+                &func,
+                &[],
+                &[IrCallArg {
+                    name: None,
+                    expr: TypedExpr::new(IrExprKind::Int(1), IrType::Int),
+                }],
+                None,
+            )
+            .map_err(|err| std::io::Error::other(format!("default arg call should emit: {err:?}")))?;
+        assert_eq!(render(tokens), "combine(1,crate::defaults::fallback())");
+        Ok(())
     }
 
     #[test]

--- a/src/backend/ir/emit/mod.rs
+++ b/src/backend/ir/emit/mod.rs
@@ -113,6 +113,12 @@ pub struct IrEmitter<'a> {
     ///
     /// Used to avoid recursively forcing the module-wide static init helper while generating static initializer code.
     in_static_initializer: RefCell<bool>,
+    /// Whether canonical calls to internal modules should be emitted with explicit `crate::...` paths.
+    ///
+    /// Normal imported calls use ordinary local bindings and imports. Default argument expressions are different: they
+    /// can be expanded at a caller outside the defining module, so imported helper calls inside those defaults need a
+    /// durable crate-qualified path.
+    qualify_internal_canonical_paths: RefCell<bool>,
     /// Stack of statement-slice analyses describing which local `StaticBinding` names need mutable Rust bindings.
     ///
     /// An Incan alias like `let live = ITEMS` is not source-level `mut`, but if later emitted Rust uses
@@ -122,6 +128,8 @@ pub struct IrEmitter<'a> {
 }
 
 impl<'a> IrEmitter<'a> {
+    /// Create an emitter using the function registry that drives call-site default argument filling and type-aware
+    /// argument conversion.
     pub fn new(function_registry: &'a FunctionRegistry) -> Self {
         Self {
             // Enable minimal allows for patterns that can't easily be made warning-free:
@@ -152,6 +160,7 @@ impl<'a> IrEmitter<'a> {
             rust_import_paths: RefCell::new(std::collections::HashMap::new()),
             module_has_local_statics: RefCell::new(false),
             in_static_initializer: RefCell::new(false),
+            qualify_internal_canonical_paths: RefCell::new(false),
             storage_binding_mut_names: RefCell::new(Vec::new()),
         }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3657,6 +3657,67 @@ def test_two() -> None:
     }
 
     #[test]
+    fn e2e_imported_default_expression_expands_with_required_scope_issue395() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let dir = write_test_project(
+            "incan.toml",
+            r#"[project]
+name = "default_expr_import_test_repro"
+version = "0.1.0"
+"#,
+        );
+        let src_dir = dir.join("src");
+        let tests_dir = dir.join("tests");
+        std::fs::create_dir_all(&src_dir)?;
+        std::fs::create_dir_all(&tests_dir)?;
+        std::fs::write(
+            src_dir.join("defaults.incn"),
+            r#"
+pub def fallback() -> int:
+    return 2
+"#,
+        )?;
+        std::fs::write(
+            src_dir.join("helper.incn"),
+            r#"
+from defaults import fallback
+
+pub def combine(left: int, middle: int = fallback(), right: int = 3) -> int:
+    return left + middle + right
+"#,
+        )?;
+        std::fs::write(
+            tests_dir.join("test_default_expr_import.incn"),
+            r#"
+from std.testing import assert_eq
+from helper import combine
+
+def test_imported_default_expression_expands_with_required_imports() -> None:
+    assert_eq(combine(left=1, right=4), 7, "default expression helper should be available after expansion")
+"#,
+        )?;
+
+        let output = run_incan_test_relative(&dir, "tests");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "expected imported default expression test to succeed.\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr,
+        );
+        assert!(
+            stdout.contains(
+                "test_default_expr_import.incn::test_imported_default_expression_expands_with_required_imports"
+            ),
+            "expected issue 395 test name in reporter output.\nstdout:\n{}",
+            stdout,
+        );
+        Ok(())
+    }
+
+    #[test]
     fn e2e_sequential_single_file_runs_do_not_cross_wire_relative_paths() {
         let dir = write_test_project(
             "incan.toml",

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -118,6 +118,7 @@ The sections above are the release story. The list below is the detailed invento
 
 - **Compiler/Codegen**: Duckborrowing ownership planning is now centralized around typed value-use sites, covering Incan call arguments, Rust interop arguments, struct fields, collection and tuple elements, assignments, returns, match scrutinees, mutable aggregate parameters, collection lookup probes, loop/comprehension traversal, and backend-inserted generic `Clone` bounds. This removes several classes of generated-Rust borrow/move failures and reduces the need for user-authored `.clone()`, `.as_ref()`, `str(...)`, and `.into()` workarounds (#121).
 - **Compiler/Codegen**: Generic class type-owned factories can now construct and return `Self` from `@classmethod` and `@staticmethod` bodies. The compiler binds `cls(...)` inside classmethods, lowers `Type[T].factory(...)` as a Rust associated call instead of a value-position index expression, and the LSP surfaces `cls` hover/completion inside classmethod bodies (#388).
+- **Compiler/Codegen**: Default argument expressions that call helpers imported into the defining module now emit those helper calls with the required module qualification when the default is expanded at another call site. This fixes generated Rust failures such as omitted defaults expanding to an unqualified `fallback()` in test runners or downstream modules (#395).
 - **Compiler/Codegen**: RFC 032 value enums now lower their raw-value metadata into IR and generate `value()`, `from_value(...)`, display, string parsing, and serde implementations that use the canonical raw representation while keeping `message()` variant-name based (#317, RFC 032).
 - **Compiler/Runtime**: Generated Rust now routes the in-scope panic-backed collection and JSON extraction paths, plus proc-macro decorator misuse stubs, through named stdlib helpers instead of open-coded fallback or `panic!` shims. The narrow checked-newtype construction panic remains tracked separately (#351).
 - **Compiler/Codegen**: `@rust.allow(...)` now emits targeted Rust `#[allow(...)]` metadata for specific generated Rust items when an Incan declaration intentionally accepts a narrow rustc or Clippy lint. The decorator supports functions, methods, models, classes, enums, and newtypes, rejects module-level directives, and blocks broad lint groups such as `warnings`, `unused`, and the common Clippy group lints (#337, RFC 057).
@@ -141,7 +142,7 @@ The sections above are the release story. The list below is the detailed invento
 ### Versioning and release track
 
 - **Project lifecycle tooling**: Added lifecycle commands for interactive `incan new` / `incan init`, `incan version`, and `incan env`, plus project lifecycle documentation and `incan.toml` environment metadata support (#73).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.10`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.11`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

Fixes #395 by emitting imported helper calls inside omitted default argument expressions with module-qualified paths when those defaults are expanded outside the defining module.

The root cause was that default argument expressions carried canonical internal helper paths through typecheck/lowering, but codegen only materialized canonical stdlib paths. When a caller in another module omitted the parameter, the expanded default could emit an unqualified helper call such as `fallback()`, which failed in generated Rust.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan test` no longer generates Rust that calls imported default-expression helpers as unqualified names from the wrong module.
- **Internals**: default-argument emission temporarily enables internal canonical path qualification, while ordinary imported helper calls keep using local bindings/imports. Standard library canonical calls still route through `crate::__incan_std`.
- **Risks**: call emission is shared, so the change includes unit coverage for both default and non-default internal canonical calls, plus the existing imported `sum` shadowing regression stayed green during the review loop.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cd <workspace-checkout> && make pre-commit` passed after merging `origin/main`.
- Full gate covered rustfmt, rustdoc, nextest (`1614 tests run: 1614 passed`), clippy, cargo-deny, smoke-test-fast, examples, and benchmark smoke builds.
- Targeted issue #395 e2e regression passed as part of nextest: `e2e_imported_default_expression_expands_with_required_scope_issue395`.
- Version metadata is bumped from main's `0.3.0-dev.10` to `0.3.0-dev.11`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
