### PR TITLE
feature - 417 add durable async timeout helpers

### DIFF
--- a/crates/incan_stdlib/src/async/time.rs
+++ b/crates/incan_stdlib/src/async/time.rs
@@ -1,6 +1,8 @@
 //! Tokio-backed time adapters for `std.async.time`.
 
+use crate::r#async::task::{JoinHandle, TaskJoinError};
 use std::fmt;
+use std::time::Duration;
 
 /// Timeout error used by the public async timing helpers.
 #[must_use]
@@ -33,40 +35,128 @@ impl fmt::Display for TimeoutError {
 
 impl std::error::Error for TimeoutError {}
 
-/// Clamp a floating-point second value to a valid `Duration`, treating negative/NaN/infinity as zero.
-pub fn clamp_seconds(seconds: f64) -> std::time::Duration {
-    if !seconds.is_finite() || seconds.is_sign_negative() {
-        return std::time::Duration::from_secs(0);
-    }
-
-    std::time::Duration::from_secs_f64(seconds)
+/// Result of waiting on a spawned task with a deadline.
+#[must_use = "inspect the outcome to preserve timed-out task handles"]
+pub enum TimeoutJoinOutcome<T> {
+    /// The task completed successfully before the deadline.
+    Completed(T),
+    /// The task completed before the deadline but failed while joining.
+    JoinFailed(TaskJoinError),
+    /// The deadline expired and the task handle is still live.
+    TimedOut(JoinHandle<T>),
 }
 
-pub fn clamp_millis(milliseconds: i64) -> std::time::Duration {
+/// Clamp a floating-point second value to a valid `Duration`, treating negative/NaN/infinity as zero.
+pub fn clamp_seconds(seconds: f64) -> Duration {
+    if !seconds.is_finite() || seconds.is_sign_negative() {
+        return Duration::from_secs(0);
+    }
+
+    Duration::from_secs_f64(seconds)
+}
+
+/// Clamp an integer millisecond value to a valid `Duration`, treating negative values as zero.
+pub fn clamp_millis(milliseconds: i64) -> Duration {
     let millis = if milliseconds.is_negative() {
         0
     } else {
         milliseconds as u64
     };
 
-    std::time::Duration::from_millis(millis)
+    Duration::from_millis(millis)
+}
+
+/// Wait for a spawned task up to a floating-point second deadline without cancelling the task on timeout.
+pub async fn timeout_join<T>(seconds: f64, handle: JoinHandle<T>) -> TimeoutJoinOutcome<T>
+where
+    T: Send + 'static,
+{
+    timeout_join_duration(clamp_seconds(seconds), handle).await
+}
+
+/// Wait for a spawned task up to an integer millisecond deadline without cancelling the task on timeout.
+pub async fn timeout_join_ms<T>(milliseconds: i64, handle: JoinHandle<T>) -> TimeoutJoinOutcome<T>
+where
+    T: Send + 'static,
+{
+    timeout_join_duration(clamp_millis(milliseconds), handle).await
+}
+
+/// Wait for a spawned task up to a concrete duration while preserving the handle when the deadline wins.
+async fn timeout_join_duration<T>(duration: Duration, mut handle: JoinHandle<T>) -> TimeoutJoinOutcome<T>
+where
+    T: Send + 'static,
+{
+    tokio::select! {
+        result = &mut handle => match result {
+            Ok(value) => TimeoutJoinOutcome::Completed(value),
+            Err(error) => TimeoutJoinOutcome::JoinFailed(error),
+        },
+        _ = tokio::time::sleep(duration) => TimeoutJoinOutcome::TimedOut(handle),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{clamp_millis, clamp_seconds};
+    use super::{TimeoutJoinOutcome, clamp_millis, clamp_seconds, timeout_join, timeout_join_ms};
+    use crate::r#async::task::spawn;
+    use std::time::Duration;
+    use tokio::sync::oneshot;
 
     #[tokio::test]
     async fn clamp_seconds_normalizes_negative_and_infinite() {
-        assert_eq!(clamp_seconds(-1.0), std::time::Duration::from_secs(0));
-        assert_eq!(clamp_seconds(f64::INFINITY), std::time::Duration::from_secs(0));
-        assert_eq!(clamp_seconds(f64::NAN), std::time::Duration::from_secs(0));
+        assert_eq!(clamp_seconds(-1.0), Duration::from_secs(0));
+        assert_eq!(clamp_seconds(f64::INFINITY), Duration::from_secs(0));
+        assert_eq!(clamp_seconds(f64::NAN), Duration::from_secs(0));
         assert!(clamp_seconds(0.25).as_nanos() > 0);
     }
 
     #[tokio::test]
     async fn clamp_millis_normalizes_negative() {
-        assert_eq!(clamp_millis(-1), std::time::Duration::from_millis(0));
-        assert_eq!(clamp_millis(500), std::time::Duration::from_millis(500));
+        assert_eq!(clamp_millis(-1), Duration::from_millis(0));
+        assert_eq!(clamp_millis(500), Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn timeout_join_returns_completed_task_result() {
+        let result = timeout_join(0.1, spawn(async { 7 })).await;
+
+        match result {
+            TimeoutJoinOutcome::Completed(value) => assert_eq!(value, 7),
+            TimeoutJoinOutcome::JoinFailed(err) => panic!("expected task value, got join error: {err}"),
+            TimeoutJoinOutcome::TimedOut(_) => panic!("expected task to complete before timeout"),
+        }
+    }
+
+    #[tokio::test]
+    async fn timeout_join_preserves_handle_when_deadline_wins() {
+        assert_timeout_preserves_handle(false, 11).await;
+    }
+
+    #[tokio::test]
+    async fn timeout_join_ms_preserves_handle_when_deadline_wins() {
+        assert_timeout_preserves_handle(true, 13).await;
+    }
+
+    async fn assert_timeout_preserves_handle(use_millis: bool, expected: i32) {
+        let (sender, receiver) = oneshot::channel::<i32>();
+        let handle = spawn(async move { receiver.await.unwrap_or(0) });
+        let result = if use_millis {
+            timeout_join_ms(0, handle).await
+        } else {
+            timeout_join(0.0, handle).await
+        };
+
+        let handle = match result {
+            TimeoutJoinOutcome::Completed(value) => panic!("expected timeout, got completed value: {value}"),
+            TimeoutJoinOutcome::JoinFailed(err) => panic!("expected timeout, got join error: {err}"),
+            TimeoutJoinOutcome::TimedOut(handle) => handle,
+        };
+
+        assert!(sender.send(expected).is_ok());
+        match handle.await {
+            Ok(value) => assert_eq!(value, expected),
+            Err(err) => panic!("expected preserved handle to finish, got join error: {err}"),
+        }
     }
 }

--- a/crates/incan_stdlib/stdlib/async/prelude.incn
+++ b/crates/incan_stdlib/stdlib/async/prelude.incn
@@ -6,7 +6,7 @@ submodule individually.
 
 It re-exports:
 
-- time helpers such as `sleep`, `timeout`, and `Duration`
+- time helpers such as `sleep`, `timeout`, `timeout_join`, and `Duration`
 - task helpers such as `spawn`, `spawn_blocking`, `yield_now`, `JoinHandle`, and `TaskJoinError`
 - channel helpers and error types
 - synchronization primitives (`Mutex`, `RwLock`, `Semaphore`, `Barrier`) and `SemaphoreAcquireError`
@@ -17,7 +17,17 @@ Example:
 """
 
 # Time primitives
-from std.async.time import sleep, sleep_ms, timeout, timeout_ms, Duration, TimeoutError
+from std.async.time import (
+    sleep,
+    sleep_ms,
+    timeout,
+    timeout_ms,
+    timeout_join,
+    timeout_join_ms,
+    Duration,
+    TimeoutError,
+    TimeoutJoinOutcome,
+)
 
 # Task spawning
 from std.async.task import spawn, spawn_blocking, yield_now, JoinHandle, TaskJoinError

--- a/crates/incan_stdlib/stdlib/async/time.incn
+++ b/crates/incan_stdlib/stdlib/async/time.incn
@@ -7,13 +7,18 @@ This module is the user-facing timing surface for `std.async`. It exposes:
 - `sleep_ms(milliseconds)` for integer millisecond delays
 - `timeout(seconds, task)` for deadline-bound async work
 - `timeout_ms(milliseconds, task)` for integer millisecond deadlines
+- `timeout_join(seconds, handle)` for deadline-bound waiting on spawned work that must keep running
+- `timeout_join_ms(milliseconds, handle)` for integer millisecond durable join deadlines
 
 Cancellation contracts:
 
 - `sleep()` and `sleep_ms()` are cancel-safe: cancelling the sleep future stops waiting and has no side effect.
 - `timeout()` and `timeout_ms()` cancel the supplied future when the deadline expires.
 - Cancelling a `timeout()` or `timeout_ms()` call before it resolves also drops the supplied future.
-- Use `std.async.task.spawn()` first when work must be durable once spawned instead of cancelled by timeout.
+- `timeout_join()` and `timeout_join_ms()` do not cancel the spawned task when the deadline expires; they return the
+  still-live handle in `TimeoutJoinOutcome.TimedOut(handle)`.
+- Cancelling a `timeout_join()` or `timeout_join_ms()` call before it resolves drops the handle owned by the helper. The
+  task continues running, but the caller loses observability unless it has arranged another completion path.
 
 Examples:
     await sleep(0.25)
@@ -30,8 +35,14 @@ Examples:
 
 import std.async
 from std.traits.error import Error
-from rust::incan_stdlib::async::task import RuntimeFuture
-from rust::incan_stdlib::async::time import clamp_seconds, clamp_millis
+from rust::incan_stdlib::async::task import JoinHandle, RuntimeFuture
+from rust::incan_stdlib::async::time import (
+    TimeoutJoinOutcome as RustTimeoutJoinOutcome,
+    clamp_seconds,
+    clamp_millis,
+    timeout_join as rust_timeout_join,
+    timeout_join_ms as rust_timeout_join_ms,
+)
 from rust::tokio::time import (
     sleep as tokio_sleep,
     timeout as tokio_timeout,
@@ -87,6 +98,17 @@ pub model Duration:
         return Duration(secs=whole, nanos=nanos)
 
 
+pub type TimeoutJoinOutcome[T] = rusttype RustTimeoutJoinOutcome[T]:
+    """
+    Result of waiting on a spawned task with a deadline.
+
+    Variants:
+        Completed(value): the task completed successfully before the deadline.
+        JoinFailed(err): the task finished before the deadline but failed while joining.
+        TimedOut(handle): the deadline expired and the task handle is still live.
+    """
+
+
 pub async def sleep(seconds: float) -> None:
     """
     Sleep for a floating-point second duration.
@@ -129,3 +151,25 @@ pub async def timeout_ms[T with (Send, Static), TaskFuture with RuntimeFuture[T]
     match await tokio_timeout(clamp_millis(milliseconds), task):
         Ok(value) => return Ok(value)
         Err(_err) => return Err(TimeoutError())
+
+
+pub async def timeout_join[T with (Send, Static)](seconds: float, handle: JoinHandle[T]) -> TimeoutJoinOutcome[T]:
+    """
+    Wait up to `seconds` for a spawned task without cancelling it when the deadline expires.
+
+    Returns `TimeoutJoinOutcome.Completed(value)` when the task completes successfully,
+    `TimeoutJoinOutcome.JoinFailed(err)` when the task finishes with a join error, and
+    `TimeoutJoinOutcome.TimedOut(handle)` when the deadline wins. In the timeout case, `handle` remains live and can be
+    awaited, stored, or aborted explicitly. For blocking work created with `spawn_blocking()`, `abort()` can only prevent
+    work that has not started yet.
+    """
+    return await rust_timeout_join(seconds, handle)
+
+
+pub async def timeout_join_ms[T with (Send, Static)](milliseconds: int, handle: JoinHandle[T]) -> TimeoutJoinOutcome[T]:
+    """
+    Wait up to `milliseconds` for a spawned task without cancelling it when the deadline expires.
+
+    This is the millisecond-duration form of `timeout_join()`.
+    """
+    return await rust_timeout_join_ms(milliseconds, handle)

--- a/src/frontend/library_exports.rs
+++ b/src/frontend/library_exports.rs
@@ -116,6 +116,7 @@ pub struct CheckedEnumExport {
 pub struct CheckedNewtypeExport {
     pub name: String,
     pub type_params: Vec<CheckedTypeParam>,
+    pub is_rusttype: bool,
     pub underlying: ResolvedType,
     pub methods: Vec<CheckedMethod>,
 }
@@ -382,10 +383,14 @@ fn checked_enum_export(enum_decl: &EnumDecl, checker: &TypeChecker) -> Option<Ch
     })
 }
 
+/// Build a manifest-ready newtype export from the checked symbol metadata.
 fn checked_newtype_export(newtype_decl: &NewtypeDecl, checker: &TypeChecker) -> Option<CheckedNewtypeExport> {
     let symbol = checker.lookup_symbol(newtype_decl.name.as_str())?;
     let SymbolKind::Type(TypeInfo::Newtype(NewtypeInfo {
-        underlying, methods, ..
+        is_rusttype,
+        underlying,
+        methods,
+        ..
     })) = &symbol.kind
     else {
         return None;
@@ -394,6 +399,7 @@ fn checked_newtype_export(newtype_decl: &NewtypeDecl, checker: &TypeChecker) -> 
     Some(CheckedNewtypeExport {
         name: newtype_decl.name.clone(),
         type_params: checked_type_params(&newtype_decl.type_params, checker),
+        is_rusttype: *is_rusttype,
         underlying: underlying.clone(),
         methods: map_methods(methods),
     })

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -1369,6 +1369,7 @@ impl TypeChecker {
         self.symbols.exit_scope();
     }
 
+    /// Validate one newtype or rusttype declaration after collection has registered its symbol.
     fn check_newtype(&mut self, nt: &NewtypeDecl) {
         self.validate_decorators(&nt.decorators);
 
@@ -1381,16 +1382,21 @@ impl TypeChecker {
             ));
         }
 
-        if nt.is_rusttype && !matches!(underlying, ResolvedType::RustPath(_)) {
+        let rusttype_path = if nt.is_rusttype {
+            self.rust_path_for_rusttype_underlying(&underlying)
+        } else {
+            None
+        };
+        if nt.is_rusttype && rusttype_path.is_none() {
             self.errors
                 .push(errors::rusttype_requires_rust_backing(&nt.name, nt.underlying.span));
         }
         if nt.is_rusttype
-            && let ResolvedType::RustPath(path) = &underlying
+            && let Some(path) = rusttype_path
         {
             self.type_info
                 .rusttype_canonical_rust_paths
-                .insert(nt.name.clone(), path.clone());
+                .insert(nt.name.clone(), path);
         }
         if !nt.is_rusttype && !nt.interop_edges.is_empty() {
             self.errors

--- a/src/frontend/typechecker/check_expr/match_.rs
+++ b/src/frontend/typechecker/check_expr/match_.rs
@@ -335,12 +335,14 @@ impl TypeChecker {
     ) -> bool {
         let is_rust_backed = match expected_ty {
             ResolvedType::RustPath(_) => true,
-            ResolvedType::Named(type_name) => self.lookup_type_info(type_name).is_some_and(|info| {
-                matches!(
-                    info,
-                    TypeInfo::Newtype(nt) if nt.is_rusttype && matches!(&nt.underlying, ResolvedType::RustPath(_))
-                )
-            }),
+            ResolvedType::Named(type_name) | ResolvedType::Generic(type_name, _) => {
+                self.lookup_type_info(type_name).is_some_and(|info| {
+                    matches!(
+                        info,
+                        TypeInfo::Newtype(nt) if nt.is_rusttype && matches!(&nt.underlying, ResolvedType::RustPath(_))
+                    )
+                })
+            }
             _ => false,
         };
         if !is_rust_backed {
@@ -376,7 +378,7 @@ impl TypeChecker {
             return false;
         }
         match expected_ty {
-            ResolvedType::Named(type_name) => info.enum_name == *type_name,
+            ResolvedType::Named(type_name) | ResolvedType::Generic(type_name, _) => info.enum_name == *type_name,
             // Scrutinee is a bare Rust path: module-level variant symbols are Incan-/manifest-scoped names.
             ResolvedType::RustPath(_) => false,
             _ => false,
@@ -406,7 +408,7 @@ impl TypeChecker {
         };
 
         let base_rust_path: String = match expected_ty {
-            ResolvedType::Named(type_name) => {
+            ResolvedType::Named(type_name) | ResolvedType::Generic(type_name, _) => {
                 if let Some(q) = enum_qualifier_opt
                     && q != type_name.as_str()
                 {
@@ -425,7 +427,8 @@ impl TypeChecker {
             _ => return None,
         };
 
-        if let Some(meta) = self.rust_item_metadata_for_path(base_rust_path.as_str())
+        let (metadata_rust_path, _) = self.rust_path_base_and_args(base_rust_path.as_str());
+        if let Some(meta) = self.rust_item_metadata_for_path(metadata_rust_path.as_str())
             && let RustItemKind::Type(info) = meta.kind
             && let Some(variant) = info.variants.iter().find(|variant| variant.name == variant_segment)
         {

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -441,7 +441,14 @@ impl TypeChecker {
 
     /// Register a newtype declaration with its underlying type and methods.
     fn collect_newtype(&mut self, nt: &NewtypeDecl, span: Span) {
-        let underlying = self.resolve_type_checked(&nt.underlying);
+        let resolved_underlying = self.resolve_type_checked(&nt.underlying);
+        let underlying = if nt.is_rusttype {
+            self.rust_path_for_rusttype_underlying(&resolved_underlying)
+                .map(ResolvedType::RustPath)
+                .unwrap_or_else(|| resolved_underlying.clone())
+        } else {
+            resolved_underlying.clone()
+        };
         let method_rebindings = nt
             .rebindings
             .iter()

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -216,6 +216,20 @@ impl TypeChecker {
                             continue;
                         }
 
+                        // Top-level stdlib type declarations (models/classes/enums/type aliases/newtypes).
+                        let type_info = self.stdlib_cache.lookup_type(&module.segments, &item.name);
+                        if let Some(info) = type_info {
+                            let local_name = item.alias.clone().unwrap_or_else(|| item.name.clone());
+                            self.validate_root_namespace(&local_name, span);
+                            self.symbols.define(Symbol {
+                                name: local_name,
+                                kind: SymbolKind::Type(info),
+                                span,
+                                scope: 0,
+                            });
+                            continue;
+                        }
+
                         // Top-level stdlib const bindings (e.g. `from std.math import PI`).
                         let const_info = self.stdlib_cache.lookup_constant(&module.segments, &item.name);
                         if let Some(info) = const_info {
@@ -935,10 +949,11 @@ impl TypeChecker {
         }
     }
 
+    /// Convert a manifest newtype export into local typechecker metadata.
     fn newtype_info_from_manifest(&self, export: &NewtypeExport) -> NewtypeInfo {
         NewtypeInfo {
             type_params: export.type_params.iter().map(|param| param.name.clone()).collect(),
-            is_rusttype: false,
+            is_rusttype: export.is_rusttype,
             has_interop: false,
             underlying: resolved_type_from_manifest_type_ref(&export.underlying),
             method_rebindings: std::collections::HashMap::new(),

--- a/src/frontend/typechecker/helpers/types.rs
+++ b/src/frontend/typechecker/helpers/types.rs
@@ -73,3 +73,59 @@ pub fn result_ty(ok: ResolvedType, err: ResolvedType) -> ResolvedType {
 pub fn tuple_generic_ty(elems: Vec<ResolvedType>) -> ResolvedType {
     ResolvedType::Generic(collection_name(CollectionTypeId::Tuple).to_string(), elems)
 }
+
+/// Render a resolved generic argument using Rust type syntax for canonical Rust paths.
+pub fn render_resolved_type_as_rust_arg(ty: &ResolvedType) -> String {
+    match ty {
+        ResolvedType::Int => "i64".to_string(),
+        ResolvedType::Float => "f64".to_string(),
+        ResolvedType::Bool => "bool".to_string(),
+        ResolvedType::Str => "String".to_string(),
+        ResolvedType::Bytes => "Vec<u8>".to_string(),
+        ResolvedType::FrozenStr => "incan_stdlib::frozen::FrozenStr".to_string(),
+        ResolvedType::FrozenBytes => "incan_stdlib::frozen::FrozenBytes".to_string(),
+        ResolvedType::Unit => "()".to_string(),
+        ResolvedType::Tuple(items) => {
+            let rendered_items = items
+                .iter()
+                .map(render_resolved_type_as_rust_arg)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("({rendered_items})")
+        }
+        ResolvedType::TypeVar(name) => name.clone(),
+        ResolvedType::SelfType => "Self".to_string(),
+        ResolvedType::RustPath(path) => path.clone(),
+        ResolvedType::Generic(name, args) => {
+            let rendered_args = args
+                .iter()
+                .map(render_resolved_type_as_rust_arg)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{name}<{rendered_args}>")
+        }
+        ResolvedType::FrozenList(elem) => {
+            format!(
+                "incan_stdlib::frozen::FrozenList<{}>",
+                render_resolved_type_as_rust_arg(elem)
+            )
+        }
+        ResolvedType::FrozenDict(key, value) => format!(
+            "incan_stdlib::frozen::FrozenDict<{}, {}>",
+            render_resolved_type_as_rust_arg(key),
+            render_resolved_type_as_rust_arg(value)
+        ),
+        ResolvedType::FrozenSet(elem) => {
+            format!(
+                "incan_stdlib::frozen::FrozenSet<{}>",
+                render_resolved_type_as_rust_arg(elem)
+            )
+        }
+        ResolvedType::Named(name) => name.clone(),
+        ResolvedType::Function(_, _)
+        | ResolvedType::Ref(_)
+        | ResolvedType::RefMut(_)
+        | ResolvedType::CallSiteInfer
+        | ResolvedType::Unknown => ty.to_string(),
+    }
+}

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -68,7 +68,7 @@ use crate::frontend::surface_semantics::SurfaceContext;
 use crate::frontend::symbols::*;
 #[cfg(feature = "rust_inspect")]
 use crate::rust_inspect::RustMetadataCache;
-use helpers::{collection_type_id, stringlike_type_id};
+use helpers::{collection_type_id, render_resolved_type_as_rust_arg, stringlike_type_id};
 use incan_core::interop::{CoercionPolicy, RustFunctionSig, RustItemKind, RustItemMetadata, RustParam, RustTypeShape};
 use incan_core::lang::surface::types as surface_types;
 use incan_core::lang::surface::types::SurfaceTypeKind;
@@ -674,6 +674,25 @@ impl TypeChecker {
             }
             _ => None,
         }
+    }
+
+    /// Resolve a source-level rusttype backing type to its canonical Rust path spelling.
+    pub(crate) fn rust_path_for_rusttype_underlying(&self, ty: &ResolvedType) -> Option<String> {
+        if let ResolvedType::RustPath(path) = ty {
+            return Some(path.clone());
+        }
+
+        let (base, _definition, args) = self.rust_identity_for_type(ty)?;
+        if args.is_empty() {
+            return Some(base);
+        }
+
+        let rendered_args = args
+            .iter()
+            .map(render_resolved_type_as_rust_arg)
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(format!("{base}<{rendered_args}>"))
     }
 
     fn rust_type_identities_compatible(&self, actual: &ResolvedType, expected: &ResolvedType) -> Option<bool> {

--- a/src/frontend/typechecker/stdlib_loader.rs
+++ b/src/frontend/typechecker/stdlib_loader.rs
@@ -32,9 +32,13 @@ use std::path::PathBuf;
 
 use crate::frontend::ast;
 use crate::frontend::symbols::VariableInfo;
-use crate::frontend::symbols::{FunctionInfo, MethodInfo, ResolvedType, TraitInfo};
+use crate::frontend::symbols::{
+    ClassInfo, EnumInfo, FieldInfo, FunctionInfo, MethodInfo, ModelInfo, NewtypeInfo, ResolvedType, TraitInfo, TypeInfo,
+};
+use crate::frontend::typechecker::helpers::render_resolved_type_as_rust_arg;
 use incan_core::lang::conventions;
 use incan_core::lang::decorators::{self, DecoratorId};
+use incan_core::lang::rust_keywords;
 use incan_core::lang::stdlib;
 use incan_core::lang::surface::functions::{self as surface_functions, SurfaceFnId};
 use incan_core::lang::types::collections::{self as collection_types, CollectionTypeId};
@@ -45,6 +49,7 @@ use incan_core::lang::types::stringlike::{self as string_types, StringLikeId};
 struct StdlibModuleData {
     functions: Vec<(String, FunctionInfo)>,
     traits: Vec<(String, TraitInfo)>,
+    types: Vec<(String, TypeInfo)>,
     constants: Vec<(String, VariableInfo)>,
     function_meta: HashMap<String, FunctionMeta>,
     trait_meta: HashMap<String, TraitMeta>,
@@ -98,6 +103,18 @@ impl StdlibAstCache {
             .traits
             .iter()
             .find(|(name, _)| name == trait_name)
+            .map(|(_, info)| info.clone())
+    }
+
+    /// Look up a specific type in a stdlib module.
+    pub fn lookup_type(&mut self, module_path: &[String], type_name: &str) -> Option<TypeInfo> {
+        self.ensure_loaded(module_path);
+        let key = module_path.join(".");
+        self.cache
+            .get(&key)?
+            .types
+            .iter()
+            .find(|(name, _)| name == type_name)
             .map(|(_, info)| info.clone())
     }
 
@@ -168,6 +185,7 @@ fn load_stdlib_module_data(module_path: &[String]) -> Option<StdlibModuleData> {
 
     let mut functions = extract_function_signatures(&program);
     let mut traits = extract_trait_signatures(&program);
+    let mut types = extract_type_signatures(&program);
     let mut constants = extract_const_signatures(&program);
     let mut function_meta = extract_function_meta(&program);
     let mut trait_meta = extract_trait_meta(&program);
@@ -181,6 +199,7 @@ fn load_stdlib_module_data(module_path: &[String]) -> Option<StdlibModuleData> {
         &program,
         &mut functions,
         &mut traits,
+        &mut types,
         &mut constants,
         &mut function_meta,
         &mut trait_meta,
@@ -189,6 +208,7 @@ fn load_stdlib_module_data(module_path: &[String]) -> Option<StdlibModuleData> {
     Some(StdlibModuleData {
         functions,
         traits,
+        types,
         constants,
         function_meta,
         trait_meta,
@@ -203,6 +223,7 @@ fn merge_reexported_metadata(
     program: &ast::Program,
     functions: &mut Vec<(String, FunctionInfo)>,
     traits: &mut Vec<(String, TraitInfo)>,
+    types: &mut Vec<(String, TypeInfo)>,
     constants: &mut Vec<(String, VariableInfo)>,
     function_meta: &mut HashMap<String, FunctionMeta>,
     trait_meta: &mut HashMap<String, TraitMeta>,
@@ -242,6 +263,13 @@ fn merge_reexported_metadata(
                 && !traits.iter().any(|(n, _)| n == effective_name)
             {
                 traits.push((effective_name.to_string(), info.clone()));
+            }
+
+            // Merge type signature.
+            if let Some((_, info)) = sub_data.types.iter().find(|(n, _)| n == &item.name)
+                && !types.iter().any(|(n, _)| n == effective_name)
+            {
+                types.push((effective_name.to_string(), info.clone()));
             }
 
             // Merge const signature.
@@ -448,12 +476,139 @@ fn extract_trait_signatures(program: &ast::Program) -> Vec<(String, TraitInfo)> 
     traits
 }
 
+/// Extract public type metadata from a parsed stdlib `.incn` program.
+///
+/// Stdlib imports are source-visible type imports, not just function imports. Keeping type metadata here lets generic
+/// rusttypes such as `TimeoutJoinOutcome[T]` retain their Rust backing when imported from `std.async.time`.
+fn extract_type_signatures(program: &ast::Program) -> Vec<(String, TypeInfo)> {
+    let rust_imports = rust_import_aliases(program);
+    let mut types = Vec::new();
+    for decl in &program.declarations {
+        match &decl.node {
+            ast::Declaration::Model(model) if model.visibility == ast::Visibility::Public => {
+                let tp_names = type_param_names(&model.type_params);
+                types.push((
+                    model.name.clone(),
+                    TypeInfo::Model(ModelInfo {
+                        type_params: tp_names.clone(),
+                        traits: model.traits.iter().map(|bound| bound.node.name.clone()).collect(),
+                        derives: Vec::new(),
+                        fields: extract_field_signatures(&model.name, &model.fields, &tp_names, &rust_imports),
+                        methods: extract_method_signatures_with_rust_imports(&model.methods, &tp_names, &rust_imports),
+                    }),
+                ));
+            }
+            ast::Declaration::Class(class) if class.visibility == ast::Visibility::Public => {
+                let tp_names = type_param_names(&class.type_params);
+                types.push((
+                    class.name.clone(),
+                    TypeInfo::Class(ClassInfo {
+                        type_params: tp_names.clone(),
+                        extends: class.extends.clone(),
+                        traits: class.traits.iter().map(|bound| bound.node.name.clone()).collect(),
+                        derives: Vec::new(),
+                        fields: extract_field_signatures(&class.name, &class.fields, &tp_names, &rust_imports),
+                        methods: extract_method_signatures_with_rust_imports(&class.methods, &tp_names, &rust_imports),
+                    }),
+                ));
+            }
+            ast::Declaration::TypeAlias(alias) if alias.visibility == ast::Visibility::Public => {
+                types.push((alias.name.clone(), TypeInfo::TypeAlias));
+            }
+            ast::Declaration::Newtype(nt) if nt.visibility == ast::Visibility::Public => {
+                let tp_names = type_param_names(&nt.type_params);
+                let underlying = ast_type_to_resolved_with_rust_imports(&nt.underlying.node, &tp_names, &rust_imports);
+                let method_rebindings = nt
+                    .rebindings
+                    .iter()
+                    .filter_map(|rebinding| {
+                        rebinding_target_method_name(&rebinding.node.target.node)
+                            .map(|target| (rebinding.node.name.clone(), target))
+                    })
+                    .collect();
+                types.push((
+                    nt.name.clone(),
+                    TypeInfo::Newtype(NewtypeInfo {
+                        type_params: tp_names.clone(),
+                        is_rusttype: nt.is_rusttype,
+                        has_interop: !nt.interop_edges.is_empty(),
+                        underlying,
+                        method_rebindings,
+                        methods: extract_method_signatures_with_rust_imports(&nt.methods, &tp_names, &rust_imports),
+                    }),
+                ));
+            }
+            ast::Declaration::Enum(en) if en.visibility == ast::Visibility::Public => {
+                types.push((
+                    en.name.clone(),
+                    TypeInfo::Enum(EnumInfo {
+                        type_params: type_param_names(&en.type_params),
+                        variants: en.variants.iter().map(|variant| variant.node.name.clone()).collect(),
+                        value_enum: None,
+                        derives: Vec::new(),
+                    }),
+                ));
+            }
+            _ => {}
+        }
+    }
+    types
+}
+
+/// Extract just the declared names from AST type parameters.
+fn type_param_names(type_params: &[ast::TypeParam]) -> Vec<String> {
+    type_params.iter().map(|tp| tp.name.clone()).collect()
+}
+
+/// Convert AST field declarations into typechecker field metadata.
+fn extract_field_signatures(
+    owner: &str,
+    fields: &[ast::Spanned<ast::FieldDecl>],
+    type_params: &[String],
+    rust_imports: &HashMap<String, String>,
+) -> HashMap<String, FieldInfo> {
+    fields
+        .iter()
+        .map(|field| {
+            (
+                field.node.name.clone(),
+                FieldInfo {
+                    ty: ast_type_to_resolved_with_rust_imports(&field.node.ty.node, type_params, rust_imports),
+                    visibility: field.node.visibility,
+                    owner: Some(owner.to_string()),
+                    has_default: field.node.default.is_some(),
+                    alias: field.node.metadata.alias.clone(),
+                    description: field.node.metadata.description.clone(),
+                },
+            )
+        })
+        .collect()
+}
+
+/// Extract the effective Rust method name from a rusttype member rebinding target.
+fn rebinding_target_method_name(target: &ast::Expr) -> Option<String> {
+    match target {
+        ast::Expr::Ident(name) => Some(name.clone()),
+        ast::Expr::Field(_, member) => Some(member.clone()),
+        _ => None,
+    }
+}
+
 /// Extract method signatures from AST method declarations.
 ///
 /// Converts each `MethodDecl` into a `MethodInfo` using lightweight type resolution (no full typechecker needed).
 fn extract_method_signatures(
     methods: &[ast::Spanned<ast::MethodDecl>],
     type_params: &[String],
+) -> HashMap<String, MethodInfo> {
+    extract_method_signatures_with_rust_imports(methods, type_params, &HashMap::new())
+}
+
+/// Extract method metadata while resolving Rust import aliases in type positions.
+fn extract_method_signatures_with_rust_imports(
+    methods: &[ast::Spanned<ast::MethodDecl>],
+    type_params: &[String],
+    rust_imports: &HashMap<String, String>,
 ) -> HashMap<String, MethodInfo> {
     methods
         .iter()
@@ -486,7 +641,13 @@ fn extract_method_signatures(
                                 type_args: bound
                                     .type_args
                                     .iter()
-                                    .map(|arg| ast_type_to_resolved(&arg.node, &all_type_params))
+                                    .map(|arg| {
+                                        ast_type_to_resolved_with_rust_imports(
+                                            &arg.node,
+                                            &all_type_params,
+                                            rust_imports,
+                                        )
+                                    })
                                     .collect(),
                             })
                             .collect(),
@@ -500,11 +661,12 @@ fn extract_method_signatures(
                 .map(|p| {
                     (
                         p.node.name.clone(),
-                        ast_type_to_resolved(&p.node.ty.node, &all_type_params),
+                        ast_type_to_resolved_with_rust_imports(&p.node.ty.node, &all_type_params, rust_imports),
                     )
                 })
                 .collect();
-            let return_type = ast_type_to_resolved(&m.node.return_type.node, &all_type_params);
+            let return_type =
+                ast_type_to_resolved_with_rust_imports(&m.node.return_type.node, &all_type_params, rust_imports);
             (
                 m.node.name.clone(),
                 MethodInfo {
@@ -663,14 +825,37 @@ fn extract_trait_meta(program: &ast::Program) -> HashMap<String, TraitMeta> {
 /// Primitive type names are resolved to their concrete `ResolvedType` variants.
 /// Unknown types are resolved to `Named(name)`.
 fn ast_type_to_resolved(ty: &ast::Type, type_params: &[String]) -> ResolvedType {
+    ast_type_to_resolved_with_rust_imports(ty, type_params, &HashMap::new())
+}
+
+/// Convert an AST type to a resolved type while honoring Rust import aliases from the same stdlib module.
+fn ast_type_to_resolved_with_rust_imports(
+    ty: &ast::Type,
+    type_params: &[String],
+    rust_imports: &HashMap<String, String>,
+) -> ResolvedType {
     match ty {
         ast::Type::Unit => ResolvedType::Unit,
         ast::Type::SelfType => ResolvedType::SelfType,
-        ast::Type::Qualified(_) => ResolvedType::Unknown,
+        ast::Type::Qualified(segments) => {
+            let Some((head, tail)) = segments.split_first() else {
+                return ResolvedType::Unknown;
+            };
+            if let Some(base) = rust_imports.get(head) {
+                let mut parts = vec![base.clone()];
+                parts.extend(tail.iter().map(|segment| rust_keywords::escape_keyword(segment)));
+                ResolvedType::RustPath(parts.join("::"))
+            } else {
+                ResolvedType::Unknown
+            }
+        }
         ast::Type::Simple(name) => {
             // Check if it's a type parameter first.
             if type_params.contains(name) {
                 return ResolvedType::TypeVar(name.clone());
+            }
+            if let Some(path) = rust_imports.get(name) {
+                return ResolvedType::RustPath(path.clone());
             }
 
             // Resolve through incan_core registries (numerics, strings, unit).
@@ -698,8 +883,17 @@ fn ast_type_to_resolved(ty: &ast::Type, type_params: &[String]) -> ResolvedType 
         ast::Type::Generic(name, args) => {
             let resolved_args: Vec<ResolvedType> = args
                 .iter()
-                .map(|a| ast_type_to_resolved(&a.node, type_params))
+                .map(|a| ast_type_to_resolved_with_rust_imports(&a.node, type_params, rust_imports))
                 .collect();
+
+            if let Some(path) = rust_imports.get(name) {
+                let rendered_args = resolved_args
+                    .iter()
+                    .map(render_resolved_type_as_rust_arg)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return ResolvedType::RustPath(format!("{path}<{rendered_args}>"));
+            }
 
             let collection_id = collection_types::from_str(name);
             match collection_id {
@@ -733,20 +927,58 @@ fn ast_type_to_resolved(ty: &ast::Type, type_params: &[String]) -> ResolvedType 
         ast::Type::Function(params, ret) => {
             let param_types: Vec<ResolvedType> = params
                 .iter()
-                .map(|p| ast_type_to_resolved(&p.node, type_params))
+                .map(|p| ast_type_to_resolved_with_rust_imports(&p.node, type_params, rust_imports))
                 .collect();
-            let ret_type = ast_type_to_resolved(&ret.node, type_params);
+            let ret_type = ast_type_to_resolved_with_rust_imports(&ret.node, type_params, rust_imports);
             ResolvedType::Function(param_types, Box::new(ret_type))
         }
         ast::Type::Tuple(elems) => {
             let elem_types: Vec<ResolvedType> = elems
                 .iter()
-                .map(|e| ast_type_to_resolved(&e.node, type_params))
+                .map(|e| ast_type_to_resolved_with_rust_imports(&e.node, type_params, rust_imports))
                 .collect();
             ResolvedType::Tuple(elem_types)
         }
         ast::Type::Infer => ResolvedType::CallSiteInfer,
     }
+}
+
+/// Collect local aliases for Rust imports declared in a stdlib module.
+fn rust_import_aliases(program: &ast::Program) -> HashMap<String, String> {
+    let mut aliases = HashMap::new();
+    for decl in &program.declarations {
+        let ast::Declaration::Import(import) = &decl.node else {
+            continue;
+        };
+        match &import.kind {
+            ast::ImportKind::RustFrom {
+                crate_name,
+                path,
+                items,
+                ..
+            } => {
+                for item in items {
+                    let local_name = item.alias.as_deref().unwrap_or(&item.name);
+                    let mut full_path = vec![rust_keywords::escape_keyword(crate_name)];
+                    full_path.extend(path.iter().map(|segment| rust_keywords::escape_keyword(segment)));
+                    full_path.push(rust_keywords::escape_keyword(&item.name));
+                    aliases.insert(local_name.to_string(), full_path.join("::"));
+                }
+            }
+            ast::ImportKind::RustCrate { crate_name, path, .. } => {
+                let local_name = import
+                    .alias
+                    .as_deref()
+                    .or_else(|| path.last().map(String::as_str))
+                    .unwrap_or(crate_name);
+                let mut full_path = vec![rust_keywords::escape_keyword(crate_name)];
+                full_path.extend(path.iter().map(|segment| rust_keywords::escape_keyword(segment)));
+                aliases.insert(local_name.to_string(), full_path.join("::"));
+            }
+            _ => {}
+        }
+    }
+    aliases
 }
 
 #[cfg(test)]
@@ -818,11 +1050,26 @@ mod tests {
     fn test_load_async_time_module() -> Result<(), Box<dyn std::error::Error>> {
         let path = vec!["std".to_string(), "async".to_string(), "time".to_string()];
         let module = load_stdlib_module_data(&path);
-        let fns = module.ok_or("failed to load stdlib/async/time.incn")?.functions;
+        let module = module.ok_or("failed to load stdlib/async/time.incn")?;
+        let fns = &module.functions;
         let sleep_fn = fns.iter().find(|(name, _)| name == "sleep");
         assert!(sleep_fn.is_some(), "should find 'sleep' function");
         let timeout_fn = fns.iter().find(|(name, _)| name == "timeout");
         assert!(timeout_fn.is_some(), "should find 'timeout' function");
+        let timeout_join_outcome = module
+            .types
+            .iter()
+            .find(|(name, _)| name == "TimeoutJoinOutcome")
+            .ok_or("TimeoutJoinOutcome type not found")?;
+        let TypeInfo::Newtype(info) = &timeout_join_outcome.1 else {
+            return Err("TimeoutJoinOutcome should load as a newtype".into());
+        };
+        assert!(info.is_rusttype);
+        assert_eq!(info.type_params, vec!["T".to_string()]);
+        assert_eq!(
+            info.underlying,
+            ResolvedType::RustPath("incan_stdlib::r#async::time::TimeoutJoinOutcome<T>".to_string())
+        );
         Ok(())
     }
 

--- a/src/library_manifest/model.rs
+++ b/src/library_manifest/model.rs
@@ -161,6 +161,8 @@ pub enum TypeRef {
     SelfType,
     /// A reference type.
     Ref { inner: Box<TypeRef> },
+    /// A canonical Rust path imported through `rust::...`.
+    RustPath { path: String },
     /// A placeholder used when the manifest intentionally preserves unknown type information.
     Unknown,
 }
@@ -323,6 +325,9 @@ pub enum EnumValueExport {
 pub struct NewtypeExport {
     pub name: String,
     pub type_params: Vec<TypeParamExport>,
+    /// Whether this newtype is a zero-cost Rust type alias (`type X = rusttype RustX`).
+    #[serde(default)]
+    pub is_rusttype: bool,
     /// Underlying wrapped type.
     pub underlying: TypeRef,
     pub methods: Vec<MethodExport>,
@@ -612,10 +617,12 @@ fn value_enum_value_from_checked(value: &ValueEnumValue) -> EnumValueExport {
     }
 }
 
+/// Convert a checked newtype export into the serialized manifest shape.
 fn newtype_export_from_checked(export: &CheckedNewtypeExport) -> NewtypeExport {
     NewtypeExport {
         name: export.name.clone(),
         type_params: export.type_params.iter().map(type_param_from_checked).collect(),
+        is_rusttype: export.is_rusttype,
         underlying: type_ref_from_resolved(&export.underlying),
         methods: export.methods.iter().map(method_from_checked).collect(),
     }

--- a/src/library_manifest/type_refs.rs
+++ b/src/library_manifest/type_refs.rs
@@ -56,7 +56,7 @@ pub(super) fn type_ref_from_resolved(ty: &ResolvedType) -> TypeRef {
         ResolvedType::RefMut(inner) => TypeRef::Ref {
             inner: Box::new(type_ref_from_resolved(inner)),
         },
-        ResolvedType::RustPath(_) => TypeRef::Unknown,
+        ResolvedType::RustPath(path) => TypeRef::RustPath { path: path.clone() },
         ResolvedType::CallSiteInfer => TypeRef::Unknown,
         ResolvedType::Unknown => TypeRef::Unknown,
     }
@@ -98,6 +98,7 @@ pub fn resolved_type_from_manifest_type_ref(ty: &TypeRef) -> ResolvedType {
         TypeRef::TypeParam { name } => ResolvedType::TypeVar(name.clone()),
         TypeRef::SelfType => ResolvedType::SelfType,
         TypeRef::Ref { inner } => ResolvedType::Ref(Box::new(resolved_type_from_manifest_type_ref(inner))),
+        TypeRef::RustPath { path } => ResolvedType::RustPath(path.clone()),
         TypeRef::Unknown => ResolvedType::Unknown,
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2793,7 +2793,7 @@ def main() -> None:
         let source = r#"
 import std.async
 from std.async.task import spawn, spawn_blocking
-from std.async.time import sleep, timeout, timeout_ms
+from std.async.time import sleep, timeout, timeout_ms, timeout_join, timeout_join_ms, TimeoutJoinOutcome
 
 async def quick_value() -> int:
     await sleep(0.01)
@@ -2830,6 +2830,25 @@ async def main() -> None:
     match await timeout_ms(1, slow_value()):
         Ok(value) => println(f"timeout_ms_unexpected_ok:{value}")
         Err(err) => println(f"timeout_ms_expired:{err.message()}")
+
+    durable = spawn(slow_value())
+    match await timeout_join(0.001, durable):
+        TimeoutJoinOutcome.Completed(value) => println(f"timeout_join_unexpected_ok:{value}")
+        TimeoutJoinOutcome.JoinFailed(err) => println(f"timeout_join_err:{err.message()}")
+        TimeoutJoinOutcome.TimedOut(handle) =>
+            println("task still running after timeout")
+            match await handle:
+                Ok(value) => println(f"timeout_join_later:{value}")
+                Err(err) => println(f"timeout_join_later_err:{err.message()}")
+
+    durable_ms = spawn(slow_value())
+    match await timeout_join_ms(1, durable_ms):
+        TimeoutJoinOutcome.Completed(value) => println(f"timeout_join_ms_unexpected_ok:{value}")
+        TimeoutJoinOutcome.JoinFailed(err) => println(f"timeout_join_ms_err:{err.message()}")
+        TimeoutJoinOutcome.TimedOut(handle) =>
+            match await handle:
+                Ok(value) => println(f"timeout_join_ms_later:{value}")
+                Err(err) => println(f"timeout_join_ms_later_err:{err.message()}")
 "#;
         let Ok(()) = std::fs::write(&source_path, source) else {
             panic!("failed to write source file");
@@ -2882,8 +2901,25 @@ async def main() -> None:
             stdout
         );
         assert!(
+            stdout.contains("task still running after timeout"),
+            "expected durable timeout message; got:\n{}",
+            stdout
+        );
+        assert!(
+            stdout.contains("timeout_join_later:99"),
+            "expected timeout_join preserved handle output; got:\n{}",
+            stdout
+        );
+        assert!(
+            stdout.contains("timeout_join_ms_later:99"),
+            "expected timeout_join_ms preserved handle output; got:\n{}",
+            stdout
+        );
+        assert!(
             !stdout.contains("timeout_unexpected_ok")
                 && !stdout.contains("timeout_ms_unexpected_ok")
+                && !stdout.contains("timeout_join_unexpected_ok")
+                && !stdout.contains("timeout_join_ms_unexpected_ok")
                 && !stdout.contains("spawn_err:")
                 && !stdout.contains("spawn_blocking_err:")
                 && !stdout.contains("timeout_err:")

--- a/tests/snapshots/codegen_snapshot_tests__std_async_time_compiled.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_async_time_compiled.snap
@@ -14,9 +14,13 @@ use incan_stdlib::prelude::*;
 use incan_derive::{FieldInfo, IncanClass};
 pub use crate::__incan_std::r#async;
 pub use crate::__incan_std::traits::error::Error;
+pub use incan_stdlib::r#async::task::JoinHandle;
 pub use incan_stdlib::r#async::task::RuntimeFuture;
+pub use incan_stdlib::r#async::time::TimeoutJoinOutcome as RustTimeoutJoinOutcome;
 pub use incan_stdlib::r#async::time::clamp_seconds;
 pub use incan_stdlib::r#async::time::clamp_millis;
+pub use incan_stdlib::r#async::time::timeout_join as rust_timeout_join;
+pub use incan_stdlib::r#async::time::timeout_join_ms as rust_timeout_join_ms;
 pub use tokio::time::sleep as tokio_sleep;
 pub use tokio::time::timeout as tokio_timeout;
 #[derive(Debug, Clone, FieldInfo, IncanClass)]
@@ -107,6 +111,7 @@ impl Duration {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+pub type TimeoutJoinOutcome<T> = RustTimeoutJoinOutcome<T>;
 pub async fn sleep(seconds: f64) {
     "\n    Sleep for a floating-point second duration.\n\n    Example:\n        await sleep(0.1)\n    ";
     tokio_sleep(clamp_seconds(seconds)).await;
@@ -142,4 +147,18 @@ pub async fn timeout_ms<T: Send + 'static, TaskFuture: RuntimeFuture<T>>(
             return Err::<T, TimeoutError>(TimeoutError {});
         }
     };
+}
+pub async fn timeout_join<T: Send + 'static>(
+    seconds: f64,
+    handle: JoinHandle<T>,
+) -> TimeoutJoinOutcome<T> {
+    "\n    Wait up to `seconds` for a spawned task without cancelling it when the deadline expires.\n\n    Returns `TimeoutJoinOutcome.Completed(value)` when the task completes successfully,\n    `TimeoutJoinOutcome.JoinFailed(err)` when the task finishes with a join error, and\n    `TimeoutJoinOutcome.TimedOut(handle)` when the deadline wins. In the timeout case, `handle` remains live and can be\n    awaited, stored, or aborted explicitly. For blocking work created with `spawn_blocking()`, `abort()` can only prevent\n    work that has not started yet.\n    ";
+    return rust_timeout_join(seconds, handle).await;
+}
+pub async fn timeout_join_ms<T: Send + 'static>(
+    milliseconds: i64,
+    handle: JoinHandle<T>,
+) -> TimeoutJoinOutcome<T> {
+    "\n    Wait up to `milliseconds` for a spawned task without cancelling it when the deadline expires.\n\n    This is the millisecond-duration form of `timeout_join()`.\n    ";
+    return rust_timeout_join_ms(milliseconds, handle).await;
 }

--- a/workspaces/docs-site/docs/language/how-to/async_programming.md
+++ b/workspaces/docs-site/docs/language/how-to/async_programming.md
@@ -99,7 +99,26 @@ async def demo() -> None:
         case Err(e): println("Operation timed out")
 ```
 
-`timeout()` and `timeout_ms()` cancel the supplied future when the deadline expires. That is appropriate for ordinary request work where the timed-out operation should stop. If the work must keep running after the deadline path returns, spawn it first and decide separately whether to await, detach, or abort the `JoinHandle`.
+`timeout()` and `timeout_ms()` cancel the supplied future when the deadline expires. That is appropriate for ordinary request work where the timed-out operation should stop. If the work must keep running after the deadline path returns, spawn it first and use `timeout_join()` so the timeout result preserves the live `JoinHandle`.
+
+### timeout_join
+
+Wait for spawned work without cancelling it when the deadline expires:
+
+```incan
+from std.async.task import spawn
+from std.async.time import timeout_join, TimeoutJoinOutcome
+
+handle = spawn(write_audit_event(event))
+
+match await timeout_join(1.0, handle):
+    case TimeoutJoinOutcome.Completed(_): println("audit event written")
+    case TimeoutJoinOutcome.JoinFailed(err): println(err.message())
+    case TimeoutJoinOutcome.TimedOut(live_handle):
+        remember(live_handle)
+```
+
+Use `timeout_join()` for side-effecting work that must keep running once spawned, such as durable writes, protocol commits, and file flushes. On timeout, the task continues running and `TimeoutJoinOutcome.TimedOut(handle)` carries the live handle so you can await it later, store it in a task registry, or abort it deliberately. For `spawn_blocking()` handles, `abort()` can only prevent queued work from starting; blocking work that has already started must finish on its own.
 
 ## Task Spawning
 
@@ -546,9 +565,9 @@ match await select_timeout(2.0, slow_operation):
     case None: println("Timed out, using default")
 ```
 
-`select_timeout()` has the same cancellation contract as `timeout()`: if the deadline wins, the supplied future is cancelled. Use it only when the timed-out future may be safely abandoned.
+`select_timeout()` has the same cancellation contract as `timeout()`: if the deadline wins, the supplied future is cancelled. Use it only when the timed-out future may be safely abandoned. For spawned work that must continue, use `timeout_join()` instead.
 
-Future `race` syntax is planned as first-completion-wins composition. Losing race arms are cancelled, so loser arms must not contain side effects that are required for correctness after their final suspension point. Put required cleanup in cancellation-safe resources, or spawn durable work before the race and keep its handle outside the race when you still need the result.
+Future `race` syntax is planned as first-completion-wins composition. Losing race arms are cancelled, so loser arms must not contain side effects that are required for correctness after their final suspension point. Put required cleanup in cancellation-safe resources, or spawn durable work before the race and use a handle-preserving wait such as `timeout_join()` when you still need the result.
 
 ## Runtime Integration
 

--- a/workspaces/docs-site/docs/language/reference/stdlib/async.md
+++ b/workspaces/docs-site/docs/language/reference/stdlib/async.md
@@ -33,24 +33,27 @@ Async APIs on this page use these contract terms:
 Import with:
 
 ```incan
-from std.async.time import sleep, timeout, TimeoutError
+from std.async.time import sleep, timeout, timeout_join, TimeoutError, TimeoutJoinOutcome
 ```
 
 **Functions**:
 
-| Function                                                                                    | Returns                   | Cancellation contract |
-| ------------------------------------------------------------------------------------------- | ------------------------- | --------------------- |
-| `sleep(seconds: float) -> None`                                                             | `None`                    | `cancel-safe` |
-| `sleep_ms(milliseconds: int) -> None`                                                       | `None`                    | `cancel-safe` |
-| `timeout[T, TaskFuture](seconds: float, task: TaskFuture) -> Result[T, TimeoutError]`       | `Result[T, TimeoutError]` | Cancels the supplied future when the deadline expires; cancelling the timeout wait also drops the supplied future. |
-| `timeout_ms[T, TaskFuture](milliseconds: int, task: TaskFuture) -> Result[T, TimeoutError]` | `Result[T, TimeoutError]` | Cancels the supplied future when the deadline expires; cancelling the timeout wait also drops the supplied future. |
+| Function                                                                                                             | Returns                                            | Cancellation contract |
+| -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------- |
+| `sleep(seconds: float) -> None`                                                                                      | `None`                                             | `cancel-safe` |
+| `sleep_ms(milliseconds: int) -> None`                                                                                | `None`                                             | `cancel-safe` |
+| `timeout[T, TaskFuture](seconds: float, task: TaskFuture) -> Result[T, TimeoutError]`                                | `Result[T, TimeoutError]`                          | Cancels the supplied future when the deadline expires; cancelling the timeout wait also drops the supplied future. |
+| `timeout_ms[T, TaskFuture](milliseconds: int, task: TaskFuture) -> Result[T, TimeoutError]`                          | `Result[T, TimeoutError]`                          | Cancels the supplied future when the deadline expires; cancelling the timeout wait also drops the supplied future. |
+| `timeout_join[T](seconds: float, handle: JoinHandle[T]) -> TimeoutJoinOutcome[T]`                                  | `TimeoutJoinOutcome[T]` | Stops waiting when the deadline expires and returns the live handle in `TimedOut(handle)`; the task continues running unless explicitly aborted. |
+| `timeout_join_ms[T](milliseconds: int, handle: JoinHandle[T]) -> TimeoutJoinOutcome[T]`                            | `TimeoutJoinOutcome[T]` | Millisecond form of `timeout_join`. |
 
-**Models**:
+**Types**:
 
-| Name           | Description                                                       |
-| -------------- | ----------------------------------------------------------------- |
-| `TimeoutError` | Error type returned by timeout helpers when the deadline expires. |
-| `Duration`     | Simple duration value object exposed as a convenience type.       |
+| Name                 | Description                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| `TimeoutJoinOutcome` | Outcome type returned by durable timeout helpers, including the recovered live handle on timeout. |
+| `TimeoutError`       | Error type returned by canceling timeout helpers when the deadline expires.                       |
+| `Duration`           | Simple duration value object exposed as a convenience type.                                       |
 
 ## Module: `std.async.select`
 
@@ -127,7 +130,7 @@ Cancellation contracts:
 
 `std.async.prelude` re-exports the following:
 
-- `time`: `sleep`, `sleep_ms`, `timeout`, `timeout_ms`, `Duration`, `TimeoutError`
+- `time`: `sleep`, `sleep_ms`, `timeout`, `timeout_ms`, `timeout_join`, `timeout_join_ms`, `Duration`, `TimeoutError`, `TimeoutJoinOutcome`
 - `task`: `spawn`, `spawn_blocking`, `yield_now`, `JoinHandle`, `TaskJoinError`
 - `channel`: `channel`, `unbounded_channel`, `oneshot`, `Sender`, `Receiver`, `OneshotSender`, `OneshotReceiver`, `SendError`, `RecvError`
 - `sync`: `Mutex`, `MutexGuard`, `RwLock`, `RwLockReadGuard`, `RwLockWriteGuard`, `Semaphore`, `SemaphorePermit`, `SemaphoreAcquireError`, `Barrier`

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -138,6 +138,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Language/Testing**: RFC 018's `assert expr[, msg]` language primitive is always available without importing `std.testing`. The `std.testing` helpers mirror assertion failure behavior for call-style checks, raises checks, and unwrap-style `Option` / `Result` helpers, while marker decorators remain imported `std.testing` APIs.
 - **Language/Testing**: Inline `module tests:` blocks in production source files are now discovered and executed by `incan test`, while production build/run output still strips those test-only declarations and imports ([RFC 018], #76).
 - **Runtime/Async**: `std.async` now documents cancellation-safety contracts and exposes channel reservation APIs so critical sends can reserve capacity before committing messages (#415, #416).
+- **Runtime/Async**: `std.async.time` adds `timeout_join`, `timeout_join_ms`, and a must-use `TimeoutJoinOutcome` so spawned work can keep running after a deadline while callers retain the live `JoinHandle` for later observation or explicit abort (#417).
 
 ### Versioning and release track
 


### PR DESCRIPTION
## Summary

This PR adds durable timeout helpers for spawned async work so callers can stop waiting at a deadline without cancelling the task or losing the live `JoinHandle`. It introduces `TimeoutJoinOutcome[T]`, exposes `timeout_join` / `timeout_join_ms` through `std.async.time`, teaches the typechecker and stdlib loader how to preserve the generic Rust adapter surface, and updates docs/tests for the cancellation-safety contract from #417.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `std.async.time.timeout_join` and `timeout_join_ms` now return a must-use `TimeoutJoinOutcome[T]`. `Completed` carries the join result; `TimedOut` carries the still-live `JoinHandle[T]` so callers can await, retain, or explicitly abort the work later.
- **Internals**: The stdlib export path now supports the generic timeout outcome type, including manifest type refs and Rust adapter rendering for stdlib-loaded generics. The compiler-side Rust type rendering policy is centralized through a shared typechecker helper to avoid source-checked and stdlib-loaded drift.
- **Risks**: The touched compiler paths affect stdlib export/type rendering and generic Rust adapter signatures. The runtime behavior is intentionally additive, but regressions would most likely show up as bad generated signatures or mismatched stdlib manifest metadata.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make fmt` passed.
- `make pre-commit` passed through formatting, rustdoc coverage, all 1614 tests, and clippy.
- `cd <workspace-checkout> && make cargo-deny-ci` passed after rerunning with access to the Cargo advisory DB lock.
- `cd <workspace-checkout> && make smoke-test-fast` passed: 51 examples checked, 32 run, 8 benchmark builds checked, 0 failed.
- `git diff --cached --check` passed before commit.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/stdlib/async.md`, `workspaces/docs-site/docs/language/how-to/async_programming.md`, `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #417