### PR TITLE
bugfix - 492 499 500 501 502 505 506 fix stdlib regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "clap",
  "hex",
@@ -1443,14 +1443,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1459,14 +1459,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "axum",
  "incan_core",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.34"
+version = "0.3.0-dev.35"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/incan_core/src/lang/surface/types.rs
+++ b/crates/incan_core/src/lang/surface/types.rs
@@ -18,6 +18,7 @@ pub enum SurfaceTypeId {
 
     // Task handles
     JoinHandle,
+    TaskJoinError,
 
     // Channels
     Sender,
@@ -100,6 +101,15 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
         &[],
         SurfaceTypeKind::Generic,
         "Handle to a spawned task.",
+        RFC::_000,
+        Since(0, 1),
+    ),
+    info(
+        SurfaceTypeId::TaskJoinError,
+        "TaskJoinError",
+        &[],
+        SurfaceTypeKind::Named,
+        "Error returned when a spawned task fails to join.",
         RFC::_000,
         Since(0, 1),
     ),
@@ -268,7 +278,7 @@ pub fn stdlib_module_path(id: SurfaceTypeId) -> Option<&'static str> {
         }
 
         // Task handles
-        SurfaceTypeId::JoinHandle => Some("std.async.task"),
+        SurfaceTypeId::JoinHandle | SurfaceTypeId::TaskJoinError => Some("std.async.task"),
 
         // Channels
         SurfaceTypeId::Sender
@@ -327,21 +337,22 @@ pub fn info_for(id: SurfaceTypeId) -> SurfaceTypeInfo {
         SurfaceTypeId::Semaphore => SURFACE_TYPES[2],
         SurfaceTypeId::Barrier => SURFACE_TYPES[3],
         SurfaceTypeId::JoinHandle => SURFACE_TYPES[4],
-        SurfaceTypeId::Sender => SURFACE_TYPES[5],
-        SurfaceTypeId::Receiver => SURFACE_TYPES[6],
-        SurfaceTypeId::OneshotSender => SURFACE_TYPES[7],
-        SurfaceTypeId::OneshotReceiver => SURFACE_TYPES[8],
-        SurfaceTypeId::Vec => SURFACE_TYPES[9],
-        SurfaceTypeId::HashMap => SURFACE_TYPES[10],
-        SurfaceTypeId::App => SURFACE_TYPES[11],
-        SurfaceTypeId::Response => SURFACE_TYPES[12],
-        SurfaceTypeId::Html => SURFACE_TYPES[13],
-        SurfaceTypeId::Json => SURFACE_TYPES[14],
-        SurfaceTypeId::Query => SURFACE_TYPES[15],
-        SurfaceTypeId::Path => SURFACE_TYPES[16],
-        SurfaceTypeId::Body => SURFACE_TYPES[17],
-        SurfaceTypeId::Request => SURFACE_TYPES[18],
-        SurfaceTypeId::FieldInfo => SURFACE_TYPES[19],
+        SurfaceTypeId::TaskJoinError => SURFACE_TYPES[5],
+        SurfaceTypeId::Sender => SURFACE_TYPES[6],
+        SurfaceTypeId::Receiver => SURFACE_TYPES[7],
+        SurfaceTypeId::OneshotSender => SURFACE_TYPES[8],
+        SurfaceTypeId::OneshotReceiver => SURFACE_TYPES[9],
+        SurfaceTypeId::Vec => SURFACE_TYPES[10],
+        SurfaceTypeId::HashMap => SURFACE_TYPES[11],
+        SurfaceTypeId::App => SURFACE_TYPES[12],
+        SurfaceTypeId::Response => SURFACE_TYPES[13],
+        SurfaceTypeId::Html => SURFACE_TYPES[14],
+        SurfaceTypeId::Json => SURFACE_TYPES[15],
+        SurfaceTypeId::Query => SURFACE_TYPES[16],
+        SurfaceTypeId::Path => SURFACE_TYPES[17],
+        SurfaceTypeId::Body => SURFACE_TYPES[18],
+        SurfaceTypeId::Request => SURFACE_TYPES[19],
+        SurfaceTypeId::FieldInfo => SURFACE_TYPES[20],
     }
 }
 

--- a/crates/incan_core/tests/lang_registry_guardrails.rs
+++ b/crates/incan_core/tests/lang_registry_guardrails.rs
@@ -304,7 +304,7 @@ fn surface_functions_spellings_unique_and_resolvable() {
 fn surface_types_spellings_unique_and_resolvable() {
     assert_registry_round_trip(RegistryRoundTrip {
         label: "surface type",
-        expected_len: 20,
+        expected_len: 21,
         items: surface_types::SURFACE_TYPES,
         id_of: |info| info.item.id,
         canonical_of: |info| info.item.canonical,

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/modules.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/modules.rs
@@ -29,6 +29,16 @@ pub fn unknown_stdlib_module(module: &str, span: Span) -> CompileError {
         .with_hint("To import from the Rust standard library, use: `from rust::std::... import ...`")
 }
 
+/// Import path `std.<module>` is known, but the requested item is not part of that stdlib module's public surface.
+pub fn stdlib_import_not_exported(name: &str, module: &str, span: Span) -> CompileError {
+    CompileError::new(
+        format!("Cannot import `{name}` from stdlib module `{module}`: it is not exported by that module"),
+        span,
+    )
+    .with_hint("Use a supported stdlib import name from this module")
+    .with_hint("To import from the Rust standard library, use: `from rust::std::... import ...`")
+}
+
 /// A crate-root `import rust::crate_name` binding was used in type position.
 ///
 /// RFC 041: crate-root imports name the crate as a namespace, not a concrete Rust type. Authors should import a

--- a/src/backend/ir/lower/expr/calls.rs
+++ b/src/backend/ir/lower/expr/calls.rs
@@ -43,6 +43,54 @@ impl AstLowering {
         }
     }
 
+    /// Rebuild a callable signature directly from a stdlib method declaration so default expressions survive import
+    /// metadata boundaries.
+    fn callable_signature_from_stdlib_method_decl(&mut self, method: &ast::MethodDecl) -> FunctionSignature {
+        FunctionSignature {
+            params: method
+                .params
+                .iter()
+                .map(|param| {
+                    let base_ty = self.lower_type(&param.node.ty.node);
+                    let ty = Self::lower_param_container_type(param.node.kind, base_ty);
+                    FunctionParam {
+                        name: param.node.name.clone(),
+                        ty,
+                        mutability: super::super::super::types::Mutability::Immutable,
+                        is_self: false,
+                        kind: param.node.kind,
+                        default: param
+                            .node
+                            .default
+                            .as_ref()
+                            .and_then(|default_expr| self.lower_expr_spanned(default_expr).ok()),
+                    }
+                })
+                .collect(),
+            return_type: self.lower_type(&method.return_type.node),
+        }
+    }
+
+    /// Resolve an imported stdlib type method signature by loading the owning stdlib stub AST.
+    ///
+    /// Function metadata already has a direct stdlib lookup path, but type-member calls such as `App.run()` arrive as
+    /// method calls. The lightweight frontend import metadata only records `has_default`, so this path rehydrates the
+    /// actual default expressions from the stdlib source declaration before IR emission fills omitted arguments.
+    pub(in crate::backend::ir::lower) fn callable_signature_for_imported_stdlib_type_method_path(
+        &mut self,
+        path: &[String],
+        method_name: &str,
+    ) -> Option<FunctionSignature> {
+        if path.len() < 3 || path.first().map(String::as_str) != Some(incan_core::lang::stdlib::STDLIB_ROOT) {
+            return None;
+        }
+        let type_name = path.last()?;
+        let module_path = &path[..path.len() - 1];
+        let mut cache = crate::frontend::typechecker::stdlib_loader::StdlibAstCache::new();
+        let method = cache.lookup_type_method_decl(module_path, type_name, method_name)?;
+        Some(self.callable_signature_from_stdlib_method_decl(&method))
+    }
+
     /// Resolve the signature for an imported stdlib function by its canonical import path.
     ///
     /// Lowered stdlib modules may import private helpers from sibling stdlib modules. Those helpers are not in the

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -501,6 +501,13 @@ impl AstLowering {
                         IrType::Unknown,
                     )
                 } else {
+                    let imported_type_method_signature =
+                        match &o.node {
+                            ast::Expr::Ident(name) => self.import_aliases.get(name).cloned().and_then(|path| {
+                                self.callable_signature_for_imported_stdlib_type_method_path(&path, m)
+                            }),
+                            _ => None,
+                        };
                     // Unknown method - keep as string-based call
                     (
                         IrExprKind::MethodCall {
@@ -508,7 +515,8 @@ impl AstLowering {
                             method: method_name,
                             type_args: lowered_type_args,
                             args: args_ir,
-                            callable_signature: self.callable_signature_for_call_span(expr_span),
+                            callable_signature: imported_type_method_signature
+                                .or_else(|| self.callable_signature_for_call_span(expr_span)),
                             arg_policy,
                         },
                         IrType::Unknown,

--- a/src/backend/ir/lower/stmt.rs
+++ b/src/backend/ir/lower/stmt.rs
@@ -74,6 +74,14 @@ struct BranchTail<'a> {
     else_body: Option<&'a [Spanned<ast::Statement>]>,
 }
 
+/// Consecutive independent `isinstance` statements that can lower through the existing narrowing chain.
+struct IndependentIsInstanceChain {
+    condition: Spanned<ast::Expr>,
+    then_body: Vec<Spanned<ast::Statement>>,
+    elif_branches: Vec<(Spanned<ast::Expr>, Vec<Spanned<ast::Statement>>)>,
+    consumed: usize,
+}
+
 impl AstLowering {
     fn resolve_named_assign_target(&self, name: &str) -> AssignTarget {
         let direct_static = self
@@ -263,6 +271,115 @@ impl AstLowering {
             || matches!(&expr.node, ast::Expr::Ident(name) if name == constructors::as_str(ConstructorId::None))
     }
 
+    /// Return the narrowed binding name from a source-level `isinstance(binding, T)` condition.
+    fn isinstance_condition_binding(condition: &Spanned<ast::Expr>) -> Option<&str> {
+        let ast::Expr::Call(callee, _, args) = &condition.node else {
+            return None;
+        };
+        let ast::Expr::Ident(call_name) = &callee.node else {
+            return None;
+        };
+        if core_builtins::from_str(call_name) != Some(BuiltinFnId::IsInstance) || args.len() != 2 {
+            return None;
+        }
+        let ast::CallArg::Positional(value) = &args[0] else {
+            return None;
+        };
+        let ast::Expr::Ident(binding) = &value.node else {
+            return None;
+        };
+        Some(binding)
+    }
+
+    /// Return whether a statement body exits the current function on all straightforward paths.
+    ///
+    /// This intentionally stays conservative because it is used to fold consecutive independent `isinstance` branches
+    /// into one narrowing chain. Folding is semantics-preserving only when a taken branch does not continue into the
+    /// following sibling statements.
+    fn statements_definitely_return(stmts: &[Spanned<ast::Statement>]) -> bool {
+        stmts
+            .last()
+            .is_some_and(|stmt| Self::statement_definitely_returns(&stmt.node))
+    }
+
+    /// Return whether one statement exits the current function on all straightforward paths.
+    fn statement_definitely_returns(stmt: &ast::Statement) -> bool {
+        match stmt {
+            ast::Statement::Return(_) => true,
+            ast::Statement::If(if_stmt) => {
+                let Some(else_body) = if_stmt.else_body.as_deref() else {
+                    return false;
+                };
+                Self::statements_definitely_return(&if_stmt.then_body)
+                    && if_stmt
+                        .elif_branches
+                        .iter()
+                        .all(|(_, body)| Self::statements_definitely_return(body))
+                    && Self::statements_definitely_return(else_body)
+            }
+            _ => false,
+        }
+    }
+
+    /// Collect consecutive simple returning `if isinstance(same_binding, T)` statements as an `elif` chain.
+    fn independent_isinstance_chain(
+        &self,
+        stmts: &[Spanned<ast::Statement>],
+        start: usize,
+    ) -> Option<IndependentIsInstanceChain> {
+        let ast::Statement::If(first_if) = &stmts.get(start)?.node else {
+            return None;
+        };
+        if !first_if.elif_branches.is_empty() || first_if.else_body.is_some() {
+            return None;
+        }
+        let ast::Condition::Expr(first_condition) = &first_if.condition else {
+            return None;
+        };
+        if !Self::statements_definitely_return(&first_if.then_body) {
+            return None;
+        }
+        if self.union_isinstance_test(first_condition).is_none()
+            && self.option_isinstance_test(first_condition).is_none()
+        {
+            return None;
+        }
+        let binding = Self::isinstance_condition_binding(first_condition)?;
+        let mut elif_branches = Vec::new();
+        let mut consumed = 1;
+
+        for stmt in &stmts[start + 1..] {
+            let ast::Statement::If(next_if) = &stmt.node else {
+                break;
+            };
+            if !next_if.elif_branches.is_empty() || next_if.else_body.is_some() {
+                break;
+            }
+            let ast::Condition::Expr(next_condition) = &next_if.condition else {
+                break;
+            };
+            if Self::isinstance_condition_binding(next_condition) != Some(binding) {
+                break;
+            }
+            if !Self::statements_definitely_return(&next_if.then_body) {
+                break;
+            }
+            elif_branches.push((next_condition.clone(), next_if.then_body.clone()));
+            consumed += 1;
+        }
+
+        if elif_branches.is_empty() {
+            return None;
+        }
+
+        Some(IndependentIsInstanceChain {
+            condition: first_condition.clone(),
+            then_body: first_if.then_body.clone(),
+            elif_branches,
+            consumed,
+        })
+    }
+
     /// Extract an `x is None` or `x is not None` test for an option-typed local.
     fn option_none_test<'a>(&self, condition: &'a Spanned<ast::Expr>) -> Option<OptionNoneTest<'a>> {
         let ast::Expr::Binary(value, op @ (ast::BinaryOp::Is | ast::BinaryOp::IsNot), right) = &condition.node else {
@@ -422,9 +539,24 @@ impl AstLowering {
 
         let lowered = (|| -> Result<Vec<IrStmt>, LoweringError> {
             let mut result = Vec::new();
-            for s in stmts {
+            let mut index = 0;
+            while index < stmts.len() {
+                if let Some(chain) = self.independent_isinstance_chain(stmts, index) {
+                    let stmt = IrStmt::new(self.lower_if_expr_stmt_kind(
+                        &chain.condition,
+                        &chain.then_body,
+                        &chain.elif_branches,
+                        None,
+                    )?);
+                    result.push(stmt);
+                    index += chain.consumed;
+                    continue;
+                }
+
+                let s = &stmts[index];
                 let stmt = self.lower_statement(&s.node, s.span)?;
                 result.push(stmt);
+                index += 1;
             }
             Ok(result)
         })();

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -48,6 +48,21 @@ impl TypeChecker {
         None
     }
 
+    fn is_rust_generic_type_param_display(rust_ty: &str) -> bool {
+        let normalized = rust_ty.trim().replace(' ', "");
+        let mut chars = normalized.chars();
+        let Some(first) = chars.next() else {
+            return false;
+        };
+        if !first.is_ascii_uppercase() || !chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_') {
+            return false;
+        }
+        !matches!(
+            normalized.as_str(),
+            "Box" | "HashMap" | "HashSet" | "Option" | "Result" | "Self" | "String" | "Vec"
+        )
+    }
+
     /// Render an Incan type into the canonical boundary vocabulary used by interop coercion policy lookup.
     ///
     /// Returns `None` for shapes not covered by the builtin boundary coercion matrix.
@@ -171,16 +186,33 @@ impl TypeChecker {
     /// boundary adapters.
     fn rust_arg_boundary_match(&self, arg_ty: &ResolvedType, rust_param_ty: &str) -> RustArgBoundaryMatch {
         let normalized = rust_param_ty.replace(' ', "");
-        if let Some((true, inner)) = Self::rust_display_borrow_kind(normalized.as_str()) {
-            let target_inner_ty = self.resolved_type_from_rust_display(inner);
-            if self.types_compatible(arg_ty, &target_inner_ty) {
-                return RustArgBoundaryMatch::Exact;
-            }
-            if let Some(incan_display) = Self::incan_boundary_type_display(arg_ty)
-                && let Some(CoercionPolicy::Exact) =
-                    admitted_builtin_coercion(incan_display.as_str(), inner.replace(' ', "").as_str())
+        let borrowed_shared = matches!(Self::rust_display_borrow_kind(normalized.as_str()), Some((false, _)));
+        if let Some((is_mut, inner)) = Self::rust_display_borrow_kind(normalized.as_str()) {
+            if Self::is_rust_generic_type_param_display(inner)
+                && !is_mut
+                && !matches!(arg_ty, ResolvedType::Ref(_) | ResolvedType::RefMut(_))
             {
                 return RustArgBoundaryMatch::Exact;
+            }
+            if !is_mut {
+                let target_inner_ty = self.resolved_type_from_rust_display(inner);
+                if Self::incan_boundary_type_display(arg_ty).is_none()
+                    && self.types_compatible(arg_ty, &target_inner_ty)
+                {
+                    return RustArgBoundaryMatch::Exact;
+                }
+            }
+            if is_mut {
+                let target_inner_ty = self.resolved_type_from_rust_display(inner);
+                if self.types_compatible(arg_ty, &target_inner_ty) {
+                    return RustArgBoundaryMatch::Exact;
+                }
+                if let Some(incan_display) = Self::incan_boundary_type_display(arg_ty)
+                    && let Some(CoercionPolicy::Exact) =
+                        admitted_builtin_coercion(incan_display.as_str(), inner.replace(' ', "").as_str())
+                {
+                    return RustArgBoundaryMatch::Exact;
+                }
             }
         }
         if let Some(incan_display) = Self::incan_boundary_type_display(arg_ty)
@@ -193,7 +225,8 @@ impl TypeChecker {
             };
         }
         let target_ty = self.resolved_type_from_rust_display(normalized.as_str());
-        if self.types_compatible(arg_ty, &target_ty) {
+        let should_try_exact_type_match = !borrowed_shared || Self::incan_boundary_type_display(arg_ty).is_none();
+        if should_try_exact_type_match && self.types_compatible(arg_ty, &target_ty) {
             return RustArgBoundaryMatch::Exact;
         }
         if let Some(kind) = self.rusttype_boundary_match(arg_ty, &target_ty) {
@@ -846,6 +879,14 @@ mod validate_rust_function_call_tests {
                 .contains_key(&(span.start, span.end)),
             "expected rust arg coercion metadata for rusttype target boundary"
         );
+    }
+
+    #[test]
+    fn borrowed_generic_rust_function_param_accepts_owned_incan_value() {
+        let checker = TypeChecker::new();
+
+        assert!(checker.rust_arg_matches_boundary(&ResolvedType::Named("Payload".to_string()), "&T",));
+        assert!(checker.rust_arg_matches_boundary(&ResolvedType::Named("Payload".to_string()), "&TValue",));
     }
 
     #[test]

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -62,6 +62,11 @@ impl<'a> FromImportContext<'a> {
         self.stdlib.as_ref().is_some_and(|stdlib| stdlib.is_unknown_module)
     }
 
+    /// Return `true` when an unmaterialized import item from this context must be rejected instead of falling back.
+    fn rejects_unmaterialized_stdlib_items(&self) -> bool {
+        self.stdlib.as_ref().is_some_and(|stdlib| !stdlib.is_unknown_module)
+    }
+
     /// Join the source module segments as the user-facing dotted stdlib path.
     fn dotted_module_path(&self) -> String {
         self.module.segments.join(".")
@@ -214,6 +219,14 @@ impl TypeChecker {
 
         for item in items {
             if self.materialize_stdlib_from_import(&context, item, testing_semantics.as_ref(), span) {
+                continue;
+            }
+            if context.rejects_unmaterialized_stdlib_items() {
+                self.errors.push(errors::stdlib_import_not_exported(
+                    &item.name,
+                    &context.dotted_module_path(),
+                    span,
+                ));
                 continue;
             }
             if self.preserve_existing_from_import_symbol(item, span) {

--- a/src/frontend/typechecker/stdlib_loader.rs
+++ b/src/frontend/typechecker/stdlib_loader.rs
@@ -120,6 +120,19 @@ impl StdlibAstCache {
             .map(|(_, info)| info.clone())
     }
 
+    /// Look up a method declaration on a stdlib type, following prelude re-exports.
+    ///
+    /// This is intentionally AST-shaped rather than `MethodInfo`-shaped so lowering can preserve default parameter
+    /// expressions when imported type methods are called with omitted arguments.
+    pub(crate) fn lookup_type_method_decl(
+        &mut self,
+        module_path: &[String],
+        type_name: &str,
+        method_name: &str,
+    ) -> Option<ast::MethodDecl> {
+        lookup_type_method_decl_inner(module_path, type_name, method_name, &mut HashSet::new())
+    }
+
     /// List public type signatures in a stdlib module.
     pub fn list_types(&mut self, module_path: &[String]) -> Vec<(String, TypeInfo)> {
         self.ensure_loaded(module_path);
@@ -411,6 +424,84 @@ fn find_stdlib_file(relative: &str) -> Option<PathBuf> {
 
     tracing::debug!(relative_path = %relative, "stdlib file not found in any search path");
     None
+}
+
+/// Find a method declaration on a stdlib type, following prelude-style re-exports.
+fn lookup_type_method_decl_inner(
+    module_path: &[String],
+    type_name: &str,
+    method_name: &str,
+    loading: &mut HashSet<String>,
+) -> Option<ast::MethodDecl> {
+    let key = module_path.join(".");
+    if !loading.insert(key.clone()) {
+        return None;
+    }
+    let result = load_stdlib_program(module_path).and_then(|program| {
+        find_method_decl_in_program(&program, type_name, method_name)
+            .or_else(|| find_reexported_type_method_decl(&program, type_name, method_name, loading))
+    });
+    loading.remove(&key);
+    result
+}
+
+/// Parse a stdlib stub module into an AST program for metadata lookups that need source expressions.
+fn load_stdlib_program(module_path: &[String]) -> Option<ast::Program> {
+    let relative = stdlib::stdlib_stub_path(module_path)?;
+    let path = find_stdlib_file(&relative)?;
+    let source = std::fs::read_to_string(path).ok()?;
+    let tokens = crate::frontend::lexer::lex(&source).ok()?;
+    crate::frontend::parser::parse(&tokens).ok()
+}
+
+/// Find a method declaration directly in a parsed stdlib program.
+fn find_method_decl_in_program(program: &ast::Program, type_name: &str, method_name: &str) -> Option<ast::MethodDecl> {
+    program.declarations.iter().find_map(|decl| match &decl.node {
+        ast::Declaration::Model(model) if model.name == type_name => find_method_decl(&model.methods, method_name),
+        ast::Declaration::Class(class) if class.name == type_name => find_method_decl(&class.methods, method_name),
+        ast::Declaration::Newtype(newtype) if newtype.name == type_name => {
+            find_method_decl(&newtype.methods, method_name)
+        }
+        ast::Declaration::Enum(enum_decl) if enum_decl.name == type_name => {
+            find_method_decl(&enum_decl.methods, method_name)
+        }
+        _ => None,
+    })
+}
+
+/// Find one named method in a type declaration's method list.
+fn find_method_decl(methods: &[ast::Spanned<ast::MethodDecl>], method_name: &str) -> Option<ast::MethodDecl> {
+    methods
+        .iter()
+        .find(|method| method.node.name == method_name)
+        .map(|method| method.node.clone())
+}
+
+/// Follow stdlib `from std.x.y import Type` re-exports while searching for the owning type declaration.
+fn find_reexported_type_method_decl(
+    program: &ast::Program,
+    type_name: &str,
+    method_name: &str,
+    loading: &mut HashSet<String>,
+) -> Option<ast::MethodDecl> {
+    program.declarations.iter().find_map(|decl| {
+        let ast::Declaration::Import(import) = &decl.node else {
+            return None;
+        };
+        let ast::ImportKind::From { module, items } = &import.kind else {
+            return None;
+        };
+        if module.segments.first().map(String::as_str) != Some(stdlib::STDLIB_ROOT) {
+            return None;
+        }
+        items.iter().find_map(|item| {
+            let effective_name = item.alias.as_ref().unwrap_or(&item.name);
+            if effective_name != type_name {
+                return None;
+            }
+            lookup_type_method_decl_inner(&module.segments, &item.name, method_name, loading)
+        })
+    })
 }
 
 /// Extract function signatures from a parsed stdlib `.incn` program.

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -7018,6 +7018,37 @@ fn test_unknown_stdlib_module_from_import() {
     );
 }
 
+#[test]
+fn test_known_stdlib_module_rejects_unknown_annotation_only_import() {
+    let source = r#"
+from std.testing import NotExported
+
+def accepts_marker(value: NotExported) -> None:
+  pass
+"#;
+    let errs = check_str_err(source, "unknown stdlib import used only as an annotation should fail");
+    assert!(
+        errs.iter().any(|e| {
+            e.message
+                .contains("Cannot import `NotExported` from stdlib module `std.testing`")
+                && e.message.contains("not exported")
+        }),
+        "Expected not-exported diagnostic for std.testing.NotExported; got: {:?}",
+        errs.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_non_stdlib_annotation_only_import_keeps_placeholder_fallback() {
+    let source = r#"
+from app.types import ExternalOnly
+
+def accepts_external(value: ExternalOnly) -> None:
+  pass
+"#;
+    assert_check_ok(source);
+}
+
 // ========================================================================
 // RFC 005: Rust interop
 // ========================================================================

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -270,9 +270,28 @@ fn source_fingerprint(source: &DependencySource, project_root: Option<&Path>) ->
             let relative = project_root
                 .and_then(|root| path.strip_prefix(root).ok())
                 .unwrap_or(path);
-            format!("path:{}", relative.to_string_lossy().replace('\\', "/"))
+            let normalized = normalize_relative_path_for_fingerprint(relative);
+            format!("path:{}", normalized.to_string_lossy().replace('\\', "/"))
         }
     }
+}
+
+fn normalize_relative_path_for_fingerprint(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(segment) => normalized.push(segment),
+            std::path::Component::ParentDir => normalized.push(".."),
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 fn normalize_version_req(input: &str) -> String {
@@ -373,6 +392,24 @@ lock = "payload"
         let fp_a = compute_deps_fingerprint(&deps_a, &[], &selection, None);
         let fp_b = compute_deps_fingerprint(&deps_b, &[], &selection, None);
         assert_ne!(fp_a, fp_b, "fingerprints should differ when features differ");
+    }
+
+    #[test]
+    fn path_dependency_fingerprint_normalizes_current_dir_segments() {
+        let mut dep_plain = sample_spec("tiny_helper", vec![]);
+        dep_plain.source = DependencySource::Path {
+            path: PathBuf::from("rust/tiny_helper"),
+        };
+        let mut dep_current_dir = dep_plain.clone();
+        dep_current_dir.source = DependencySource::Path {
+            path: PathBuf::from("./rust/tiny_helper"),
+        };
+        let selection = CargoFeatureSelection::default();
+
+        assert_eq!(
+            compute_deps_fingerprint(&[dep_plain], &[], &selection, Some(Path::new("."))),
+            compute_deps_fingerprint(&[dep_current_dir], &[], &selection, Some(Path::new("."))),
+        );
     }
 
     // ---- Phase 4: stale fingerprint detection ----

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -287,6 +287,131 @@ def test_smoke() -> None:
 }
 
 #[test]
+fn test_lock_with_path_rust_dependency_stays_fresh_for_test_issue505() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "cli_lock_path_dep_fresh_for_test_project",
+        r#"
+
+[rust-dependencies]
+tiny_helper = { path = "rust/tiny_helper" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::tiny_helper import plus_one
+
+pub def value() -> int:
+  return plus_one(0)
+
+def main() -> None:
+  println(value())
+"#,
+    )?;
+    let tests_dir = tmp.path().join("tests");
+    fs::create_dir_all(&tests_dir)?;
+    fs::write(
+        tests_dir.join("test_main.incn"),
+        r#"from std.testing import assert_eq
+from crate.main import value
+
+def test_value() -> None:
+  assert_eq(value(), 1)
+"#,
+    )?;
+    let helper_src = tmp.path().join("rust").join("tiny_helper").join("src");
+    fs::create_dir_all(&helper_src)?;
+    fs::write(
+        helper_src
+            .parent()
+            .ok_or("helper src has no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "tiny_helper"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        helper_src.join("lib.rs"),
+        "pub fn plus_one(value: i64) -> i64 { value + 1 }\n",
+    )?;
+
+    let lock_output = run_incan(
+        tmp.path(),
+        &["lock", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(&lock_output, "incan lock with path Rust dependency");
+
+    let test_output = run_incan(tmp.path(), &["test"])?;
+
+    assert_success(&test_output, "incan test after lock with path Rust dependency");
+    let stderr = String::from_utf8_lossy(&test_output.stderr);
+    assert!(
+        !stderr.contains("incan.lock is out of date"),
+        "fresh lock should not warn as stale for path Rust dependencies, got:\n{stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn run_accepts_owned_incan_value_for_borrowed_generic_rust_param_issue506() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "cli_borrowed_generic_rust_param_project",
+        r#"
+
+[rust-dependencies]
+borrow_helper = { path = "rust/borrow_helper" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::borrow_helper import takes_ref
+
+model Payload:
+  name: str
+
+def main() -> None:
+  payload = Payload(name="demo")
+  println(takes_ref(payload))
+"#,
+    )?;
+    let helper_src = tmp.path().join("rust").join("borrow_helper").join("src");
+    fs::create_dir_all(&helper_src)?;
+    fs::write(
+        helper_src
+            .parent()
+            .ok_or("helper src has no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "borrow_helper"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        helper_src.join("lib.rs"),
+        "pub fn takes_ref<TValue>(_value: &TValue) -> i64 { 1 }\n",
+    )?;
+
+    let output = run_incan(
+        tmp.path(),
+        &["run", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+
+    assert_success(&output, "incan run with borrowed generic Rust param");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains('1'),
+        "expected borrowed generic Rust helper output, got:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn build_locked_rejects_stale_lockfile() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "cli_locked_project", "")?;

--- a/tests/codegen_snapshot_tests.rs
+++ b/tests/codegen_snapshot_tests.rs
@@ -718,6 +718,22 @@ fn test_std_web_routing_compiled_codegen() {
 }
 
 #[test]
+fn imported_stdlib_static_method_defaults_expand_at_call_site_issue500() {
+    let source = r#"
+from std.web import App
+
+def main() -> None:
+  App.run()
+"#;
+    let rust_code = generate_rust(source);
+    let compact = rust_code.chars().filter(|ch| !ch.is_whitespace()).collect::<String>();
+    assert!(
+        compact.contains("App::run(\"127.0.0.1\".to_string(),8080)"),
+        "imported stdlib static method call should expand omitted defaults:\n{rust_code}"
+    );
+}
+
+#[test]
 fn test_web_route_extractors_nested_module_codegen() {
     let main_source = r#"
 import std.async
@@ -1102,6 +1118,30 @@ fn test_match_statements_codegen() {
 }
 
 #[test]
+fn test_issue492_rust_result_match_does_not_clone_scrutinee() {
+    let rust_code = generate_rust(
+        r#"
+from rust::std::fs import read_dir
+from rust::std::path import Path as RustPath
+
+def main() -> None:
+    match read_dir(RustPath.new(".")):
+        Ok(entries) =>
+            for entry_result in entries:
+                match entry_result:
+                    Ok(entry) => println(entry.path().to_string_lossy().into_owned())
+                    Err(err) => println(err.to_string())
+        Err(err) => println(err.to_string())
+"#,
+    );
+
+    assert!(
+        !rust_code.contains("entry_result.clone()"),
+        "Rust Result match scrutinee must not be cloned for non-Clone payloads:\n{rust_code}"
+    );
+}
+
+#[test]
 fn test_type_annotations_codegen() {
     let source = load_test_file("type_annotations");
     let rust_code = generate_rust(&source);
@@ -1117,6 +1157,50 @@ fn test_rfc029_union_types_codegen() {
         "union isinstance chains must fully lower before Rust emission:\n{rust_code}"
     );
     insta::assert_snapshot!("rfc029_union_types", rust_code);
+}
+
+#[test]
+fn test_issue501_option_union_isinstance_codegen_no_raw_call() {
+    let rust_code = generate_rust(
+        r#"
+@derive(Clone)
+type LocalPath = newtype str
+
+pub def describe(value: Option[LocalPath | str]) -> str:
+  if value is not None:
+    if isinstance(value, str):
+      return value.upper()
+    elif isinstance(value, LocalPath):
+      return value.0
+  return "missing"
+"#,
+    );
+
+    assert!(
+        !rust_code.contains("isinstance("),
+        "Option[Union] isinstance narrowing must fully lower before Rust emission:\n{rust_code}"
+    );
+}
+
+#[test]
+fn test_issue502_exhaustive_independent_isinstance_branches_codegen_has_no_unit_fallback() {
+    let rust_code = generate_rust(
+        r#"
+@derive(Clone)
+type LocalPath = newtype str
+
+pub def normalize_path_like(value: LocalPath | str) -> LocalPath:
+  if isinstance(value, str):
+    return LocalPath(value)
+  if isinstance(value, LocalPath):
+    return value
+"#,
+    );
+
+    assert!(
+        !rust_code.contains("=> {}"),
+        "exhaustive independent isinstance branches must not emit unit fallthrough arms:\n{rust_code}"
+    );
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2819,6 +2819,91 @@ def main() -> None:
     }
 
     #[test]
+    fn test_issue502_independent_union_narrowing_branches_compile_and_run() -> Result<(), Box<dyn std::error::Error>> {
+        let output = Command::new(incan_debug_binary())
+            .args([
+                "run",
+                "-c",
+                r#"
+@derive(Clone)
+type LocalPath = newtype str
+
+def normalize_path_like(value: LocalPath | str) -> LocalPath:
+    if isinstance(value, str):
+        return LocalPath(value)
+    if isinstance(value, LocalPath):
+        return value
+
+def main() -> None:
+    println(normalize_path_like("from-string").0)
+    println(normalize_path_like(LocalPath("from-path")).0)
+"#,
+            ])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            output.status.success(),
+            "independent union narrowing branch regression failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = strip_ansi_escapes(&String::from_utf8_lossy(&output.stdout));
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            lines,
+            vec!["from-string", "from-path"],
+            "unexpected independent union narrowing output:\n{stdout}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_issue501_option_union_isinstance_narrowing_compile_and_run() -> Result<(), Box<dyn std::error::Error>> {
+        let output = Command::new(incan_debug_binary())
+            .args([
+                "run",
+                "-c",
+                r#"
+@derive(Clone)
+type LocalPath = newtype str
+
+def describe(value: Option[LocalPath | str]) -> str:
+    if value is not None:
+        if isinstance(value, str):
+            return value.upper()
+        elif isinstance(value, LocalPath):
+            return value.0
+    return "missing"
+
+def main() -> None:
+    println(describe("from-string"))
+    println(describe(LocalPath("from-path")))
+    println(describe(None))
+"#,
+            ])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            output.status.success(),
+            "Option[Union] isinstance narrowing regression failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = strip_ansi_escapes(&String::from_utf8_lossy(&output.stdout));
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            lines,
+            vec!["FROM-STRING", "from-path", "missing"],
+            "unexpected Option[Union] narrowing output:\n{stdout}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_filtered_comprehensions_run_with_borrowed_iterables() -> Result<(), Box<dyn std::error::Error>> {
         let output = Command::new(incan_debug_binary())
             .args([

--- a/workspaces/docs-site/docs/language/reference/language.md
+++ b/workspaces/docs-site/docs/language/reference/language.md
@@ -496,6 +496,7 @@ def main() -> None:
 | Semaphore | `Semaphore` |  | Named | Async/runtime semaphore. | RFC 000 | 0.1 | Stable |
 | Barrier | `Barrier` |  | Named | Async/runtime barrier. | RFC 000 | 0.1 | Stable |
 | JoinHandle | `JoinHandle` |  | Generic | Handle to a spawned task. | RFC 000 | 0.1 | Stable |
+| TaskJoinError | `TaskJoinError` |  | Named | Error returned when a spawned task fails to join. | RFC 000 | 0.1 | Stable |
 | Sender | `Sender` |  | Generic | Bounded channel sender. | RFC 000 | 0.1 | Stable |
 | Receiver | `Receiver` |  | Generic | Bounded channel receiver. | RFC 000 | 0.1 | Stable |
 | OneshotSender | `OneshotSender` |  | Generic | Oneshot channel sender. | RFC 000 | 0.1 | Stable |

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -307,6 +307,8 @@ The sections above are the release story. The list below is the detailed invento
 - **Language/Compiler**: List and dict comprehensions now accept tuple-unpack iteration targets such as `for idx, name in enumerate(xs)`, matching ordinary `for` loop binding syntax (#483).
 - **Language/Compiler**: RFC 006 adds lazy `Generator[T]` values, including `yield`-based generator functions, full-clause generator expressions, iteration-protocol compatibility, and the minimum helper surface `.map()`, `.filter()`, `.take()`, and `.collect()` (#324, RFC 006).
 - **Language/Compiler**: Multi-file web builds now retain private route-decorated handlers and the private models they use in dependency modules, so route registration works without forcing those declarations public (#117).
+- **Language/Compiler**: Stdlib import validation now rejects unknown names from known stdlib modules, imported stdlib static method calls preserve default arguments at the call site, union narrowing lowers chained `isinstance` branches without leaking raw `isinstance` calls or unit fallthroughs into generated Rust, and Rust interop accepts owned Incan values for shared borrowed generic parameters such as `&T` (#499, #500, #501, #502, #506).
+- **Tooling**: `incan test` no longer reports a freshly generated `incan.lock` as stale when a project uses local path Rust dependencies (#505).
 
 ### Versioning and release track
 
@@ -314,7 +316,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Dependency policy**: The rust-analyzer proc-macro API dependency is patched locally to request `postcard` without default features, removing the unmaintained `atomic-polyfill` crate from the workspace dependency graph and letting `cargo deny check` run without the `RUSTSEC-2023-0089` advisory ignore (#260).
 - **Dependency policy**: The workspace now builds against Wasmtime `44.0.1` / Wasmtime WASI `44.0.1` and raises the Rust MSRV to `1.92`, matching Wasmtime 44's compiler requirement.
 - **Dependency policy**: Dependabot security alerts for the VS Code extension lockfile, docs-site Python pins, and Rust `rand` lock entries are remediated, while repo-owned GitHub Actions are moved to Node 24-compatible action releases (#475, #464).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.34`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.35`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

Fixes a grouped set of stdlib, lowering, Rust interop, and lockfile regressions:

- Fixes #492 by preventing generated Rust from cloning non-Clone Rust `Result` match scrutinees.
- Fixes #499 by rejecting unknown names imported from known stdlib modules instead of preserving them as annotation-only placeholders.
- Fixes #500 by preserving imported stdlib static method default arguments at the call site, including `App.run()`.
- Fixes #501 and #502 by lowering `Option[Union]` and consecutive returning `isinstance` branches without leaking raw `isinstance` calls or unit fallthrough arms into generated Rust.
- Fixes #505 by normalizing current-directory segments in path dependency lock fingerprints so `incan test` does not warn that a fresh lockfile is stale.
- Fixes #506 by allowing owned Incan values to satisfy shared borrowed generic Rust parameters such as `&T` and `&TValue`, while keeping concrete borrowed builtin handling intact.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Users get stricter stdlib import diagnostics, working imported stdlib static method defaults, working union narrowing for the reported shapes, stable lock freshness for local Rust path dependencies, and smoother Rust interop for shared borrowed generic parameters.
- **Internals**: Lowering can rehydrate stdlib method default expressions from stub ASTs, stdlib import collection now rejects unexported names from known modules, independent returning `isinstance` statements fold through the existing narrowing chain, lock dependency fingerprints normalize `.` path segments, and Rust boundary matching recognizes identifier-like generic parameter displays while excluding known concrete Rust boundary types.
- **Risks**: The main risk is behavior around Rust boundary display heuristics for generic parameters, covered by both positive `&T` / `&TValue` tests and the borrowed `String` regression guard.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo run -p incan_core --bin generate_lang_reference` — passed and generated the `TaskJoinError` surface type reference row.
- `make fmt` — passed.
- `cargo test --lib borrowed_generic_rust_function_param_accepts_owned_incan_value` — passed.
- `cargo test --lib rust_function_call_accepts_string_for_borrowed_string_param` — passed.
- `cargo test --test cli_integration run_accepts_owned_incan_value_for_borrowed_generic_rust_param_issue506` — passed.
- `cargo test -p incan_core --test lang_registry_guardrails surface_types_spellings_unique_and_resolvable` — passed.
- `git diff --cached --check` — passed.
- `make pre-commit` — passed: 1993 tests passed, clippy passed, cargo-deny passed, smoke-test-fast passed, benchmark build checks passed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/language.md`, `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
