### PR TITLE
bugfix - inject shared docs theme for release builds (#369)

### DIFF
--- a/.github/workflows/docs_site_deploy.yml
+++ b/.github/workflows/docs_site_deploy.yml
@@ -46,6 +46,37 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Prepare shared Incapunk theme
+        run: |
+          set -euo pipefail
+
+          git -C "$GITHUB_WORKSPACE" fetch origin main
+          git -C "$GITHUB_WORKSPACE" checkout origin/main -- workspaces/docs-site/docs/shared/incapunk
+
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("mkdocs.yml")
+          lines = path.read_text().splitlines()
+
+          if "  logo: /shared/incapunk/wordmark_small_001.png" not in lines:
+              for index, line in enumerate(lines):
+                  if line == "  name: material":
+                      lines.insert(index + 1, "  logo: /shared/incapunk/wordmark_small_001.png")
+                      break
+
+          if "  - /shared/incapunk/incapunk.css" not in lines:
+              for index, line in enumerate(lines):
+                  if line == "extra_css:":
+                      insert_at = index + 1
+                      while insert_at < len(lines) and lines[insert_at].startswith("  - "):
+                          insert_at += 1
+                      lines.insert(insert_at, "  - /shared/incapunk/incapunk.css")
+                      break
+
+          path.write_text("\n".join(lines) + "\n")
+          PY
+
       - name: Publish shared docs assets
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

This PR fixes the manual version redeploy path added for the Incapunk docs theme. Release branches `release/v0.1` and `release/v0.2` do not contain the new Incapunk `mkdocs.yml` entries or `docs/shared/incapunk` assets, so building those refs directly would redeploy the old Material styling. The workflow now keeps the requested release branch content, restores the shared Incapunk assets from `origin/main`, and injects the shared logo/CSS references into the checked-out `mkdocs.yml` before publishing assets and deploying with `mike`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Manual redeploys for old docs versions can apply the current Incapunk theme without patching `release/v0.1` or `release/v0.2`.
- **Internals**: Adds a workflow preparation step that fetches `origin/main`, restores `workspaces/docs-site/docs/shared/incapunk`, and idempotently inserts the shared logo and stylesheet references into `workspaces/docs-site/mkdocs.yml` for the checked-out docs source.
- **Risks**: This mutates the workflow working tree before build, but only for generated docs output. The release branch source commits remain untouched.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Parsed `.github/workflows/docs_site_deploy.yml` with PyYAML.
- Verified `origin/main` contains all three shared Incapunk assets.
- Applied the workflow injection logic to `origin/release/v0.1` and verified `mkdocs.yml` receives `/shared/incapunk` logo/CSS references.
- Applied the workflow injection logic to `origin/release/v0.2` and verified `mkdocs.yml` receives `/shared/incapunk` logo/CSS references.
- Built `release/v0.1` docs locally with `INCAN_DOCS_BASE_PREFIX=v0.1 python -m mkdocs build --strict` after injection.
- Built `release/v0.2` docs locally with `INCAN_DOCS_BASE_PREFIX=v0.2 python -m mkdocs build --strict` after injection.
- Verified both generated `site/index.html` files reference `/shared/incapunk/incapunk.css` and `/shared/incapunk/wordmark_small_001.png`.
- `git diff --check origin/main...HEAD`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `.github/workflows/docs_site_deploy.yml`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #369