### PR TITLE
chore - unify CLI typecheck orchestration and harden help-path tests (280)

### DIFF
--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 use super::common::{
     build_source_map, cargo_command_flags, collect_inline_rust_imports, collect_modules, collect_project_requirements,
     format_dependency_error, imported_module_deps_for_with_index, merge_project_requirement_dependencies,
-    module_key_index, resolve_project_root, validate_output_dir,
+    module_key_index, resolve_project_root, typecheck_modules_with_import_graph, validate_output_dir,
 };
 #[cfg(feature = "rust_inspect")]
 use super::common::{collect_rust_inspect_query_paths, ensure_rust_inspect_workspace, prewarm_rust_inspect_workspace};
@@ -385,40 +385,13 @@ fn prepare_project(
     let project_requirements = collect_project_requirements(&modules, &library_manifest_index)?;
 
     // Type check all modules (dependencies + stdlib first), so diagnostics are associated with the correct file.
-    let declared = manifest.as_ref().map(|m| m.declared_rust_crate_names());
-    let mut all_errors: String = String::new();
-    let module_idx_by_key = module_key_index(&modules);
-    for (idx, module) in modules.iter().enumerate() {
-        let deps_for_module = imported_module_deps_for_with_index(&modules, idx, &module_idx_by_key);
-        let mut checker = typechecker::TypeChecker::new();
-        if let Some(names) = declared.clone() {
-            checker.set_declared_crate_names(names);
-        }
-        checker.set_library_manifest_index(library_manifest_index.clone());
-
-        match checker.check_with_imports(&module.ast, &deps_for_module) {
-            Ok(()) => {
-                for warn in checker.warnings() {
-                    eprint!(
-                        "{}",
-                        diagnostics::format_error(module.file_path.to_string_lossy().as_ref(), &module.source, warn)
-                    );
-                }
-            }
-            Err(errs) => {
-                for err in &errs {
-                    all_errors.push_str(&diagnostics::format_error(
-                        module.file_path.to_string_lossy().as_ref(),
-                        &module.source,
-                        err,
-                    ));
-                }
-            }
-        }
-    }
-    if !all_errors.is_empty() {
-        return Err(CliError::failure(all_errors.trim_end()));
-    }
+    typecheck_modules_with_import_graph(
+        &modules,
+        manifest.as_ref(),
+        &library_manifest_index,
+        #[cfg(feature = "rust_inspect")]
+        None,
+    )?;
 
     // Derive project name (manifest overrides filename)
     let project_name = manifest

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -17,7 +17,7 @@ use crate::dependency_resolver::{DependencyError, InlineRustImport};
 use crate::frontend::ast::{ImportKind, Program, Span};
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::module::{canonicalize_source_module_segments, resolve_source_module_from_base};
-use crate::frontend::{diagnostics, lexer, parser, vocab_desugar_pass};
+use crate::frontend::{diagnostics, lexer, parser, typechecker, vocab_desugar_pass};
 use crate::lockfile::CargoFeatureSelection;
 use crate::manifest::ProjectManifest;
 use crate::manifest::{DependencySource, DependencySpec};
@@ -1302,6 +1302,61 @@ pub(crate) fn imported_module_deps_for_with_index<'m>(
         .collect()
 }
 
+/// Typecheck all collected modules in dependency-safe order using shared CLI diagnostics formatting.
+///
+/// This helper centralizes the per-module checker setup used by `build` and `check` paths so warning/error rendering
+/// stays consistent across command flows.
+pub(crate) fn typecheck_modules_with_import_graph(
+    modules: &[ParsedModule],
+    manifest: Option<&ProjectManifest>,
+    library_manifest_index: &LibraryManifestIndex,
+    #[cfg(feature = "rust_inspect")] rust_inspect_manifest_dir: Option<&Path>,
+) -> CliResult<()> {
+    let declared = manifest.map(|m| m.declared_rust_crate_names());
+    let module_idx_by_key = module_key_index(modules);
+    let mut all_errors = String::new();
+
+    for (idx, module) in modules.iter().enumerate() {
+        let deps_for_module = imported_module_deps_for_with_index(modules, idx, &module_idx_by_key);
+
+        let mut checker = typechecker::TypeChecker::new();
+        if let Some(names) = declared.clone() {
+            checker.set_declared_crate_names(names);
+        }
+        checker.set_library_manifest_index(library_manifest_index.clone());
+        #[cfg(feature = "rust_inspect")]
+        if let Some(rust_inspect_manifest_dir) = rust_inspect_manifest_dir {
+            checker.set_rust_inspect_manifest_dir(rust_inspect_manifest_dir.to_path_buf());
+        }
+
+        match checker.check_with_imports(&module.ast, &deps_for_module) {
+            Ok(()) => {
+                for warn in checker.warnings() {
+                    eprint!(
+                        "{}",
+                        diagnostics::format_error(module.file_path.to_string_lossy().as_ref(), &module.source, warn)
+                    );
+                }
+            }
+            Err(errs) => {
+                for err in &errs {
+                    all_errors.push_str(&diagnostics::format_error(
+                        module.file_path.to_string_lossy().as_ref(),
+                        &module.source,
+                        err,
+                    ));
+                }
+            }
+        }
+    }
+
+    if all_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CliError::failure(all_errors.trim_end()))
+    }
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -2293,6 +2348,47 @@ pub def main() -> int:
             1,
             "second call with identical inputs should skip regeneration"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn typecheck_modules_with_import_graph_accepts_valid_program() -> Result<(), Box<dyn std::error::Error>> {
+        let module = parsed_module_for_test(
+            r#"
+def main() -> None:
+    pass
+"#,
+        )?;
+
+        typecheck_modules_with_import_graph(
+            &[module],
+            None,
+            &LibraryManifestIndex::default(),
+            #[cfg(feature = "rust_inspect")]
+            None,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn typecheck_modules_with_import_graph_reports_errors() -> Result<(), Box<dyn std::error::Error>> {
+        let module = parsed_module_for_test(
+            r#"
+def main() -> None:
+    missing_symbol()
+"#,
+        )?;
+
+        let result = typecheck_modules_with_import_graph(
+            &[module],
+            None,
+            &LibraryManifestIndex::default(),
+            #[cfg(feature = "rust_inspect")]
+            None,
+        );
+        assert!(result.is_err(), "expected unresolved symbol to fail typecheck");
 
         Ok(())
     }

--- a/src/cli/commands/debug.rs
+++ b/src/cli/commands/debug.rs
@@ -5,14 +5,12 @@
 use crate::backend::IrCodegen;
 use crate::cli::{CliError, CliResult, ExitCode};
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
-use crate::frontend::{diagnostics, lexer, parser, typechecker};
+use crate::frontend::{diagnostics, lexer, parser};
 use crate::manifest::ProjectManifest;
 use std::env;
 use std::path::{Path, PathBuf};
 
-use super::common::{
-    collect_modules, imported_module_deps_for_with_index, module_key_index, read_source, resolve_project_root,
-};
+use super::common::{collect_modules, read_source, resolve_project_root, typecheck_modules_with_import_graph};
 
 /// Lex and display tokens.
 pub fn lex_file(file_path: &str) -> CliResult<ExitCode> {
@@ -76,46 +74,17 @@ pub fn check_file(file_path: &str) -> CliResult<ExitCode> {
     };
     let project_root = resolve_project_root(&normalized_file_path);
     let manifest = ProjectManifest::discover(&project_root).map_err(|e| CliError::failure(e.to_string()))?;
-    let declared = manifest.as_ref().map(|m| m.declared_rust_crate_names());
     let library_manifest_index = manifest
         .as_ref()
         .map(LibraryManifestIndex::from_project_manifest)
         .unwrap_or_default();
-
-    let mut all_errors: String = String::new();
-    let module_idx_by_key = module_key_index(&modules);
-    for (idx, module) in modules.iter().enumerate() {
-        let deps_for_module = imported_module_deps_for_with_index(&modules, idx, &module_idx_by_key);
-
-        let mut checker = typechecker::TypeChecker::new();
-        if let Some(names) = declared.clone() {
-            checker.set_declared_crate_names(names);
-        }
-        checker.set_library_manifest_index(library_manifest_index.clone());
-        match checker.check_with_imports(&module.ast, &deps_for_module) {
-            Ok(()) => {
-                for warn in checker.warnings() {
-                    eprint!(
-                        "{}",
-                        diagnostics::format_error(module.file_path.to_string_lossy().as_ref(), &module.source, warn)
-                    );
-                }
-            }
-            Err(errs) => {
-                for err in &errs {
-                    all_errors.push_str(&diagnostics::format_error(
-                        module.file_path.to_string_lossy().as_ref(),
-                        &module.source,
-                        err,
-                    ));
-                }
-            }
-        }
-    }
-
-    if !all_errors.is_empty() {
-        return Err(CliError::failure(all_errors.trim_end()));
-    }
+    typecheck_modules_with_import_graph(
+        &modules,
+        manifest.as_ref(),
+        &library_manifest_index,
+        #[cfg(feature = "rust_inspect")]
+        None,
+    )?;
 
     println!("✓ Type check passed!");
     Ok(ExitCode::SUCCESS)
@@ -171,4 +140,27 @@ pub fn emit_rust(file_path: &str, strict: bool) -> CliResult<ExitCode> {
 
     println!("{}", output);
     Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn check_file_reports_type_errors() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let source_path = tmp.path().join("main.incn");
+        fs::write(
+            &source_path,
+            r#"
+def main() -> None:
+    missing_symbol()
+"#,
+        )?;
+
+        let result = check_file(source_path.to_string_lossy().as_ref());
+        assert!(result.is_err(), "expected unresolved symbol to fail check_file");
+        Ok(())
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -43,7 +43,7 @@ use std::path::PathBuf;
 use std::process;
 
 use crate::manifest::ProjectManifest;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use commands::lifecycle::{EnvOutputFormat, VersionBumpArg};
 use commands::tools::ToolsDoctorFormat;
 
@@ -716,9 +716,20 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
                 commands::check_file(&file.to_string_lossy())
             } else {
                 // No command and no file - show help
-                Err(CliError::new("", ExitCode::FAILURE))
+                Err(CliError::new(render_cli_help_text(), ExitCode::FAILURE))
             }
         }
+    }
+}
+
+/// Render top-level CLI help text.
+fn render_cli_help_text() -> String {
+    let mut command = Cli::command();
+    let mut out = Vec::new();
+    if command.write_help(&mut out).is_ok() {
+        String::from_utf8_lossy(&out).to_string()
+    } else {
+        "Run `incan --help` for usage.".to_string()
     }
 }
 
@@ -1161,6 +1172,29 @@ mod tests {
         assert!(!command_prefers_banner(&parse_cli(["incan", "version", "patch"])?));
         assert!(!command_prefers_banner(&parse_cli(["incan", "new", "demo"])?));
         assert!(!command_prefers_banner(&parse_cli(["incan", "--check", "main.incn"])?));
+        Ok(())
+    }
+
+    #[test]
+    fn test_execute_without_args_returns_help_text() -> Result<(), clap::Error> {
+        let cli = parse_cli(["incan"])?;
+        let result = execute(cli, false);
+        let Err(err) = result else {
+            return Err(expected_command("help failure"));
+        };
+        assert_eq!(err.exit_code, ExitCode::FAILURE);
+        assert!(
+            !err.message.trim().is_empty(),
+            "expected help text for no-arg invocation"
+        );
+        assert!(
+            err.message.contains("Usage:"),
+            "expected clap usage block in help output"
+        );
+        assert!(
+            err.message.contains("build") && err.message.contains("run"),
+            "expected top-level command tokens in help output"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

This PR consolidates duplicated CLI module typechecking orchestration into a shared helper used by both `build` and `debug check`, and strengthens CLI regressions around no-arg help output and debug typecheck failures. The goal is to reduce orchestration drift across commands while locking behavior with targeted tests.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: No-arg CLI execution now returns populated top-level help text (with usage/command tokens) instead of an empty error message. `debug check` and `build` continue to report type diagnostics, now via the same shared path.
- **Internals**: Added `typecheck_modules_with_import_graph` in `src/cli/commands/common.rs` and switched both `build` and `debug::check_file` to use it, removing duplicated checker setup/looping logic.
- **Risks**: Centralizing typecheck orchestration changes two command paths at once; if the helper regresses, both `build` and `debug check` could be affected. New focused tests were added to limit this risk.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Ran `make pre-commit` end-to-end in `<workspace-checkout>` (passed).
- Added/ran targeted tests:
  - `typecheck_modules_with_import_graph_accepts_valid_program`
  - `typecheck_modules_with_import_graph_reports_errors`
  - `check_file_reports_type_errors`
  - `test_execute_without_args_returns_help_text`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): …

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #280
