### PR TITLE
feature - RFC 030: std.collections (#164)

### DIFF
--- a/crates/incan_core/src/lang/magic_methods.rs
+++ b/crates/incan_core/src/lang/magic_methods.rs
@@ -9,6 +9,8 @@ pub enum MagicMethodId {
     Str,
     ClassName,
     Fields,
+    FieldValue,
+    FieldItems,
     Slice,
 }
 
@@ -50,6 +52,22 @@ pub const MAGIC_METHODS: &[MagicMethodInfo] = &[
         Since(0, 1),
     ),
     info(
+        MagicMethodId::FieldValue,
+        "__field_value__",
+        &[],
+        "Return a reflected field value by runtime field name.",
+        RFC::_030,
+        Since(0, 3),
+    ),
+    info(
+        MagicMethodId::FieldItems,
+        "__field_items__",
+        &[],
+        "Return reflected field name/value pairs.",
+        RFC::_030,
+        Since(0, 3),
+    ),
+    info(
         MagicMethodId::Slice,
         "__slice__",
         &[],
@@ -88,7 +106,9 @@ pub fn info_for(id: MagicMethodId) -> MagicMethodInfo {
         MagicMethodId::Str => MAGIC_METHODS[1],
         MagicMethodId::ClassName => MAGIC_METHODS[2],
         MagicMethodId::Fields => MAGIC_METHODS[3],
-        MagicMethodId::Slice => MAGIC_METHODS[4],
+        MagicMethodId::FieldValue => MAGIC_METHODS[4],
+        MagicMethodId::FieldItems => MAGIC_METHODS[5],
+        MagicMethodId::Slice => MAGIC_METHODS[6],
     }
 }
 

--- a/crates/incan_core/src/lang/registry.rs
+++ b/crates/incan_core/src/lang/registry.rs
@@ -76,6 +76,9 @@ pub const RFC_028: RfcId = "RFC 028";
 /// RFC 029 — union types and narrowing predicates.
 pub const RFC_029: RfcId = "RFC 029";
 
+/// RFC 030 — std.collections and field-overlay reflection.
+pub const RFC_030: RfcId = "RFC 030";
+
 /// RFC 040 — scoped DSL surface forms.
 pub const RFC_040: RfcId = "RFC 040";
 
@@ -140,6 +143,8 @@ impl RFC {
     pub const _028: RfcId = RFC_028;
     /// RFC 029 — union types and narrowing predicates.
     pub const _029: RfcId = RFC_029;
+    /// RFC 030 — std.collections and field-overlay reflection.
+    pub const _030: RfcId = RFC_030;
     /// RFC 040 — scoped DSL surface forms.
     pub const _040: RfcId = RFC_040;
     /// RFC 052 — module static storage.

--- a/crates/incan_core/src/lang/stdlib.rs
+++ b/crates/incan_core/src/lang/stdlib.rs
@@ -279,6 +279,13 @@ pub const STDLIB_NAMESPACES: &[StdlibNamespace] = &[
         typechecker_only: false,
     },
     StdlibNamespace {
+        name: "collections",
+        feature: None,
+        extra_crate_deps: &[],
+        submodules: &[],
+        typechecker_only: false,
+    },
+    StdlibNamespace {
         name: "io",
         feature: None,
         extra_crate_deps: &[StdlibExtraCrateDep {
@@ -463,6 +470,7 @@ mod tests {
         assert!(is_known_stdlib_module(&segs(&["std", "graph"])));
         assert!(is_known_stdlib_module(&segs(&["std", "io"])));
         assert!(is_known_stdlib_module(&segs(&["std", "tempfile"])));
+        assert!(is_known_stdlib_module(&segs(&["std", "collections"])));
         assert!(is_known_stdlib_module(&segs(&["std", "rust"])));
         assert!(is_known_stdlib_module(&segs(&["std", "builtins"])));
     }
@@ -481,6 +489,7 @@ mod tests {
         assert!(!is_known_stdlib_module(&segs(&["std", "f64", "consts"])));
         assert!(!is_known_stdlib_module(&segs(&["std", "web", "missing"])));
         assert!(!is_known_stdlib_module(&segs(&["std", "math", "extra"])));
+        assert!(!is_known_stdlib_module(&segs(&["std", "collections", "deque"])));
     }
 
     #[test]
@@ -521,6 +530,10 @@ mod tests {
             stdlib_stub_path(&segs(&["std", "tempfile"])),
             Some("stdlib/tempfile.incn".to_string())
         );
+        assert_eq!(
+            stdlib_stub_path(&segs(&["std", "collections"])),
+            Some("stdlib/collections.incn".to_string())
+        );
     }
 
     #[test]
@@ -547,6 +560,7 @@ mod tests {
         assert!(hint.contains(&"std.web.app".to_string()));
         assert!(hint.contains(&"std.async.prelude".to_string()));
         assert!(hint.contains(&"std.builtins".to_string()));
+        assert!(hint.contains(&"std.collections".to_string()));
     }
 
     #[test]
@@ -609,6 +623,7 @@ mod tests {
         let traits_ns = find_namespace("traits");
         let math_ns = find_namespace("math");
         let graph_ns = find_namespace("graph");
+        let collections_ns = find_namespace("collections");
 
         assert_eq!(async_ns.and_then(|ns| ns.feature), Some("async"));
         assert_eq!(reflection_ns.map(|ns| ns.submodules.is_empty()), Some(true));
@@ -625,6 +640,10 @@ mod tests {
         );
         assert_eq!(graph_ns.map(|ns| ns.feature), Some(None));
         assert_eq!(graph_ns.map(|ns| ns.submodules.is_empty()), Some(true));
+        assert_eq!(collections_ns.map(|ns| ns.feature), Some(None));
+        assert_eq!(collections_ns.map(|ns| ns.extra_crate_deps.is_empty()), Some(true));
+        assert_eq!(collections_ns.map(|ns| ns.submodules.is_empty()), Some(true));
+        assert_eq!(collections_ns.map(|ns| ns.typechecker_only), Some(false));
         assert_eq!(
             find_namespace("io")
                 .and_then(|ns| ns.extra_crate_deps.first())

--- a/crates/incan_core/tests/lang_registry_guardrails.rs
+++ b/crates/incan_core/tests/lang_registry_guardrails.rs
@@ -262,7 +262,7 @@ fn traits_spellings_unique_and_resolvable() {
 fn magic_methods_spellings_unique_and_resolvable() {
     assert_registry_round_trip(RegistryRoundTrip {
         label: "magic method",
-        expected_len: 5,
+        expected_len: 7,
         items: magic_methods::MAGIC_METHODS,
         id_of: |info| info.id,
         canonical_of: |info| info.canonical,

--- a/crates/incan_stdlib/stdlib/collections.incn
+++ b/crates/incan_stdlib/stdlib/collections.incn
@@ -1,0 +1,1778 @@
+"""
+Pure Incan extended collection types.
+
+RFC 030 defines `std.collections` as an explicit stdlib namespace for specialized containers above builtin `list`,
+`dict`, `set`, and tuple values. These containers are ordinary Incan declarations and use builtin `list` storage
+internally rather than Rust-backed dispatch.
+"""
+
+
+pub enum PriorityOrder:
+    """
+    Ordering policy for `PriorityQueue` construction.
+
+    `MinFirst` pops the smallest value first. `MaxFirst` pops the largest value first.
+    """
+
+    MinFirst
+    MaxFirst
+
+
+@derive(Clone)
+pub model _MapEntry[K with Clone, V with Clone]:
+    pub key: K
+    pub value: V
+
+
+@derive(Clone)
+pub model Deque[T with (Clone, Eq)]:
+    """
+    Double-ended queue value.
+
+    Values are stored in front-to-back order. The deque exposes both `append()` / `appendleft()` and
+    `push_back()` / `push_front()` spellings so callers can use the convention that fits their codebase.
+
+    Example:
+
+    ```incan
+    queue = Deque[int]()
+    queue.append(1)
+    queue.appendleft(0)
+    println(queue.pop())      # 1
+    println(queue.popleft())  # 0
+    ```
+    """
+
+    pub items: list[T] = []
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create an empty deque.
+
+        Returns:
+            A deque with no values.
+        """
+        return Deque(items=[])
+
+    @staticmethod
+    def from_iter(items: list[T]) -> Self:
+        """
+        Create a deque from a list.
+
+        Args:
+            items: Values to copy into the deque from front to back.
+
+        Returns:
+            A deque containing the values in their original order.
+        """
+        mut out = Deque(items=[])
+        for item in items:
+            out.push_back(item)
+        return out
+
+    def __len__(self) -> int:
+        """
+        Return the number of values in the deque.
+
+        Returns:
+            The current length.
+        """
+        return len(self.items)
+
+    def __iter__(self) -> list[T]:
+        """
+        Iterate from front to back.
+
+        Returns:
+            A list snapshot in deque order.
+        """
+        return self.items
+
+    def __getitem__(self, index: int) -> T:
+        """
+        Return the value at an index.
+
+        Args:
+            index: Zero-based position from the front of the deque.
+
+        Returns:
+            The value at `index`.
+        """
+        return self.items[index]
+
+    def __contains__(self, value: T) -> bool:
+        """
+        Check whether a value appears in the deque.
+
+        Args:
+            value: Value to search for.
+
+        Returns:
+            `true` when an equal value is present.
+        """
+        return _contains_value(self.items, value)
+
+    def push_back(mut self, value: T) -> None:
+        """
+        Append a value at the back of the deque.
+
+        Args:
+            value: Value to add after the current back element.
+        """
+        self.items.append(value)
+
+    def append(mut self, value: T) -> None:
+        """
+        Append a value at the back of the deque.
+
+        Args:
+            value: Value to add after the current back element.
+        """
+        self.push_back(value)
+
+    def push_front(mut self, value: T) -> None:
+        """
+        Append a value at the front of the deque.
+
+        Args:
+            value: Value to add before the current front element.
+        """
+        self.items.append(value)
+        mut index = len(self.items) - 1
+        while index > 0:
+            self.items.swap(index, index - 1)
+            index -= 1
+
+    def appendleft(mut self, value: T) -> None:
+        """
+        Append a value at the front of the deque.
+
+        Args:
+            value: Value to add before the current front element.
+        """
+        self.push_front(value)
+
+    def pop_back(mut self) -> T:
+        """
+        Remove and return the back value.
+
+        Returns:
+            The value that was at the back of the deque.
+        """
+        return self.items.pop()
+
+    def pop(mut self) -> T:
+        """
+        Remove and return the back value.
+
+        Returns:
+            The value that was at the back of the deque.
+        """
+        return self.pop_back()
+
+    def pop_front(mut self) -> T:
+        """
+        Remove and return the front value.
+
+        Returns:
+            The value that was at the front of the deque.
+        """
+        value = self.items[0]
+        self.items.remove(0)
+        return value
+
+    def popleft(mut self) -> T:
+        """
+        Remove and return the front value.
+
+        Returns:
+            The value that was at the front of the deque.
+        """
+        return self.pop_front()
+
+    def clear(mut self) -> None:
+        """
+        Remove every value from the deque.
+
+        The deque remains usable after clearing.
+        """
+        while len(self.items) > 0:
+            self.items.pop()
+
+    def to_list(self) -> list[T]:
+        """
+        Return the deque as a list.
+
+        Returns:
+            A list snapshot in front-to-back order.
+        """
+        return self.items
+
+
+@derive(Clone)
+pub model Counter[T with (Clone, Eq)]:
+    """
+    Multiset-style counted collection.
+
+    `Counter` stores non-negative counts and removes entries whose count reaches zero. Iteration returns distinct
+    values in first-seen order; `elements()` expands counts back into repeated values.
+
+    Example:
+
+    ```incan
+    counts = Counter.from_iter(["a", "b", "a"])
+    println(counts["a"])        # 2
+    println(counts.total())     # 3
+    println(counts.elements())  # ["a", "a", "b"]
+    ```
+    """
+
+    pub entries: list[_MapEntry[T, int]] = []
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create an empty counter.
+
+        Returns:
+            A counter with no counted values.
+        """
+        return Counter(entries=[])
+
+    @staticmethod
+    def from_iter(items: list[T]) -> Self:
+        """
+        Count values from a list.
+
+        Args:
+            items: Values to count.
+
+        Returns:
+            A counter containing one occurrence for each value in `items`.
+        """
+        mut out = Counter(entries=[])
+        out.update(items)
+        return out
+
+    def __len__(self) -> int:
+        """
+        Return the number of distinct counted values.
+
+        Returns:
+            The number of values with positive stored counts.
+        """
+        return len(self.entries)
+
+    def __iter__(self) -> list[T]:
+        """
+        Iterate over distinct counted values.
+
+        Returns:
+            Counted values in first-seen order.
+        """
+        return self.keys()
+
+    def __contains__(self, key: T) -> bool:
+        """
+        Check whether a value has a positive count.
+
+        Args:
+            key: Value to search for.
+
+        Returns:
+            `true` when the value is counted.
+        """
+        return self.get(key) > 0
+
+    def __getitem__(self, key: T) -> int:
+        """
+        Return the count for a value.
+
+        Args:
+            key: Value to inspect.
+
+        Returns:
+            The stored count, or zero when the value is absent.
+        """
+        return self.get(key)
+
+    def get(self, key: T) -> int:
+        """
+        Return the count for a value.
+
+        Args:
+            key: Value to inspect.
+
+        Returns:
+            The stored count, or zero when the value is absent.
+        """
+        index = self.index_of(key)
+        if index < 0:
+            return 0
+        return self.entries[index].value
+
+    def set(mut self, key: T, count: int) -> None:
+        """
+        Store a count for a value.
+
+        Args:
+            key: Value whose count should change.
+            count: New non-negative count. A zero count removes the value.
+        """
+        if count < 0:
+            _runtime_error("Counter counts must be non-negative")
+            return
+        index = self.index_of(key)
+        if count == 0:
+            if index >= 0:
+                self.entries.remove(index)
+            return
+        if index >= 0:
+            self.entries[index] = _MapEntry(key=key, value=count)
+        else:
+            self.entries.append(_MapEntry(key=key, value=count))
+
+    def increment(mut self, key: T, amount: int = 1) -> None:
+        """
+        Increase a value's count.
+
+        Args:
+            key: Value to increment.
+            amount: Non-negative amount to add.
+        """
+        if amount < 0:
+            _runtime_error("Counter.increment requires a non-negative amount")
+            return
+        self.set(key, self.get(key) + amount)
+
+    def decrement(mut self, key: T, amount: int = 1) -> None:
+        """
+        Decrease a value's count.
+
+        Args:
+            key: Value to decrement.
+            amount: Non-negative amount to subtract.
+        """
+        if amount < 0:
+            _runtime_error("Counter.decrement requires a non-negative amount")
+            return
+        current = self.get(key)
+        if amount >= current:
+            self.set(key, 0)
+        else:
+            self.set(key, current - amount)
+
+    def subtract_strict(self, other: Counter[T]) -> Result[Counter[T], str]:
+        """
+        Subtract another counter without flooring negative results.
+
+        Args:
+            other: Counter whose counts should be subtracted.
+
+        Returns:
+            `Ok(counter)` when every result count is non-negative, otherwise `Err(str)`.
+        """
+        mut out = Counter(entries=[])
+        for entry in self.entries:
+            other_count = other.get(entry.key)
+            if other_count > entry.value:
+                return Err("Counter subtraction would produce a negative count")
+            out.set(entry.key, entry.value - other_count)
+        for entry in other.entries:
+            if self.get(entry.key) == 0 and entry.value > 0:
+                return Err("Counter subtraction would produce a negative count")
+        return Ok(out)
+
+    def update(mut self, items: list[T]) -> None:
+        """
+        Add one occurrence for each value.
+
+        Args:
+            items: Values to add to the counter.
+        """
+        for item in items:
+            self.increment(item)
+
+    def subtract(mut self, items: list[T]) -> None:
+        """
+        Subtract one occurrence for each value, flooring at zero.
+
+        Args:
+            items: Values to subtract from the counter.
+        """
+        for item in items:
+            self.decrement(item)
+
+    def total(self) -> int:
+        """
+        Return the sum of all counts.
+
+        Returns:
+            The total number of counted occurrences.
+        """
+        mut total = 0
+        for entry in self.entries:
+            total += entry.value
+        return total
+
+    def keys(self) -> list[T]:
+        """
+        Return distinct counted values.
+
+        Returns:
+            Counted values in first-seen order.
+        """
+        return _entry_keys(self.entries)
+
+    def items(self) -> list[Tuple[T, int]]:
+        """
+        Return counted entries.
+
+        Returns:
+            `(value, count)` pairs in first-seen order.
+        """
+        return _entry_items(self.entries)
+
+    def elements(self) -> list[T]:
+        """
+        Expand counts into repeated values.
+
+        Returns:
+            A list containing each value repeated by its count.
+        """
+        return _counter_elements(self.entries)
+
+    def most_common(self, n: int = -1) -> list[Tuple[T, int]]:
+        """
+        Return the most common values.
+
+        Args:
+            n: Maximum number of pairs to return. A negative value returns every pair.
+
+        Returns:
+            `(value, count)` pairs sorted from highest count to lowest count.
+        """
+        return _counter_most_common(self.entries, n)
+
+    def plus(self, other: Counter[T]) -> Counter[T]:
+        """
+        Add counts from another counter.
+
+        Args:
+            other: Counter whose counts should be added.
+
+        Returns:
+            A new counter containing count-wise sums.
+        """
+        mut out = Counter(entries=[])
+        for entry in self.entries:
+            out.set(entry.key, entry.value)
+        for entry in other.entries:
+            out.increment(entry.key, entry.value)
+        return out
+
+    def minus(self, other: Counter[T]) -> Counter[T]:
+        """
+        Subtract counts from another counter.
+
+        Args:
+            other: Counter whose counts should be subtracted.
+
+        Returns:
+            A new counter containing only positive count-wise results.
+        """
+        mut out = Counter(entries=[])
+        for entry in self.entries:
+            remaining = entry.value - other.get(entry.key)
+            if remaining > 0:
+                out.set(entry.key, remaining)
+        return out
+
+    def index_of(self, key: T) -> int:
+        return _entry_index(self.entries, key)
+
+
+pub model DefaultDict[K with (Clone, Eq), V with Clone]:
+    """
+    Mapping that materializes missing keys.
+
+    A `DefaultDict` can use a stored default value or a zero-argument factory. Indexing a missing key creates and
+    stores a value; `get()` inspects only already materialized keys.
+
+    Example:
+
+    ```incan
+    counts = DefaultDict.with_default(0)
+    counts["apple"] = counts["apple"] + 1
+    println(counts["apple"])  # 1
+    ```
+    """
+
+    pub entries: list[_MapEntry[K, V]] = []
+    pub default_value: Option[V] = None
+    pub default_factory: Option[() -> V] = None
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create an empty default dict with no configured default.
+
+        Returns:
+            A default dict that raises on missing-key materialization.
+        """
+        return DefaultDict(entries=[], default_value=None, default_factory=None)
+
+    @staticmethod
+    def with_default(value: V) -> Self:
+        """
+        Create a default dict from a stored default value.
+
+        Args:
+            value: Value copied into each newly materialized key.
+
+        Returns:
+            An empty default dict configured with `value`.
+        """
+        return DefaultDict(entries=[], default_value=Some(value), default_factory=None)
+
+    @staticmethod
+    def with_factory(factory: () -> V) -> Self:
+        """
+        Create a default dict from a default factory.
+
+        Args:
+            factory: Zero-argument function called for each newly materialized key.
+
+        Returns:
+            An empty default dict configured with `factory`.
+        """
+        return DefaultDict(entries=[], default_value=None, default_factory=Some(factory))
+
+    def __len__(self) -> int:
+        """
+        Return the number of materialized keys.
+
+        Returns:
+            The number of keys currently stored.
+        """
+        return len(self.entries)
+
+    def __iter__(self) -> list[K]:
+        """
+        Iterate over materialized keys.
+
+        Returns:
+            Keys in insertion order.
+        """
+        return self.keys()
+
+    def __contains__(self, key: K) -> bool:
+        """
+        Check whether a key is already materialized.
+
+        Args:
+            key: Key to search for.
+
+        Returns:
+            `true` when the key is currently stored.
+        """
+        return self.index_of(key) >= 0
+
+    def __getitem__(mut self, key: K) -> V:
+        """
+        Return a value, materializing the key when needed.
+
+        Args:
+            key: Key to read or create.
+
+        Returns:
+            The stored value for `key`.
+        """
+        index = self.index_of(key)
+        if index >= 0:
+            return self.entries[index].value
+        value: V = self.make_default()
+        self.entries.append(_MapEntry(key=key.clone(), value=value.clone()))
+        return self.entries[len(self.entries) - 1].value
+
+    def __setitem__(mut self, key: K, value: V) -> None:
+        """
+        Insert or replace a key.
+
+        Args:
+            key: Key to write.
+            value: Value to store.
+        """
+        self.set(key, value)
+
+    def get(self, key: K) -> Option[V]:
+        """
+        Inspect a materialized key without creating a default.
+
+        Args:
+            key: Key to look up.
+
+        Returns:
+            `Some(value)` when the key is stored; otherwise `None`.
+        """
+        index = self.index_of(key)
+        if index < 0:
+            return None
+        return Some(self.entries[index].value)
+
+    def set(mut self, key: K, value: V) -> None:
+        """
+        Insert or replace a key.
+
+        Args:
+            key: Key to write.
+            value: Value to store.
+        """
+        index = self.index_of(key)
+        if index >= 0:
+            self.entries[index] = _MapEntry(key=key, value=value)
+        else:
+            self.entries.append(_MapEntry(key=key, value=value))
+
+    def keys(self) -> list[K]:
+        """
+        Return materialized keys.
+
+        Returns:
+            Keys in insertion order.
+        """
+        return _entry_keys(self.entries)
+
+    def values(self) -> list[V]:
+        """
+        Return materialized values.
+
+        Returns:
+            Values in key insertion order.
+        """
+        return _entry_values(self.entries)
+
+    def items(self) -> list[Tuple[K, V]]:
+        """
+        Return materialized items.
+
+        Returns:
+            `(key, value)` pairs in insertion order.
+        """
+        return _entry_items(self.entries)
+
+    def make_default(self) -> V:
+        match self.default_factory:
+            Some(factory) => return factory()
+            None => pass
+        match self.default_value:
+            Some(value) => return value
+            None => return _missing_value[V]()
+
+    def index_of(self, key: K) -> int:
+        return _entry_index(self.entries, key)
+
+
+@derive(Clone)
+pub model OrderedDict[K with (Clone, Eq), V with Clone]:
+    """
+    Insertion-ordered mapping.
+
+    Updating an existing key replaces its value without moving it. Iteration, `keys()`, `values()`, and `items()` follow
+    first insertion order.
+    """
+
+    pub entries: list[_MapEntry[K, V]] = []
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create an empty ordered dict.
+
+        Returns:
+            An ordered dict with no keys.
+        """
+        return OrderedDict(entries=[])
+
+    @staticmethod
+    def from_items(items: list[Tuple[K, V]]) -> Self:
+        """
+        Create an ordered dict from pairs.
+
+        Args:
+            items: `(key, value)` pairs to insert in order.
+
+        Returns:
+            An ordered dict containing the pairs. Later duplicate keys replace earlier values without moving the key.
+        """
+        mut out = OrderedDict(entries=[])
+        for key, value in items:
+            out.set(key, value)
+        return out
+
+    def __len__(self) -> int:
+        """
+        Return the number of keys.
+
+        Returns:
+            The number of stored keys.
+        """
+        return len(self.entries)
+
+    def __iter__(self) -> list[K]:
+        """
+        Iterate over keys.
+
+        Returns:
+            Keys in insertion order.
+        """
+        return self.keys()
+
+    def __contains__(self, key: K) -> bool:
+        """
+        Check whether a key is present.
+
+        Args:
+            key: Key to search for.
+
+        Returns:
+            `true` when the key is stored.
+        """
+        return self.index_of(key) >= 0
+
+    def __getitem__(self, key: K) -> V:
+        """
+        Return a value by key.
+
+        Args:
+            key: Key to look up.
+
+        Returns:
+            The stored value for `key`.
+        """
+        index = self.index_of(key)
+        if index < 0:
+            return _missing_value[V]()
+        return self.entries[index].value
+
+    def __setitem__(mut self, key: K, value: V) -> None:
+        """
+        Insert or replace a key.
+
+        Args:
+            key: Key to write.
+            value: Value to store.
+        """
+        self.set(key, value)
+
+    def set(mut self, key: K, value: V) -> None:
+        """
+        Insert or replace a key without moving existing keys.
+
+        Args:
+            key: Key to write.
+            value: Value to store.
+        """
+        index = self.index_of(key)
+        if index >= 0:
+            self.entries[index] = _MapEntry(key=key, value=value)
+        else:
+            self.entries.append(_MapEntry(key=key, value=value))
+
+    def get(self, key: K) -> Option[V]:
+        """
+        Look up a key without raising on absence.
+
+        Args:
+            key: Key to look up.
+
+        Returns:
+            `Some(value)` when the key is stored; otherwise `None`.
+        """
+        index = self.index_of(key)
+        if index < 0:
+            return None
+        return Some(self.entries[index].value)
+
+    def remove(mut self, key: K) -> V:
+        """
+        Remove a key and return its value.
+
+        Args:
+            key: Key to remove.
+
+        Returns:
+            The removed value.
+        """
+        index = self.index_of(key)
+        if index < 0:
+            return _missing_value[V]()
+        value = self.entries[index].value
+        self.entries.remove(index)
+        return value
+
+    def keys(self) -> list[K]:
+        """
+        Return stored keys.
+
+        Returns:
+            Keys in insertion order.
+        """
+        return _entry_keys(self.entries)
+
+    def values(self) -> list[V]:
+        """
+        Return stored values.
+
+        Returns:
+            Values in key insertion order.
+        """
+        return _entry_values(self.entries)
+
+    def items(self) -> list[Tuple[K, V]]:
+        """
+        Return stored items.
+
+        Returns:
+            `(key, value)` pairs in insertion order.
+        """
+        return _entry_items(self.entries)
+
+    def index_of(self, key: K) -> int:
+        return _entry_index(self.entries, key)
+
+
+@derive(Clone)
+pub model OrderedSet[T with (Clone, Eq)]:
+    """
+    Insertion-ordered set.
+
+    Reinserting an existing value does not duplicate or move it. Iteration follows the order in which values were first
+    added.
+    """
+
+    pub items: list[T] = []
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create an empty ordered set.
+
+        Returns:
+            An ordered set with no values.
+        """
+        return OrderedSet(items=[])
+
+    @staticmethod
+    def from_iter(items: list[T]) -> Self:
+        """
+        Create an ordered set from a list.
+
+        Args:
+            items: Values to insert in order.
+
+        Returns:
+            An ordered set containing the first occurrence of each value.
+        """
+        mut out = OrderedSet(items=[])
+        for item in items:
+            out.add(item)
+        return out
+
+    def __len__(self) -> int:
+        """
+        Return the number of values.
+
+        Returns:
+            The number of stored values.
+        """
+        return len(self.items)
+
+    def __iter__(self) -> list[T]:
+        """
+        Iterate over stored values.
+
+        Returns:
+            Values in insertion order.
+        """
+        return self.items
+
+    def __contains__(self, value: T) -> bool:
+        """
+        Check whether a value is present.
+
+        Args:
+            value: Value to search for.
+
+        Returns:
+            `true` when the value is stored.
+        """
+        return self.contains(value)
+
+    def add(mut self, value: T) -> None:
+        """
+        Insert a value if it is absent.
+
+        Args:
+            value: Value to add.
+        """
+        if not self.contains(value):
+            self.items.append(value)
+
+    def remove(mut self, value: T) -> None:
+        """
+        Remove a value when present.
+
+        Args:
+            value: Value to remove.
+        """
+        index = self.index_of(value)
+        if index >= 0:
+            self.items.remove(index)
+
+    def contains(self, value: T) -> bool:
+        """
+        Check whether a value is present.
+
+        Args:
+            value: Value to search for.
+
+        Returns:
+            `true` when the value is stored.
+        """
+        return self.index_of(value) >= 0
+
+    def to_list(self) -> list[T]:
+        """
+        Return the set as a list.
+
+        Returns:
+            Values in insertion order.
+        """
+        return self.items
+
+    def index_of(self, value: T) -> int:
+        return _value_index(self.items, value)
+
+
+@derive(Clone)
+pub model SortedDict[K with (Clone, Ord), V with Clone]:
+    """
+    Key-sorted mapping.
+
+    Keys must implement `Ord`. Iteration, `keys()`, `values()`, and `items()` use sorted-key order rather than insertion
+    order.
+    """
+
+    pub entries: list[_MapEntry[K, V]] = []
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create an empty sorted dict.
+
+        Returns:
+            A sorted dict with no keys.
+        """
+        return SortedDict(entries=[])
+
+    @staticmethod
+    def from_items(items: list[Tuple[K, V]]) -> Self:
+        """
+        Create a sorted dict from pairs.
+
+        Args:
+            items: `(key, value)` pairs to insert.
+
+        Returns:
+            A sorted dict containing the pairs in sorted-key order.
+        """
+        mut out = SortedDict(entries=[])
+        for key, value in items:
+            out.set(key, value)
+        return out
+
+    def __len__(self) -> int:
+        """
+        Return the number of keys.
+
+        Returns:
+            The number of stored keys.
+        """
+        return len(self.entries)
+
+    def __iter__(self) -> list[K]:
+        """
+        Iterate over keys.
+
+        Returns:
+            Keys in sorted order.
+        """
+        return self.keys()
+
+    def __contains__(self, key: K) -> bool:
+        """
+        Check whether a key is present.
+
+        Args:
+            key: Key to search for.
+
+        Returns:
+            `true` when the key is stored.
+        """
+        return self.index_of(key) >= 0
+
+    def __getitem__(self, key: K) -> V:
+        """
+        Return a value by key.
+
+        Args:
+            key: Key to look up.
+
+        Returns:
+            The stored value for `key`.
+        """
+        index = self.index_of(key)
+        if index < 0:
+            return _missing_value[V]()
+        return self.entries[index].value
+
+    def __setitem__(mut self, key: K, value: V) -> None:
+        """
+        Insert or replace a key.
+
+        Args:
+            key: Key to write.
+            value: Value to store.
+        """
+        self.set(key, value)
+
+    def set(mut self, key: K, value: V) -> None:
+        """
+        Insert or replace a key while preserving sorted-key order.
+
+        Args:
+            key: Key to write.
+            value: Value to store.
+        """
+        index = self.index_of(key)
+        if index >= 0:
+            self.entries[index] = _MapEntry(key=key, value=value)
+            return
+        self.entries.append(_MapEntry(key=key, value=value))
+        self.bubble_entry_left(len(self.entries) - 1)
+
+    def get(self, key: K) -> Option[V]:
+        """
+        Look up a key without raising on absence.
+
+        Args:
+            key: Key to look up.
+
+        Returns:
+            `Some(value)` when the key is stored; otherwise `None`.
+        """
+        index = self.index_of(key)
+        if index < 0:
+            return None
+        return Some(self.entries[index].value)
+
+    def remove(mut self, key: K) -> V:
+        """
+        Remove a key and return its value.
+
+        Args:
+            key: Key to remove.
+
+        Returns:
+            The removed value.
+        """
+        index = self.index_of(key)
+        if index < 0:
+            return _missing_value[V]()
+        value = self.entries[index].value
+        self.entries.remove(index)
+        return value
+
+    def keys(self) -> list[K]:
+        """
+        Return stored keys.
+
+        Returns:
+            Keys in sorted order.
+        """
+        return _entry_keys(self.entries)
+
+    def values(self) -> list[V]:
+        """
+        Return stored values.
+
+        Returns:
+            Values in sorted-key order.
+        """
+        return _entry_values(self.entries)
+
+    def items(self) -> list[Tuple[K, V]]:
+        """
+        Return stored items.
+
+        Returns:
+            `(key, value)` pairs in sorted-key order.
+        """
+        return _entry_items(self.entries)
+
+    def range_keys(self, start: K, end: K) -> list[K]:
+        """
+        Return keys in a half-open range.
+
+        Args:
+            start: Inclusive lower bound.
+            end: Exclusive upper bound.
+
+        Returns:
+            Keys where `start <= key < end`, in sorted order.
+        """
+        return _entry_range_keys(self.entries, start, end)
+
+    def range_items(self, start: K, end: K) -> list[Tuple[K, V]]:
+        """
+        Return items in a half-open key range.
+
+        Args:
+            start: Inclusive lower bound.
+            end: Exclusive upper bound.
+
+        Returns:
+            `(key, value)` pairs where `start <= key < end`, in sorted-key order.
+        """
+        return _entry_range_items(self.entries, start, end)
+
+    def index_of(self, key: K) -> int:
+        for index in range(len(self.entries)):
+            if self.entries[index].key == key:
+                return index
+        return -1
+
+    def bubble_entry_left(mut self, start: int) -> None:
+        mut index = start
+        while index > 0 and self.entries[index].key < self.entries[index - 1].key:
+            self.entries.swap(index, index - 1)
+            index -= 1
+
+
+@derive(Clone)
+pub model SortedSet[T with (Clone, Ord)]:
+    """
+    Value-sorted set.
+
+    Values must implement `Ord`. Iteration and `to_list()` return values in sorted order.
+    """
+
+    pub items: list[T] = []
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create an empty sorted set.
+
+        Returns:
+            A sorted set with no values.
+        """
+        return SortedSet(items=[])
+
+    @staticmethod
+    def from_iter(items: list[T]) -> Self:
+        """
+        Create a sorted set from a list.
+
+        Args:
+            items: Values to insert.
+
+        Returns:
+            A sorted set containing unique values in sorted order.
+        """
+        mut out = SortedSet(items=[])
+        for item in items:
+            out.add(item)
+        return out
+
+    def __len__(self) -> int:
+        """
+        Return the number of values.
+
+        Returns:
+            The number of stored values.
+        """
+        return len(self.items)
+
+    def __iter__(self) -> list[T]:
+        """
+        Iterate over stored values.
+
+        Returns:
+            Values in sorted order.
+        """
+        return self.items
+
+    def __contains__(self, value: T) -> bool:
+        """
+        Check whether a value is present.
+
+        Args:
+            value: Value to search for.
+
+        Returns:
+            `true` when the value is stored.
+        """
+        return self.contains(value)
+
+    def add(mut self, value: T) -> None:
+        """
+        Insert a value if it is absent.
+
+        Args:
+            value: Value to add while preserving sorted order.
+        """
+        if self.contains(value):
+            return
+        self.items.append(value)
+        self.bubble_value_left(len(self.items) - 1)
+
+    def remove(mut self, value: T) -> None:
+        """
+        Remove a value when present.
+
+        Args:
+            value: Value to remove.
+        """
+        index = self.index_of(value)
+        if index >= 0:
+            self.items.remove(index)
+
+    def contains(self, value: T) -> bool:
+        """
+        Check whether a value is present.
+
+        Args:
+            value: Value to search for.
+
+        Returns:
+            `true` when the value is stored.
+        """
+        return self.index_of(value) >= 0
+
+    def range(self, start: T, end: T) -> list[T]:
+        """
+        Return values in a half-open range.
+
+        Args:
+            start: Inclusive lower bound.
+            end: Exclusive upper bound.
+
+        Returns:
+            Values where `start <= value < end`, in sorted order.
+        """
+        return _value_range(self.items, start, end)
+
+    def to_list(self) -> list[T]:
+        """
+        Return the set as a list.
+
+        Returns:
+            Values in sorted order.
+        """
+        return self.items
+
+    def index_of(self, value: T) -> int:
+        return _value_index(self.items, value)
+
+    def bubble_value_left(mut self, start: int) -> None:
+        mut index = start
+        while index > 0 and self.items[index] < self.items[index - 1]:
+            self.items.swap(index, index - 1)
+            index -= 1
+
+
+@derive(Clone)
+pub model ChainMap[K with (Clone, Eq), V with Clone]:
+    """
+    Layered lookup across ordered mapping layers.
+
+    Earlier layers override later layers. Writes go to the first mapping layer. Model and class values participate by
+    passing their compiler-generated `__field_items__()` snapshot as a read-only field layer.
+    """
+
+    pub layers: list[OrderedDict[K, V]] = []
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create a chain map with one empty mapping layer.
+
+        Returns:
+            A chain map ready for reads and writes.
+        """
+        return ChainMap(layers=[OrderedDict(entries=[])])
+
+    @staticmethod
+    def from_layers(layers: list[OrderedDict[K, V]]) -> Self:
+        """
+        Create a chain map from mapping layers.
+
+        Args:
+            layers: Layers ordered from highest precedence to lowest precedence.
+
+        Returns:
+            A chain map containing `layers`, or one empty layer when `layers` is empty.
+        """
+        if len(layers) == 0:
+            return ChainMap(layers=[OrderedDict(entries=[])])
+        return ChainMap(layers=layers)
+
+    @staticmethod
+    def from_field_layers(layers: list[list[Tuple[K, V]]]) -> Self:
+        """
+        Create a chain map from read-only field overlay layers.
+
+        Args:
+            layers: Field snapshots ordered from highest precedence to lowest precedence.
+
+        Returns:
+            A chain map containing each snapshot as an ordered layer.
+        """
+        return ChainMap.from_layers([OrderedDict.from_items(layer) for layer in layers])
+
+    def __len__(self) -> int:
+        """
+        Return the number of visible keys.
+
+        Returns:
+            The number of distinct keys visible through the chain.
+        """
+        return len(self.keys())
+
+    def __iter__(self) -> list[K]:
+        """
+        Iterate over visible keys.
+
+        Returns:
+            Distinct keys in first-visible-layer order.
+        """
+        return self.keys()
+
+    def __contains__(self, key: K) -> bool:
+        """
+        Check whether a key appears in any layer.
+
+        Args:
+            key: Key to search for.
+
+        Returns:
+            `true` when any layer contains the key.
+        """
+        return self.contains(key)
+
+    def __getitem__(self, key: K) -> V:
+        """
+        Return the first visible value for a key.
+
+        Args:
+            key: Key to look up across layers.
+
+        Returns:
+            The value from the highest-precedence layer containing `key`.
+        """
+        for layer in self.layers:
+            match layer.get(key):
+                Some(value) => return value
+                None => pass
+        return _missing_value[V]()
+
+    def __setitem__(mut self, key: K, value: V) -> None:
+        """
+        Write a key to the highest-precedence mapping layer.
+
+        Args:
+            key: Key to write.
+            value: Value to store.
+        """
+        self.set(key, value)
+
+    def set(mut self, key: K, value: V) -> None:
+        """
+        Write a key to the highest-precedence mapping layer.
+
+        Args:
+            key: Key to write.
+            value: Value to store.
+        """
+        if len(self.layers) == 0:
+            empty: OrderedDict[K, V] = OrderedDict(entries=[])
+            self.layers.append(empty.clone())
+        mut layer = self.layers[0]
+        layer.set(key, value)
+        self.layers[0] = layer
+
+    def push_layer(mut self, layer: OrderedDict[K, V]) -> None:
+        """
+        Add a highest-precedence layer.
+
+        Args:
+            layer: Mapping layer to place before all existing layers.
+        """
+        self.layers.append(layer)
+        mut index = len(self.layers) - 1
+        while index > 0:
+            self.layers.swap(index, index - 1)
+            index -= 1
+
+    def push_field_layer(mut self, layer: list[Tuple[K, V]]) -> None:
+        """
+        Add a highest-precedence field overlay layer.
+
+        Args:
+            layer: Field snapshot such as `value.__field_items__()`.
+        """
+        self.push_layer(OrderedDict.from_items(layer))
+
+    def pop_layer(mut self) -> OrderedDict[K, V]:
+        """
+        Remove and return the highest-precedence layer.
+
+        Returns:
+            The removed layer, or an empty ordered dict when the chain has no layers.
+        """
+        if len(self.layers) == 0:
+            return OrderedDict(entries=[])
+        layer = self.layers[0]
+        self.layers.remove(0)
+        return layer
+
+    def contains(self, key: K) -> bool:
+        """
+        Check whether a key appears in any layer.
+
+        Args:
+            key: Key to search for.
+
+        Returns:
+            `true` when any layer contains the key.
+        """
+        for layer in self.layers:
+            if key in layer:
+                return True
+        return False
+
+    def keys(self) -> list[K]:
+        """
+        Return visible keys.
+
+        Returns:
+            Distinct keys in first-visible-layer order.
+        """
+        return _chain_keys(self.layers)
+
+    def items(self) -> list[Tuple[K, V]]:
+        """
+        Return visible items.
+
+        Returns:
+            Distinct `(key, value)` pairs in first-visible-layer order.
+        """
+        return _chain_items(self.layers)
+
+
+@derive(Clone)
+pub model PriorityQueue[T with (Clone, Ord)]:
+    """
+    Priority queue with a construction-time ordering policy.
+
+    `PriorityQueue()` uses `PriorityOrder.MinFirst`. Use `max_first()` or `with_order(PriorityOrder.MaxFirst)` when the
+    largest value should be popped first.
+    """
+
+    pub items: list[T] = []
+    pub order: PriorityOrder = PriorityOrder.MinFirst
+
+    @staticmethod
+    def __incan_new() -> Self:
+        """
+        Create an empty min-first priority queue.
+
+        Returns:
+            A priority queue that pops the smallest value first.
+        """
+        return PriorityQueue(items=[], order=PriorityOrder.MinFirst)
+
+    @staticmethod
+    def with_order(order: PriorityOrder) -> Self:
+        """
+        Create an empty priority queue with an explicit ordering policy.
+
+        Args:
+            order: Ordering policy used for future `push()` and `pop()` operations.
+
+        Returns:
+            An empty priority queue.
+        """
+        return PriorityQueue(items=[], order=order)
+
+    @staticmethod
+    def max_first() -> Self:
+        """
+        Create an empty max-first priority queue.
+
+        Returns:
+            A priority queue that pops the largest value first.
+        """
+        return PriorityQueue(items=[], order=PriorityOrder.MaxFirst)
+
+    @staticmethod
+    def from_iter(items: list[T], order: PriorityOrder = PriorityOrder.MinFirst) -> Self:
+        """
+        Create a priority queue from a list.
+
+        Args:
+            items: Values to enqueue.
+            order: Ordering policy used to arrange values.
+
+        Returns:
+            A priority queue containing `items` in pop order.
+        """
+        mut out = PriorityQueue(items=[], order=order)
+        for item in items:
+            out.push(item)
+        return out
+
+    def __len__(self) -> int:
+        """
+        Return the number of queued values.
+
+        Returns:
+            The current queue length.
+        """
+        return len(self.items)
+
+    def __iter__(self) -> list[T]:
+        """
+        Iterate over queued values without consuming the queue.
+
+        Returns:
+            Values in pop order.
+        """
+        return self.items
+
+    def push(mut self, value: T) -> None:
+        """
+        Insert a value according to the queue ordering policy.
+
+        Args:
+            value: Value to enqueue.
+        """
+        self.items.append(value)
+        self.bubble_value_left(len(self.items) - 1)
+
+    def pop(mut self) -> T:
+        """
+        Remove and return the next priority value.
+
+        Returns:
+            The smallest or largest queued value, depending on the queue order.
+        """
+        value = self.items[0]
+        self.items.remove(0)
+        return value
+
+    def peek(self) -> Option[T]:
+        """
+        Inspect the next priority value without removing it.
+
+        Returns:
+            `Some(value)` for the next value, or `None` when the queue is empty.
+        """
+        if len(self.items) == 0:
+            return None
+        return Some(self.items[0])
+
+    def is_empty(self) -> bool:
+        """
+        Check whether the queue is empty.
+
+        Returns:
+            `true` when no values are queued.
+        """
+        return len(self.items) == 0
+
+    def to_list(self) -> list[T]:
+        """
+        Return queued values as a list.
+
+        Returns:
+            Values in pop order.
+        """
+        return self.items
+
+    def bubble_value_left(mut self, start: int) -> None:
+        mut index = start
+        while index > 0 and self.higher_priority(self.items[index], self.items[index - 1]):
+            self.items.swap(index, index - 1)
+            index -= 1
+
+    def higher_priority(self, left: T, right: T) -> bool:
+        match self.order:
+            PriorityOrder.MinFirst => return left < right
+            PriorityOrder.MaxFirst => return right < left
+
+
+def _highest_count_index[T with (Clone, Eq)](entries: list[_MapEntry[T, int]]) -> int:
+    mut best_index = 0
+    mut best_count = entries[0].value
+    for index in range(len(entries)):
+        if entries[index].value > best_count:
+            best_count = entries[index].value
+            best_index = index
+    return best_index
+
+
+def _counter_elements[T with (Clone, Eq)](entries: list[_MapEntry[T, int]]) -> list[T]:
+    mut out: list[T] = []
+    for entry in entries:
+        for _ in range(entry.value):
+            out.append(entry.key)
+    return out
+
+
+def _counter_most_common[T with (Clone, Eq)](source: list[_MapEntry[T, int]], n: int) -> list[Tuple[T, int]]:
+    mut entries: list[_MapEntry[T, int]] = source
+    mut out: list[Tuple[T, int]] = []
+    while len(entries) > 0 and (n < 0 or len(out) < n):
+        mut best_index = 0
+        mut best_count = entries[0].value
+        for index in range(len(entries)):
+            if entries[index].value > best_count:
+                best_count = entries[index].value
+                best_index = index
+        best = entries[best_index]
+        entries.remove(best_index)
+        out.append((best.key, best.value))
+    return out
+
+
+def _entry_index[K with (Clone, Eq), V with Clone](entries: list[_MapEntry[K, V]], key: K) -> int:
+    for index in range(len(entries)):
+        if entries[index].key == key:
+            return index
+    return -1
+
+
+def _entry_keys[K with Clone, V with Clone](entries: list[_MapEntry[K, V]]) -> list[K]:
+    mut out: list[K] = []
+    for entry in entries:
+        out.append(entry.key)
+    return out
+
+
+def _entry_values[K with Clone, V with Clone](entries: list[_MapEntry[K, V]]) -> list[V]:
+    mut out: list[V] = []
+    for entry in entries:
+        out.append(entry.value)
+    return out
+
+
+def _entry_items[K with Clone, V with Clone](entries: list[_MapEntry[K, V]]) -> list[Tuple[K, V]]:
+    mut out: list[Tuple[K, V]] = []
+    for entry in entries:
+        out.append((entry.key, entry.value))
+    return out
+
+
+def _entry_range_keys[K with (Clone, Ord), V with Clone](entries: list[_MapEntry[K, V]], start: K, end: K) -> list[K]:
+    mut out: list[K] = []
+    for entry in entries:
+        if entry.key >= start and entry.key < end:
+            out.append(entry.key)
+    return out
+
+
+def _entry_range_items[K with (Clone, Ord), V with Clone](
+    entries: list[_MapEntry[K, V]],
+    start: K,
+    end: K,
+) -> list[Tuple[K, V]]:
+    mut out: list[Tuple[K, V]] = []
+    for entry in entries:
+        if entry.key >= start and entry.key < end:
+            out.append((entry.key, entry.value))
+    return out
+
+
+def _value_index[T with (Clone, Eq)](items: list[T], value: T) -> int:
+    for index in range(len(items)):
+        if items[index] == value:
+            return index
+    return -1
+
+
+def _contains_value[T with (Clone, Eq)](items: list[T], value: T) -> bool:
+    for item in items:
+        if item.clone() == value:
+            return True
+    return False
+
+
+def _value_range[T with (Clone, Ord)](items: list[T], start: T, end: T) -> list[T]:
+    mut out: list[T] = []
+    for item in items:
+        value: T = item.clone()
+        if value >= start and value < end:
+            out.append(value)
+    return out
+
+
+def _chain_keys[K with (Clone, Eq), V with Clone](layers: list[OrderedDict[K, V]]) -> list[K]:
+    mut out: list[K] = []
+    for layer in layers:
+        for entry in layer.entries:
+            key: K = entry.key
+            mut seen = False
+            for existing in out:
+                if existing.clone() == key:
+                    seen = True
+            if not seen:
+                out.append(key.clone())
+    return out
+
+
+def _chain_items[K with (Clone, Eq), V with Clone](layers: list[OrderedDict[K, V]]) -> list[Tuple[K, V]]:
+    mut out: list[Tuple[K, V]] = []
+    mut visible: list[K] = []
+    for layer in layers:
+        for entry in layer.entries:
+            key: K = entry.key
+            mut seen = False
+            for existing in visible:
+                if existing.clone() == key:
+                    seen = True
+            if not seen:
+                visible.append(key.clone())
+    for key in visible:
+        for layer in layers:
+            match layer.get(key):
+                Some(value) =>
+                    pair: Tuple[K, V] = (key.clone(), value.clone())
+                    out.append(pair)
+                    break
+                None => pass
+    return out
+
+
+def _missing_value[T with Clone]() -> T:
+    missing: list[T] = []
+    return missing[0]
+
+
+def _runtime_error(message: str) -> None:
+    _ = message
+    missing: list[int] = []
+    missing[0]

--- a/src/backend/ir/emit/decls/impls.rs
+++ b/src/backend/ir/emit/decls/impls.rs
@@ -5,12 +5,13 @@
 
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
+use std::collections::HashSet;
 
 use incan_core::lang::conventions;
 use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::magic_methods;
 
-use super::super::super::types::IrType;
+use super::super::super::types::{IR_UNION_TYPE_NAME, IrType};
 use super::super::{EmitError, IrEmitter};
 
 impl<'a> IrEmitter<'a> {
@@ -201,6 +202,8 @@ impl<'a> IrEmitter<'a> {
                                 | magic_methods::MagicMethodId::Str
                                 | magic_methods::MagicMethodId::ClassName
                                 | magic_methods::MagicMethodId::Fields
+                                | magic_methods::MagicMethodId::FieldValue
+                                | magic_methods::MagicMethodId::FieldItems
                         )
                     )
                 })
@@ -274,6 +277,45 @@ impl<'a> IrEmitter<'a> {
         )
     }
 
+    /// Emit compiler-generated field overlay methods for a struct, independent of source impl blocks.
+    pub(in crate::backend::ir::emit) fn emit_field_overlay_methods_for_struct(
+        &self,
+        strukt: &super::super::super::decl::IrStruct,
+        explicit_method_names: &HashSet<String>,
+    ) -> Result<Option<TokenStream>, EmitError> {
+        let field_value_name = magic_methods::as_str(magic_methods::MagicMethodId::FieldValue);
+        let field_items_name = magic_methods::as_str(magic_methods::MagicMethodId::FieldItems);
+        let mut methods = Vec::new();
+        let used_methods = &self.generated_use_analysis.borrow().used_methods;
+
+        if !explicit_method_names.contains(field_value_name)
+            && used_methods.contains(&(strukt.name.clone(), field_value_name.to_string()))
+            && let Some(field_value_method) = self.emit_field_value_method(&strukt.name)?
+        {
+            methods.push(field_value_method);
+        }
+
+        if !explicit_method_names.contains(field_items_name)
+            && used_methods.contains(&(strukt.name.clone(), field_items_name.to_string()))
+            && let Some(field_items_method) = self.emit_field_items_method(&strukt.name)?
+        {
+            methods.push(field_items_method);
+        }
+
+        if methods.is_empty() {
+            return Ok(None);
+        }
+
+        let target_type = Self::rust_ident(&strukt.name);
+        let generics = self.emit_type_params(&strukt.type_params);
+        let generics_bare = self.emit_type_params_bare(&strukt.type_params);
+        Ok(Some(quote! {
+            impl #generics #target_type #generics_bare {
+                #(#methods)*
+            }
+        }))
+    }
+
     /// Emit the generated `__fields__` reflection method for a struct when field metadata is available.
     fn emit_fields_method(&self, struct_name: &str) -> Result<Option<TokenStream>, EmitError> {
         let Some(field_names) = self.struct_field_names.get(struct_name) else {
@@ -324,6 +366,134 @@ impl<'a> IrEmitter<'a> {
             pub fn __fields__(&self) -> incan_stdlib::frozen::FrozenList<incan_stdlib::reflection::FieldInfo> {
                 static __INCAN_FIELDS: [incan_stdlib::reflection::FieldInfo; #field_count] = [#(#field_infos),*];
                 incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+            }
+        }))
+    }
+
+    /// Resolve the Rust value type shared by generated field overlay methods for a lowered struct.
+    ///
+    /// The generated `__field_value__()` and `__field_items__()` methods expose a single value slot type. Homogeneous
+    /// fields use their common type directly; heterogeneous concrete fields use an anonymous union. Generic field
+    /// shapes are skipped because anonymous union definitions are monomorphic today.
+    fn field_overlay_value_type_for_struct(&self, struct_name: &str) -> Result<Option<IrType>, EmitError> {
+        let Some(field_names) = self.struct_field_names.get(struct_name) else {
+            return Ok(None);
+        };
+        let mut value_types = Vec::new();
+        for field_name in field_names {
+            let key = (struct_name.to_string(), field_name.clone());
+            let ty = self.struct_field_types.get(&key).ok_or_else(|| {
+                EmitError::Unsupported(format!(
+                    "missing field type metadata for '{}.{}'",
+                    struct_name, field_name
+                ))
+            })?;
+            if ty.contains_generic_parameter() {
+                return Ok(None);
+            }
+            value_types.push(ty.clone());
+        }
+        if value_types.is_empty() {
+            return Ok(Some(IrType::Unit));
+        }
+        value_types.sort_by_key(IrType::rust_name);
+        value_types.dedup();
+        if value_types.len() == 1 {
+            Ok(value_types.pop())
+        } else {
+            Ok(Some(IrType::NamedGeneric(IR_UNION_TYPE_NAME.to_string(), value_types)))
+        }
+    }
+
+    /// Emit the Rust expression that converts one struct field into the overlay value slot type.
+    ///
+    /// Heterogeneous overlays wrap cloned field values in the generated union variant that corresponds to the field's
+    /// concrete type. Homogeneous overlays can clone the field value directly.
+    fn field_overlay_value_expr(&self, value_ty: &IrType, field_ty: &IrType, field_name: &str) -> TokenStream {
+        let field_ident = format_ident!("{}", field_name);
+        if value_ty.is_union()
+            && let Some(variant_index) = value_ty.union_variant_index_for_member(field_ty)
+        {
+            let variant_ident = format_ident!("{}", IrType::union_variant_name(variant_index));
+            let union_path = self.emit_union_type_path(value_ty);
+            return quote! { #union_path :: #variant_ident(self.#field_ident.clone()) };
+        }
+        quote! { self.#field_ident.clone() }
+    }
+
+    /// Emit the compiler-provided `__field_value__` method for a concrete model or class struct.
+    ///
+    /// The method accepts canonical field names and model aliases, returning `None` for unknown names. It is omitted
+    /// when field metadata is missing or when the field value shape cannot be represented as a concrete Rust type.
+    fn emit_field_value_method(&self, struct_name: &str) -> Result<Option<TokenStream>, EmitError> {
+        let Some(field_names) = self.struct_field_names.get(struct_name) else {
+            return Ok(None);
+        };
+        let Some(value_ty) = self.field_overlay_value_type_for_struct(struct_name)? else {
+            return Ok(None);
+        };
+        let value_ty_tokens = self.emit_type(&value_ty);
+        let mut arms = Vec::new();
+        for field_name in field_names {
+            let key = (struct_name.to_string(), field_name.clone());
+            let field_ty = self.struct_field_types.get(&key).ok_or_else(|| {
+                EmitError::Unsupported(format!(
+                    "missing field type metadata for '{}.{}'",
+                    struct_name, field_name
+                ))
+            })?;
+            let value = self.field_overlay_value_expr(&value_ty, field_ty, field_name);
+            let mut keys = vec![field_name.clone()];
+            if let Some(Some(alias)) = self.struct_field_aliases.get(&key)
+                && alias != field_name
+            {
+                keys.push(alias.clone());
+            }
+            for lookup_key in keys {
+                arms.push(quote! { #lookup_key => Some(#value) });
+            }
+        }
+
+        Ok(Some(quote! {
+            /// Return a public field value by canonical field name or model alias.
+            pub fn __field_value__(&self, name: String) -> Option<#value_ty_tokens> {
+                match name.as_str() {
+                    #(#arms,)*
+                    _ => None,
+                }
+            }
+        }))
+    }
+
+    /// Emit the compiler-provided `__field_items__` method for a concrete model or class struct.
+    ///
+    /// The returned vector preserves lowered field order, including inherited class fields that lowering already
+    /// prepended before child fields.
+    fn emit_field_items_method(&self, struct_name: &str) -> Result<Option<TokenStream>, EmitError> {
+        let Some(field_names) = self.struct_field_names.get(struct_name) else {
+            return Ok(None);
+        };
+        let Some(value_ty) = self.field_overlay_value_type_for_struct(struct_name)? else {
+            return Ok(None);
+        };
+        let value_ty_tokens = self.emit_type(&value_ty);
+        let mut items = Vec::new();
+        for field_name in field_names {
+            let key = (struct_name.to_string(), field_name.clone());
+            let field_ty = self.struct_field_types.get(&key).ok_or_else(|| {
+                EmitError::Unsupported(format!(
+                    "missing field type metadata for '{}.{}'",
+                    struct_name, field_name
+                ))
+            })?;
+            let value = self.field_overlay_value_expr(&value_ty, field_ty, field_name);
+            items.push(quote! { (#field_name.to_string(), #value) });
+        }
+
+        Ok(Some(quote! {
+            /// Return public field name/value pairs in declaration order.
+            pub fn __field_items__(&self) -> Vec<(String, #value_ty_tokens)> {
+                vec![#(#items),*]
             }
         }))
     }

--- a/src/backend/ir/emit/mod.rs
+++ b/src/backend/ir/emit/mod.rs
@@ -101,6 +101,8 @@ pub struct IrEmitter<'a> {
     enum_variant_fields: std::collections::HashMap<(String, String), VariantFields>,
     /// Struct field type lookup: (StructName, FieldName) -> IrType
     struct_field_types: std::collections::HashMap<(String, String), IrType>,
+    /// Struct field visibility lookup: (StructName, FieldName) -> Visibility
+    struct_field_visibilities: std::collections::HashMap<(String, String), Visibility>,
     /// Struct field name order (as declared): StructName -> [FieldName...]
     struct_field_names: std::collections::HashMap<String, Vec<String>>,
     /// Struct field alias lookup: (StructName, FieldName) -> alias
@@ -202,6 +204,7 @@ impl<'a> IrEmitter<'a> {
             external_rust_functions: std::collections::HashSet::new(),
             enum_variant_fields: std::collections::HashMap::new(),
             struct_field_types: std::collections::HashMap::new(),
+            struct_field_visibilities: std::collections::HashMap::new(),
             struct_field_names: std::collections::HashMap::new(),
             struct_field_aliases: std::collections::HashMap::new(),
             struct_field_descriptions: std::collections::HashMap::new(),

--- a/src/backend/ir/emit/program.rs
+++ b/src/backend/ir/emit/program.rs
@@ -30,7 +30,7 @@ use super::super::decl::{
 };
 use super::super::expr::{IrDictEntry, IrExprKind, IrGeneratorClause, IrListEntry, MethodKind, Pattern, VarRefKind};
 use super::super::stmt::AssignTarget;
-use super::super::types::IrType;
+use super::super::types::{IR_UNION_TYPE_NAME, IrType};
 use super::super::{FunctionRegistry, FunctionSignature, IrDecl, IrProgram, IrStmt, IrStmtKind, TypedExpr};
 use super::{EmitError, GeneratedUseAnalysis, IrEmitter};
 
@@ -1158,6 +1158,28 @@ impl<'program> GeneratedUseAnalyzer<'program> {
 }
 
 impl<'a> IrEmitter<'a> {
+    /// Return the anonymous union shape needed by generated field overlay methods for a concrete struct.
+    ///
+    /// This mirrors `emit_field_overlay_methods_for_struct()` so the crate-level union definitions are available
+    /// before generated impls are emitted. Generic field shapes are skipped because anonymous union definitions are
+    /// currently monomorphic.
+    fn field_overlay_value_type_from_struct(strukt: &super::super::decl::IrStruct) -> Option<IrType> {
+        let mut value_types: Vec<IrType> = strukt.fields.iter().map(|field| field.ty.clone()).collect();
+        if value_types.iter().any(IrType::contains_generic_parameter) {
+            return None;
+        }
+        if value_types.is_empty() {
+            return None;
+        }
+        value_types.sort_by_key(IrType::rust_name);
+        value_types.dedup();
+        if value_types.len() == 1 {
+            value_types.pop()
+        } else {
+            Some(IrType::NamedGeneric(IR_UNION_TYPE_NAME.to_string(), value_types))
+        }
+    }
+
     /// Collect anonymous union shapes that appear inside a type.
     fn collect_union_types_from_type(ty: &IrType, out: &mut HashMap<String, IrType>) {
         if let Some(name) = ty.union_type_name() {
@@ -1576,6 +1598,8 @@ impl<'a> IrEmitter<'a> {
                 for field in &s.fields {
                     self.struct_field_types
                         .insert((s.name.clone(), field.name.clone()), field.ty.clone());
+                    self.struct_field_visibilities
+                        .insert((s.name.clone(), field.name.clone()), field.visibility);
                     self.struct_field_aliases
                         .insert((s.name.clone(), field.name.clone()), field.alias.clone());
                     self.struct_field_descriptions
@@ -1696,10 +1720,40 @@ impl<'a> IrEmitter<'a> {
             items.push(quote! { use crate::#std_namespace::traits::error::Error; });
         }
 
+        let mut explicit_methods_by_type: HashMap<String, HashSet<String>> = HashMap::new();
+        for decl in &emitted_declarations {
+            if let IrDeclKind::Impl(impl_block) = &decl.kind
+                && impl_block.trait_name.is_none()
+            {
+                explicit_methods_by_type
+                    .entry(impl_block.target_type.clone())
+                    .or_default()
+                    .extend(impl_block.methods.iter().map(|method| method.name.clone()));
+            }
+        }
+
         if self.emit_generated_union_definitions {
             let mut union_types = self.generated_union_types.clone();
             for decl in &emitted_declarations {
                 Self::collect_union_types_from_decl(decl, &mut union_types);
+            }
+            let field_value_name = magic_methods::as_str(magic_methods::MagicMethodId::FieldValue);
+            let field_items_name = magic_methods::as_str(magic_methods::MagicMethodId::FieldItems);
+            let empty_methods = HashSet::new();
+            let used_methods = &self.generated_use_analysis.borrow().used_methods;
+            for decl in &emitted_declarations {
+                if let IrDeclKind::Struct(strukt) = &decl.kind {
+                    let explicit_methods = explicit_methods_by_type.get(&strukt.name).unwrap_or(&empty_methods);
+                    let needs_field_value = !explicit_methods.contains(field_value_name)
+                        && used_methods.contains(&(strukt.name.clone(), field_value_name.to_string()));
+                    let needs_field_items = !explicit_methods.contains(field_items_name)
+                        && used_methods.contains(&(strukt.name.clone(), field_items_name.to_string()));
+                    if (needs_field_value || needs_field_items)
+                        && let Some(value_ty) = Self::field_overlay_value_type_from_struct(strukt)
+                    {
+                        Self::collect_union_types_from_type(&value_ty, &mut union_types);
+                    }
+                }
             }
             let mut union_type_items: Vec<_> = union_types.into_iter().collect();
             union_type_items.sort_by(|(left, _), (right, _)| left.cmp(right));
@@ -1745,7 +1799,7 @@ impl<'a> IrEmitter<'a> {
 
         // Emit all declarations.
         let mut decl_items = Vec::new();
-        for decl in emitted_declarations {
+        for decl in &emitted_declarations {
             decl_items.push(self.emit_decl(decl)?);
             if let IrDeclKind::Function(func) = &decl.kind {
                 let adapters = self.borrowed_function_adapters.borrow();
@@ -1760,6 +1814,17 @@ impl<'a> IrEmitter<'a> {
                         decl_items.push(helper);
                     }
                 }
+            }
+        }
+        let empty_methods = HashSet::new();
+        for decl in emitted_declarations {
+            if let IrDeclKind::Struct(strukt) = &decl.kind
+                && let Some(overlay_impl) = self.emit_field_overlay_methods_for_struct(
+                    strukt,
+                    explicit_methods_by_type.get(&strukt.name).unwrap_or(&empty_methods),
+                )?
+            {
+                decl_items.push(overlay_impl);
             }
         }
 

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -79,6 +79,22 @@ impl AstLowering {
         }
     }
 
+    /// Return whether a generic type parameter should keep Rust's comparison operators instead of lowering to a
+    /// dunder-style method call.
+    ///
+    /// Generic `T with Ord`/`PartialOrd` bounds lower to Rust trait bounds such as `PartialOrd`; they do not introduce
+    /// inherent `__lt__`/`__le__` methods on `T`. Keeping the operator form lets Rust type-check the generic bound.
+    fn generic_comparison_uses_rust_operator(&self, left: &Spanned<ast::Expr>, method: &str) -> bool {
+        if !matches!(method, "__ne__" | "__lt__" | "__le__" | "__gt__" | "__ge__") {
+            return false;
+        }
+        self.type_info
+            .as_ref()
+            .and_then(|info| info.expr_type(left.span))
+            .map(|ty| self.lower_resolved_type(ty))
+            .is_some_and(|ty| matches!(ty, IrType::Generic(_)))
+    }
+
     /// Lower a control-flow condition, rewriting validated `__bool__` hooks into direct method calls.
     pub(in crate::backend::ir::lower) fn lower_condition_expr(
         &mut self,
@@ -296,6 +312,7 @@ impl AstLowering {
                     && resolved_operator.kind == ResolvedOperatorKind::Binary
                     // `__eq__` is represented in generated Rust as `PartialEq::eq`, not as an inherent method.
                     && resolved_operator.method != magic_methods::as_str(MagicMethodId::Eq)
+                    && !self.generic_comparison_uses_rust_operator(l, &resolved_operator.method)
                 {
                     let receiver = self.lower_expr_spanned(l)?;
                     let arg_expr = self.lower_expr_spanned(r)?;

--- a/src/backend/ir/types.rs
+++ b/src/backend/ir/types.rs
@@ -108,6 +108,28 @@ pub enum IrType {
 }
 
 impl IrType {
+    /// Return whether this type mentions an unbound generic type parameter.
+    pub fn contains_generic_parameter(&self) -> bool {
+        match self {
+            IrType::List(inner)
+            | IrType::Set(inner)
+            | IrType::Option(inner)
+            | IrType::Ref(inner)
+            | IrType::RefMut(inner) => inner.contains_generic_parameter(),
+            IrType::Dict(key, value) | IrType::Result(key, value) => {
+                key.contains_generic_parameter() || value.contains_generic_parameter()
+            }
+            IrType::Tuple(items) | IrType::NamedGeneric(_, items) => {
+                items.iter().any(IrType::contains_generic_parameter)
+            }
+            IrType::Function { params, ret } => {
+                params.iter().any(IrType::contains_generic_parameter) || ret.contains_generic_parameter()
+            }
+            IrType::Generic(_) => true,
+            _ => false,
+        }
+    }
+
     /// Check if this type is Copy in Rust
     ///
     /// Returns true for primitive types (unit, bool, int, float) and string references

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -988,12 +988,61 @@ impl TypeChecker {
     ///
     /// These methods are compiler-provided rather than declared in user-visible source, so the typechecker must model
     /// their return types directly.
-    fn reflection_magic_method_return_type(&self, method: &str) -> Option<ResolvedType> {
+    fn field_overlay_value_type_for_nominal(&self, ty: &ResolvedType) -> Option<ResolvedType> {
+        let (type_name, type_args) = match ty {
+            ResolvedType::Named(name) => (name.as_str(), None),
+            ResolvedType::Generic(name, args) => (name.as_str(), Some(args.as_slice())),
+            _ => return None,
+        };
+        let type_info = self.lookup_semantic_type_info(type_name)?;
+        let (type_params, fields): (&[String], Vec<&FieldInfo>) = match type_info {
+            TypeInfo::Model(model) => (model.type_params.as_slice(), model.fields.values().collect()),
+            TypeInfo::Class(class) => (
+                class.type_params.as_slice(),
+                class
+                    .fields
+                    .values()
+                    .filter(|field| matches!(field.visibility, Visibility::Public))
+                    .collect(),
+            ),
+            _ => return None,
+        };
+        if fields.is_empty() {
+            return Some(ResolvedType::Unit);
+        }
+        let subst = type_args.map(|args| type_param_subst_map(type_params, args));
+        let mut value_types: Vec<ResolvedType> = fields
+            .into_iter()
+            .map(|field| match &subst {
+                Some(subst) => substitute_resolved_type(&field.ty, subst),
+                None => field.ty.clone(),
+            })
+            .collect();
+        value_types.sort_by_key(|ty| ty.to_string());
+        value_types.dedup();
+        if value_types.len() == 1 {
+            value_types.pop()
+        } else {
+            Some(union_ty(value_types))
+        }
+    }
+
+    /// Return the declared surface type for a compiler-provided reflection magic method.
+    ///
+    /// These methods do not have user-visible source declarations, so method-call checking uses this helper to expose
+    /// their synthesized return types while preserving nominal receiver-specific field value typing.
+    fn reflection_magic_method_return_type(&self, receiver_ty: &ResolvedType, method: &str) -> Option<ResolvedType> {
         match magic_methods::from_str(method) {
             Some(magic_methods::MagicMethodId::ClassName) => Some(ResolvedType::Str),
             Some(magic_methods::MagicMethodId::Fields) => Some(ResolvedType::FrozenList(Box::new(
                 ResolvedType::Named(surface_types::as_str(SurfaceTypeId::FieldInfo).to_string()),
             ))),
+            Some(magic_methods::MagicMethodId::FieldValue) => {
+                self.field_overlay_value_type_for_nominal(receiver_ty).map(option_ty)
+            }
+            Some(magic_methods::MagicMethodId::FieldItems) => self
+                .field_overlay_value_type_for_nominal(receiver_ty)
+                .map(|value_ty| list_ty(ResolvedType::Tuple(vec![ResolvedType::Str, value_ty]))),
             _ => None,
         }
     }
@@ -1018,6 +1067,12 @@ impl TypeChecker {
                 matches!(
                     self.lookup_semantic_type_info(type_name),
                     Some(TypeInfo::Model(_) | TypeInfo::Class(_) | TypeInfo::Newtype(_))
+                )
+            }
+            Some(magic_methods::MagicMethodId::FieldValue | magic_methods::MagicMethodId::FieldItems) => {
+                matches!(
+                    self.lookup_semantic_type_info(type_name),
+                    Some(TypeInfo::Model(_) | TypeInfo::Class(_))
                 )
             }
             _ => false,
@@ -2399,7 +2454,7 @@ impl TypeChecker {
         }
 
         if self.nominal_type_supports_reflection_magic(&base_ty, method)
-            && let Some(ret) = self.reflection_magic_method_return_type(method)
+            && let Some(ret) = self.reflection_magic_method_return_type(&base_ty, method)
         {
             return ret;
         }

--- a/src/frontend/typechecker/stdlib_loader.rs
+++ b/src/frontend/typechecker/stdlib_loader.rs
@@ -1367,6 +1367,45 @@ mod tests {
     }
 
     #[test]
+    fn test_load_collections_module_exports_public_types() -> Result<(), Box<dyn std::error::Error>> {
+        let path = vec!["std".to_string(), "collections".to_string()];
+        let module = load_stdlib_module_data(&path).ok_or("failed to load stdlib/collections.incn")?;
+        let names = module
+            .types
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        for expected in [
+            "PriorityOrder",
+            "Deque",
+            "Counter",
+            "DefaultDict",
+            "OrderedDict",
+            "OrderedSet",
+            "SortedDict",
+            "SortedSet",
+            "ChainMap",
+            "PriorityQueue",
+        ] {
+            assert!(names.contains(expected), "std.collections should export {expected}");
+        }
+
+        let deque = module
+            .types
+            .iter()
+            .find(|(name, _)| name == "Deque")
+            .ok_or("Deque export not found")?;
+        let TypeInfo::Model(deque_info) = &deque.1 else {
+            return Err("Deque should be an AST-loaded model export".into());
+        };
+        assert!(deque_info.methods.contains_key("appendleft"));
+        assert!(deque_info.methods.contains_key("popleft"));
+
+        Ok(())
+    }
+
+    #[test]
     fn extract_type_signatures_preserves_same_name_method_overloads() -> Result<(), Box<dyn std::error::Error>> {
         let source = r#"
 pub trait Convert[T]:

--- a/tests/fixtures/rfc030_field_overlay_reflection.incn
+++ b/tests/fixtures/rfc030_field_overlay_reflection.incn
@@ -1,0 +1,119 @@
+"""RFC 030: Runtime checks for compiler-generated field overlay views."""
+
+model UniformSettings:
+    region: str
+    profile: str
+
+model MixedSettings:
+    region: str
+    retries: int
+    enabled: bool
+
+class RuntimeSettings:
+    pub region: str
+    retries: int
+
+class RuntimeSettingsChild extends RuntimeSettings:
+    pub label: str
+
+
+def describe_mixed(value: str | int | bool) -> str:
+    match value:
+        bool(flag) =>
+            if flag:
+                return "bool:true"
+            return "bool:false"
+        int(number) =>
+            return f"int:{number}"
+        str(text) =>
+            return f"str:{text}"
+
+
+def describe_mixed_option(value: Option[str | int | bool]) -> str:
+    match value:
+        bool(flag) =>
+            if flag:
+                return "bool:true"
+            return "bool:false"
+        int(number) =>
+            return f"int:{number}"
+        str(text) =>
+            return f"str:{text}"
+        None =>
+            return "missing"
+
+
+def describe_class_value(value: str | int) -> str:
+    match value:
+        int(number) =>
+            return f"int:{number}"
+        str(text) =>
+            return f"str:{text}"
+
+
+def describe_class_option(value: Option[str | int]) -> str:
+    match value:
+        int(number) =>
+            return f"int:{number}"
+        str(text) =>
+            return f"str:{text}"
+        None =>
+            return "missing"
+
+
+def assert_uniform_model(settings: UniformSettings) -> None:
+    region: Option[str] = settings.__field_value__("region")
+    profile: Option[str] = settings.__field_value__("profile")
+    missing: Option[str] = settings.__field_value__("missing")
+    items: list[tuple[str, str]] = settings.__field_items__()
+
+    assert region == Some("eu-west-1")
+    assert profile == Some("prod")
+    assert missing == None
+    assert items == [("region", "eu-west-1"), ("profile", "prod")]
+
+
+def assert_mixed_model(settings: MixedSettings) -> None:
+    region: Option[str | int | bool] = settings.__field_value__("region")
+    retries: Option[str | int | bool] = settings.__field_value__("retries")
+    enabled: Option[str | int | bool] = settings.__field_value__("enabled")
+    missing: Option[str | int | bool] = settings.__field_value__("missing")
+    items: list[tuple[str, str | int | bool]] = settings.__field_items__()
+
+    assert describe_mixed_option(region) == "str:eu-west-1"
+    assert describe_mixed_option(retries) == "int:3"
+    assert describe_mixed_option(enabled) == "bool:true"
+    assert describe_mixed_option(missing) == "missing"
+    mut names: list[str] = []
+    mut values: list[str] = []
+    for name, value in items:
+        names.append(name)
+        values.append(describe_mixed(value))
+    assert names == ["region", "retries", "enabled"]
+    assert values == ["str:eu-west-1", "int:3", "bool:true"]
+
+
+def assert_class_overlay(settings: RuntimeSettingsChild) -> None:
+    region: Option[str | int] = settings.__field_value__("region")
+    retries: Option[str | int] = settings.__field_value__("retries")
+    label: Option[str | int] = settings.__field_value__("label")
+    missing: Option[str | int] = settings.__field_value__("missing")
+    items: list[tuple[str, str | int]] = settings.__field_items__()
+
+    assert describe_class_option(region) == "str:eu-west-1"
+    assert describe_class_option(retries) == "int:3"
+    assert describe_class_option(label) == "str:prod"
+    assert describe_class_option(missing) == "missing"
+    mut names: list[str] = []
+    mut values: list[str] = []
+    for name, value in items:
+        names.append(name)
+        values.append(describe_class_value(value))
+    assert names == ["region", "retries", "label"]
+    assert values == ["str:eu-west-1", "int:3", "str:prod"]
+
+
+def main() -> None:
+    assert_uniform_model(UniformSettings(region="eu-west-1", profile="prod"))
+    assert_mixed_model(MixedSettings(region="eu-west-1", retries=3, enabled=true))
+    assert_class_overlay(RuntimeSettingsChild(region="eu-west-1", retries=3, label="prod"))

--- a/tests/fixtures/rfc030_std_collections_behavior.incn
+++ b/tests/fixtures/rfc030_std_collections_behavior.incn
@@ -1,0 +1,91 @@
+"""RFC 030: Runtime behavior checks for pure Incan std.collections."""
+
+from std.collections import ChainMap, Counter, DefaultDict, Deque, OrderedDict, OrderedSet, PriorityOrder, PriorityQueue, SortedDict, SortedSet
+
+
+model RuntimeDefaults:
+    host: int
+    port: int
+
+
+def zero() -> int:
+    return 0
+
+
+def main() -> None:
+    mut deque = Deque[int]()
+    deque.append(2)
+    deque.appendleft(1)
+    deque.push_back(3)
+    assert deque.to_list() == [1, 2, 3]
+    assert deque.popleft() == 1
+    assert deque.pop_back() == 3
+    assert len(deque) == 1
+
+    mut counter = Counter[str]()
+    counter.update(["red", "blue", "red"])
+    assert counter.get("red") == 2
+    counter.decrement("red", 5)
+    assert counter.get("red") == 0
+    assert "red" not in counter
+    assert counter.total() == 1
+
+    mut defaults: DefaultDict[str, int] = DefaultDict.with_default(7)
+    assert defaults.__getitem__("missing") == 7
+    defaults.set("missing", 9)
+    assert defaults.get("missing") == Some(9)
+
+    mut factories: DefaultDict[str, int] = DefaultDict.with_factory(zero)
+    assert factories.__getitem__("count") == 0
+
+    mut ordered: OrderedDict[str, int] = OrderedDict()
+    ordered.set("b", 2)
+    ordered.set("a", 1)
+    ordered.set("b", 3)
+    assert ordered.keys() == ["b", "a"]
+    assert ordered.items() == [("b", 3), ("a", 1)]
+
+    mut ordered_set = OrderedSet[str]()
+    ordered_set.add("b")
+    ordered_set.add("a")
+    ordered_set.add("b")
+    assert ordered_set.to_list() == ["b", "a"]
+
+    mut sorted: SortedDict[str, int] = SortedDict()
+    sorted.set("b", 2)
+    sorted.set("a", 1)
+    assert sorted.keys() == ["a", "b"]
+
+    mut sorted_set = SortedSet[int]()
+    sorted_set.add(3)
+    sorted_set.add(1)
+    sorted_set.add(2)
+    sorted_set.add(1)
+    assert sorted_set.to_list() == [1, 2, 3]
+
+    first: OrderedDict[str, int] = OrderedDict.from_items([("host", 1)])
+    second: OrderedDict[str, int] = OrderedDict.from_items([("host", 2), ("port", 3)])
+    chain: ChainMap[str, int] = ChainMap.from_layers([first, second])
+    assert chain.__getitem__("host") == 1
+    assert chain.__getitem__("port") == 3
+    assert chain.keys() == ["host", "port"]
+
+    runtime_defaults = RuntimeDefaults(host=2, port=3)
+    mut overlay_chain: ChainMap[str, int] = ChainMap.from_field_layers([runtime_defaults.__field_items__()])
+    overlay_chain.push_layer(first)
+    assert overlay_chain.__getitem__("host") == 1
+    assert overlay_chain.__getitem__("port") == 3
+    assert overlay_chain.keys() == ["host", "port"]
+
+    mut min_queue = PriorityQueue[int]()
+    min_queue.push(3)
+    min_queue.push(1)
+    min_queue.push(2)
+    assert min_queue.pop() == 1
+    assert min_queue.peek() == Some(2)
+
+    mut max_queue = PriorityQueue[int].with_order(PriorityOrder.MaxFirst)
+    max_queue.push(3)
+    max_queue.push(1)
+    max_queue.push(2)
+    assert max_queue.pop() == 3

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4862,6 +4862,42 @@ async def main() -> None:
     }
 
     #[test]
+    fn test_run_rfc030_std_collections_behavior() {
+        let Ok(output) = Command::new(incan_debug_binary())
+            .args(["run", "tests/fixtures/rfc030_std_collections_behavior.incn"])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()
+        else {
+            panic!("failed to run incan");
+        };
+
+        assert!(
+            output.status.success(),
+            "incan run rfc030_std_collections_behavior failed: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn test_run_rfc030_field_overlay_reflection() {
+        let Ok(output) = Command::new(incan_debug_binary())
+            .args(["run", "tests/fixtures/rfc030_field_overlay_reflection.incn"])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()
+        else {
+            panic!("failed to run incan");
+        };
+
+        assert!(
+            output.status.success(),
+            "incan run rfc030_field_overlay_reflection failed: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
     fn test_check_cyclic_explicit_call_site_generics_cross_module_succeeds() -> Result<(), Box<dyn std::error::Error>> {
         let project_dir = make_temp_dir("incan_cycle_explicit_call_site_check");
         let main_path = super::write_cycle_explicit_call_site_generics_project(&project_dir)?;

--- a/tests/layering_guard.rs
+++ b/tests/layering_guard.rs
@@ -3,6 +3,8 @@
 //! The compiler (`incan` crate) may only use `incan_stdlib` as a **dev-dependency** (for parity tests).
 //! This test scans the root `Cargo.toml` and fails if `incan_stdlib` appears in `[dependencies]`.
 
+use incan_core::lang::stdlib;
+
 #[test]
 fn compiler_does_not_depend_on_stdlib_in_main_dependencies() {
     let manifest = include_str!("../Cargo.toml");
@@ -31,5 +33,40 @@ fn compiler_does_not_depend_on_stdlib_in_main_dependencies() {
         if line_no_comment.starts_with("incan_stdlib") {
             panic!("`incan_stdlib` must not appear in [dependencies]; use [dev-dependencies] instead");
         }
+    }
+}
+
+#[test]
+fn std_collections_namespace_stays_source_stdlib_only() {
+    let ns = stdlib::find_namespace("collections").expect("std.collections should be registered");
+
+    assert_eq!(ns.feature, None, "std.collections must not activate a Cargo feature");
+    assert!(
+        ns.extra_crate_deps.is_empty(),
+        "std.collections must not add Rust crate dependencies"
+    );
+    assert!(
+        ns.submodules.is_empty(),
+        "std.collections should resolve as a leaf stdlib source module"
+    );
+    assert!(
+        !ns.typechecker_only,
+        "std.collections must load through the ordinary stdlib source path"
+    );
+}
+
+#[test]
+fn std_collections_source_has_no_rust_backed_dispatch_markers_when_present() {
+    let source_path = std::path::Path::new("crates/incan_stdlib/stdlib/collections.incn");
+    let Ok(source) = std::fs::read_to_string(source_path) else {
+        // The stdlib-source worker owns this file. This guard starts checking it once their slice is integrated.
+        return;
+    };
+
+    for forbidden in ["rust.module", "@rust.extern"] {
+        assert!(
+            !source.contains(forbidden),
+            "`{forbidden}` is not allowed in pure-Incan std.collections"
+        );
     }
 }

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/030_std_collections.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/030_std_collections.md
@@ -1,18 +1,18 @@
 # RFC 030: `std.collections` — extended collection types
 
 
-- **Status:** Draft
+- **Status:** Implemented
 - **Created:** 2026-03-06
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 022 (stdlib namespacing), RFC 023 (compilable stdlib), RFC 028 (operator overloading)
 - **Issue:** [#164](https://github.com/dannys-code-corner/incan/issues/164)
 - **RFC PR:** —
 - **Written against:** v0.2
-- **Shipped in:** —
+- **Shipped in:** v0.3
 
 ## Summary
 
-Introduce `std.collections` as Incan's standard library namespace for non-builtin container types that are common, user-facing, and semantically distinct from `List`, `Dict`, `Set`, and `Tuple`. The north-star module includes queue, multiset, ordered-map, ordered-set, sorted-map, sorted-set, default-valued map, layered-map, and priority-queue surfaces: `Deque[T]`, `Counter[T]`, `DefaultDict[K, V]`, `OrderedDict[K, V]`, `OrderedSet[T]`, `SortedDict[K, V]`, `SortedSet[T]`, `ChainMap[K, V]`, and `PriorityQueue[T]`. These are ordinary stdlib types under the RFC 022 / RFC 023 model: imported explicitly, specified in Incan-facing terms, and backed by Rust implementations where that is the practical runtime strategy.
+Introduce `std.collections` as Incan's standard library namespace for non-builtin container types that are common, user-facing, and semantically distinct from `List`, `Dict`, `Set`, and `Tuple`. The north-star module includes queue, multiset, ordered-map, ordered-set, sorted-map, sorted-set, default-valued map, layered-map, and priority-queue surfaces: `Deque[T]`, `Counter[T]`, `DefaultDict[K, V]`, `OrderedDict[K, V]`, `OrderedSet[T]`, `SortedDict[K, V]`, `SortedSet[T]`, `ChainMap[K, V]`, and `PriorityQueue[T]`. These are ordinary stdlib types under the RFC 022 / RFC 023 model: imported explicitly, specified in Incan-facing terms, and implemented as Incan-source stdlib code rather than Rust-backed stdlib dispatch.
 
 This RFC is not a proposal to turn every interesting Rust or Python container into a builtin or direct re-export. It is a commitment that Incan should provide a coherent user-facing collections module with first-class, batteries-included types for the collection shapes that repeatedly matter in real application, analytics, and tooling code.
 
@@ -23,7 +23,7 @@ This RFC is not a proposal to turn every interesting Rust or Python container in
 - builtins remain the default, always-available containers for general-purpose code
 - `std.collections` provides opt-in specialized containers with distinct semantics
 - these types are library types, not parser keywords or compiler primitives
-- the public contract is Pythonic at the surface where that improves DX, while still taking advantage of Rust-backed implementations where they are clearly stronger
+- the public contract is Pythonic at the surface where that improves DX, while the implementation dogfoods ordinary Incan-source stdlib code
 
 The intended north-star module surface is:
 
@@ -35,7 +35,7 @@ The intended north-star module surface is:
 - `SortedDict[K, V]`: key-sorted mapping with deterministic order and range-oriented behavior
 - `SortedSet[T]`: value-sorted set with deterministic order and range-oriented behavior
 - `ChainMap[K, V]`: layered lookup across multiple maps and record-like layers
-- `PriorityQueue[T]`: heap-backed priority queue
+- `PriorityQueue[T]`: priority queue with explicit ordering policy
 
 ## Motivation
 
@@ -103,14 +103,14 @@ for key, value in prices.items():
     print(key, value)
 ```
 
-Python's `collections` module proves the user demand, while Rust's `std::collections` and adjacent ecosystem give us stronger backing choices for ordered, sorted, and queue-like structures. Incan should not mirror either language blindly. It should standardize the collection types that actually make the language feel complete for systems, data, and library work.
+Python's `collections` module proves the user demand, while Rust's collection vocabulary remains useful prior art for semantics and performance expectations. Incan should not mirror either language blindly. It should standardize the collection types that actually make the language feel complete for systems, data, and library work, and the stdlib implementation should remain pure Incan unless a future RFC explicitly creates a host-backed escape hatch.
 
 ## Goals
 
 - Provide a coherent north-star `std.collections` module rather than a narrow two-type sketch.
 - Keep builtins and specialized containers clearly separated.
 - Make Pythonic surfaces first-class where that improves usability.
-- Use Rust-backed implementations where they materially improve correctness, determinism, or performance.
+- Dogfood pure Incan stdlib implementations instead of adding Rust-backed dispatch for this module.
 - Include ordered and sorted collection families explicitly rather than forcing everything through future `Dict` redesign speculation.
 - Support layered lookup as a general collection utility, including model-heavy Incan workflows.
 
@@ -118,6 +118,7 @@ Python's `collections` module proves the user demand, while Rust's `std::collect
 
 - Making these collection types compiler builtins.
 - Re-exporting Rust container APIs wholesale.
+- Adding Rust-backed stdlib dispatch, Rust runtime wrappers, or host-only collection methods for `std.collections`.
 - Freezing every method and convenience helper down to the last alias in this draft.
 - Solving the entire future `Dict` / `FrozenDict` redesign space here.
 - Settling every comparison-policy detail for `PriorityQueue[T]` in this draft.
@@ -192,7 +193,7 @@ groups = DefaultDict[List[str]](...)
 groups["a"].append("x")
 ```
 
-The exact constructor/default-factory contract is still open in this draft, but the type itself is not.
+`DefaultDict` supports both a copied default value and a zero-argument default factory. Use the default-value constructor when every missing key should start from the same cloned value; use the default-factory constructor when each missing key should be materialized from a callable.
 
 ### `OrderedDict[K, V]` and `OrderedSet[T]`
 
@@ -289,7 +290,7 @@ Additional collection types may be added later, but the module should already re
 - both Python-style and Rust-style end-operation names are true aliases
 - iteration order is front-to-back
 - indexed access is allowed, but random access is not the motivation for the type
-- Rust backing: `VecDeque<T>`
+- implementation must be Incan-source stdlib code, not a Rust `VecDeque<T>` wrapper
 
 #### `Counter[T]`
 
@@ -309,14 +310,14 @@ Additional collection types may be added later, but the module should already re
 
 - insertion order is preserved by iteration and order-sensitive serialization
 - reinserting an existing key/value does not create a duplicate entry
-- Rust backing: `IndexMap` / `IndexSet` or equivalent ordered hash collections
+- implementation must be Incan-source stdlib code, not `IndexMap` / `IndexSet` wrappers or equivalent Rust-backed dispatch
 
 #### `SortedDict[K, V]` and `SortedSet[T]`
 
 - iteration order is sorted order
 - the types support order-aware traversal and range-oriented operations
 - keys/values must satisfy the language's ordering requirements for sorted collections
-- Rust backing: `BTreeMap` / `BTreeSet`
+- implementation must be Incan-source stdlib code, not `BTreeMap` / `BTreeSet` wrappers
 
 #### `ChainMap[K, V]`
 
@@ -331,7 +332,7 @@ Additional collection types may be added later, but the module should already re
 #### `PriorityQueue[T]`
 
 - heap semantics are the point of the type
-- the underlying backing is heap-based (`BinaryHeap` or equivalent)
+- the implementation must provide priority-queue semantics in Incan-source stdlib code rather than wrapping `BinaryHeap` or equivalent Rust runtime state
 - the exact public ordering contract remains open in this draft
 
 ### Compatibility / migration
@@ -345,8 +346,8 @@ This RFC is additive. It introduces new opt-in stdlib types under a new namespac
 The module should be designed from Incan's point of view, not as a copy of either source ecosystem:
 
 - Python gives the strongest user-facing intuition for `Deque`, `Counter`, `DefaultDict`, `OrderedDict`, and `ChainMap`
-- Rust gives stronger backing choices and vocabulary for `VecDeque`, `BTreeMap`, `BTreeSet`, `BinaryHeap`, and the `IndexMap`/`IndexSet` family
-- Incan should standardize the public semantics that make sense, then back them with Rust implementations where that is the cleanest runtime strategy
+- Rust gives useful vocabulary for queue, sorted-map, sorted-set, and priority-queue semantics, but those names are design references rather than implementation permission
+- Incan should standardize the public semantics that make sense, then implement the module in pure Incan-source stdlib code so the language dogfoods its own collection abstractions
 
 ### Why separate map and set types still make sense
 
@@ -381,6 +382,10 @@ Rejected because these are specialized containers, not global-language defaults.
 
 Rejected because that would leak Rust names and backend details into the public contract instead of giving Incan a deliberate collections story.
 
+### Back `std.collections` with Rust runtime dispatch
+
+Rejected because this module is intended to prove ordinary Incan-source stdlib expressiveness. Rust-backed dispatch would hide gaps in model methods, generics, indexing traits, iteration, and module loading that this RFC is supposed to exercise directly.
+
 ### Leave all specialized collections to third-party libraries
 
 Rejected because this is basic language completeness territory, not an exotic ecosystem extension.
@@ -395,26 +400,96 @@ Rejected because this is basic language completeness territory, not an exotic ec
 ## Layers affected
 
 - **Stdlib registry** — `std.collections` remains a registered stdlib namespace.
-- **Stdlib source** — public Incan-facing declarations, docs, examples, and protocol integration for the full type set.
-- **Stdlib runtime** — Rust-backed implementations over `VecDeque`, `HashMap`, `IndexMap`, `IndexSet`, `BTreeMap`, `BTreeSet`, `BinaryHeap`, and equivalent runtime structures where appropriate.
+- **Stdlib source** — public Incan-facing declarations, docs, examples, and pure Incan-source implementations for the full type set.
+- **Stdlib runtime** — no new Rust-backed dispatch or Rust wrapper state for this module; existing builtin collection primitives may be used only through ordinary Incan syntax and stdlib source.
 - **Typechecker / protocol surface** — generic collection typing, iteration behavior, ordering constraints for sorted collections, and record-layer participation in `ChainMap`.
 - **Serialization / docs / tooling** — deterministic-order behavior for ordered and sorted types must be documented and surfaced consistently in docs, completions, and examples.
+
+## Implementation Plan
+
+### RFC lifecycle and source contract
+
+- Keep the RFC, issue, and implementation aligned on a pure Incan-source stdlib contract.
+- Register `std.collections` as an ordinary stdlib namespace without extra Rust crate dependencies.
+- Ensure any implementation blocker caused by missing language support is reported as a compiler or stdlib dogfooding gap, not worked around through Rust-backed dispatch.
+
+### Stdlib collection module
+
+- Add `std.collections` source under `crates/incan_stdlib/stdlib/collections.incn`.
+- Implement the full public type set in Incan source: `Deque[T]`, `Counter[T]`, `DefaultDict[K, V]`, `OrderedDict[K, V]`, `OrderedSet[T]`, `SortedDict[K, V]`, `SortedSet[T]`, `ChainMap[K, V]`, and `PriorityQueue[T]`.
+- Provide both Python-style and Rust-style `Deque` end-operation aliases as true synonyms.
+- Implement `Counter[T]` with non-negative core counts; arithmetic helpers may produce intermediate negative counts only where the method contract explicitly says so.
+- Implement `DefaultDict[K, V]` with both default-value and default-factory construction paths.
+- Implement `PriorityQueue[T]` with a construction-time ordering policy and a min-first default.
+
+### Compiler and tooling integration
+
+- Extend the stdlib namespace registry so `from std.collections import ...` resolves through the normal stdlib loading path.
+- Verify exported types, generic annotations, method surfaces, and doc metadata are visible through existing stdlib import, typechecker, and LSP/documentation machinery.
+- Do not add parser keywords, builtin type IDs, special lowering paths, or Rust runtime wrappers for the `std.collections` types.
+
+### Tests and docs
+
+- Add focused import/typechecker coverage for all public `std.collections` types.
+- Add compile/run or snapshot coverage for representative behavior across queue, counter, defaulting, ordered, sorted, layered, and priority queue semantics.
+- Update the authored stdlib reference/docs navigation for `std.collections`.
+- Add release notes and bump the active development version.
+
+## Implementation log
+
+### Spec / design
+
+- [x] Resolve the implementation backing contract as pure Incan-source stdlib code.
+- [x] Resolve `PriorityQueue[T]` ordering as a construction-time policy with min-first default.
+- [x] Resolve `Counter[T]` as non-negative core counts with explicitly contracted arithmetic exceptions.
+- [x] Resolve `DefaultDict[K, V]` construction as both default-value and default-factory.
+
+### Stdlib registry
+
+- [x] Register `std.collections` in `STDLIB_NAMESPACES` without extra Rust crate dependencies.
+- [x] Add namespace/path tests for `std.collections`.
+
+### Stdlib source
+
+- [x] Add `crates/incan_stdlib/stdlib/collections.incn`.
+- [x] Implement `Deque[T]` with alias method pairs.
+- [x] Implement `Counter[T]` with non-negative core operations and counting helpers.
+- [x] Implement `DefaultDict[K, V]` with default value and default factory.
+- [x] Implement `OrderedDict[K, V]` and `OrderedSet[T]` with insertion-order behavior.
+- [x] Implement `SortedDict[K, V]` and `SortedSet[T]` with deterministic sorted behavior.
+- [x] Implement `ChainMap[K, V]` for mapping layers.
+- [x] Add `ChainMap[K, V]` record/model field overlays through compiler-generated field snapshots.
+- [x] Implement `PriorityQueue[T]` with construction-time ordering policy and min-first default.
+
+### Compiler / tooling
+
+- [x] Verify imported public collection types are visible to the typechecker and library export metadata.
+- [x] Verify no parser, builtin, lowering, emission, or Rust runtime special case is added for `std.collections`.
+- [x] Verify docs/LSP-facing metadata exposes the new module.
+
+### Tests
+
+- [x] Add targeted typechecker/import tests for all public collection types.
+- [x] Add behavior coverage for `Deque`, `Counter`, `DefaultDict`, ordered collections, sorted collections, `ChainMap`, and `PriorityQueue`.
+- [x] Add a guard that `std.collections` has no extra Rust-backed crate dependency or runtime wrapper.
+- [x] Run targeted verification.
+- [x] Run the repository pre-commit gate.
+
+### Docs / release
+
+- [x] Update stdlib reference docs and navigation for `std.collections`.
+- [x] Add release notes for RFC 030.
+- [x] Bump the active development version.
 
 ## Design Decisions
 
 1. `std.collections` is a full north-star module, not a narrow `Deque + Counter` placeholder.
 2. `DefaultDict`, `OrderedDict`, and `OrderedSet` are first-class public types in this RFC.
-3. `SortedDict` and `SortedSet` belong in the stdlib surface and should be backed by sorted-tree structures.
+3. `SortedDict` and `SortedSet` belong in the stdlib surface and must be implemented in pure Incan-source stdlib code rather than backed by Rust sorted-tree wrappers.
 4. `ChainMap` remains in scope and should align with RFC 033's precedence intuition without being defined in terms of `ctx`.
 5. `ChainMap` supports both mapping layers and record/model layers; record/model layers are read-only field overlays in this RFC.
-6. `PriorityQueue[T]` remains in scope even though one core policy question is still unresolved.
+6. `PriorityQueue[T]` uses a construction-time ordering policy and defaults to min-first behavior.
 7. `NamedTuple` is out of scope; Incan `model` already covers the named-record use case better.
 8. `FrozenDeque` is out of scope for now; this RFC is about specialized mutable/runtime collection semantics first.
-
-## Unresolved questions
-
-1. What is the public ordering contract for `PriorityQueue[T]`: max-first only, min-first only, or a construction-time policy?
-2. Should `Counter[T]` counts be fully signed, or should the core contract remain non-negative except where arithmetic helpers explicitly produce negatives?
-3. What is the best first-class construction contract for `DefaultDict[K, V]`: default value, default factory, or both?
-
-<!-- Rename this section to "Design Decisions" once all questions have been resolved. An RFC cannot move from Draft to Planned until no unresolved questions remain. -->
+9. `Counter[T]` has non-negative core counts; arithmetic helpers may expose negative intermediate counts only where explicitly documented.
+10. `DefaultDict[K, V]` supports both default-value and default-factory construction.

--- a/workspaces/docs-site/docs/language/how-to/choosing_collections.md
+++ b/workspaces/docs-site/docs/language/how-to/choosing_collections.md
@@ -1,0 +1,172 @@
+# Choosing collection types
+
+Use builtin `list`, `dict`, and `set` first. Reach for `std.collections` when the collection's behavior is part of the program design rather than just a storage detail.
+
+| Need | Use |
+| --- | --- |
+| Append and pop at both ends | `Deque[T]` |
+| Count occurrences | `Counter[T]` |
+| Materialize a value for missing keys | `DefaultDict[K, V]` |
+| Keep insertion order visible | `OrderedDict[K, V]` or `OrderedSet[T]` |
+| Traverse in sorted order | `SortedDict[K, V]` or `SortedSet[T]` |
+| Layer overrides over defaults | `ChainMap[K, V]` |
+| Always process the next highest-priority item | `PriorityQueue[T]` |
+
+## Use `Deque` for front-and-back queues
+
+Use `Deque[T]` when both ends are active. If you only append and pop at the end, a builtin `list` is simpler.
+
+```incan
+from std.collections import Deque
+
+def main() -> None:
+    mut queue = Deque[str]()
+    queue.append("normal")
+    queue.appendleft("urgent")
+
+    next = queue.popleft()
+    println(next)
+```
+
+`Deque` exposes both Python-style names (`appendleft`, `popleft`) and Rust-style names (`push_front`, `pop_front`). Choose one style in a module and stay consistent.
+
+## Use `Counter` for counted membership
+
+Use `Counter[T]` when the count is the data model. Do not hand-roll a `dict[T, int]` unless the update rules are unusual enough that the named collection would hide the intent.
+
+```incan
+from std.collections import Counter
+
+def main() -> None:
+    counts = Counter.from_iter(["red", "blue", "red"])
+
+    assert counts.get("red") == 2
+    assert counts.total() == 3
+```
+
+## Use `DefaultDict` when missing keys should create values
+
+Use `DefaultDict[K, V]` when reading a missing key should materialize a default. Use `get()` when you want to inspect a key without creating it.
+
+```incan
+from std.collections import DefaultDict
+
+def zero() -> int:
+    return 0
+
+def main() -> None:
+    mut counts: DefaultDict[str, int] = DefaultDict.with_factory(zero)
+    counts["red"] = counts["red"] + 1
+
+    assert counts.get("red") == Some(1)
+```
+
+Use `with_default(value)` when cloning one value is right for every missing key. Use `with_factory(factory)` when each missing key should get a fresh value.
+
+## Use ordered collections when insertion order matters
+
+Use `OrderedDict[K, V]` and `OrderedSet[T]` when display, serialization, or user-facing iteration must follow insertion order. Use builtin `dict` or `set` when order is not part of the contract.
+
+```incan
+from std.collections import OrderedDict, OrderedSet
+
+def main() -> None:
+    mut headers = OrderedDict[str, str]()
+    headers.set("content-type", "application/json")
+    headers.set("cache-control", "no-store")
+
+    assert headers.keys() == ["content-type", "cache-control"]
+
+    mut seen = OrderedSet[str]()
+    seen.add("alice")
+    seen.add("bob")
+    seen.add("alice")
+
+    assert seen.to_list() == ["alice", "bob"]
+```
+
+## Use sorted collections for deterministic sorted traversal
+
+Use `SortedDict[K, V]` and `SortedSet[T]` when consumers rely on sorted order. The key or value type must support normal ordering.
+
+```incan
+from std.collections import SortedDict, SortedSet
+
+def main() -> None:
+    mut scores = SortedDict[str, int]()
+    scores.set("bob", 7)
+    scores.set("alice", 10)
+
+    assert scores.keys() == ["alice", "bob"]
+
+    mut ids = SortedSet[int]()
+    ids.add(30)
+    ids.add(10)
+    ids.add(20)
+
+    assert ids.to_list() == [10, 20, 30]
+```
+
+## Use `ChainMap` for layered configuration
+
+Use `ChainMap[K, V]` when lookup should prefer overrides but fall back to defaults. Earlier layers win.
+
+```incan
+from std.collections import ChainMap, OrderedDict
+
+def main() -> None:
+    overrides = OrderedDict.from_items([("region", "us-east-1")])
+    defaults = OrderedDict.from_items([("region", "eu-west-1"), ("retries", "3")])
+
+    cfg = ChainMap.from_layers([overrides, defaults])
+
+    assert cfg["region"] == "us-east-1"
+    assert cfg["retries"] == "3"
+```
+
+For model or class defaults, pass a field snapshot. The snapshot is read-only inside the chain map.
+
+```incan
+from std.collections import ChainMap, OrderedDict
+
+model RuntimeDefaults:
+    host: int
+    port: int
+
+def main() -> None:
+    defaults = RuntimeDefaults(host=2, port=3)
+    mut cfg: ChainMap[str, int] = ChainMap.from_field_layers([defaults.__field_items__()])
+
+    cfg.push_layer(OrderedDict.from_items([("host", 1)]))
+
+    assert cfg["host"] == 1
+    assert cfg["port"] == 3
+```
+
+## Use `PriorityQueue` for next-item scheduling
+
+Use `PriorityQueue[T]` when every pop should return the next item by ordering. The default is min-first; use `PriorityOrder.MaxFirst` when larger values should come first.
+
+```incan
+from std.collections import PriorityOrder, PriorityQueue
+
+def main() -> None:
+    mut next_retry = PriorityQueue[int]()
+    next_retry.push(30)
+    next_retry.push(10)
+    next_retry.push(20)
+
+    assert next_retry.pop() == 10
+
+    mut largest_first = PriorityQueue[int].with_order(PriorityOrder.MaxFirst)
+    largest_first.push(30)
+    largest_first.push(10)
+
+    assert largest_first.pop() == 30
+```
+
+## See also
+
+- [std.collections reference](../reference/stdlib/collections.md)
+- [Collections and iteration tutorial](../tutorials/book/08_collections_and_iteration.md)
+- [Collection protocols](../reference/stdlib_traits/collection_protocols.md)

--- a/workspaces/docs-site/docs/language/reference/index.md
+++ b/workspaces/docs-site/docs/language/reference/index.md
@@ -24,7 +24,7 @@ For step-by-step learning and patterns, see [Tutorials](../tutorials/book/index.
 - [Imports and modules](imports_and_modules.md): import syntax, module paths, and module resolution rules
 - [Static storage](static_storage.md): `static`, `pub static`, initialization rules, and live shared module state
 - [std.testing](stdlib/testing.md): assertions, markers, fixtures, and parametrization
-- [Standard library reference](stdlib/index.md): signatures for `std.*` modules (`std.math`, `std.async`, `std.testing`, ...)
+- [Standard library reference](stdlib/index.md): signatures for `std.*` modules (`std.math`, `std.async`, `std.collections`, ...)
 - [Numeric semantics](numeric_semantics.md): numeric operators, promotion rules, and edge cases
 - [Strings](strings.md): string types, formatting, and string operations
 - [Union types](union_types.md): anonymous closed unions, `A | B`, narrowing, and `match` type patterns

--- a/workspaces/docs-site/docs/language/reference/language.md
+++ b/workspaces/docs-site/docs/language/reference/language.md
@@ -109,6 +109,7 @@ Soft keywords are only reserved when their activating `std.*` namespace is impor
 | `std.math` | - | - | - |
 | `std.fs` | - | `std.fs.path`, `std.fs.file`, `std.fs.metadata`, `std.fs.glob`, `std.fs.prelude` | - |
 | `std.graph` | - | - | - |
+| `std.collections` | - | - | - |
 | `std.io` | - | - | - |
 | `std.tempfile` | - | - | - |
 | `std.rust` | - | - | - |

--- a/workspaces/docs-site/docs/language/reference/reflection.md
+++ b/workspaces/docs-site/docs/language/reference/reflection.md
@@ -65,3 +65,14 @@ Check if a field exists:
 ```incan
 has_email = any(f.name == "email" for f in user.__fields__())
 ```
+
+## Runtime Field Overlay Views
+
+Models and classes also expose compiler-generated read-only field value views. These hooks are intended for collection and reflection protocols that need to treat a model or class value as a stable named-field overlay without using stringly dynamic attribute access.
+
+| API | Returns | Description |
+| --- | --- | --- |
+| `obj.__field_value__(name: str)` | `Option[T]` | Returns `Some(value)` for a known field and `None` for an unknown field name. `T` is the common field type when all exposed fields share one type, otherwise a union of the exposed field types. |
+| `obj.__field_items__()` | `list[tuple[str, T]]` | Returns `(field_name, value)` pairs in the same field order used by `__fields__()`. `T` follows the same common-type-or-union rule as `__field_value__`. |
+
+For `class` values, inherited fields are included before fields declared on the child class, matching `__fields__()` ordering. The returned views are read-only snapshots of field names and values; mutating a returned list does not add, remove, rename, or update object fields.

--- a/workspaces/docs-site/docs/language/reference/stdlib/collections.md
+++ b/workspaces/docs-site/docs/language/reference/stdlib/collections.md
@@ -1,0 +1,191 @@
+# std.collections reference
+
+`std.collections` provides specialized collection types for cases where builtin `list`, `dict`, and `set` are too broad. Use these types when the collection semantics are part of the program contract.
+
+```incan
+from std.collections import ChainMap, Counter, DefaultDict, Deque, OrderedDict, OrderedSet, PriorityQueue, SortedDict, SortedSet
+```
+
+The module is an ordinary Incan stdlib source module. It is imported explicitly, has no feature gate, and does not use Rust-backed stdlib dispatch.
+
+## Types
+
+| Type | Purpose |
+| --- | --- |
+| `Deque[T]` | Double-ended queue with efficient front and back operations. |
+| `Counter[T]` | Multiset that stores occurrence counts. |
+| `DefaultDict[K, V]` | Mapping that materializes a configured default value for missing keys. |
+| `OrderedDict[K, V]` | Mapping whose iteration order follows insertion order. |
+| `OrderedSet[T]` | Set whose iteration order follows insertion order. |
+| `SortedDict[K, V]` | Mapping whose iteration order follows sorted key order. |
+| `SortedSet[T]` | Set whose iteration order follows sorted value order. |
+| `ChainMap[K, V]` | Layered lookup across mapping and record-shaped layers. |
+| `PriorityQueue[T]` | Heap-shaped queue for priority ordering. |
+
+Builtin collections remain the default for ordinary data. Reach for `std.collections` when the named behavior matters: front-of-queue work, counted membership, missing-key defaulting, insertion-order stability, sorted traversal, layered configuration, or priority scheduling.
+
+For task-oriented guidance, see [Choosing collection types](../../how-to/choosing_collections.md).
+
+## Deque
+
+`Deque[T]` stores values in front-to-back order and supports both Python-style and Rust-style method names for the same end operations.
+
+| API | Returns | Description |
+| --- | --- | --- |
+| `Deque[T]()` | `Deque[T]` | Construct an empty deque. |
+| `len(deque)` | `int` | Number of elements. |
+| `deque.push_back(value)` / `deque.append(value)` | `None` | Add to the back. |
+| `deque.push_front(value)` / `deque.appendleft(value)` | `None` | Add to the front. |
+| `deque.pop_back()` / `deque.pop()` | `T` | Remove from the back. Empty queues fail through builtin list indexing behavior. |
+| `deque.pop_front()` / `deque.popleft()` | `T` | Remove from the front. Empty queues fail through builtin list indexing behavior. |
+| `deque.to_list()` | `list[T]` | Snapshot values in front-to-back order. |
+| `deque.clear()` | `None` | Remove all values. |
+
+```incan
+from std.collections import Deque
+
+mut queue = Deque[str]()
+queue.append("normal")
+queue.appendleft("urgent")
+
+next = queue.popleft()
+```
+
+## Counter
+
+`Counter[T]` stores counts by element. Missing elements read as zero.
+
+| API | Returns | Description |
+| --- | --- | --- |
+| `Counter[T]()` | `Counter[T]` | Construct an empty counter. |
+| `Counter.from_iter(values: list[T])` | `Counter[T]` | Count values from an iterable collection. |
+| `counter.get(value)` | `int` | Count for one value, or zero when absent. |
+| `counter.set(value, count: int)` | `None` | Set the count for one value. |
+| `counter.update(values: list[T])` | `None` | Add one count for each value. |
+| `counter.subtract(values: list[T])` | `None` | Subtract one count for each value. |
+| `counter.total()` | `int` | Sum of counts. |
+| `counter.most_common(n: int = -1)` | `list[tuple[T, int]]` | Highest-count elements, or all elements when `n` is negative. |
+| `counter.elements()` | `list[T]` | Expand positive counts back into repeated elements. |
+
+```incan
+from std.collections import Counter
+
+counts = Counter.from_iter(["apple", "banana", "apple"])
+assert counts.get("apple") == 2
+```
+
+## DefaultDict
+
+`DefaultDict[K, V]` makes missing-key defaulting explicit. Use it when default creation is part of the data model rather than a local convenience branch around an ordinary `dict`.
+
+| API | Returns | Description |
+| --- | --- | --- |
+| `DefaultDict.with_default(value: V)` | `DefaultDict[K, V]` | Construct a map that clones `value` for missing keys. |
+| `DefaultDict.with_factory(factory: () -> V)` | `DefaultDict[K, V]` | Construct a map that calls `factory` for missing keys. |
+| `default_dict[key]` | `V` | Return the existing value or materialize the default. |
+| `default_dict.get(key)` | `Option[V]` | Return the existing value without materializing. |
+| `default_dict.set(key, value)` | `None` | Store a value. |
+| `key in default_dict` | `bool` | Whether the key is present. |
+| `default_dict.keys()` | `list[K]` | Current keys. |
+| `default_dict.values()` | `list[V]` | Current values. |
+| `default_dict.items()` | `list[tuple[K, V]]` | Current key/value pairs. |
+
+## Ordered Collections
+
+`OrderedDict[K, V]` and `OrderedSet[T]` preserve insertion order for iteration, display, and order-sensitive serialization.
+
+| API | Returns | Description |
+| --- | --- | --- |
+| `OrderedDict[K, V]()` | `OrderedDict[K, V]` | Construct an empty ordered map. |
+| `ordered_dict.set(key, value)` | `None` | Insert or replace a key without duplicating its position. |
+| `ordered_dict.get(key)` | `Option[V]` | Lookup by key. |
+| `ordered_dict.remove(key)` | `V` | Remove one key. Missing keys fail through builtin list indexing behavior. |
+| `ordered_dict.keys()` | `list[K]` | Keys in insertion order. |
+| `ordered_dict.values()` | `list[V]` | Values in key insertion order. |
+| `ordered_dict.items()` | `list[tuple[K, V]]` | Items in key insertion order. |
+| `OrderedSet[T]()` | `OrderedSet[T]` | Construct an empty ordered set. |
+| `ordered_set.add(value)` | `None` | Add a value if it is absent. |
+| `ordered_set.remove(value)` | `None` | Remove a value when present. |
+| `ordered_set.contains(value)` | `bool` | Membership check. |
+| `ordered_set.to_list()` | `list[T]` | Values in insertion order. |
+
+## Sorted Collections
+
+`SortedDict[K, V]` and `SortedSet[T]` preserve sorted order for iteration and range-oriented work. Keys or values must support the ordinary ordering protocol.
+
+| API | Returns | Description |
+| --- | --- | --- |
+| `SortedDict[K, V]()` | `SortedDict[K, V]` | Construct an empty sorted map. |
+| `sorted_dict.set(key, value)` | `None` | Insert or replace a key. |
+| `sorted_dict.get(key)` | `Option[V]` | Lookup by key. |
+| `sorted_dict.remove(key)` | `V` | Remove one key. Missing keys fail through builtin list indexing behavior. |
+| `sorted_dict.keys()` | `list[K]` | Keys in sorted order. |
+| `sorted_dict.values()` | `list[V]` | Values in sorted-key order. |
+| `sorted_dict.items()` | `list[tuple[K, V]]` | Items in sorted-key order. |
+| `SortedSet[T]()` | `SortedSet[T]` | Construct an empty sorted set. |
+| `sorted_set.add(value)` | `None` | Add a value if it is absent. |
+| `sorted_set.remove(value)` | `None` | Remove a value when present. |
+| `sorted_set.contains(value)` | `bool` | Membership check. |
+| `sorted_set.range(start, end)` | `list[T]` | Values where `start <= value < end`. |
+| `sorted_set.to_list()` | `list[T]` | Values in sorted order. |
+
+## ChainMap
+
+`ChainMap[K, V]` performs layered lookup from first layer to last. Earlier layers override later layers.
+
+| API | Returns | Description |
+| --- | --- | --- |
+| `ChainMap.from_layers(layers: list[OrderedDict[K, V]])` | `ChainMap[K, V]` | Construct a layered map. |
+| `chain[key]` | `V` | Return the first matching value. Missing keys fail through builtin list indexing behavior. |
+| `chain.set(key, value)` | `None` | Write to the first writable mapping layer. |
+| `chain.contains(key)` | `bool` | Whether any layer contains the key. |
+| `chain.keys()` | `list[K]` | Distinct visible keys. |
+| `chain.items()` | `list[tuple[K, V]]` | Distinct visible key/value pairs. |
+| `chain.push_layer(layer)` | `None` | Add a highest-precedence mapping layer. |
+| `ChainMap.from_field_layers(layers: list[list[tuple[K, V]]])` | `ChainMap[K, V]` | Construct from read-only field snapshots such as `model.__field_items__()`. |
+| `chain.push_field_layer(layer)` | `None` | Add a highest-precedence read-only field snapshot. |
+| `chain.pop_layer()` | `OrderedDict[K, V]` | Remove the highest-precedence mapping layer. |
+
+Model and class field overlays use compiler-generated `__field_value__(name: str) -> Option[T]` and `__field_items__() -> list[tuple[str, T]]` views, where `T` is either the common field type or a union of the exposed field types. `ChainMap` accepts `__field_items__()` snapshots through `from_field_layers()` and `push_field_layer()`; these layers are read-only snapshots and preserve the field ordering reported by `__fields__()`.
+
+```incan
+from std.collections import ChainMap
+
+defaults = OrderedDict.from_items([("region", "eu-west-1"), ("retries", "3")])
+override = OrderedDict.from_items([("region", "us-east-1")])
+cfg = ChainMap.from_layers([override, defaults])
+
+assert cfg["region"] == "us-east-1"
+assert cfg["retries"] == "3"
+```
+
+```incan
+model Defaults:
+    region: str
+    retries: str
+
+cfg = ChainMap.from_field_layers([Defaults(region="eu-west-1", retries="3").__field_items__()])
+cfg.push_layer(OrderedDict.from_items([("region", "us-east-1")]))
+
+assert cfg["region"] == "us-east-1"
+assert cfg["retries"] == "3"
+```
+
+## PriorityQueue
+
+`PriorityQueue[T]` stores values according to priority order.
+
+| API | Returns | Description |
+| --- | --- | --- |
+| `PriorityQueue[T]()` | `PriorityQueue[T]` | Construct an empty priority queue. |
+| `PriorityQueue.with_order(order)` | `PriorityQueue[T]` | Construct an empty queue with an explicit ordering policy. |
+| `PriorityQueue.max_first()` | `PriorityQueue[T]` | Construct an empty max-first queue. |
+| `PriorityQueue.from_iter(values, order)` | `PriorityQueue[T]` | Construct a queue from values and an ordering policy. |
+| `queue.push(value)` | `None` | Add a value. |
+| `queue.peek()` | `Option[T]` | Read the next value without removing it. |
+| `queue.pop()` | `T` | Remove and return the next value. Empty queues fail through builtin list indexing behavior. |
+| `len(queue)` | `int` | Number of queued values. |
+| `queue.is_empty()` | `bool` | Whether the queue is empty. |
+| `queue.to_list()` | `list[T]` | Queued values in pop order. |
+
+Values must support the ordering protocol used by the queue.

--- a/workspaces/docs-site/docs/language/reference/stdlib/index.md
+++ b/workspaces/docs-site/docs/language/reference/stdlib/index.md
@@ -7,6 +7,7 @@ Pages in this section are curated and checked into the repository.
 ## Available modules
 
 - [`std.async`](async.md) (curated)
+- [`std.collections`](collections.md) (curated)
 - [`std.derives.*`](derives.md) (curated)
 - [`std.fs`](fs.md) (curated)
 - [`std.graph`](graph.md) (curated)

--- a/workspaces/docs-site/docs/language/reference/stdlib/reflection.md
+++ b/workspaces/docs-site/docs/language/reference/stdlib/reflection.md
@@ -40,3 +40,7 @@ Notes:
 
 - Field metadata like `[alias="..."]` and `[description="..."]` is model-only.
 - For a `class`, `FieldInfo.alias` and `FieldInfo.description` are always `None` and `FieldInfo.wire_name == FieldInfo.name`.
+
+## Compiler-generated field value views
+
+Model and class values expose `__field_value__(name: str) -> Option[T]` and `__field_items__() -> list[tuple[str, T]]` directly; no `std.reflection` import is required. `T` is the common field type when all exposed fields share one type, otherwise a union of the exposed field types. These views are read-only and use the same field ordering as `__fields__()`.

--- a/workspaces/docs-site/docs/language/tutorials/book/08_collections_and_iteration.md
+++ b/workspaces/docs-site/docs/language/tutorials/book/08_collections_and_iteration.md
@@ -199,6 +199,7 @@ def numbers() -> Generator[int]:
 
 ## Where to learn more
 
+- Specialized collections: [Choosing collection types](../../how-to/choosing_collections.md)
 - Strings and slicing: [Strings](../../reference/strings.md)
 - Generators: [Use generators for lazy pipelines](../../how-to/generators.md)
 - Control flow overview: [Control flow](../../explanation/control_flow.md)

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -2,7 +2,7 @@
 
 Incan 0.3 is the current development release. It picks up after the `0.2` line, which made the language surface more explicit around stdlib imports, Rust interop, library manifests, module state, and call-site generics.
 
-`0.3` now includes a larger numeric surface, a new control-flow surface, richer enum behavior, a graph stdlib surface, iterator adapter chains, Result combinators, and tighter tooling contracts. RFC 009 makes numeric annotations precise enough for Rust interop, wire formats, data schemas, and fixed-scale decimal values; RFC 016 adds `loop:` and `break <value>` so loops can produce values directly; RFC 047 adds `std.graph` for explicit in-memory dependency and plan graphs; RFC 050 lets enums declare methods and adopt traits; RFC 088 standardizes lazy iterator adapters and terminal consumers; RFC 070 adds Rust-shaped `Result[T, E]` composition with `map`, `map_err`, `and_then`, `or_else`, `inspect`, and `inspect_err`; and RFC 053 tightens the formatter contract so output is less dependent on local heuristics and more predictable across CLI, editor, and library entry points.
+`0.3` now includes a larger numeric surface, a new control-flow surface, richer enum behavior, graph and collections stdlib surfaces, iterator adapter chains, Result combinators, and tighter tooling contracts. RFC 009 makes numeric annotations precise enough for Rust interop, wire formats, data schemas, and fixed-scale decimal values; RFC 016 adds `loop:` and `break <value>` so loops can produce values directly; RFC 030 adds `std.collections` for specialized collection semantics; RFC 047 adds `std.graph` for explicit in-memory dependency and plan graphs; RFC 050 lets enums declare methods and adopt traits; RFC 088 standardizes lazy iterator adapters and terminal consumers; RFC 070 adds Rust-shaped `Result[T, E]` composition with `map`, `map_err`, `and_then`, `or_else`, `inspect`, and `inspect_err`; and RFC 053 tightens the formatter contract so output is less dependent on local heuristics and more predictable across CLI, editor, and library entry points.
 
 This page will grow as more `0.3` work lands. If you are looking for the shipped `0.2` story, start with [Release 0.2](0_2.md).
 
@@ -22,6 +22,7 @@ The release is still early, but the initial direction is already visible:
 - enum-owned behavior should live on the enum itself, and enums should be able to adopt the same trait protocols as models and classes
 - operator overloading should present traits as nominal capability contracts while keeping dunder methods as the explicit implementation hooks
 - in-memory graph-shaped data should have one small stdlib vocabulary for node ids, edge ids, directed graphs, DAGs, multigraphs, adjacency, traversal, and cycle-aware ordering
+- specialized collection semantics should have explicit stdlib types instead of forcing every queue, multiset, ordered map, sorted set, layered map, or priority queue through bare builtin containers
 - user-facing tooling behavior should match the docs closely enough that CI and editor integrations can rely on it
 - testing should feel like a first-class workflow, with inline unit tests, fixtures, parametrization, selection, scheduling, and machine-readable reports owned by Incan rather than delegated to ad hoc scripts
 - iterator pipelines should be lazy by default, with terminal consumers such as `.collect()`, `.count()`, `.any()`, `.all()`, `.find()`, and `.fold()` making realization or summarization explicit
@@ -265,6 +266,16 @@ The v1 surface is intentionally not a graph database, persistence layer, query l
 
 See also: [std.graph reference](../language/reference/stdlib/graph.md), [RFC 047].
 
+### RFC 030 `std.collections`
+
+`std.collections` now provides the standard-library namespace for specialized container types that are semantically distinct from builtin `list`, `dict`, and `set`. The module covers `Deque[T]`, `Counter[T]`, `DefaultDict[K, V]`, `OrderedDict[K, V]`, `OrderedSet[T]`, `SortedDict[K, V]`, `SortedSet[T]`, `ChainMap[K, V]`, and `PriorityQueue[T]`.
+
+These are ordinary Incan stdlib types. They import through `from std.collections import ...`, resolve through the standard stdlib registry and source loader, and do not use Rust-backed stdlib dispatch.
+
+Use builtin collections for ordinary values. Use `std.collections` when the collection behavior is the point: double-ended queue operations, counted membership, missing-key defaulting, insertion-order stability, sorted traversal, layered configuration, or priority scheduling.
+
+See also: [std.collections reference](../language/reference/stdlib/collections.md), [RFC 030].
+
 ## Detailed inventory
 
 The sections above are the release story. The list below is the detailed inventory of language, compiler, runtime, tooling, and docs changes that have landed for `0.3`, grouped roughly by theme rather than by the order work happened to land.
@@ -328,6 +339,7 @@ The sections above are the release story. The list below is the detailed invento
 ### Parser and syntax
 
 - **Language/Stdlib**: `std.graph` adds explicit in-memory graph values with direct `DiGraph[T]()`, `Dag[T]()`, and `MultiDiGraph[T]()` construction, acyclicity-enforcing DAGs, stable `EdgeId` values for parallel multigraph edges, stable `NodeId` values, typed node payloads, node and edge removal, adjacency queries, roots and sinks, BFS/DFS traversal helpers, and cycle-reporting topological order for dependency and plan graphs (#204, RFC 047).
+- **Language/Stdlib**: `std.collections` adds explicit specialized collection types for double-ended queues, multisets, default-valued maps, ordered maps and sets, sorted maps and sets, layered maps, and priority queues. The namespace is registered as an ordinary source stdlib module with no feature gate, no extra Cargo dependencies, and no Rust-backed stdlib dispatch (#164, RFC 030).
 - **Language/Compiler**: RFC 029 adds anonymous closed union annotations with canonical `Union[A, B, ...]` and `A | B` syntax. The compiler normalizes duplicates, nested unions, ordering, and `None`-containing unions, accepts member-to-union and union-to-union assignability, lowers ordinary unions to generated closed Rust enums, preserves `None` unions on the existing `Option[...]` path, and supports `isinstance` narrowing for true branches, else branches, wider unions, chained `elif` branches, and `Option[Union[...]]`, plus `is None` / `is not None` narrowing and exhaustive `match` type patterns (#163, RFC 029).
 - **Language/Stdlib**: RFC 028 expands `std.traits.ops` into the nominal operator capability vocabulary for custom types, including `FloorDiv`, `Pow`, shifts, bitwise operators, pipe operators, `MatMul`, unary `Not`, `GetItem` / `SetItem`, and explicit in-place compound-assignment traits for `+=`, `-=`, `*=`, `/=`, `//=`, `%=`, `@=`, `&=`, `|=`, `^=`, `<<=`, and `>>=` (#162, RFC 028).
 - **Language/Stdlib**: RFC 055 introduces `std.fs` as the path-centric filesystem module: `Path`, `File`, `OpenOptions`, directory entries, metadata, disk usage, structured `IoError`, whole-file byte/text helpers, chunked file handles, traversal, globbing, copy/move, recursive deletion, links, permissions, and explicit durability syncs (#286, RFC 055).
@@ -388,6 +400,7 @@ The sections above are the release story. The list below is the detailed invento
 - Extensible derive protocol: [RFC 024]
 - Trait-based operator overloading: [RFC 028]
 - Union types and type narrowing: [RFC 029]
+- Extended collection types: [RFC 030]
 - Value enums: [RFC 032]
 - Variadic positional arguments and keyword capture: [RFC 038]
 - Computed properties: [RFC 046]

--- a/workspaces/docs-site/mkdocs.yml
+++ b/workspaces/docs-site/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
           - Generators: language/how-to/generators.md
           - Imports and modules: language/how-to/imports_and_modules.md
           - Module state: language/how-to/module_state.md
+          - Choosing collection types: language/how-to/choosing_collections.md
           - Choosing numeric types: language/how-to/choosing_numeric_types.md
           - Modeling with enums: language/how-to/modeling_with_enums.md
           - Project lifecycle: language/how-to/project_lifecycle.md
@@ -150,6 +151,7 @@ nav:
           - Standard library:
               - Overview: language/reference/stdlib/index.md
               - std.async: language/reference/stdlib/async.md
+              - std.collections: language/reference/stdlib/collections.md
               - std.derives.*: language/reference/stdlib/derives.md
               - std.fs: language/reference/stdlib/fs.md
               - std.graph: language/reference/stdlib/graph.md


### PR DESCRIPTION
## Summary

This PR implements RFC 030 as a pure Incan-source `std.collections` module, adds the language support needed for `ChainMap` model/class field overlays, and closes out the RFC as implemented for v0.3. The public module now includes `Deque`, `Counter`, `DefaultDict`, ordered and sorted maps/sets, `ChainMap`, and `PriorityQueue` without Rust-backed stdlib dispatch.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `from std.collections import ...` now exposes specialized collection types for double-ended queues, counters, default-valued maps, insertion-ordered maps/sets, sorted maps/sets, layered maps, and priority queues. `ChainMap` can consume read-only model/class field snapshots through `__field_items__()`.
- **Internals**: Registers `std.collections` as a source stdlib namespace, adds compiler-generated `__field_value__()` and `__field_items__()` hooks for field overlays, emits overlay methods only when used, and keeps generic comparison operators on Rust operator lowering for generic `Ord`/`PartialOrd` type parameters. RFC 030 is moved to `workspaces/docs-site/docs/RFCs/closed/implemented/030_std_collections.md`.
- **Risks**: The main compiler-sensitive area is generated field-overlay emission and generic comparison lowering. The implementation deliberately avoids Rust-backed `std.collections` dispatch; performance is source-stdlib/simple-list based rather than host-wrapper optimized.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed before the final rebase onto `origin/main`; the final rebase only brought in `.agents/skills/yeet-pr/*` updates from main.
- Focused RFC030 checks passed after the final rebase:
  - `cargo test rfc030 --test integration_tests -- --nocapture`
- The full pre-commit run included formatting/rustdoc checks, 2144 nextest tests, clippy, cargo-deny, `smoke-test-fast`, 57 checked examples, 34 runnable examples, and 8 benchmark build checks.
- `python -m mkdocs build --strict` passed before the final rebase.
- `git diff --check origin/main...HEAD` passed after the final rebase.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/stdlib/collections.md`
- Link(s): `workspaces/docs-site/docs/language/how-to/choosing_collections.md`
- Link(s): `workspaces/docs-site/docs/language/tutorials/book/08_collections_and_iteration.md`
- Link(s): `workspaces/docs-site/docs/RFCs/closed/implemented/030_std_collections.md`
- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #164
