### PR TITLE
bugfix - wrap long formatter signatures (#248)

### DIFF
--- a/src/format/formatter/declarations.rs
+++ b/src/format/formatter/declarations.rs
@@ -627,23 +627,29 @@ impl Formatter {
         }
     }
 
+    /// Format a function declaration, wrapping its parameter list when the header exceeds the line-length target.
     fn format_function(&mut self, func: &FunctionDecl) {
         for dec in &func.decorators {
             self.format_decorator(&dec.node);
         }
 
-        self.write_visibility(func.visibility);
-        if func.is_async() {
-            self.writer.write("async ");
-        }
-        self.writer.write("def ");
-        self.writer.write(&func.name);
-        self.format_type_params(&func.type_params);
+        let checkpoint = self.writer.checkpoint();
+        self.write_function_prefix(func.visibility, func.is_async(), &func.name, &func.type_params);
         self.writer.write("(");
         self.format_params(&func.params);
         self.writer.write(") -> ");
         self.format_type(&func.return_type.node);
-        self.writer.writeln(":");
+        self.writer.write(":");
+        if self.writer.line_length_exceeded() {
+            self.writer.restore(checkpoint);
+            self.write_function_prefix(func.visibility, func.is_async(), &func.name, &func.type_params);
+            self.writer.write("(");
+            self.format_params_multiline(None, &func.params);
+            self.writer.write(") -> ");
+            self.format_type(&func.return_type.node);
+            self.writer.write(":");
+        }
+        self.writer.newline();
 
         self.writer.indent();
 
@@ -667,43 +673,45 @@ impl Formatter {
         self.writer.dedent();
     }
 
+    /// Format a method declaration, wrapping receiver and parameter lines when the header exceeds the target length.
     fn format_method(&mut self, method: &MethodDecl) {
         for dec in &method.decorators {
             self.format_decorator(&dec.node);
         }
 
-        if method.is_async() {
-            self.writer.write("async ");
-        }
-        self.writer.write("def ");
-        self.writer.write(&method.name);
-        if !method.type_params.is_empty() {
-            self.format_type_params(&method.type_params);
-        }
+        let checkpoint = self.writer.checkpoint();
+        self.write_method_prefix(method);
         self.writer.write("(");
-
-        let has_receiver = method.receiver.is_some();
-        if let Some(receiver) = &method.receiver {
-            match receiver {
-                Receiver::Immutable => self.writer.write("self"),
-                Receiver::Mutable => self.writer.write("mut self"),
-            }
-        }
-
-        if has_receiver && !method.params.is_empty() {
-            self.writer.write(", ");
-        }
-        self.format_params(&method.params);
-
+        self.format_receiver_and_params(method.receiver.as_ref(), &method.params);
         self.writer.write(") -> ");
         self.format_type(&method.return_type.node);
 
         if method.body.is_none() {
-            self.writer.writeln(": ...");
+            self.writer.write(": ...");
+            if self.writer.line_length_exceeded() {
+                self.writer.restore(checkpoint);
+                self.write_method_prefix(method);
+                self.writer.write("(");
+                self.format_params_multiline(method.receiver.as_ref(), &method.params);
+                self.writer.write(") -> ");
+                self.format_type(&method.return_type.node);
+                self.writer.write(": ...");
+            }
+            self.writer.newline();
             return;
         }
 
-        self.writer.writeln(":");
+        self.writer.write(":");
+        if self.writer.line_length_exceeded() {
+            self.writer.restore(checkpoint);
+            self.write_method_prefix(method);
+            self.writer.write("(");
+            self.format_params_multiline(method.receiver.as_ref(), &method.params);
+            self.writer.write(") -> ");
+            self.format_type(&method.return_type.node);
+            self.writer.write(":");
+        }
+        self.writer.newline();
         self.writer.indent();
 
         if let Some(body) = &method.body {
@@ -721,6 +729,70 @@ impl Formatter {
             }
         }
 
+        self.writer.dedent();
+    }
+
+    /// Write the reusable prefix before a function's opening parameter parenthesis.
+    fn write_function_prefix(&mut self, visibility: Visibility, is_async: bool, name: &str, type_params: &[TypeParam]) {
+        self.write_visibility(visibility);
+        if is_async {
+            self.writer.write("async ");
+        }
+        self.writer.write("def ");
+        self.writer.write(name);
+        self.format_type_params(type_params);
+    }
+
+    /// Write the reusable prefix before a method's opening parameter parenthesis.
+    fn write_method_prefix(&mut self, method: &MethodDecl) {
+        if method.is_async() {
+            self.writer.write("async ");
+        }
+        self.writer.write("def ");
+        self.writer.write(&method.name);
+        if !method.type_params.is_empty() {
+            self.format_type_params(&method.type_params);
+        }
+    }
+
+    /// Format an explicit method receiver.
+    fn format_receiver(&mut self, receiver: &Receiver) {
+        match receiver {
+            Receiver::Immutable => self.writer.write("self"),
+            Receiver::Mutable => self.writer.write("mut self"),
+        }
+    }
+
+    /// Format an inline method receiver followed by ordinary parameters.
+    fn format_receiver_and_params(&mut self, receiver: Option<&Receiver>, params: &[Spanned<Param>]) {
+        if let Some(receiver) = receiver {
+            self.format_receiver(receiver);
+            if !params.is_empty() {
+                self.writer.write(", ");
+            }
+        }
+        self.format_params(params);
+    }
+
+    /// Format a multiline receiver/parameter list inside an already-opened signature.
+    fn format_params_multiline(&mut self, receiver: Option<&Receiver>, params: &[Spanned<Param>]) {
+        let trailing_commas = self.writer.config().trailing_commas;
+        self.writer.newline();
+        self.writer.indent();
+        if let Some(receiver) = receiver {
+            self.format_receiver(receiver);
+            if trailing_commas || !params.is_empty() {
+                self.writer.write(",");
+            }
+            self.writer.newline();
+        }
+        for (i, param) in params.iter().enumerate() {
+            self.format_param(&param.node);
+            if trailing_commas || i + 1 < params.len() {
+                self.writer.write(",");
+            }
+            self.writer.newline();
+        }
         self.writer.dedent();
     }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -360,6 +360,57 @@ def MixedName() -> int:
     }
 
     #[test]
+    fn test_format_source_wraps_long_function_signature() -> Result<(), FormatError> {
+        let source = r#"def append_node(store_id: int, kind: PrismNodeKind, input_ids: list[int], named_table: str, predicate: bool, limit_count: int) -> int:
+  return 1
+"#;
+        let formatted = format_source(source)?;
+        let expected = r#"def append_node(
+    store_id: int,
+    kind: PrismNodeKind,
+    input_ids: list[int],
+    named_table: str,
+    predicate: bool,
+    limit_count: int,
+) -> int:
+    return 1
+"#;
+        assert_eq!(formatted, expected);
+        assert!(
+            formatted.lines().all(|line| line.len() <= 120),
+            "expected wrapped signature to stay within 120 columns; got:\n{formatted}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_source_wraps_long_method_signature() -> Result<(), FormatError> {
+        let source = r#"class Store:
+  def append_node(self, store_id: int, kind: PrismNodeKind, input_ids: list[int], named_table: str, predicate: bool, limit_count: int) -> int:
+    return 1
+"#;
+        let formatted = format_source(source)?;
+        let expected = r#"class Store:
+    def append_node(
+        self,
+        store_id: int,
+        kind: PrismNodeKind,
+        input_ids: list[int],
+        named_table: str,
+        predicate: bool,
+        limit_count: int,
+    ) -> int:
+        return 1
+"#;
+        assert_eq!(formatted, expected);
+        assert!(
+            formatted.lines().all(|line| line.len() <= 120),
+            "expected wrapped method signature to stay within 120 columns; got:\n{formatted}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_format_source_invalid_syntax() {
         let source = "def foo(";
         let result = format_source(source);

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -53,7 +53,7 @@ See also: [Control Flow](../language/explanation/control_flow.md), [Book chapter
 
 The formatter also normalizes docstring payload indentation while collapsing actual docstring blank-line runs to one blank line, keeps abstract trait methods tight until a following default/body-bearing method, treats stand-alone comments as leading or trailing bundles even when their target statement wraps, preserves a single authored blank line between statement groups after nested suites, keeps short single-statement `match` arms inline, normalizes blank lines after suite headers and match-arm arrows, strips trailing blank lines at EOF, and allows two consecutive blank lines only at root level.
 
-Long constructor and call expressions now participate in formatter wrapping: calls that overflow the configured line-length target are rewritten with one argument per line and respect the existing trailing-comma setting.
+Long call-like expressions and signatures now participate in formatter wrapping: overflowing constructor calls, ordinary calls, function signatures, and method signatures are rewritten across multiple lines and respect the existing trailing-comma setting.
 
 The same spacing contract applies through the CLI and the library formatter API. `FormatConfig` still controls ordinary formatting options such as indentation and line length, but vertical-spacing buckets and comment placement are not configurable.
 
@@ -126,7 +126,7 @@ The sections above are the release story. The list below is the detailed invento
 ### Tooling and formatter
 
 - **Compiler/Tooling**: RFC 053’s vertical-spacing contract is now reflected in `incan fmt`: top-level `def` / `model` / `type`-like declarations keep two blank lines around them, adjacent constants/statics stay grouped unless they border one of those declarations, trait abstract methods stay tight until a following body-bearing member, docstring indentation is normalized while actual blank-line runs collapse to one blank line, single readability gaps between statement groups survive nested suites, short single-statement `match` arms stay inline, blank lines after suite headers and match-arm arrows are normalized, trailing EOF blank lines are removed, two consecutive blank lines are allowed only at root level, and stand-alone comments attach as leading/trailing bundles even when the formatter wraps the target statement (#336, RFC 053).
-- **Compiler/Tooling**: `incan fmt` now wraps overflowing call and constructor argument lists across multiple lines, with trailing commas controlled by the existing formatter setting (#336).
+- **Compiler/Tooling**: `incan fmt` now wraps overflowing call and constructor argument lists, plus function and method signatures, across multiple lines with trailing commas controlled by the existing formatter setting (#336, #248).
 - **Tooling**: Vocab extraction helper tests now reuse the workspace lockfile when resolving helper dependencies, so focused vocab extraction coverage can run in restricted-network environments once local workspace dependencies are present (#211).
 
 ### Parser and syntax
@@ -146,7 +146,7 @@ The sections above are the release story. The list below is the detailed invento
 
 ## Known limitations (0.3)
 
-- `incan fmt` remains intentionally conservative on broader wrapping and may leave ordinary signatures and some nested expressions beyond the documented 120-character line-length target (#248). RFC 053 / #336 narrows the vertical-spacing contract and adds call/constructor wrapping, but it is not a general wrapping/configuration overhaul.
+- `incan fmt` remains intentionally conservative on broader wrapping and may still leave indivisible tokens or unsupported expression shapes beyond the documented 120-character line-length target. RFC 053 / #336 narrows the vertical-spacing contract and adds call/constructor wrapping, while #248 adds common function/method signature wrapping; this is still not a general wrapping/configuration overhaul.
 - `0.3` is still a development release. This page is intentionally incomplete until more post-`0.2` work lands.
 
 ## RFCs implemented


### PR DESCRIPTION
## Summary

This PR fixes `incan fmt` handling for long function and method signatures. The formatter now tries the existing inline layout first, then falls back to one parameter per line when the signature exceeds the configured line-length target.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan fmt` now wraps overflowing function and method signatures instead of leaving ordinary long parameter lists beyond the documented line-length target.
- **Internals**: Function and method formatting use the existing writer checkpoint pattern: emit inline first, restore, then emit multiline receiver/parameter lists only when the header exceeds the configured target.
- **Risks**: Formatter output changes for long signatures. Existing short signatures and already-wrapped multiline parameter lists should remain unchanged.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan wraps_long` passed after rebasing onto latest `origin/main`.
- Earlier full local gate passed before the final rebase: `make pre-commit`, including formatter checks, rustdoc gate, 1609 tests, clippy, cargo-deny, and smoke-test-fast.
- Local issue #248 repro formatted with no lines over 120 characters.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #248
