### PR TITLE
bugfix - borrow Rust method args from call-site metadata (#508)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "clap",
  "hex",
@@ -1443,14 +1443,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1459,14 +1459,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "axum",
  "incan_core",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.35"
+version = "0.3.0-dev.36"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -2649,6 +2649,92 @@ pub def forward(value: Thing) -> None:
         Ok(())
     }
 
+    #[cfg(feature = "rust_inspect")]
+    #[test]
+    fn test_codegen_borrows_rust_backed_method_args_from_metadata() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::frontend::typechecker::TypeChecker;
+        use incan_core::interop::{
+            RustFunctionSig, RustItemKind, RustItemMetadata, RustMethodSig, RustParam, RustTypeInfo, RustVisibility,
+        };
+
+        let source = r#"
+from rust::demo import Builder
+
+model Payload:
+  name: str
+
+pub def forward(payload: Payload) -> int:
+  builder = Builder.new()
+  return builder.json(payload)
+"#;
+        let tokens = must_ok(lexer::lex(source));
+        let ast = must_ok(parser::parse(&tokens));
+
+        let tmp = seeded_rust_inspect_workspace()?;
+        let manifest_dir = tmp.path().to_path_buf();
+        let mut tc = TypeChecker::new();
+        tc.set_rust_inspect_manifest_dir(manifest_dir.clone());
+        tc.rust_inspect_cache
+            .insert_test_item(
+                &manifest_dir,
+                RustItemMetadata {
+                    canonical_path: "demo::Builder".to_string(),
+                    definition_path: Some("demo::Builder".to_string()),
+                    visibility: RustVisibility::Public,
+                    kind: RustItemKind::Type(RustTypeInfo {
+                        methods: vec![
+                            RustMethodSig {
+                                name: "new".to_string(),
+                                signature: RustFunctionSig {
+                                    params: Vec::new(),
+                                    return_type: "demo::Builder".to_string(),
+                                    is_async: false,
+                                    is_unsafe: false,
+                                },
+                            },
+                            RustMethodSig {
+                                name: "json".to_string(),
+                                signature: RustFunctionSig {
+                                    params: vec![RustParam {
+                                        name: Some("value".to_string()),
+                                        type_display: "&T".to_string(),
+                                    }],
+                                    return_type: "i64".to_string(),
+                                    is_async: false,
+                                    is_unsafe: false,
+                                },
+                            },
+                        ],
+                        fields: Vec::new(),
+                        variants: Vec::new(),
+                    }),
+                },
+            )
+            .map_err(|e| std::io::Error::other(format!("seed rust-inspect type: {e}")))?;
+        tc.check_program(&ast)
+            .map_err(|errs| std::io::Error::other(format!("typecheck failed: {errs:?}")))?;
+
+        let mut lowering = AstLowering::new_with_type_info(tc.type_info().clone());
+        let ir_program = lowering
+            .lower_program(&ast)
+            .map_err(|err| std::io::Error::other(format!("lowering failed: {err:?}")))?;
+
+        let mut codegen = IrCodegen::new();
+        codegen.collect_external_rust_functions(&ast);
+
+        let mut emitter = IrEmitter::new(&ir_program.function_registry);
+        emitter.set_external_rust_functions(codegen.external_rust_functions.clone());
+        let code = emitter
+            .emit_program(&ir_program)
+            .map_err(|err| std::io::Error::other(format!("emit failed: {err:?}")))?;
+
+        assert!(
+            code.contains("builder.json(&payload);"),
+            "expected borrowed rust method arg in generated code; got:\n{code}"
+        );
+        Ok(())
+    }
+
     #[test]
     fn test_codegen_keeps_nested_rust_associated_calls_type_like_when_outer_receiver_is_unknown()
     -> Result<(), Box<dyn std::error::Error>> {

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -298,7 +298,10 @@ impl TypeCheckInfo {
 
     /// Record callable metadata needed by lowering when the callee expression alone cannot carry it.
     pub(crate) fn record_call_site_callable_params(&mut self, span: Span, params: &[CallableParam]) {
-        if params.iter().any(|param| param.kind != ParamKind::Normal) {
+        if params
+            .iter()
+            .any(|param| param.kind != ParamKind::Normal || callable_param_needs_boundary_snapshot(&param.ty))
+        {
             self.call_site_callable_params
                 .insert((span.start, span.end), params.to_vec());
         }
@@ -333,5 +336,27 @@ impl TypeCheckInfo {
     /// Record a custom `for` iteration protocol route.
     pub(crate) fn record_protocol_iteration(&mut self, span: Span, info: ProtocolIterationInfo) {
         self.protocol_iterations.insert((span.start, span.end), info);
+    }
+}
+
+/// Return whether a callable parameter type carries borrow shape that lowering cannot recover from the callee alone.
+fn callable_param_needs_boundary_snapshot(ty: &ResolvedType) -> bool {
+    match ty {
+        ResolvedType::Ref(_) | ResolvedType::RefMut(_) => true,
+        ResolvedType::Function(params, ret) => {
+            params
+                .iter()
+                .any(|param| callable_param_needs_boundary_snapshot(&param.ty))
+                || callable_param_needs_boundary_snapshot(ret)
+        }
+        ResolvedType::Generic(_, args) => args.iter().any(callable_param_needs_boundary_snapshot),
+        ResolvedType::FrozenList(inner) | ResolvedType::FrozenSet(inner) => {
+            callable_param_needs_boundary_snapshot(inner)
+        }
+        ResolvedType::FrozenDict(key, value) => {
+            callable_param_needs_boundary_snapshot(key) || callable_param_needs_boundary_snapshot(value)
+        }
+        ResolvedType::Tuple(items) => items.iter().any(callable_param_needs_boundary_snapshot),
+        _ => false,
     }
 }

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -307,7 +307,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Language/Compiler**: List and dict comprehensions now accept tuple-unpack iteration targets such as `for idx, name in enumerate(xs)`, matching ordinary `for` loop binding syntax (#483).
 - **Language/Compiler**: RFC 006 adds lazy `Generator[T]` values, including `yield`-based generator functions, full-clause generator expressions, iteration-protocol compatibility, and the minimum helper surface `.map()`, `.filter()`, `.take()`, and `.collect()` (#324, RFC 006).
 - **Language/Compiler**: Multi-file web builds now retain private route-decorated handlers and the private models they use in dependency modules, so route registration works without forcing those declarations public (#117).
-- **Language/Compiler**: Stdlib import validation now rejects unknown names from known stdlib modules, imported stdlib static method calls preserve default arguments at the call site, union narrowing lowers chained `isinstance` branches without leaking raw `isinstance` calls or unit fallthroughs into generated Rust, and Rust interop accepts owned Incan values for shared borrowed generic parameters such as `&T` (#499, #500, #501, #502, #506).
+- **Language/Compiler**: Stdlib import validation now rejects unknown names from known stdlib modules, imported stdlib static method calls preserve default arguments at the call site, union narrowing lowers chained `isinstance` branches without leaking raw `isinstance` calls or unit fallthroughs into generated Rust, and Rust interop accepts owned Incan values for shared borrowed generic parameters such as `&T` in both free-function and method-call positions (#499, #500, #501, #502, #506, #508).
 - **Tooling**: `incan test` no longer reports a freshly generated `incan.lock` as stale when a project uses local path Rust dependencies (#505).
 
 ### Versioning and release track
@@ -316,7 +316,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Dependency policy**: The rust-analyzer proc-macro API dependency is patched locally to request `postcard` without default features, removing the unmaintained `atomic-polyfill` crate from the workspace dependency graph and letting `cargo deny check` run without the `RUSTSEC-2023-0089` advisory ignore (#260).
 - **Dependency policy**: The workspace now builds against Wasmtime `44.0.1` / Wasmtime WASI `44.0.1` and raises the Rust MSRV to `1.92`, matching Wasmtime 44's compiler requirement.
 - **Dependency policy**: Dependabot security alerts for the VS Code extension lockfile, docs-site Python pins, and Rust `rand` lock entries are remediated, while repo-owned GitHub Actions are moved to Node 24-compatible action releases (#475, #464).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.35`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.36`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

This PR fixes Rust interop method calls whose inspected Rust signature requires borrowed ordinary parameters, including generic params like `&T`. The typechecker now preserves borrow-shaped call-site callable metadata so lowering and emission can generate `builder.json(&payload)` instead of moving `payload` into APIs such as `RequestBuilder::json`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Incan can now call imported Rust methods that require borrowed generic arguments from ordinary value syntax, so `builder.json(payload)` works when Rust expects `&T`.
- **Internals**: `TypeCheckInfo` now snapshots callable params that carry borrow shape, not only non-normal/rest params. Existing method emission then uses the preserved `IrType::Ref` signature metadata to borrow the argument.
- **Risks**: The snapshot retention is intentionally narrow, but it does affect call-site metadata size for callable params containing nested refs.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Added `test_codegen_borrows_rust_backed_method_args_from_metadata`
- `cargo test test_codegen_borrows_rust_backed_method_args_from_metadata --features rust_inspect -- --nocapture`
- `cargo run --bin incan -- run <workspace-checkout>/src/main.incn` prints `1`
- `cargo check --workspace --features rust_inspect`
- `git diff --check`
- `make pre-commit`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #508