### PR TITLE
bugfix - retain private route handlers in dependency modules (#117)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "clap",
  "hex",
@@ -1443,14 +1443,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1459,14 +1459,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "axum",
  "incan_core",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.30"
+version = "0.3.0-dev.31"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -33,10 +33,12 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::frontend::ast::{Declaration, Expr, ImportKind, ImportPath, Program};
+use crate::frontend::ast::{self, Declaration, Expr, ImportKind, ImportPath, Program};
+use crate::frontend::decorator_resolution;
 use crate::frontend::diagnostics::CompileError;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::module::canonicalize_source_module_segments;
+use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
 use incan_core::lang::decorators::{self, DecoratorId};
 use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::stdlib;
@@ -108,6 +110,33 @@ fn should_preserve_dependency_public_items(module_path: &[String], preserve_non_
         module_path.first().map(String::as_str),
         Some(stdlib::INCAN_STD_NAMESPACE)
     )
+}
+
+/// Return whether a function carries the stdlib-backed web route decorator that lowers to a Rust proc-macro attribute.
+///
+/// Binary-style dependency emission prunes otherwise-unreferenced private items. Route handlers are different because
+/// their Rust attribute expands into inventory registration after IR emission, so the function itself is a generated
+/// entrypoint even when no Incan expression calls it directly.
+fn has_web_route_passthrough_decorator(
+    func: &ast::FunctionDecl,
+    aliases: &HashMap<String, Vec<String>>,
+    stdlib_cache: &mut StdlibAstCache,
+) -> bool {
+    func.decorators.iter().any(|decorator| {
+        let resolved = decorator_resolution::resolve_decorator_path(&decorator.node, aliases);
+        if resolved.len() < 2 {
+            return false;
+        }
+        let module_segments = &resolved[..resolved.len() - 1];
+        let name = &resolved[resolved.len() - 1];
+        if name != "route" {
+            return false;
+        }
+        let Some(meta) = stdlib_cache.lookup_function_meta(module_segments, name) else {
+            return false;
+        };
+        meta.is_rust_extern && meta.rust_module_path.as_deref() == Some("incan_web_macros")
+    })
 }
 
 /// Collect dependency-module declarations that are referenced through imports.
@@ -188,6 +217,21 @@ fn collect_externally_reachable_items_by_module(
                 }
                 false
             });
+        }
+        if module_paths.contains(current_module_path) {
+            let aliases = decorator_resolution::collect_import_aliases(program);
+            let mut stdlib_cache = StdlibAstCache::new();
+            for decl in &program.declarations {
+                let Declaration::Function(func) = &decl.node else {
+                    continue;
+                };
+                if has_web_route_passthrough_decorator(func, &aliases, &mut stdlib_cache) {
+                    reachable
+                        .entry(current_module_path.to_vec())
+                        .or_default()
+                        .insert(func.name.clone());
+                }
+            }
         }
     }
 

--- a/tests/codegen_snapshot_tests.rs
+++ b/tests/codegen_snapshot_tests.rs
@@ -764,6 +764,84 @@ async def search(id: int) -> int:
 }
 
 #[test]
+fn test_web_route_private_nested_module_codegen() {
+    let main_source = r#"
+import std.async
+import api::routes
+from std.web import App
+
+def main() -> None:
+  App.run(host="127.0.0.1", port=0)
+"#;
+    let routes_source = r#"
+import std.async
+from std.web import route, Json
+
+@derive(Serialize)
+model User:
+  id: int
+  name: str
+
+@route("/users/{id}")
+async def list_user(id: int) -> Json[User]:
+  return Json(User(id=id, name="Ada"))
+"#;
+
+    let Ok(main_tokens) = lexer::lex(main_source) else {
+        panic!("lexer failed")
+    };
+    let Ok(main_ast) = parser::parse(&main_tokens) else {
+        panic!("parser failed")
+    };
+    let Ok(routes_tokens) = lexer::lex(routes_source) else {
+        panic!("lexer failed")
+    };
+    let Ok(routes_ast) = parser::parse(&routes_tokens) else {
+        panic!("parser failed")
+    };
+
+    let routes_path = vec!["api".to_string(), "routes".to_string()];
+    let mut codegen = IrCodegen::new();
+    codegen.set_preserve_dependency_public_items(false);
+    codegen.add_module_with_path_segments("api_routes", &routes_ast, routes_path.clone());
+    let Ok((main_code, modules)) =
+        codegen.try_generate_multi_file_nested(&main_ast, std::slice::from_ref(&routes_path))
+    else {
+        panic!("codegen must succeed");
+    };
+    let Some(routes_code) = modules.get(&routes_path) else {
+        panic!("routes module should be emitted");
+    };
+    let main_code = normalize_codegen_output(&main_code);
+    let routes_code = normalize_codegen_output(routes_code);
+
+    assert!(
+        routes_code.contains("#[incan_web_macros::route(\"/users/{id}\")]"),
+        "route proc-macro attribute should be retained in dependency module:\n{routes_code}"
+    );
+    assert!(
+        routes_code.contains("struct User"),
+        "private response model should be retained in dependency module:\n{routes_code}"
+    );
+    assert!(
+        !routes_code.contains("pub struct User"),
+        "route response model should not be forced public:\n{routes_code}"
+    );
+    assert!(
+        routes_code.contains("async fn list_user"),
+        "private route handler should be retained in dependency module:\n{routes_code}"
+    );
+    assert!(
+        !routes_code.contains("pub async fn list_user"),
+        "route handler should not be forced public:\n{routes_code}"
+    );
+    assert!(
+        !main_code.contains("api::routes::list_user"),
+        "main module should not call dependency route handler directly:\n{main_code}"
+    );
+}
+
+#[test]
 fn test_async_main_runtime_bootstrap_codegen() {
     let source = r#"
 import std.async

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -224,6 +224,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Runtime/Async**: `std.async.time` adds `timeout_join`, `timeout_join_ms`, and a must-use `TimeoutJoinOutcome` so spawned work can keep running after a deadline while callers retain the live `JoinHandle` for later observation or explicit abort (#417).
 - **Runtime/Async**: `std.async.sync.Barrier.wait()` now uses Incan-owned generation bookkeeping so cancelling a pending wait withdraws that participant and frees its arrival slot instead of corrupting barrier progress (#418).
 - **Language/Compiler**: List and dict comprehensions now accept tuple-unpack iteration targets such as `for idx, name in enumerate(xs)`, matching ordinary `for` loop binding syntax (#483).
+- **Language/Compiler**: Multi-file web builds now retain private route-decorated handlers and the private models they use in dependency modules, so route registration works without forcing those declarations public (#117).
 
 ### Versioning and release track
 
@@ -231,7 +232,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Dependency policy**: The rust-analyzer proc-macro API dependency is patched locally to request `postcard` without default features, removing the unmaintained `atomic-polyfill` crate from the workspace dependency graph and letting `cargo deny check` run without the `RUSTSEC-2023-0089` advisory ignore (#260).
 - **Dependency policy**: The workspace now builds against Wasmtime `44.0.1` / Wasmtime WASI `44.0.1` and raises the Rust MSRV to `1.92`, matching Wasmtime 44's compiler requirement.
 - **Dependency policy**: Dependabot security alerts for the VS Code extension lockfile, docs-site Python pins, and Rust `rand` lock entries are remediated, while repo-owned GitHub Actions are moved to Node 24-compatible action releases (#475, #464).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.30`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.31`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

This PR fixes multi-file web codegen so private route-decorated handlers in dependency modules are retained even when binary-style dependency pruning is active. The fix preserves the private handler and private response model needed for route registration without making either declaration public or adding a direct call from `main`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Multi-file web projects can keep route handlers and their route-only models private inside dependency modules while still registering those routes.
- **Internals**: Dependency reachability now treats stdlib-backed `std.web.route` passthrough decorators as generated entrypoints. Existing generated-use scanning then retains nominal types referenced by the reachable handler.
- **Risks**: The change is scoped to route-decorated dependency functions identified through stdlib metadata, so the main risk is missed alternate import forms rather than broad over-retention.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Added `test_web_route_private_nested_module_codegen`.
- Ran targeted route codegen tests.
- Ran `cargo check --workspace --offline`.
- Ran `git diff --check`.
- Ran full `make pre-commit`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #117
