### PR TITLE
feature - add doctor offline-readiness diagnostics (#460)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "clap",
  "hex",
@@ -1427,14 +1427,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1443,14 +1443,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "axum",
  "incan_core",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.23"
+version = "0.3.0-dev.24"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.91"

--- a/src/cli/commands/tools.rs
+++ b/src/cli/commands/tools.rs
@@ -1,8 +1,10 @@
 //! Local toolchain inspection commands.
 
+use std::collections::BTreeSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use clap::ValueEnum;
 use serde_json::json;
@@ -334,19 +336,22 @@ struct DoctorReport {
     path_incan_lsp: ToolPath,
     cargo_bin_incan: CargoBinEntry,
     cargo_bin_incan_lsp: CargoBinEntry,
+    offline_readiness: OfflineReadiness,
 }
 
 impl DoctorReport {
     /// Collect local process, PATH, and cargo-bin state for the doctor report.
     fn collect() -> Self {
+        let cwd = env::current_dir().ok();
         Self {
             version: crate::version::INCAN_VERSION,
             current_exe: env::current_exe().ok(),
-            cwd: env::current_dir().ok(),
+            cwd: cwd.clone(),
             path_incan: ToolPath::resolve("incan"),
             path_incan_lsp: ToolPath::resolve("incan-lsp"),
             cargo_bin_incan: CargoBinEntry::from_home("incan"),
             cargo_bin_incan_lsp: CargoBinEntry::from_home("incan-lsp"),
+            offline_readiness: OfflineReadiness::collect(cwd.as_deref()),
         }
     }
 
@@ -369,6 +374,8 @@ impl DoctorReport {
             "  if either setting is explicit, use a literal executable path; shell syntax like $HOME or ~ is not expanded"
         );
         println!("  after rebuilding or changing paths, reload VS Code/Cursor so it starts a fresh incan-lsp process");
+        println!();
+        self.offline_readiness.print_text();
     }
 
     /// Print the doctor report as pretty JSON for editor integrations and issue templates.
@@ -390,7 +397,8 @@ impl DoctorReport {
                 "recommended_compiler_path": "",
                 "literal_path_settings": true,
                 "reload_after_rebuild": true
-            }
+            },
+            "offline_readiness": self.offline_readiness.as_json()
         });
         let output = serde_json::to_string_pretty(&value)
             .map_err(|error| CliError::failure(format!("failed to serialize doctor report: {error}")))?;
@@ -477,6 +485,514 @@ impl CargoBinEntry {
             "executable": self.executable,
         })
     }
+}
+
+#[derive(Debug)]
+struct OfflineReadiness {
+    advisory_only: bool,
+    status: OfflineReadinessStatus,
+    cargo: CargoCommandInfo,
+    cargo_home: CargoHomeInfo,
+    registry_cache: CachePathHint,
+    registry_index: CachePathHint,
+    registry_src: CachePathHint,
+    git_checkouts: CachePathHint,
+    git_db: CachePathHint,
+    cargo_config: CargoConfigHints,
+    next_steps: Vec<String>,
+}
+
+impl OfflineReadiness {
+    /// Collect advisory local signals without network access, resolution, or builds.
+    fn collect(cwd: Option<&Path>) -> Self {
+        let cargo = CargoCommandInfo::collect();
+        let cargo_home = CargoHomeInfo::collect();
+        let registry_cache =
+            CachePathHint::from_optional_path(cargo_home.path.as_deref().map(|path| path.join("registry/cache")));
+        let registry_index =
+            CachePathHint::from_optional_path(cargo_home.path.as_deref().map(|path| path.join("registry/index")));
+        let registry_src =
+            CachePathHint::from_optional_path(cargo_home.path.as_deref().map(|path| path.join("registry/src")));
+        let git_checkouts =
+            CachePathHint::from_optional_path(cargo_home.path.as_deref().map(|path| path.join("git/checkouts")));
+        let git_db = CachePathHint::from_optional_path(cargo_home.path.as_deref().map(|path| path.join("git/db")));
+        let cargo_config = CargoConfigHints::collect(cwd, cargo_home.path.as_deref());
+        let status = OfflineReadinessStatus::from_signals(
+            &cargo,
+            &cargo_home,
+            [&registry_cache, &registry_index, &registry_src, &git_checkouts, &git_db],
+            &cargo_config,
+        );
+        let next_steps = build_offline_next_steps(
+            &cargo,
+            &cargo_home,
+            [&registry_cache, &registry_index, &registry_src, &git_checkouts, &git_db],
+            &cargo_config,
+        );
+
+        Self {
+            advisory_only: true,
+            status,
+            cargo,
+            cargo_home,
+            registry_cache,
+            registry_index,
+            registry_src,
+            git_checkouts,
+            git_db,
+            cargo_config,
+            next_steps,
+        }
+    }
+
+    /// Print the advisory offline-readiness section.
+    fn print_text(&self) {
+        println!("offline readiness:");
+        println!("  status: {}", self.status.as_str());
+        println!("  advisory_only: {}", self.advisory_only);
+        println!("  note: advisory local signals only; Cargo and RFC 020 policy flags remain authoritative");
+        println!("  cargo:");
+        println!("    command: {}", self.cargo.command);
+        println!("    available: {}", self.cargo.available);
+        println!("    version: {}", self.cargo.version.as_deref().unwrap_or("(unknown)"));
+        println!("    error: {}", self.cargo.error.as_deref().unwrap_or("(none)"));
+        println!("  cargo_home:");
+        println!("    source: {}", self.cargo_home.source.as_str());
+        println!("    path: {}", display_option_path(&self.cargo_home.path));
+        println!("    exists: {}", self.cargo_home.exists);
+        self.registry_cache.print_text("registry_cache");
+        self.registry_index.print_text("registry_index");
+        self.registry_src.print_text("registry_src");
+        self.git_checkouts.print_text("git_checkouts");
+        self.git_db.print_text("git_db");
+        println!("  cargo_config:");
+        println!("    files_checked: {}", self.cargo_config.files.len());
+        println!(
+            "    source_replacement_detected: {}",
+            self.cargo_config.source_replacement_detected
+        );
+        println!(
+            "    vendor_source_detected: {}",
+            self.cargo_config.vendor_source_detected
+        );
+        println!("    net_offline_detected: {}", self.cargo_config.net_offline_detected);
+        for file in &self.cargo_config.files {
+            println!("    file: {}", file.path.display());
+            println!("      readable: {}", file.readable);
+            println!("      source_replacement: {}", file.source_replacement);
+            println!("      vendor_source: {}", file.vendor_source);
+            println!("      net_offline: {}", file.net_offline);
+            println!("      parse_error: {}", file.parse_error.as_deref().unwrap_or("(none)"));
+        }
+        println!("  next_steps:");
+        for step in &self.next_steps {
+            println!("    - {step}");
+        }
+    }
+
+    /// Convert advisory offline-readiness into stable JSON.
+    fn as_json(&self) -> serde_json::Value {
+        json!({
+            "advisory_only": self.advisory_only,
+            "status": self.status.as_str(),
+            "source_of_truth": "Cargo and RFC 020 policy flags",
+            "cargo": self.cargo.as_json(),
+            "cargo_home": self.cargo_home.as_json(),
+            "caches": {
+                "registry_cache": self.registry_cache.as_json(),
+                "registry_index": self.registry_index.as_json(),
+                "registry_src": self.registry_src.as_json(),
+                "git_checkouts": self.git_checkouts.as_json(),
+                "git_db": self.git_db.as_json(),
+            },
+            "cargo_config": self.cargo_config.as_json(),
+            "next_steps": self.next_steps,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OfflineReadinessStatus {
+    Present,
+    Missing,
+    Unknown,
+}
+
+impl OfflineReadinessStatus {
+    /// Classify whether local offline-readiness signals are present, missing, or unknown.
+    fn from_signals(
+        cargo: &CargoCommandInfo,
+        cargo_home: &CargoHomeInfo,
+        caches: [&CachePathHint; 5],
+        cargo_config: &CargoConfigHints,
+    ) -> Self {
+        if !cargo.available || cargo_home.path.is_none() {
+            return Self::Missing;
+        }
+        if caches.iter().any(|cache| cache.exists && cache.has_entries)
+            || cargo_config.source_replacement_detected
+            || cargo_config.vendor_source_detected
+        {
+            return Self::Present;
+        }
+        if cargo_home.exists {
+            Self::Unknown
+        } else {
+            Self::Missing
+        }
+    }
+
+    /// Return the stable JSON/text spelling for this advisory status.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Present => "present",
+            Self::Missing => "missing",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CargoCommandInfo {
+    command: &'static str,
+    available: bool,
+    version: Option<String>,
+    error: Option<String>,
+}
+
+impl CargoCommandInfo {
+    /// Run only `cargo --version`; this does not resolve packages or access the network.
+    fn collect() -> Self {
+        match Command::new("cargo").arg("--version").output() {
+            Ok(output) if output.status.success() => {
+                let version = String::from_utf8(output.stdout)
+                    .ok()
+                    .map(|text| text.trim().to_string())
+                    .filter(|text| !text.is_empty());
+                Self {
+                    command: "cargo",
+                    available: true,
+                    version,
+                    error: None,
+                }
+            }
+            Ok(output) => {
+                let error = String::from_utf8(output.stderr)
+                    .ok()
+                    .map(|text| text.trim().to_string())
+                    .filter(|text| !text.is_empty())
+                    .unwrap_or_else(|| format!("cargo --version exited with {}", output.status));
+                Self {
+                    command: "cargo",
+                    available: false,
+                    version: None,
+                    error: Some(error),
+                }
+            }
+            Err(error) => Self {
+                command: "cargo",
+                available: false,
+                version: None,
+                error: Some(error.to_string()),
+            },
+        }
+    }
+
+    /// Convert Cargo command availability into JSON.
+    fn as_json(&self) -> serde_json::Value {
+        json!({
+            "command": self.command,
+            "available": self.available,
+            "version": self.version,
+            "error": self.error,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct CargoHomeInfo {
+    source: CargoHomeSource,
+    path: Option<PathBuf>,
+    exists: bool,
+}
+
+impl CargoHomeInfo {
+    /// Resolve the effective Cargo home from `CARGO_HOME` or the default home directory.
+    fn collect() -> Self {
+        let (source, path) = if let Some(path) = env::var_os("CARGO_HOME").map(PathBuf::from) {
+            (CargoHomeSource::CargoHomeEnv, Some(path))
+        } else if let Some(home) = home_dir() {
+            (CargoHomeSource::HomeDefault, Some(home.join(".cargo")))
+        } else {
+            (CargoHomeSource::Unknown, None)
+        };
+        let exists = path.as_deref().is_some_and(Path::exists);
+        Self { source, path, exists }
+    }
+
+    /// Convert the effective Cargo home into JSON.
+    fn as_json(&self) -> serde_json::Value {
+        json!({
+            "source": self.source.as_str(),
+            "path": self.path.as_deref().map(path_to_string),
+            "exists": self.exists,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CargoHomeSource {
+    CargoHomeEnv,
+    HomeDefault,
+    Unknown,
+}
+
+impl CargoHomeSource {
+    /// Return the stable JSON/text spelling for the Cargo home source.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CargoHomeEnv => "CARGO_HOME",
+            Self::HomeDefault => "HOME/.cargo",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CachePathHint {
+    path: Option<PathBuf>,
+    exists: bool,
+    has_entries: bool,
+}
+
+impl CachePathHint {
+    /// Inspect whether one optional cache path exists and contains entries.
+    fn from_optional_path(path: Option<PathBuf>) -> Self {
+        let exists = path.as_deref().is_some_and(Path::exists);
+        let has_entries = path.as_deref().is_some_and(path_has_entries);
+        Self {
+            path,
+            exists,
+            has_entries,
+        }
+    }
+
+    /// Print one cache path hint in the doctor text report.
+    fn print_text(&self, label: &str) {
+        println!("  {label}:");
+        println!("    path: {}", display_option_path(&self.path));
+        println!("    exists: {}", self.exists);
+        println!("    has_entries: {}", self.has_entries);
+    }
+
+    /// Convert one cache path hint into JSON.
+    fn as_json(&self) -> serde_json::Value {
+        json!({
+            "path": self.path.as_deref().map(path_to_string),
+            "exists": self.exists,
+            "has_entries": self.has_entries,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct CargoConfigHints {
+    files: Vec<CargoConfigFileHint>,
+    source_replacement_detected: bool,
+    vendor_source_detected: bool,
+    net_offline_detected: bool,
+}
+
+impl CargoConfigHints {
+    /// Collect local Cargo config files that may affect offline or vendored builds.
+    fn collect(cwd: Option<&Path>, cargo_home: Option<&Path>) -> Self {
+        let files = cargo_config_candidates(cwd, cargo_home)
+            .into_iter()
+            .filter(|path| path.is_file())
+            .map(CargoConfigFileHint::from_path)
+            .collect::<Vec<_>>();
+        let source_replacement_detected = files.iter().any(|file| file.source_replacement);
+        let vendor_source_detected = files.iter().any(|file| file.vendor_source);
+        let net_offline_detected = files.iter().any(|file| file.net_offline);
+        Self {
+            files,
+            source_replacement_detected,
+            vendor_source_detected,
+            net_offline_detected,
+        }
+    }
+
+    /// Convert Cargo config hints into JSON.
+    fn as_json(&self) -> serde_json::Value {
+        json!({
+            "files": self.files.iter().map(CargoConfigFileHint::as_json).collect::<Vec<_>>(),
+            "source_replacement_detected": self.source_replacement_detected,
+            "vendor_source_detected": self.vendor_source_detected,
+            "net_offline_detected": self.net_offline_detected,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct CargoConfigFileHint {
+    path: PathBuf,
+    readable: bool,
+    source_replacement: bool,
+    vendor_source: bool,
+    net_offline: bool,
+    parse_error: Option<String>,
+}
+
+impl CargoConfigFileHint {
+    /// Parse one Cargo config file and extract offline/source replacement hints.
+    fn from_path(path: PathBuf) -> Self {
+        let Ok(content) = fs::read_to_string(&path) else {
+            return Self {
+                path,
+                readable: false,
+                source_replacement: false,
+                vendor_source: false,
+                net_offline: false,
+                parse_error: Some("failed to read Cargo config".to_string()),
+            };
+        };
+        let parsed = toml::from_str::<toml::Value>(&content);
+        match parsed {
+            Ok(value) => Self {
+                path,
+                readable: true,
+                source_replacement: cargo_config_has_source_replacement(&value),
+                vendor_source: cargo_config_has_vendor_source(&value),
+                net_offline: cargo_config_has_net_offline(&value),
+                parse_error: None,
+            },
+            Err(error) => Self {
+                path,
+                readable: true,
+                source_replacement: content.contains("replace-with"),
+                vendor_source: content.contains("directory") || content.contains("vendor"),
+                net_offline: content.contains("offline"),
+                parse_error: Some(error.to_string()),
+            },
+        }
+    }
+
+    /// Convert one Cargo config file hint into JSON.
+    fn as_json(&self) -> serde_json::Value {
+        json!({
+            "path": path_to_string(&self.path),
+            "readable": self.readable,
+            "source_replacement": self.source_replacement,
+            "vendor_source": self.vendor_source,
+            "net_offline": self.net_offline,
+            "parse_error": self.parse_error,
+        })
+    }
+}
+
+/// Build the ordered list of Cargo config paths that can influence the current directory.
+fn cargo_config_candidates(cwd: Option<&Path>, cargo_home: Option<&Path>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(cwd) = cwd {
+        for ancestor in cwd.ancestors() {
+            candidates.push(ancestor.join(".cargo").join("config.toml"));
+            candidates.push(ancestor.join(".cargo").join("config"));
+        }
+    }
+    if let Some(cargo_home) = cargo_home {
+        candidates.push(cargo_home.join("config.toml"));
+        candidates.push(cargo_home.join("config"));
+    }
+
+    let mut seen = BTreeSet::new();
+    candidates
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}
+
+/// Return whether a parsed Cargo config defines any source replacement.
+fn cargo_config_has_source_replacement(value: &toml::Value) -> bool {
+    value
+        .get("source")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|sources| {
+            sources.values().any(|source| {
+                source
+                    .as_table()
+                    .is_some_and(|table| table.get("replace-with").and_then(toml::Value::as_str).is_some())
+            })
+        })
+}
+
+/// Return whether a parsed Cargo config points at a vendored or local registry source.
+fn cargo_config_has_vendor_source(value: &toml::Value) -> bool {
+    value
+        .get("source")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|sources| {
+            sources.iter().any(|(name, source)| {
+                name.contains("vendor")
+                    || source.as_table().is_some_and(|table| {
+                        table.get("directory").and_then(toml::Value::as_str).is_some()
+                            || table
+                                .get("local-registry")
+                                .and_then(toml::Value::as_str)
+                                .is_some_and(|path| path.contains("vendor"))
+                    })
+            })
+        })
+}
+
+/// Return whether a parsed Cargo config enables Cargo's offline mode by default.
+fn cargo_config_has_net_offline(value: &toml::Value) -> bool {
+    value
+        .get("net")
+        .and_then(toml::Value::as_table)
+        .and_then(|net| net.get("offline"))
+        .and_then(toml::Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Build concrete next steps for missing or incomplete offline-readiness signals.
+fn build_offline_next_steps(
+    cargo: &CargoCommandInfo,
+    cargo_home: &CargoHomeInfo,
+    caches: [&CachePathHint; 5],
+    cargo_config: &CargoConfigHints,
+) -> Vec<String> {
+    let mut steps = Vec::new();
+    if !cargo.available {
+        steps.push("Install Cargo or put the cargo executable on PATH.".to_string());
+    }
+    if cargo_home.path.is_none() {
+        steps.push("Set CARGO_HOME or HOME so Cargo cache locations can be inspected.".to_string());
+    } else if !cargo_home.exists {
+        steps.push("Run an online Cargo command once, or restore a prepared CARGO_HOME cache.".to_string());
+    }
+    if !caches.iter().any(|cache| cache.exists && cache.has_entries) {
+        steps.push("Populate Cargo registry/git caches before relying on offline builds.".to_string());
+    }
+    if !cargo_config.source_replacement_detected && !cargo_config.vendor_source_detected {
+        steps.push(
+            "For vendor-based offline builds, add Cargo source replacement config such as a vendored source directory."
+                .to_string(),
+        );
+    }
+    if !cargo_config.net_offline_detected {
+        steps.push("Use Incan RFC 020 policy flags, or Cargo offline/frozen policy, for enforcement; this report is advisory only.".to_string());
+    }
+    if steps.is_empty() {
+        steps.push("Local offline-readiness signals are present, but run the intended Incan command with the desired RFC 020 policy flags for authoritative validation.".to_string());
+    }
+    steps
+}
+
+/// Return whether a directory can be read and contains at least one entry.
+fn path_has_entries(path: &Path) -> bool {
+    fs::read_dir(path)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
 }
 
 /// Resolve the current user's home directory from platform-standard environment variables.
@@ -581,6 +1097,34 @@ pub def label() -> str:
         assert_eq!(package.modules.len(), 1);
         assert_eq!(package.modules[0].module_path, vec!["lib".to_string()]);
         assert_eq!(package.modules[0].declarations.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn cargo_config_hints_detect_vendor_source_replacement() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let cargo_dir = tmp.path().join(".cargo");
+        fs::create_dir_all(&cargo_dir)?;
+        let config = cargo_dir.join("config.toml");
+        fs::write(
+            config,
+            r#"
+[net]
+offline = true
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+"#,
+        )?;
+
+        let hints = CargoConfigHints::collect(Some(tmp.path()), None);
+        assert!(hints.source_replacement_detected);
+        assert!(hints.vendor_source_detected);
+        assert!(hints.net_offline_detected);
+        assert_eq!(hints.files.len(), 1);
         Ok(())
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -250,6 +250,14 @@ fn tools_doctor_reports_text_and_json() -> Result<(), Box<dyn std::error::Error>
         text.contains("editor setup"),
         "text report should include editor recovery guidance, got:\n{text}"
     );
+    assert!(
+        text.contains("offline readiness"),
+        "text report should include offline-readiness diagnostics, got:\n{text}"
+    );
+    assert!(
+        text.contains("advisory local signals only"),
+        "offline-readiness text should avoid guaranteeing offline success, got:\n{text}"
+    );
 
     let json_output = run_incan(tmp.path(), &["tools", "doctor", "--format", "json"])?;
     assert_success(&json_output, "incan tools doctor --format json");
@@ -289,6 +297,54 @@ fn tools_doctor_reports_text_and_json() -> Result<(), Box<dyn std::error::Error>
         json.pointer("/editor_setup/reload_after_rebuild")
             .and_then(serde_json::Value::as_bool),
         Some(true)
+    );
+    assert_eq!(
+        json.pointer("/offline_readiness/advisory_only")
+            .and_then(serde_json::Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        json.pointer("/offline_readiness/source_of_truth")
+            .and_then(serde_json::Value::as_str),
+        Some("Cargo and RFC 020 policy flags")
+    );
+    assert!(
+        matches!(
+            json.pointer("/offline_readiness/status")
+                .and_then(serde_json::Value::as_str),
+            Some("present" | "missing" | "unknown")
+        ),
+        "doctor JSON should include stable offline-readiness status: {json}"
+    );
+    assert!(
+        json.pointer("/offline_readiness/cargo/available")
+            .and_then(serde_json::Value::as_bool)
+            .is_some(),
+        "doctor JSON should include cargo availability: {json}"
+    );
+    assert!(
+        json.pointer("/offline_readiness/cargo_home/source")
+            .and_then(serde_json::Value::as_str)
+            .is_some(),
+        "doctor JSON should include effective Cargo home source: {json}"
+    );
+    assert!(
+        json.pointer("/offline_readiness/caches/registry_cache/exists")
+            .and_then(serde_json::Value::as_bool)
+            .is_some(),
+        "doctor JSON should include registry cache hints: {json}"
+    );
+    assert!(
+        json.pointer("/offline_readiness/cargo_config/source_replacement_detected")
+            .and_then(serde_json::Value::as_bool)
+            .is_some(),
+        "doctor JSON should include Cargo config source replacement hints: {json}"
+    );
+    assert!(
+        json.pointer("/offline_readiness/next_steps")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|steps| !steps.is_empty()),
+        "doctor JSON should include concrete next steps: {json}"
     );
     Ok(())
 }

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -174,6 +174,7 @@ The sections above are the release story. The list below is the detailed invento
 
 ### Tooling and formatter
 
+- **Tooling**: `incan tools doctor` now includes advisory offline-readiness diagnostics in text and JSON output, reporting Cargo availability, effective Cargo home, cache/config hints, and remediation steps before users rely on RFC 020 offline or frozen policy in restricted environments (#460).
 - **Tooling/Editor**: `incan tools doctor` and the VS Code/Cursor **Incan: Doctor** command now report local `incan` / `incan-lsp` path resolution, cargo-bin symlink state, and recovery guidance for stale editor diagnostics or mismatched local binaries (#426).
 - **Compiler/Tooling**: RFC 048 checked contract metadata is now compiler-visible through canonical model bundle validation, project materialization, deterministic `incan tools metadata model` emit from projects, bundle JSON, and `.incnlib` artifacts, artifact embedding for publishable bundles, strict checked API docstring validation, `incan tools metadata api` JSON extraction, and LSP hover/emit integration (#205, #438, RFC 048).
 - **Compiler/Tooling**: `incan tools metadata api` emits checked public API metadata JSON for an Incan source file or project directory, including public declarations, checked signatures, stable anchors, parsed docstring sections, public import aliases with resolved targets, resolved decorator paths, safe decorator arguments, safe public const values, and model field alias/description metadata (#205, #438).
@@ -209,7 +210,7 @@ The sections above are the release story. The list below is the detailed invento
 
 - **Project lifecycle tooling**: Added lifecycle commands for interactive `incan new` / `incan init`, `incan version`, and `incan env`, plus project lifecycle documentation and `incan.toml` environment metadata support (#73).
 - **Dependency policy**: The rust-analyzer proc-macro API dependency is patched locally to request `postcard` without default features, removing the unmaintained `atomic-polyfill` crate from the workspace dependency graph and letting `cargo deny check` run without the `RUSTSEC-2023-0089` advisory ignore (#260).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.23`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.24`.
 
 ## Known limitations (0.3)
 

--- a/workspaces/docs-site/docs/tooling/how-to/dependencies.md
+++ b/workspaces/docs-site/docs/tooling/how-to/dependencies.md
@@ -129,6 +129,14 @@ incan build src/main.incn --locked
 incan build src/main.incn --frozen
 ```
 
+Before relying on `--frozen` in a restricted or offline environment, run:
+
+```bash
+incan tools doctor
+```
+
+`incan tools doctor` is the supported preflight path for local offline-readiness diagnostics. Its report is advisory, not a guarantee: `--frozen` still asks Cargo to use offline/locked policy, so any crate source that is missing from Cargo's local inputs can still make the build fail.
+
 If the lock file is missing or stale, the command fails with a clear message:
 
 ```text

--- a/workspaces/docs-site/docs/tooling/how-to/troubleshooting.md
+++ b/workspaces/docs-site/docs/tooling/how-to/troubleshooting.md
@@ -77,6 +77,14 @@ The first `make release` (or first `incan build`) will compile Rust dependencies
 Some builds may download Rust crates via Cargo on first run. Ensure your environment can reach crates.io (or your configured
 proxy/mirror).
 
+For restricted or offline environments, run the supported preflight before the build:
+
+```bash
+incan tools doctor
+```
+
+The doctor report includes offline-readiness diagnostics for local dependency inputs. Treat it as advisory: it can flag likely problems before Cargo runs, but it cannot guarantee that a later `incan build --frozen` or `incan test --frozen` will succeed. Offline policy prevents fetching; it does not remove crate dependencies, so crates that are not already available to Cargo locally can still make an offline build fail.
+
 ## macOS: toolchain/linker issues
 
 If you see errors about a missing C toolchain or linker, install Xcode Command Line Tools:

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -396,7 +396,7 @@ Usage:
 incan tools doctor [OPTIONS]
 ```
 
-Inspects local CLI/LSP/editor pathing. Use this when the terminal and editor appear to be using different `incan` or `incan-lsp` binaries, or when diagnostics look stale after rebuilding.
+Inspects local CLI/LSP/editor pathing and offline-readiness signals. Use this when the terminal and editor appear to be using different `incan` or `incan-lsp` binaries, when diagnostics look stale after rebuilding, or before a restricted/offline build where Cargo may be unable to fetch missing dependency inputs.
 
 Options:
 
@@ -408,6 +408,13 @@ The report includes:
 - `incan` and `incan-lsp` resolution from `PATH`
 - `~/.cargo/bin/incan` and `~/.cargo/bin/incan-lsp` existence, executable status, and symlink targets
 - editor setup guidance for `incan.lsp.path`, `incan.compiler.path`, and reload behavior
+
+Offline-readiness:
+
+- The doctor report is the supported preflight path for restricted or offline environments.
+- The offline-readiness section is advisory. It checks local signals that affect whether Cargo can satisfy `--frozen` policy without fetching, but it does not guarantee a later `incan build --frozen` or `incan test --frozen` will succeed.
+- Offline/locked policy constrains dependency resolution and fetching. Projects may still depend on Rust crates; those crates must already be available through Cargo's local inputs for an offline build to proceed.
+- Use `--format json` when an editor, CI preflight, or issue template needs the same information in a machine-readable form.
 
 Examples:
 


### PR DESCRIPTION
## Summary

This PR extends `incan tools doctor` with advisory offline-readiness diagnostics for Cargo-backed builds, including text and JSON output for Cargo availability, effective Cargo home, cache/config hints, and remediation steps. It also documents doctor as the supported preflight path for restricted or offline environments.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan tools doctor` now reports advisory offline-readiness signals before users rely on `--offline` or `--frozen`.
- **Internals**: Doctor collects local-only signals without network access, Cargo resolution, or builds.
- **Risks**: The report is intentionally advisory; Cargo remains authoritative for actual offline/frozen enforcement.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo fmt` passed
- `git diff --check` passed
- `cargo test --test cli_integration tools_doctor_reports_text_and_json` passed
- `cargo test cargo_config_hints_detect_vendor_source_replacement` passed
- `make docs-build` passed
- `cargo clippy --workspace --all-features -- -D warnings` passed
- Full `make pre-commit` was attempted twice but was externally SIGTERM'd during nextest after formatting/rustdoc passed and no test failure had appeared.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s):
  - `workspaces/docs-site/docs/tooling/reference/cli_reference.md`
  - `workspaces/docs-site/docs/tooling/how-to/troubleshooting.md`
  - `workspaces/docs-site/docs/tooling/how-to/dependencies.md`
  - `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #460