### PR TITLE
chore: reduce CI cache write pressure

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,5 +16,7 @@ leak-timeout = "2s"
 [profile.ci]
 # In CI, run all tests even after a failure to collect the full picture.
 fail-fast = false
-status-level = "fail"
+status-level = "slow"
+final-status-level = "slow"
+slow-timeout = "30s"
 leak-timeout = "2s"

--- a/.github/actions/setup-rust-sccache/action.yml
+++ b/.github/actions/setup-rust-sccache/action.yml
@@ -1,5 +1,5 @@
 name: Setup Rust sccache
-description: Install sccache and configure Cargo/Rust jobs to use the GitHub Actions cache backend.
+description: Install sccache and configure Cargo/Rust jobs to use a local compiler cache.
 inputs:
   version:
     description: sccache release version to install.
@@ -14,5 +14,4 @@ runs:
     - name: Configure Rust sccache
       shell: bash
       run: |
-        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
         echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          # Share registry/target across stable jobs (clippy/test/smoke) to improve cache hit rate on later runs.
+          # Share registry/target across stable jobs; the Linux test shard is the cache writer.
           shared-key: incan-stable
+          save-if: false
       - uses: ./.github/actions/setup-rust-sccache
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -66,6 +67,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: incan-stable
+          # Only one matrix leg writes the shared cache; every leg can restore it.
+          save-if: ${{ github.ref == 'refs/heads/main' && matrix.partition == 1 }}
       - uses: ./.github/actions/setup-rust-sccache
       - uses: taiki-e/install-action@nextest
       - name: Run test shard
@@ -106,6 +109,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: incan-stable
+          # Only one matrix leg writes the shared cache; every leg can restore it.
+          save-if: ${{ github.ref == 'refs/heads/main' && matrix.partition == 1 }}
       - uses: ./.github/actions/setup-rust-sccache
       - uses: taiki-e/install-action@nextest
       - name: Run test shard
@@ -141,6 +146,8 @@ jobs:
       - name: Install WASI target for vocab desugarers
         run: rustup target add wasm32-wasip1
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-rust-sccache
       - name: Cargo build (locked)
         run: cargo build --locked
@@ -166,6 +173,9 @@ jobs:
       - name: Install WASI target for vocab desugarers
         run: rustup target add wasm32-wasip1
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only one matrix leg writes the shared cache; every leg can restore it.
+          save-if: ${{ github.ref == 'refs/heads/main' && matrix.partition == 1 }}
       - uses: ./.github/actions/setup-rust-sccache
       - uses: taiki-e/install-action@nextest
       - name: Cargo test shard (locked)
@@ -201,6 +211,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run cargo audit
@@ -213,6 +225,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
       - name: Run cargo deny
@@ -228,6 +242,8 @@ jobs:
           profile: minimal
       - uses: ./.github/actions/install-nightly-toolchain
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-rust-sccache
       - name: Install cargo-udeps
         run: cargo install cargo-udeps --locked
@@ -245,10 +261,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          # Keep release-profile artifacts separate from the dev/test cache. Do not enable sccache
-          # in this job: its GitHub-cache writes can prevent rust-cache from saving this target cache.
+          # Keep release-profile artifacts separate from the dev/test cache.
           shared-key: incan-stable-release
           cache-workspace-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build release compiler once
         run: make smoke-test-release
       - name: Upload release compiler
@@ -294,6 +310,8 @@ jobs:
         with:
           shared-key: incan-stable
           cache-targets: false
+          # Smoke shards only need restore access; stable test shards own this shared cache.
+          save-if: false
       - uses: ./.github/actions/setup-rust-sccache
       - name: Install WASI target for vocab desugarers
         if: ${{ matrix.wasi }}
@@ -340,6 +358,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-rust-sccache
       - name: Build docs
         run: cargo doc --no-deps
@@ -372,6 +392,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-rust-sccache
       - name: Regenerate language reference
         run: cargo run -p incan_core --bin generate_lang_reference


### PR DESCRIPTION
## Summary
- make `rust-cache` restore-only on PR refs, with shared cache writes limited to one canonical main-branch writer per shared key
- switch the sccache helper to local-only compiler caching instead of GitHub-cache-backed sccache
- make the CI nextest profile print slow successful tests (`status-level`/`final-status-level = "slow"`, `slow-timeout = "30s"`)

## Why
The post-merge CI run for #466 showed the release cache was not stable on `main`: `Smoke Release Build` logged `No cache found`, then `You've hit a rate limit`, then failed to save `v0-rust-incan-stable-release-Linux-x64-ae62368c-20659a47`. The same run showed low sccache hit rates with hundreds of write errors on long shards, so the remote sccache backend appears to be increasing GitHub Actions cache pressure without enough benefit.

The first experiment run confirmed the PR behavior (`save-if: false`, local sccache, zero sccache write errors), but it also exposed a remaining main-branch issue: matrix jobs with the same cache key would still stampede the same save key after a miss. This revision makes only one matrix leg write each shared cache while all legs can still restore it.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/actions/setup-rust-sccache/action.yml"); puts "yaml ok"'`
- `cargo nextest show-config test-groups --profile ci`
- `git diff --check`

This is an experiment PR. The pass/fail result matters, but the important evidence is whether PR logs stay restore-only/local-only and whether the next main run can save durable caches without cache API rate-limit/write-error noise.