### PR TITLE
bugfix - keep docs deploy source-driven (#369)

### DIFF
--- a/.github/workflows/docs_site_deploy.yml
+++ b/.github/workflows/docs_site_deploy.yml
@@ -46,37 +46,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Prepare shared Incapunk theme
-        run: |
-          set -euo pipefail
-
-          git -C "$GITHUB_WORKSPACE" fetch origin main
-          git -C "$GITHUB_WORKSPACE" checkout origin/main -- workspaces/docs-site/docs/shared/incapunk
-
-          python - <<'PY'
-          from pathlib import Path
-
-          path = Path("mkdocs.yml")
-          lines = path.read_text().splitlines()
-
-          if "  logo: /shared/incapunk/wordmark_small_001.png" not in lines:
-              for index, line in enumerate(lines):
-                  if line == "  name: material":
-                      lines.insert(index + 1, "  logo: /shared/incapunk/wordmark_small_001.png")
-                      break
-
-          if "  - /shared/incapunk/incapunk.css" not in lines:
-              for index, line in enumerate(lines):
-                  if line == "extra_css:":
-                      insert_at = index + 1
-                      while insert_at < len(lines) and lines[insert_at].startswith("  - "):
-                          insert_at += 1
-                      lines.insert(insert_at, "  - /shared/incapunk/incapunk.css")
-                      break
-
-          path.write_text("\n".join(lines) + "\n")
-          PY
-
       - name: Publish shared docs assets
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

This PR removes the workflow-time Incapunk theme injection added for old docs versions. The release branches now carry their own required docs theme assets and `mkdocs.yml` references, so the deploy workflow should build whichever `source_ref` it checks out rather than patching historical branch content during CI.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: No docs UI behavior change by itself; release docs styling now comes from the release branch source instead of workflow mutation.
- **Internals**: Removes the `Prepare shared Incapunk theme` workflow step. The workflow still supports `docs_version` and `source_ref`, still publishes shared docs assets from the checked-out source, and still deploys via `mike`.
- **Risks**: Manual docs deploys now require the selected `source_ref` branch to contain the docs assets/config it needs. `release/v0.1` and `release/v0.2` were patched directly for this.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Parsed `.github/workflows/docs_site_deploy.yml` with PyYAML.
- `git diff --check`
- Built patched `release/v0.1` docs locally with `INCAN_DOCS_BASE_PREFIX=v0.1 python -m mkdocs build --strict`.
- Built patched `release/v0.2` docs locally with `INCAN_DOCS_BASE_PREFIX=v0.2 python -m mkdocs build --strict`.
- Verified both generated release home pages reference `/shared/incapunk/incapunk.css` and `/shared/incapunk/wordmark_small_001.png`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `.github/workflows/docs_site_deploy.yml`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #369