### PR TITLE
bugfix - restore docs version selector (#369)

### DIFF
--- a/workspaces/docs-site/docs/stylesheets/incapunk.css
+++ b/workspaces/docs-site/docs/stylesheets/incapunk.css
@@ -183,7 +183,7 @@ body::after {
   max-width: 1500px;
 }
 
-/* Header: sticky Material bar with the generated topic replaced by DOCS. */
+/* Header: sticky Material bar with the generated topic text replaced by DOCS. */
 .md-header {
   position: sticky;
   top: 0;
@@ -246,7 +246,8 @@ body::after {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  min-width: 2.85rem;
+  gap: 0.5rem;
+  min-width: 0;
   margin-left: -0.62rem;
   margin-right: 0.3rem;
   font-family: var(--inc-font-body);
@@ -255,15 +256,47 @@ body::after {
   text-transform: uppercase;
 }
 
+.md-header__ellipsis {
+  display: contents;
+}
+
 .md-header__topic {
+  display: contents;
+}
+
+.md-header__topic > .md-ellipsis {
   display: none;
 }
 
-.md-header__title::after {
+.md-header__title::before {
   content: "DOCS";
+  flex: 0 0 auto;
   color: #ffcf72;
   font-size: 0.92rem;
   text-shadow: 0 0 12px rgba(255, 177, 72, 0.32), 0 0 18px rgba(72, 240, 239, 0.1), 0 0 18px rgba(255, 92, 105, 0.08);
+}
+
+.md-version,
+[data-md-component="version"] {
+  flex: 0 0 auto;
+  min-width: max-content;
+  color: rgba(255, 240, 183, 0.82);
+  font-family: var(--inc-font-body);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+
+.md-version__current,
+.md-version__link {
+  color: inherit;
+}
+
+.md-version:hover,
+.md-version:focus-within {
+  color: var(--inc-gold-1);
+  text-shadow: 0 0 12px rgba(255, 193, 90, 0.24);
 }
 
 .md-search {


### PR DESCRIPTION
## Summary

This PR fixes a deployed docs theme regression where the MkDocs Material/mike version dropdown disappeared from the header. The Incapunk header styling previously hid the full `.md-header__topic` container to replace the generated title with `DOCS`; deployed mike builds use that header title/topic area for the version selector, so the CSS now hides only the generated text spans while preserving the container for Material-managed controls.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Deployed docs should show the version dropdown in the navbar again while keeping the `DOCS` header label.
- **Internals**: Replaced broad `.md-header__topic { display: none; }` behavior with text-only suppression, flattened header title wrappers with `display: contents`, and added explicit Incapunk styling for `.md-version` / `[data-md-component="version"]`.
- **Risks**: Local non-mike builds do not render the dropdown, so the fix is verified structurally against Material's generated header area and by docs build, but final confirmation still depends on a mike deployment render.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- [x] `make docs-build`
- [x] Confirmed the fix is a one-file CSS diff against current `origin/main`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/stylesheets/incapunk.css`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions

Follow-up to #471 / #369.