### PR TITLE
feature - 146 add async typechecker validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "byteorder",
  "clap",
@@ -1450,14 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,14 +1466,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "axum",
  "incan_core",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.39"
+version = "0.3.0-dev.40"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -120,6 +120,13 @@ pub enum SurfaceExprTypeCheck {
     AwaitCheck,
 }
 
+/// Describes how to typecheck a declaration-level surface modifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SurfaceModifierTypeCheck {
+    /// The modifier marks the callable as async and applies async callable validation rules.
+    AsyncCallable,
+}
+
 /// Runtime requirement implied by a surface feature.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RuntimeRequirement {
@@ -176,6 +183,11 @@ pub trait SurfaceSemanticsPack {
 
     /// Return the typecheck action for a surface expression, or `None` if not handled.
     fn typecheck_surface_expr_action(&self, _key: &SurfaceFeatureKey) -> Option<SurfaceExprTypeCheck> {
+        None
+    }
+
+    /// Return the typecheck action for a declaration-level surface modifier, or `None` if not handled.
+    fn typecheck_surface_modifier_action(&self, _key: &SurfaceFeatureKey) -> Option<SurfaceModifierTypeCheck> {
         None
     }
 
@@ -271,6 +283,13 @@ impl<'a> SurfaceSemanticsRegistry<'a> {
         self.packs
             .iter()
             .find_map(|pack| pack.typecheck_surface_expr_action(key))
+    }
+
+    /// Return the declaration-modifier typecheck action selected by the first pack that recognizes `key`.
+    pub fn typecheck_surface_modifier_action(&self, key: &SurfaceFeatureKey) -> Option<SurfaceModifierTypeCheck> {
+        self.packs
+            .iter()
+            .find_map(|pack| pack.typecheck_surface_modifier_action(key))
     }
 
     // ---- Lowering dispatch ----

--- a/crates/incan_semantics_stdlib/src/lib.rs
+++ b/crates/incan_semantics_stdlib/src/lib.rs
@@ -29,8 +29,9 @@ use incan_core::lang::keywords::KeywordId;
 use incan_core::lang::stdlib;
 use incan_semantics_core::{
     AssertShape, DecoratorFeature, RuntimeRequirement, SurfaceCallTarget, SurfaceExprLoweringAction,
-    SurfaceExprPayloadKind, SurfaceExprTypeCheck, SurfaceFeatureKey, SurfaceModifierKind, SurfaceSemanticsPack,
-    SurfaceStmtLoweringAction, SurfaceStmtPayloadKind, SurfaceStmtTypeCheck, decorator_feature_from_id,
+    SurfaceExprPayloadKind, SurfaceExprTypeCheck, SurfaceFeatureKey, SurfaceModifierKind, SurfaceModifierTypeCheck,
+    SurfaceSemanticsPack, SurfaceStmtLoweringAction, SurfaceStmtPayloadKind, SurfaceStmtTypeCheck,
+    decorator_feature_from_id,
 };
 
 /// Stdlib semantics pack implementation.
@@ -132,6 +133,16 @@ impl SurfaceSemanticsPack for StdlibSemanticsPack {
         #[cfg(feature = "std_async")]
         if matches!(key, SurfaceFeatureKey::SoftKeyword(KeywordId::Await)) {
             return Some(SurfaceExprTypeCheck::AwaitCheck);
+        }
+        let _ = key;
+        None
+    }
+
+    /// Route `async` declaration modifiers to async callable validation when `std_async` is enabled.
+    fn typecheck_surface_modifier_action(&self, key: &SurfaceFeatureKey) -> Option<SurfaceModifierTypeCheck> {
+        #[cfg(feature = "std_async")]
+        if matches!(key, SurfaceFeatureKey::SoftKeyword(KeywordId::Async)) {
+            return Some(SurfaceModifierTypeCheck::AsyncCallable);
         }
         let _ = key;
         None

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -455,6 +455,15 @@ pub fn await_outside_async(span: Span) -> CompileError {
     .with_hint("Declare the enclosing function or method with the `async` keyword (after importing `std.async`)")
 }
 
+/// An async callable was invoked in a context where the returned future is not awaited directly.
+pub fn async_call_without_await(callable: &str, span: Span) -> CompileError {
+    CompileError::warning(format!("Async call `{callable}` is not awaited"), span)
+        .with_note("Calling an async function or method produces work that should usually be awaited")
+        .with_hint(format!(
+            "Use `await {callable}(...)` when the result should be observed here"
+        ))
+}
+
 /// `break` appeared outside any enclosing loop body.
 pub fn break_outside_loop(span: Span) -> CompileError {
     CompileError::type_error("`break` is only valid inside loops".to_string(), span)

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -19,6 +19,7 @@ use incan_core::lang::decorators::{self, DecoratorId};
 use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::magic_methods;
 use incan_core::lang::stdlib;
+use incan_semantics_core::SurfaceModifierTypeCheck;
 use std::collections::{HashMap, HashSet};
 
 /// Structural equality for trait method signatures (RFC 042 diamond / obligation merging).
@@ -300,6 +301,33 @@ impl TypeChecker {
                 }
             }
         }
+    }
+
+    /// Run declaration-level typecheck actions selected by the surface semantics registry.
+    fn validate_surface_modifier_typecheck_actions(
+        &mut self,
+        modifiers: &[SurfaceModifier],
+        return_type: &Spanned<Type>,
+    ) {
+        use crate::semantics_registry::semantics_registry;
+
+        for modifier in modifiers {
+            let Some(action) = semantics_registry().typecheck_surface_modifier_action(&modifier.key) else {
+                continue;
+            };
+            match action {
+                SurfaceModifierTypeCheck::AsyncCallable => self.validate_async_callable_return_type(return_type),
+            }
+        }
+    }
+
+    /// Validate return annotations for an async callable.
+    ///
+    /// Incan async declarations spell the callable's logical output type, not an explicit `Future[T]` wrapper, so no
+    /// additional return-type rejection is currently applicable. Keeping this routed through the semantics registry
+    /// prevents `async` from becoming another hardcoded declaration special case.
+    fn validate_async_callable_return_type(&mut self, return_type: &Spanned<Type>) {
+        let _ = return_type;
     }
 
     /// Return whether a method carries a resolved builtin decorator.
@@ -2780,8 +2808,7 @@ impl TypeChecker {
                 },
             );
         }
-        // TODO(#146): add async return-type and related validation here via the surface semantics registry — not
-        // hardcoded KeywordId checks.
+        self.validate_surface_modifier_typecheck_actions(&func.surface_modifiers, &func.return_type);
 
         // Define type parameters so explicit generic bounds are visible in function-level type resolution.
         for param in &func.type_params {
@@ -2997,7 +3024,7 @@ impl TypeChecker {
             receiver: method.receiver,
         });
         self.validate_callable_rest_params(&method.params);
-        // TODO(#146): add async return-type and related validation for methods via the surface semantics registry.
+        self.validate_surface_modifier_typecheck_actions(&method.surface_modifiers, &method.return_type);
 
         // Define owner type parameters so generic wrappers can use them in bodies and annotations.
         for type_param in owner_type_params {

--- a/src/frontend/typechecker/check_expr/calls/args.rs
+++ b/src/frontend/typechecker/check_expr/calls/args.rs
@@ -80,7 +80,9 @@ impl TypeChecker {
     /// Type-check all call arguments, including unpack arguments.
     pub(in crate::frontend::typechecker::check_expr) fn check_call_args(&mut self, args: &[CallArg]) {
         for arg in args {
+            self.call_argument_depth += 1;
             self.check_expr(Self::call_arg_expr(arg));
+            self.call_argument_depth -= 1;
         }
     }
 
@@ -90,7 +92,12 @@ impl TypeChecker {
         args: &[CallArg],
     ) -> Vec<ResolvedType> {
         args.iter()
-            .map(|arg| self.check_expr(Self::call_arg_expr(arg)))
+            .map(|arg| {
+                self.call_argument_depth += 1;
+                let ty = self.check_expr(Self::call_arg_expr(arg));
+                self.call_argument_depth -= 1;
+                ty
+            })
             .collect()
     }
 
@@ -115,7 +122,9 @@ impl TypeChecker {
                         .map(|param| param.ty.clone())
                         .or_else(|| rest_positional.map(|param| param.ty.clone()));
                     positional_index += 1;
+                    self.call_argument_depth += 1;
                     arg_types.push(self.check_expr_with_expected(expr, expected.as_ref()));
+                    self.call_argument_depth -= 1;
                 }
                 CallArg::Named(name, expr) => {
                     let expected = normal_params
@@ -123,7 +132,9 @@ impl TypeChecker {
                         .find(|param| param.name() == Some(name.as_str()))
                         .map(|param| param.ty.clone())
                         .or_else(|| rest_keyword.map(|param| param.ty.clone()));
+                    self.call_argument_depth += 1;
                     arg_types.push(self.check_expr_with_expected(expr, expected.as_ref()));
+                    self.call_argument_depth -= 1;
                 }
                 CallArg::PositionalUnpack(expr) => {
                     if let Some(items) = Self::shaped_positional_unpack_items(expr) {
@@ -136,7 +147,9 @@ impl TypeChecker {
                             if positional_index < normal_params.len() {
                                 positional_index += 1;
                             }
+                            self.call_argument_depth += 1;
                             item_types.push(self.check_expr_with_expected(item, expected.as_ref()));
+                            self.call_argument_depth -= 1;
                         }
                         let plan_item_types = item_types.clone();
                         let ty = ResolvedType::Tuple(item_types);
@@ -145,7 +158,9 @@ impl TypeChecker {
                         arg_types.push(ty);
                     } else {
                         let expected = rest_positional.map(|param| list_ty(param.ty.clone()));
+                        self.call_argument_depth += 1;
                         let ty = self.check_expr_with_expected(expr, expected.as_ref());
+                        self.call_argument_depth -= 1;
                         if let Some(item_types) = Self::shaped_positional_unpack_types(&ty) {
                             self.record_fixed_unpack_plan(expr.span, FixedUnpackPlan::Positional(item_types.to_vec()));
                         }
@@ -156,7 +171,9 @@ impl TypeChecker {
                     if let Some(entries) = Self::shaped_keyword_unpack_entries(expr) {
                         let mut value_types = Vec::with_capacity(entries.len());
                         for (key, value) in &entries {
+                            self.call_argument_depth += 1;
                             self.check_expr(key);
+                            self.call_argument_depth -= 1;
                             let expected = Self::static_string_key(key)
                                 .and_then(|name| {
                                     normal_params
@@ -165,7 +182,9 @@ impl TypeChecker {
                                         .map(|param| param.ty.clone())
                                 })
                                 .or_else(|| rest_keyword.map(|param| param.ty.clone()));
+                            self.call_argument_depth += 1;
                             value_types.push(self.check_expr_with_expected(value, expected.as_ref()));
+                            self.call_argument_depth -= 1;
                         }
                         let value_ty = value_types.first().cloned().unwrap_or(ResolvedType::Unknown);
                         self.record_expr_type(expr.span, dict_ty(ResolvedType::Str, value_ty));
@@ -181,7 +200,9 @@ impl TypeChecker {
                         arg_types.push(ResolvedType::Tuple(value_types));
                     } else {
                         let expected = rest_keyword.map(|param| dict_ty(ResolvedType::Str, param.ty.clone()));
+                        self.call_argument_depth += 1;
                         arg_types.push(self.check_expr_with_expected(expr, expected.as_ref()));
+                        self.call_argument_depth -= 1;
                     }
                 }
             }

--- a/src/frontend/typechecker/check_expr/calls/generic_bounds.rs
+++ b/src/frontend/typechecker/check_expr/calls/generic_bounds.rs
@@ -68,6 +68,9 @@ impl TypeChecker {
             &type_bindings,
             call_span,
         );
+        if info.is_async {
+            self.warn_if_unawaited_async_call(func_name, call_span);
+        }
 
         let explicit_arity_ok = explicit_type_args.is_empty() || explicit_type_args.len() == info.type_params.len();
         if !explicit_type_args.is_empty() && explicit_arity_ok {
@@ -194,6 +197,9 @@ impl TypeChecker {
         let (params, return_type) = self.method_types_substituting_call_site_self(&method_info, receiver_ty);
         self.validate_callable_arg_bindings(method, &params, args, arg_types, &mut type_bindings, call_site_span);
         self.type_info.record_call_site_callable_params(call_site_span, &params);
+        if method_info.is_async {
+            self.warn_if_unawaited_async_call(method, call_site_span);
+        }
 
         self.emit_explicit_bound_errors(
             method,

--- a/src/frontend/typechecker/check_expr/control_flow.rs
+++ b/src/frontend/typechecker/check_expr/control_flow.rs
@@ -29,7 +29,9 @@ impl TypeChecker {
             return ResolvedType::Unknown;
         }
 
+        let prev_await_operand_span = self.await_operand_span.replace((inner.span.start, inner.span.end));
         let inner_ty = self.check_expr(inner);
+        self.await_operand_span = prev_await_operand_span;
 
         if let ResolvedType::Generic(name, args) = &inner_ty
             && surface_types::from_str(name.as_str()) == Some(SurfaceTypeId::JoinHandle)

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -141,6 +141,10 @@ pub struct TypeChecker {
     pub(crate) current_yield_context: YieldContext,
     /// Whether the body currently being checked belongs to an `async def` or async method.
     pub(crate) in_async_body: bool,
+    /// Expression span currently being typechecked as an `await` operand.
+    pub(crate) await_operand_span: Option<(usize, usize)>,
+    /// Nesting depth for expressions being checked as call arguments.
+    pub(crate) call_argument_depth: usize,
     /// Stack of active loop contexts, innermost last.
     pub(crate) loop_stack: Vec<LoopContext>,
     /// Active trait @requires context for default method bodies.
@@ -253,6 +257,8 @@ impl TypeChecker {
             current_return_error_type: None,
             current_yield_context: YieldContext::Disallowed,
             in_async_body: false,
+            await_operand_span: None,
+            call_argument_depth: 0,
             loop_stack: Vec::new(),
             current_trait_requires: None,
             current_trait_properties: None,
@@ -312,6 +318,19 @@ impl TypeChecker {
     /// Borrow the innermost active loop so `break` checking can append inferred break types.
     pub(crate) fn current_loop_context_mut(&mut self) -> Option<&mut LoopContext> {
         self.loop_stack.last_mut()
+    }
+
+    /// Return whether this call expression is inside the active `await` operand.
+    pub(crate) fn is_in_await_operand(&self, span: Span) -> bool {
+        self.await_operand_span
+            .is_some_and(|(start, end)| start <= span.start && span.end <= end)
+    }
+
+    /// Emit the missing-await warning for a direct async call when the current expression context should report it.
+    pub(crate) fn warn_if_unawaited_async_call(&mut self, callable: &str, span: Span) {
+        if !self.is_in_await_operand(span) && self.call_argument_depth == 0 {
+            self.errors.push(errors::async_call_without_await(callable, span));
+        }
     }
 
     /// Resolve the final type of a `loop:` expression from the `break` types observed in its body.

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -46,6 +46,22 @@ fn check_str_err(source: &str, context: &str) -> Vec<CompileError> {
     }
 }
 
+fn check_str_warnings(source: &str, context: &str) -> Vec<CompileError> {
+    let tokens = match lexer::lex(source) {
+        Ok(tokens) => tokens,
+        Err(errs) => panic!("{context} lex failed: {errs:?}"),
+    };
+    let ast = match parser::parse(&tokens) {
+        Ok(ast) => ast,
+        Err(errs) => panic!("{context} parse failed: {errs:?}"),
+    };
+    let mut checker = TypeChecker::new();
+    if let Err(errs) = checker.check_program(&ast) {
+        panic!("{context} typecheck failed: {errs:?}");
+    }
+    checker.warnings
+}
+
 fn has_unknown_symbol_error(errors: &[CompileError], symbol: &str) -> bool {
     let needle = format!("Unknown symbol '{symbol}'");
     errors.iter().any(|err| err.message.contains(&needle))
@@ -3019,6 +3035,107 @@ model Widget:
         errs.iter()
             .any(|e| e.message.contains("await") && e.message.contains("async")),
         "expected await-outside-async diagnostic, got: {errs:?}"
+    );
+}
+
+#[test]
+fn test_unawaited_async_function_call_warns() {
+    let source = r#"
+import std.async
+
+async def fetch() -> int:
+  return 1
+
+async def main() -> None:
+  fetch()
+"#;
+    let warnings = check_str_warnings(source, "unawaited async function call should warn");
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.message.contains("Async call `fetch` is not awaited")),
+        "expected missing-await warning, got: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_awaited_async_function_call_does_not_warn() {
+    let source = r#"
+import std.async
+
+async def fetch() -> int:
+  return 1
+
+async def main() -> None:
+  value = await fetch()
+"#;
+    let warnings = check_str_warnings(source, "awaited async function call should not warn");
+    assert!(
+        warnings
+            .iter()
+            .all(|warning| !warning.message.contains("Async call `fetch` is not awaited")),
+        "did not expect missing-await warning, got: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_awaited_async_try_call_does_not_warn() {
+    let source = r#"
+import std.async
+
+async def fetch() -> Result[int, str]:
+  return Ok(1)
+
+async def main() -> Result[None, str]:
+  value = await fetch()?
+  return Ok(None)
+"#;
+    let warnings = check_str_warnings(source, "awaited async try call should not warn");
+    assert!(
+        warnings
+            .iter()
+            .all(|warning| !warning.message.contains("Async call `fetch` is not awaited")),
+        "did not expect missing-await warning, got: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_unawaited_imported_async_function_call_warns() {
+    let source = r#"
+from std.async.time import sleep
+
+async def main() -> None:
+  sleep(1.0)
+"#;
+    let warnings = check_str_warnings(source, "unawaited imported async function call should warn");
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.message.contains("Async call `sleep` is not awaited")),
+        "expected missing-await warning, got: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_unawaited_async_method_call_warns() {
+    let source = r#"
+import std.async
+
+model Worker:
+  id: int
+
+  async def run(self) -> int:
+    return self.id
+
+async def main(worker: Worker) -> None:
+  worker.run()
+"#;
+    let warnings = check_str_warnings(source, "unawaited async method call should warn");
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.message.contains("Async call `run` is not awaited")),
+        "expected missing-await warning, got: {warnings:?}"
     );
 }
 

--- a/workspaces/docs-site/docs/language/how-to/async_programming.md
+++ b/workspaces/docs-site/docs/language/how-to/async_programming.md
@@ -66,7 +66,7 @@ async def process() -> str:
     return result
 ```
 
-`await` is only valid inside `async def` bodies and **async** methods Using `await` in an ordinary `def` or sync method is a type error.
+`await` is only valid inside `async def` bodies and **async** methods. Using `await` in an ordinary `def` or sync method is a type error. Calling an async function or method as a direct value without `await` produces a compiler warning; pass async work to task APIs such as `spawn()` when another async API should consume it.
 
 !!! info "Coming from Python?"
     Incan's `await` follows the same rules as in Python: it is disallowed outside an `async` scope.

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -345,6 +345,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Runtime/Async**: `std.async` now documents cancellation-safety contracts and exposes channel reservation APIs so critical sends can reserve capacity before committing messages (#415, #416).
 - **Runtime/Async**: `std.async.time` adds `timeout_join`, `timeout_join_ms`, and a must-use `TimeoutJoinOutcome` so spawned work can keep running after a deadline while callers retain the live `JoinHandle` for later observation or explicit abort (#417).
 - **Runtime/Async**: `std.async.sync.Barrier.wait()` now uses Incan-owned generation bookkeeping so cancelling a pending wait withdraws that participant and frees its arrival slot instead of corrupting barrier progress (#418).
+- **Language/Compiler**: Async semantic validation now warns when a direct async function or method call is not awaited, and the existing `await`-outside-async type error is routed through the same registry-backed async surface (#146).
 - **Language/Compiler**: List and dict comprehensions now accept tuple-unpack iteration targets such as `for idx, name in enumerate(xs)`, matching ordinary `for` loop binding syntax (#483).
 - **Language/Compiler**: RFC 006 adds lazy `Generator[T]` values, including `yield`-based generator functions, full-clause generator expressions, iteration-protocol compatibility, and the minimum helper surface `.map()`, `.filter()`, `.take()`, and `.collect()` (#324, RFC 006).
 - **Language/Stdlib**: RFC 069 adds import-free `list.repeat(value, count)` for fixed-length list initialization. The compiler infers `list[T]`, enforces clone-compatible repeated values and `count: int`, lowers recognized calls to the stdlib helper, and raises `ValueError` with the bad count for negative runtime counts (#385, RFC 069).
@@ -362,7 +363,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Dependency policy**: The rust-analyzer proc-macro API dependency is patched locally to request `postcard` without default features, removing the unmaintained `atomic-polyfill` crate from the workspace dependency graph and letting `cargo deny check` run without the `RUSTSEC-2023-0089` advisory ignore (#260).
 - **Dependency policy**: The workspace now builds against Wasmtime `44.0.1` / Wasmtime WASI `44.0.1` and raises the Rust MSRV to `1.92`, matching Wasmtime 44's compiler requirement.
 - **Dependency policy**: Dependabot security alerts for the VS Code extension lockfile, docs-site Python pins, and Rust `rand` lock entries are remediated, while repo-owned GitHub Actions are moved to Node 24-compatible action releases (#475, #464).
-- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.39`.
+- **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.40`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

Adds issue #146 async typechecker validation so direct async function and method calls produce a missing-`await` warning, while already-awaited calls and async calls passed as call arguments do not get noisy diagnostics. The change also routes declaration-level async modifier validation through the surface semantics registry and removes the stale `check_decl.rs` TODO path.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: direct calls to async functions or methods now emit an Incan warning when the call is not directly awaited.
- **Internals**: async declaration modifier validation is routed through `SurfaceModifierTypeCheck` in the semantics registry, and call-site diagnostics use shared await operand and call-argument context in the typechecker.
- **Risks**: warning placement depends on expression span containment; focused coverage includes `await fetch()?` to guard against false positives around await operands with try expressions.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo fmt`
- `cargo test -p incan --lib unawaited_async -- --nocapture`
- `cargo test -p incan --lib async -- --nocapture`
- `cargo test -p incan --lib awaited_async -- --nocapture`
- `git diff --check`
- `rg -n "TODO\\(#146\\)|0\\.3\\.0-dev\\.39" .`
- `cd <workspace-checkout> && make pre-commit`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/how-to/async_programming.md`, `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions