### PR TITLE
bugfix - 505 508 close reopened regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "byteorder",
  "clap",
@@ -1450,14 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,14 +1466,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "axum",
  "incan_core",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.37"
+version = "0.3.0-dev.38"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -2009,6 +2009,49 @@ edition = "2021"
     }
 
     #[cfg(feature = "rust_inspect")]
+    fn reqwest_shaped_rust_inspect_workspace() -> Result<tempfile::TempDir, Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            r#"[package]
+name = "reqwest"
+version = "0.0.0"
+edition = "2021"
+"#,
+        )?;
+        fs::create_dir_all(tmp.path().join("src"))?;
+        fs::write(
+            tmp.path().join("src").join("lib.rs"),
+            r#"
+pub struct Client;
+
+pub struct RequestBuilder;
+
+pub trait IntoUrl {}
+
+impl IntoUrl for &str {}
+
+impl Client {
+    pub fn new() -> Client {
+        Client
+    }
+
+    pub fn post<U: IntoUrl>(&self, _url: U) -> RequestBuilder {
+        RequestBuilder
+    }
+}
+
+impl RequestBuilder {
+    pub fn json<T: ?Sized>(self, _json: &T) -> RequestBuilder {
+        self
+    }
+}
+"#,
+        )?;
+        Ok(tmp)
+    }
+
+    #[cfg(feature = "rust_inspect")]
     fn prewarm_metadata(manifest_dir: &std::path::Path, paths: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
         let inspector =
             crate::rust_inspect::Inspector::new(crate::rust_inspect::InspectorConfig::new(manifest_dir.to_path_buf()));
@@ -2742,6 +2785,63 @@ pub def forward(payload: Payload) -> int:
         assert!(
             code.contains("builder.json(&payload);"),
             "expected borrowed rust method arg in generated code; got:\n{code}"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "rust_inspect")]
+    #[test]
+    fn test_codegen_borrows_reqwest_json_payload_returned_from_registry_client()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::frontend::typechecker::TypeChecker;
+
+        let source = r#"
+from rust::reqwest import Client
+
+model Payload:
+  name: str
+
+pub def forward(payload: Payload) -> None:
+  builder = Client.new().post("https://example.invalid")
+  _ = builder.json(payload)
+"#;
+        let tokens = must_ok(lexer::lex(source));
+        let ast = must_ok(parser::parse(&tokens));
+
+        let tmp = reqwest_shaped_rust_inspect_workspace()?;
+        let manifest_dir = tmp.path().to_path_buf();
+        prewarm_metadata(&manifest_dir, &["reqwest::Client"])?;
+
+        let mut tc = TypeChecker::new();
+        tc.set_rust_inspect_manifest_dir(manifest_dir);
+        tc.check_program(&ast)
+            .map_err(|errs| std::io::Error::other(format!("typecheck failed: {errs:?}")))?;
+
+        let mut lowering = AstLowering::new_with_type_info(tc.type_info().clone());
+        let ir_program = lowering
+            .lower_program(&ast)
+            .map_err(|err| std::io::Error::other(format!("lowering failed: {err:?}")))?;
+
+        let mut codegen = IrCodegen::new();
+        codegen.collect_external_rust_functions(&ast);
+
+        let mut emitter = IrEmitter::new(&ir_program.function_registry);
+        emitter.set_external_rust_functions(codegen.external_rust_functions.clone());
+        let code = emitter
+            .emit_program(&ir_program)
+            .map_err(|err| std::io::Error::other(format!("emit failed: {err:?}")))?;
+
+        assert!(
+            code.contains("builder.json(&payload);"),
+            "expected registry-returned reqwest RequestBuilder::json payload to be borrowed; got:\n{code}"
+        );
+        assert!(
+            code.contains(r#"Client::new().post("https://example.invalid")"#),
+            "expected generic reqwest Client::post string literal to keep inferable &str shape; got:\n{code}"
+        );
+        assert!(
+            !code.contains(r#".post("https://example.invalid".into())"#),
+            "generic reqwest Client::post must not force ambiguous `.into()` on string literals; got:\n{code}"
         );
         Ok(())
     }

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -61,6 +61,14 @@ fn rust_collection_family_for_ir_type(ty: &IrType) -> Option<RustCollectionFamil
 }
 
 impl<'a> IrEmitter<'a> {
+    /// Return whether an argument already has Rust reference shape for a method parameter.
+    fn method_arg_already_borrowed_for_ref_param(arg_ty: &IrType) -> bool {
+        matches!(
+            arg_ty,
+            IrType::Ref(_) | IrType::RefMut(_) | IrType::StrRef | IrType::StaticStr
+        )
+    }
+
     /// Emit method-call arguments with Rust-boundary borrowing and union wrapping applied from callable metadata.
     fn emit_method_call_args(
         &self,
@@ -138,12 +146,19 @@ impl<'a> IrEmitter<'a> {
                     base_use_site,
                     ValueUseSite::ExternalCallArg { .. } | ValueUseSite::MethodArg
                 );
+                let param = callable_signature.and_then(|sig| sig.params.get(idx));
+                let arg_use_site =
+                    if external_method_shape && matches!(param.map(|param| &param.ty), Some(IrType::Generic(_))) {
+                        ValueUseSite::MethodArg
+                    } else {
+                        base_use_site
+                    };
                 let previous_qualify = if *from_default {
                     Some(self.qualify_internal_canonical_paths.replace(true))
                 } else {
                     None
                 };
-                let emitted = self.emit_expr_for_use(arg, base_use_site);
+                let emitted = self.emit_expr_for_use(arg, arg_use_site);
                 if let Some(previous) = previous_qualify {
                     self.qualify_internal_canonical_paths.replace(previous);
                 }
@@ -172,7 +187,7 @@ impl<'a> IrEmitter<'a> {
                 {
                     return Ok(wrapped);
                 }
-                let Some(param) = callable_signature.and_then(|sig| sig.params.get(idx)) else {
+                let Some(param) = param else {
                     if external_method_shape && idx == 0 && Self::method_arg_needs_fallback_mut_borrow(method, &arg.ty)
                     {
                         emitted = quote! { &mut #emitted };
@@ -194,8 +209,9 @@ impl<'a> IrEmitter<'a> {
                     return Ok(quote! { &#emitted });
                 }
                 match &param.ty {
+                    IrType::Ref(_) if matches!(base_use_site, ValueUseSite::MethodArg) => {}
                     IrType::Ref(_) => match &arg.ty {
-                        IrType::Ref(_) | IrType::RefMut(_) => {}
+                        _ if Self::method_arg_already_borrowed_for_ref_param(&arg.ty) => {}
                         _ => emitted = quote! { &#emitted },
                     },
                     IrType::RefMut(_) => match &arg.ty {

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -916,11 +916,11 @@ impl<'a> IrEmitter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::ir::FunctionRegistry;
     use crate::backend::ir::expr::{
         CollectionMethodKind, IrCallArg, IrCallArgKind, IteratorMethodKind, MethodCallArgPolicy, MethodKind, VarAccess,
         VarRefKind,
     };
+    use crate::backend::ir::{FunctionParam, FunctionRegistry, FunctionSignature, Mutability};
     use incan_core::lang::traits::{self as core_traits, TraitId};
 
     #[test]
@@ -1086,7 +1086,17 @@ mod tests {
                         expr: TypedExpr::new(IrExprKind::Bool(true), IrType::Bool),
                     },
                 ],
-                callable_signature: None,
+                callable_signature: Some(FunctionSignature {
+                    params: vec![FunctionParam {
+                        name: "k".to_string(),
+                        ty: IrType::Ref(Box::new(IrType::Generic("Q".to_string()))),
+                        mutability: Mutability::Immutable,
+                        is_self: false,
+                        kind: crate::frontend::ast::ParamKind::Normal,
+                        default: None,
+                    }],
+                    return_type: IrType::Option(Box::new(IrType::Ref(Box::new(IrType::Int)))),
+                }),
                 arg_policy: MethodCallArgPolicy::Default,
             },
             IrType::Struct("Dataset".to_string()),

--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -3,6 +3,7 @@
 //! Handles creating and validating `incan.lock` files that pin dependency versions for reproducible builds.
 //! Used by both `incan lock` and the build pipeline.
 
+use std::collections::BTreeSet;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -47,77 +48,42 @@ pub fn lock_project(
         .map_err(|e| CliError::failure(e.to_string()))?
         .ok_or_else(|| CliError::failure("No incan.toml found (run `incan init`)"))?;
 
-    let entry_path = if let Some(file) = entry_file {
-        file.to_path_buf()
-    } else if let Some(project) = &manifest.project {
-        if let Some(main) = project.scripts.get("main") {
-            manifest.project_root().join(main)
-        } else {
-            return Err(CliError::failure(
-                "incan lock requires a FILE argument or [project.scripts].main",
-            ));
-        }
-    } else {
-        return Err(CliError::failure(
-            "incan lock requires a FILE argument or [project.scripts].main",
-        ));
-    };
-
-    let modules = collect_modules(&entry_path.to_string_lossy())?;
-    let library_manifest_index = LibraryManifestIndex::from_project_manifest(&manifest);
-    let library_imported_vocab = library_manifest_index.library_imported_vocab();
-    let library_imported_dsl_surfaces = library_manifest_index.library_imported_dsl_surfaces();
-    let project_requirements = collect_project_requirements(&modules, &library_manifest_index)?;
-    let mut inline_imports = Vec::new();
-    for module in &modules {
-        inline_imports.extend(collect_inline_rust_imports(module, false));
-    }
-
-    inline_imports.extend(collect_test_inline_imports(
-        manifest.project_root(),
-        Some(&library_imported_vocab),
-        Some(&library_imported_dsl_surfaces),
-        Some(&library_manifest_index),
-    )?);
-
     let cargo_features = CargoFeatureSelection {
         cargo_features,
         cargo_no_default_features,
         cargo_all_features,
     }
     .normalized();
-
-    let mut resolved =
-        resolve_dependencies(Some(&manifest), &inline_imports, true, &cargo_features).map_err(|errors| {
-            let mut msg = String::new();
-            let sources = build_source_map(&modules);
-            for err in errors {
-                msg.push_str(&format_dependency_error(&err, &sources));
-            }
-            CliError::failure(msg.trim_end())
+    let context = collect_project_lock_context(&manifest, entry_file.map(PathBuf::as_path), &cargo_features)?
+        .ok_or_else(|| {
+            CliError::failure("incan lock requires a FILE argument or at least one [project.scripts] entry")
         })?;
-    merge_project_requirement_dependencies(&mut resolved, &project_requirements)?;
 
     let project_name = manifest
         .project
         .as_ref()
         .and_then(|p| p.name.clone())
-        .or_else(|| entry_path.file_stem().and_then(|s| s.to_str()).map(|s| s.to_string()))
+        .or_else(|| {
+            context
+                .modules
+                .first()
+                .and_then(|module| module.file_path.file_stem())
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+        })
         .unwrap_or_else(|| "incan_project".to_string());
     let rust_edition = manifest.build.as_ref().and_then(|b| b.rust_edition.clone());
     let cargo_policy = CargoPolicy::explicit(false, false, false, Vec::new());
-    #[cfg(feature = "rust_inspect")]
-    let rust_inspect_query_paths = collect_rust_inspect_query_paths(&modules);
     generate_lockfile(
         manifest.project_root(),
         &project_name,
         rust_edition,
-        &resolved,
-        &project_requirements,
+        &context.resolved,
+        &context.project_requirements,
         &cargo_features,
         &cargo_policy,
         #[cfg(feature = "rust_inspect")]
-        &rust_inspect_query_paths,
+        &context.rust_inspect_query_paths,
     )?;
 
     Ok(ExitCode::SUCCESS)
@@ -162,6 +128,22 @@ pub(crate) fn resolve_lock_payload(request: LockResolutionRequest<'_>) -> CliRes
     if manifest.is_none() {
         return Ok(None);
     }
+
+    let project_context = if let Some(manifest) = manifest {
+        collect_project_lock_context(manifest, None, cargo_features)?
+    } else {
+        None
+    };
+    let (resolved, project_requirements) = if let Some(context) = project_context.as_ref() {
+        (&context.resolved, &context.project_requirements)
+    } else {
+        (resolved, project_requirements)
+    };
+    #[cfg(feature = "rust_inspect")]
+    let rust_inspect_query_paths = project_context
+        .as_ref()
+        .map(|context| context.rust_inspect_query_paths.as_slice())
+        .unwrap_or(rust_inspect_query_paths);
 
     let lock_path = project_root.join("incan.lock");
     let rust_edition = manifest.and_then(|m| m.build.as_ref().and_then(|b| b.rust_edition.clone()));
@@ -223,6 +205,93 @@ pub(crate) fn resolve_lock_payload(request: LockResolutionRequest<'_>) -> CliRes
         rust_inspect_query_paths,
     )?;
     Ok(Some(lock.cargo_lock_payload))
+}
+
+/// Fully collected dependency inputs that define a manifest project's lock freshness surface.
+struct ProjectLockContext {
+    modules: Vec<ParsedModule>,
+    resolved: ResolvedDependencies,
+    project_requirements: ProjectRequirements,
+    #[cfg(feature = "rust_inspect")]
+    rust_inspect_query_paths: Vec<String>,
+}
+
+/// Test-file dependency inputs that must participate in the same project lock fingerprint as normal scripts.
+struct TestLockInputs {
+    inline_imports: Vec<InlineRustImport>,
+    project_requirement_modules: Vec<ParsedModule>,
+}
+
+/// Return sorted manifest script entry paths plus an optional explicitly requested entry file.
+fn project_lock_entry_paths(manifest: &ProjectManifest, explicit_entry_file: Option<&Path>) -> Vec<PathBuf> {
+    let mut paths = BTreeSet::new();
+    if let Some(project) = &manifest.project {
+        for script in project.scripts.values() {
+            paths.insert(manifest.project_root().join(script));
+        }
+    }
+    if let Some(file) = explicit_entry_file {
+        paths.insert(file.to_path_buf());
+    }
+    paths.into_iter().collect()
+}
+
+/// Collect the project-wide script and test dependency inputs used for both lock generation and freshness checks.
+fn collect_project_lock_context(
+    manifest: &ProjectManifest,
+    explicit_entry_file: Option<&Path>,
+    cargo_features: &CargoFeatureSelection,
+) -> CliResult<Option<ProjectLockContext>> {
+    let entry_paths = project_lock_entry_paths(manifest, explicit_entry_file);
+    if entry_paths.is_empty() {
+        return Ok(None);
+    }
+
+    let library_manifest_index = LibraryManifestIndex::from_project_manifest(manifest);
+    let library_imported_vocab = library_manifest_index.library_imported_vocab();
+    let library_imported_dsl_surfaces = library_manifest_index.library_imported_dsl_surfaces();
+    let mut modules = Vec::new();
+    for entry_path in entry_paths {
+        modules.extend(collect_modules(&entry_path.to_string_lossy())?);
+    }
+
+    let test_inputs = collect_test_lock_inputs(
+        manifest.project_root(),
+        Some(&library_imported_vocab),
+        Some(&library_imported_dsl_surfaces),
+        Some(&library_manifest_index),
+    )?;
+
+    let mut project_requirement_modules = modules.clone();
+    project_requirement_modules.extend(test_inputs.project_requirement_modules);
+    let project_requirements = collect_project_requirements(&project_requirement_modules, &library_manifest_index)?;
+
+    let mut inline_imports = Vec::new();
+    for module in &modules {
+        inline_imports.extend(collect_inline_rust_imports(module, false));
+    }
+    inline_imports.extend(test_inputs.inline_imports);
+
+    let mut resolved =
+        resolve_dependencies(Some(manifest), &inline_imports, true, cargo_features).map_err(|errors| {
+            let mut msg = String::new();
+            let sources = build_source_map(&project_requirement_modules);
+            for err in errors {
+                msg.push_str(&format_dependency_error(&err, &sources));
+            }
+            CliError::failure(msg.trim_end())
+        })?;
+    merge_project_requirement_dependencies(&mut resolved, &project_requirements)?;
+    #[cfg(feature = "rust_inspect")]
+    let rust_inspect_query_paths = collect_rust_inspect_query_paths(&project_requirement_modules);
+
+    Ok(Some(ProjectLockContext {
+        modules,
+        resolved,
+        project_requirements,
+        #[cfg(feature = "rust_inspect")]
+        rust_inspect_query_paths,
+    }))
 }
 
 struct LockDependencyPreheatGuard {
@@ -556,14 +625,15 @@ pub(crate) fn generate_lockfile(
     Ok(lock)
 }
 
-/// Collect inline Rust crate imports from test files for lock resolution.
-fn collect_test_inline_imports(
+/// Collect inline Rust crate imports and stdlib/provider requirements from test files for lock resolution.
+fn collect_test_lock_inputs(
     project_root: &Path,
     library_imported_vocab: Option<&parser::ImportedLibraryVocab>,
     library_imported_dsl_surfaces: Option<&parser::ImportedLibraryDslSurfaces>,
     library_manifest_index: Option<&LibraryManifestIndex>,
-) -> CliResult<Vec<InlineRustImport>> {
-    let mut imports = Vec::new();
+) -> CliResult<TestLockInputs> {
+    let mut inline_imports = Vec::new();
+    let mut project_requirement_modules = Vec::new();
     let test_files = crate::cli::test_runner::discover_test_files(project_root);
     let source_root = project_root.join("src");
 
@@ -603,7 +673,8 @@ fn collect_test_inline_imports(
             source: source.clone(),
             ast: ast.clone(),
         };
-        imports.extend(collect_inline_rust_imports(&test_module, true));
+        inline_imports.extend(collect_inline_rust_imports(&test_module, true));
+        project_requirement_modules.push(test_module);
 
         let source_modules = crate::cli::test_runner::collect_source_modules_for_test(
             &ast,
@@ -614,11 +685,15 @@ fn collect_test_inline_imports(
         )
         .map_err(CliError::failure)?;
         for module in &source_modules {
-            imports.extend(collect_inline_rust_imports(module, false));
+            inline_imports.extend(collect_inline_rust_imports(module, false));
         }
+        project_requirement_modules.extend(source_modules);
     }
 
-    Ok(imports)
+    Ok(TestLockInputs {
+        inline_imports,
+        project_requirement_modules,
+    })
 }
 
 /// Check whether any resolved dependency uses a git branch source, which is forbidden in strict
@@ -712,7 +787,8 @@ mod tests {
             "from internal import SessionContext\nfrom rust::tokio @ \"1\" import spawn\n",
         )?;
 
-        let imports = collect_test_inline_imports(project_root, None, None, None)?;
+        let inputs = collect_test_lock_inputs(project_root, None, None, None)?;
+        let imports = inputs.inline_imports;
         let tokio = imports
             .iter()
             .find(|import| import.crate_name == "tokio")

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -878,6 +878,14 @@ impl TypeChecker {
                     // not yet extracted. Stay permissive rather than false-positiving on valid calls.
                     return Some(ResolvedType::Unknown);
                 };
+                if Self::rust_signature_has_receiver(&sig)
+                    && sig.params[1..].iter().any(|param| {
+                        let normalized = param.type_display.replace(' ', "");
+                        Self::rust_display_type_var_name(normalized.as_str()).is_some()
+                    })
+                {
+                    self.type_info.record_regular_method_arg_shape(receiver_span, method);
+                }
                 let callable_display = format!("rust::{rust_path}.{method}");
                 Some(self.validate_rust_method_call(
                     callable_display.as_str(),

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -21,6 +21,42 @@ enum RustArgBoundaryMatch {
 }
 
 impl TypeChecker {
+    /// Eagerly cache metadata for Rust path types returned by inspected Rust calls.
+    ///
+    /// CLI prewarm covers explicit `from rust::... import Item` paths, but chained registry APIs often return helper
+    /// types that users never import directly. Caching those returned receiver types while the originating Rust
+    /// signature is known lets the next method call validate against its real signature instead of falling back to
+    /// permissive unknown-method lowering.
+    fn prewarm_rust_return_type_metadata(&self, ty: &ResolvedType) {
+        match ty {
+            ResolvedType::RustPath(path) => {
+                let _ = self.rust_item_metadata_for_path_blocking(path);
+            }
+            ResolvedType::Ref(inner) | ResolvedType::RefMut(inner) => self.prewarm_rust_return_type_metadata(inner),
+            ResolvedType::Generic(_, args) | ResolvedType::Tuple(args) => {
+                for arg in args {
+                    self.prewarm_rust_return_type_metadata(arg);
+                }
+            }
+            ResolvedType::FrozenList(inner) | ResolvedType::FrozenSet(inner) => {
+                self.prewarm_rust_return_type_metadata(inner);
+            }
+            ResolvedType::FrozenDict(key, value) => {
+                self.prewarm_rust_return_type_metadata(key);
+                self.prewarm_rust_return_type_metadata(value);
+            }
+            ResolvedType::Function(_, ret) => self.prewarm_rust_return_type_metadata(ret),
+            _ => {}
+        }
+    }
+
+    /// Resolve an inspected Rust return display and cache any returned Rust receiver metadata.
+    fn resolved_rust_return_type_from_sig(&self, sig: &RustFunctionSig) -> ResolvedType {
+        let return_ty = self.resolved_type_from_rust_display(sig.return_type.as_str());
+        self.prewarm_rust_return_type_metadata(&return_ty);
+        return_ty
+    }
+
     fn rusttype_boundary_match(&self, arg_ty: &ResolvedType, target_ty: &ResolvedType) -> Option<RustArgCoercionKind> {
         if let ResolvedType::Named(type_name) = arg_ty
             && let Some(TypeInfo::Newtype(newtype)) = self.lookup_type_info(type_name)
@@ -310,7 +346,7 @@ impl TypeChecker {
                 arg_types.len(),
                 span,
             ));
-            return self.resolved_type_from_rust_display(sig.return_type.as_str());
+            return self.resolved_rust_return_type_from_sig(sig);
         }
 
         for ((arg, arg_ty), param) in args.iter().zip(arg_types.iter()).zip(params.iter()) {
@@ -342,7 +378,7 @@ impl TypeChecker {
             }
         }
 
-        self.resolved_type_from_rust_display(sig.return_type.as_str())
+        self.resolved_rust_return_type_from_sig(sig)
     }
 
     /// Validate a direct Rust function call (`rust::path::item(...)`) and record boundary coercions.
@@ -358,7 +394,7 @@ impl TypeChecker {
         if arg_types.len() != sig.params.len() {
             self.errors
                 .push(errors::builtin_arity(path, sig.params.len(), arg_types.len(), span));
-            return self.resolved_type_from_rust_display(sig.return_type.as_str());
+            return self.resolved_rust_return_type_from_sig(sig);
         }
 
         for ((arg, arg_ty), param) in args.iter().zip(arg_types.iter()).zip(sig.params.iter()) {
@@ -387,7 +423,7 @@ impl TypeChecker {
             }
         }
 
-        self.resolved_type_from_rust_display(sig.return_type.as_str())
+        self.resolved_rust_return_type_from_sig(sig)
     }
 }
 

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -824,6 +824,16 @@ impl TypeChecker {
         }
     }
 
+    /// Return a Rust generic type-parameter name when the display is the simple identifier form rust-analyzer uses
+    /// for params like `T` or `U`.
+    pub(crate) fn rust_display_type_var_name(normalized: &str) -> Option<&str> {
+        if normalized.len() == 1 && normalized.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()) {
+            Some(normalized)
+        } else {
+            None
+        }
+    }
+
     /// Convert a Rust parameter display type into a [`ResolvedType`] while preserving borrow shape.
     ///
     /// `resolved_type_from_rust_display()` intentionally maps borrowed scalar-like returns such as `&str` and `&[u8]`
@@ -833,6 +843,9 @@ impl TypeChecker {
         let trimmed = rust_ty.trim();
         let no_lifetimes = trimmed.replace("'static ", "").replace("'_", "").replace(' ', "");
         let normalized = no_lifetimes.trim_start_matches("::").to_string();
+        if let Some(name) = Self::rust_display_type_var_name(normalized.as_str()) {
+            return ResolvedType::TypeVar(name.to_string());
+        }
         if let Some((is_mut, inner)) = Self::rust_display_borrow_kind(normalized.as_str()) {
             let inner_ty = match inner {
                 "str" => ResolvedType::Str,

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -356,6 +356,116 @@ edition = "2021"
 }
 
 #[test]
+fn multi_entrypoint_lock_covers_project_scripts_and_tests_issue505() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "cli_multi_entry_lock_freshness_project",
+        r#"
+extra = "src/extra.incn"
+
+[rust-dependencies]
+tiny_helper = { path = "rust/tiny_helper" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"pub def value() -> int:
+  return 1
+
+def main() -> None:
+  println(value())
+"#,
+    )?;
+    let extra_path = tmp.path().join("src").join("extra.incn");
+    fs::write(
+        &extra_path,
+        r#"from rust::tiny_helper import plus_one
+
+def main() -> None:
+  println(plus_one(1))
+"#,
+    )?;
+
+    let tests_dir = tmp.path().join("tests");
+    fs::create_dir_all(&tests_dir)?;
+    fs::write(
+        tests_dir.join("test_main.incn"),
+        r#"from std.serde.json import Serialize
+from std.testing import assert_eq
+from crate.main import value
+
+model Event with Serialize:
+  id: int
+
+def test_value() -> None:
+  event = Event(id=1)
+  assert_eq(event.to_json(), "{\"id\":1}")
+  assert_eq(value(), 1)
+"#,
+    )?;
+
+    let helper_src = tmp.path().join("rust").join("tiny_helper").join("src");
+    fs::create_dir_all(&helper_src)?;
+    fs::write(
+        helper_src
+            .parent()
+            .ok_or("helper src has no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "tiny_helper"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        helper_src.join("lib.rs"),
+        "pub fn plus_one(value: i64) -> i64 { value + 1 }\n",
+    )?;
+
+    let assert_no_stale_warning = |output: &Output, context: &str| {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("incan.lock is out of date"),
+            "{context} should not warn that incan.lock is stale, got:\n{stderr}"
+        );
+    };
+
+    let default_lock_output = run_incan(tmp.path(), &["lock"])?;
+    assert_success(&default_lock_output, "default incan lock");
+
+    let test_after_default_lock = run_incan(tmp.path(), &["test"])?;
+    assert_success(&test_after_default_lock, "incan test after default lock");
+    assert_no_stale_warning(&test_after_default_lock, "incan test after default lock");
+
+    let extra_after_default_lock = run_incan(
+        tmp.path(),
+        &["run", extra_path.to_str().ok_or("extra path was not valid UTF-8")?],
+    )?;
+    assert_success(&extra_after_default_lock, "incan run extra after default lock");
+    assert_no_stale_warning(&extra_after_default_lock, "incan run extra after default lock");
+
+    let extra_lock_output = run_incan(
+        tmp.path(),
+        &["lock", extra_path.to_str().ok_or("extra path was not valid UTF-8")?],
+    )?;
+    assert_success(&extra_lock_output, "incan lock extra");
+
+    let extra_after_extra_lock = run_incan(
+        tmp.path(),
+        &["run", extra_path.to_str().ok_or("extra path was not valid UTF-8")?],
+    )?;
+    assert_success(&extra_after_extra_lock, "incan run extra after extra lock");
+    assert_no_stale_warning(&extra_after_extra_lock, "incan run extra after extra lock");
+
+    let test_after_extra_lock = run_incan(tmp.path(), &["test"])?;
+    assert_success(&test_after_extra_lock, "incan test after extra lock");
+    assert_no_stale_warning(&test_after_extra_lock, "incan test after extra lock");
+
+    Ok(())
+}
+
+#[test]
 fn run_accepts_owned_incan_value_for_borrowed_generic_rust_param_issue506() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -329,7 +329,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Language/Compiler**: RFC 006 adds lazy `Generator[T]` values, including `yield`-based generator functions, full-clause generator expressions, iteration-protocol compatibility, and the minimum helper surface `.map()`, `.filter()`, `.take()`, and `.collect()` (#324, RFC 006).
 - **Language/Compiler**: Multi-file web builds now retain private route-decorated handlers and the private models they use in dependency modules, so route registration works without forcing those declarations public (#117).
 - **Language/Compiler**: Stdlib import validation now rejects unknown names from known stdlib modules, imported stdlib static method calls preserve default arguments at the call site, union narrowing lowers chained `isinstance` branches without leaking raw `isinstance` calls or unit fallthroughs into generated Rust, and Rust interop accepts owned Incan values for shared borrowed generic parameters such as `&T` in both free-function and method-call positions (#499, #500, #501, #502, #506, #508).
-- **Tooling**: `incan test` no longer reports a freshly generated `incan.lock` as stale when a project uses local path Rust dependencies (#505).
+- **Tooling**: `incan lock` now treats manifest projects as a project-wide lock surface, covering declared scripts and test harness dependency inputs so multi-entrypoint projects do not alternate stale-lock warnings between `incan test` and `incan run src/extra.incn` (#505).
 
 ### Versioning and release track
 
@@ -337,7 +337,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Dependency policy**: The rust-analyzer proc-macro API dependency is patched locally to request `postcard` without default features, removing the unmaintained `atomic-polyfill` crate from the workspace dependency graph and letting `cargo deny check` run without the `RUSTSEC-2023-0089` advisory ignore (#260).
 - **Dependency policy**: The workspace now builds against Wasmtime `44.0.1` / Wasmtime WASI `44.0.1` and raises the Rust MSRV to `1.92`, matching Wasmtime 44's compiler requirement.
 - **Dependency policy**: Dependabot security alerts for the VS Code extension lockfile, docs-site Python pins, and Rust `rand` lock entries are remediated, while repo-owned GitHub Actions are moved to Node 24-compatible action releases (#475, #464).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.37`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.38`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

This PR closes the reopened #508 and #505 regressions. Rust builder chains now keep real inspected return metadata across chained calls, so `reqwest::Client::post(...).json(payload)` emits the correct borrowed payload shape and preserves inferable string literal arguments. Lock freshness now uses a project-wide dependency surface across manifest scripts and test harness inputs, so `incan lock`, `incan run <entrypoint>`, and `incan test` stop alternating stale-lock warnings in multi-entrypoint projects.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Incan can call real Rust builder-style APIs such as `reqwest::RequestBuilder::json(&T)` without a Rust shim, and manifest projects no longer get stale lock warnings just because different scripts or tests exercise different dependency inputs.
- **Internals**: Rust return type resolution now prewarms metadata for returned Rust receiver types, Rust generic parameter displays are preserved as type variables, and method argument emission uses callable metadata rather than method-name guesses. Lock generation and freshness checks now collect manifest script entries, explicit entrypoints, test inline imports, test source modules, project requirements, resolved dependencies, and rust-inspect query paths into one project lock context.
- **Risks**: The Rust boundary changes touch method argument borrowing and external method shape detection; regressions would likely show up around generic Rust method calls with borrowed parameters. The lock change broadens the freshness fingerprint surface for manifest projects and could affect unusual projects with intentionally divergent script dependency sets.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test test_codegen_borrows_reqwest_json_payload_returned_from_registry_client --features rust_inspect`
- `cargo test external_nominal_method_call_keeps_external_string_conversion`
- `cargo test type_name_associated_call_does_not_borrow_string_arguments`
- `cargo test regular_hash_map_get_preserves_borrowed_probe_shape`
- `cargo test --test cli_integration multi_entrypoint_lock_covers_project_scripts_and_tests_issue505 -- --nocapture`
- Exact #508 scratch reqwest repro build emitted `client.post("http://127.0.0.1:1").json(&payload).send().await`
- Scratch #505 alternation sequence passed with no stale-lock warnings across `incan lock`, `incan test`, `incan run src/extra.incn`, `incan lock src/extra.incn`, `incan run src/extra.incn`, `incan test`
- `make fmt`
- `git diff --check`
- `make pre-commit` passed, including 2024 nextest tests, clippy, cargo-deny, and `smoke-test-fast`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #505
Closes #508