### PR TITLE
feature - RFC 044: body-less trait methods (#201)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "byteorder",
  "clap",
@@ -1450,14 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,14 +1466,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "axum",
  "incan_core",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.40"
+version = "0.3.0-dev.41"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/syntax.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/syntax.rs
@@ -230,11 +230,9 @@ pub fn enum_variant_type_annotations(span: Span) -> CompileError {
 
 // -- Method & field declarations ---------------------------------------------
 
+/// Report a method declaration that omitted the colon required before a concrete method body.
 pub fn method_decl_expected_body(span: Span) -> CompileError {
-    CompileError::syntax(
-        "Expected ':' after return type or newline for abstract method".to_string(),
-        span,
-    )
+    CompileError::syntax("Expected ':' after method return type".to_string(), span)
 }
 
 pub fn static_only_allowed_at_module_scope(span: Span) -> CompileError {

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -812,6 +812,15 @@ pub fn ambiguous_trait_method_call(method: &str, span: Span) -> CompileError {
         .with_hint("Add an expected result type or make the call arguments select one trait instantiation")
 }
 
+/// Report an abstract method spelling used where a concrete type method body is required.
+pub fn concrete_method_requires_body(method: &str, span: Span) -> CompileError {
+    CompileError::type_error(
+        format!("Method '{}' must have a body outside trait declarations", method),
+        span,
+    )
+    .with_hint("Use `:` followed by an indented method body")
+}
+
 pub fn missing_trait_method(trait_name: &str, method: &str, span: Span) -> CompileError {
     CompileError::type_error(
         format!("Trait '{}' requires method '{}' to be implemented", trait_name, method),

--- a/crates/incan_syntax/src/parser/decl/adt.rs
+++ b/crates/incan_syntax/src/parser/decl/adt.rs
@@ -33,7 +33,7 @@ impl<'a> Parser<'a> {
 
             if self.starts_surface_function_decl() {
                 parsing_methods = true;
-                methods.push(self.method_decl(method_decorators)?);
+                methods.push(self.method_decl(method_decorators, false)?);
             } else {
                 if !method_decorators.is_empty() {
                     return Err(CompileError::syntax(

--- a/crates/incan_syntax/src/parser/decl/functions.rs
+++ b/crates/incan_syntax/src/parser/decl/functions.rs
@@ -43,8 +43,12 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse a method declaration.
-    fn method_decl(&mut self, decorators: Vec<Spanned<Decorator>>) -> Result<Spanned<MethodDecl>, CompileError> {
+    /// Parse a method declaration, optionally allowing abstract body-less methods in trait contexts.
+    fn method_decl(
+        &mut self,
+        decorators: Vec<Spanned<Decorator>>,
+        allow_abstract: bool,
+    ) -> Result<Spanned<MethodDecl>, CompileError> {
         let start = self.current_span().start;
         let mut surface_modifiers = Vec::new();
         while let Some(id) = self.match_surface_keyword(KeywordSurfaceKind::DeclarationModifier) {
@@ -68,9 +72,11 @@ impl<'a> Parser<'a> {
         self.expect_punct(PunctuationId::Arrow, "Expected '->' before return type")?;
         let return_type = self.type_expr()?;
 
-        // Check for abstract method (no body), ellipsis, or block
+        // Check for abstract method (no body), ellipsis, or block.
         let body = if self.check(&TokenKind::Newline) {
-            // Abstract method with just newline (trait definition)
+            if !allow_abstract {
+                return Err(errors::method_decl_expected_body(self.current_span()));
+            }
             None
         } else if self.match_punct(PunctuationId::Colon) {
             if self.match_punct(PunctuationId::Ellipsis) {

--- a/crates/incan_syntax/src/parser/decl/models.rs
+++ b/crates/incan_syntax/src/parser/decl/models.rs
@@ -135,7 +135,7 @@ impl<'a> Parser<'a> {
                 } else if self.starts_property_decl() {
                     properties.push(self.property_decl(method_decorators, true)?);
                 } else {
-                    methods.push(self.method_decl(method_decorators)?);
+                    methods.push(self.method_decl(method_decorators, true)?);
                 }
                 self.skip_newlines();
             }
@@ -179,7 +179,7 @@ impl<'a> Parser<'a> {
 
             // Check if it's a method (`def` or surface-modifier-prefixed `def`).
             if self.starts_surface_function_decl() {
-                methods.push(self.method_decl(decorators)?);
+                methods.push(self.method_decl(decorators, false)?);
             } else if self.starts_surface_property_decl() {
                 properties.push(self.property_decl(decorators, false)?);
             } else if self.starts_method_alias_decl() {

--- a/crates/incan_syntax/src/parser/decl/types.rs
+++ b/crates/incan_syntax/src/parser/decl/types.rs
@@ -115,7 +115,7 @@ impl<'a> Parser<'a> {
                 }
 
                 let method_decorators = self.decorators()?;
-                methods.push(self.method_decl(method_decorators)?);
+                methods.push(self.method_decl(method_decorators, false)?);
                 self.skip_newlines();
             }
 

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -430,6 +430,50 @@ class Box:
     }
 
     #[test]
+    fn test_parse_trait_bodyless_method_is_abstract() -> Result<(), Vec<CompileError>> {
+        let source = r#"
+trait Serializer:
+  def serialize(self, value: str) -> str
+  def deserialize(self, data: str) -> str: ...
+"#;
+        let program = parse_str(source)?;
+        let trait_decl = require_trait_decl(&program.declarations[0])?;
+        assert_eq!(trait_decl.methods.len(), 2);
+        assert_eq!(trait_decl.methods[0].node.name, "serialize");
+        assert!(trait_decl.methods[0].node.body.is_none());
+        assert_eq!(trait_decl.methods[1].node.name, "deserialize");
+        assert!(trait_decl.methods[1].node.body.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bodyless_methods_outside_traits_are_rejected() {
+        for source in [
+            "model User:\n  def name(self) -> str\n",
+            "class User:\n  def name(self) -> str\n",
+            "type UserId = newtype str:\n  def display(self) -> str\n",
+            "enum Token:\n  Word\n  def text(self) -> str\n",
+        ] {
+            let errs = parse_str_err(source, "bodyless methods outside traits should fail");
+            assert!(
+                errs.iter()
+                    .any(|err| err.message.contains("Expected ':' after method return type")),
+                "expected method body diagnostic, got: {errs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_bodyless_trait_method_followed_by_docstring_is_rejected() {
+        let source = r#"
+trait Named:
+  def name(self) -> str
+    "Return the display name."
+"#;
+        parse_str_err(source, "bodyless trait method docstring should require a colon body");
+    }
+
+    #[test]
     fn test_parse_pub_class_preserves_authored_field_visibility() -> Result<(), Vec<CompileError>> {
         let source = r#"
 pub class LazyFrame:

--- a/src/format/formatter/declarations.rs
+++ b/src/format/formatter/declarations.rs
@@ -784,7 +784,6 @@ impl Formatter {
         self.format_type(&method.return_type.node);
 
         if method.body.is_none() {
-            self.writer.write(": ...");
             if self.writer.line_length_exceeded() {
                 self.writer.restore(checkpoint);
                 self.write_method_prefix(method);
@@ -792,7 +791,6 @@ impl Formatter {
                 self.format_params_multiline(method.receiver.as_ref(), &method.params);
                 self.writer.write(") -> ");
                 self.format_type(&method.return_type.node);
-                self.writer.write(": ...");
             }
             self.writer.newline();
             return;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -415,7 +415,7 @@ mod tests {
 "#;
         let formatted = format_source(source)?;
         let expected = r#"trait OrderedCollection[T] with Collection[T], Serializable:
-    def sorted(self) -> OrderedCollection[T]: ...
+    def sorted(self) -> OrderedCollection[T]
 "#;
         assert_eq!(formatted, expected);
         Ok(())
@@ -1619,7 +1619,14 @@ enum Status(int):
 "#
         );
         let formatted = format_source(&source)?;
-        assert_eq!(formatted, source);
+        let expected = format!(
+            r#"trait Described:
+{DOC}
+
+    def tag(self) -> str
+"#
+        );
+        assert_eq!(formatted, expected);
         let prog = program_from_source(&formatted)?;
         assert_first_trait_decl_has_marker_docstring(&prog, "trait + method after format")?;
         Ok(())
@@ -2043,7 +2050,7 @@ pub def allocate_prism_store_id() -> int:
     }
 
     #[test]
-    fn test_format_trait_abstract_methods_stay_tight_before_default_method() -> Result<(), FormatError> {
+    fn test_format_trait_abstract_methods_prefer_bodyless_form_before_default_method() -> Result<(), FormatError> {
         let source = r#"trait Service:
   def connect(self) -> None: ...
   def close(self) -> None: ...
@@ -2053,8 +2060,8 @@ pub def allocate_prism_store_id() -> int:
         let result = format_source(source)?;
 
         let expected = r#"trait Service:
-    def connect(self) -> None: ...
-    def close(self) -> None: ...
+    def connect(self) -> None
+    def close(self) -> None
 
     def reset(self) -> None:
         pass
@@ -2110,7 +2117,7 @@ pub def allocate_prism_store_id() -> int:
 
     #[test]
     fn test_format_source_with_custom_config_keeps_rfc053_spacing() -> Result<(), FormatError> {
-        let source = r#"model User:
+        let source = r#"trait User:
   def connect(self) -> None: ...
   def reset(self) -> None:
     pass
@@ -2121,8 +2128,8 @@ def build_user() -> User:
         let config = FormatConfig::new().with_indent_width(2);
         let formatted = format_source_with_config(source, config)?;
 
-        let expected = r#"model User:
-  def connect(self) -> None: ...
+        let expected = r#"trait User:
+  def connect(self) -> None
 
   def reset(self) -> None:
     pass

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -3284,6 +3284,14 @@ impl TypeChecker {
     /// Validate a model, class, enum, or newtype method body using the concrete nominal owner as `self`.
     fn check_method_with_owner_type_params(&mut self, method: &MethodDecl, owner: &str, owner_params: &[TypeParam]) {
         self.validate_decorators_allowing_user_defined(&method.decorators);
+        if method.body.is_none() {
+            self.errors.push(errors::concrete_method_requires_body(
+                &method.name,
+                method.return_type.span,
+            ));
+            self.apply_user_defined_method_decorators(method, owner);
+            return;
+        }
         let owner_type_params = self
             .lookup_type_info(owner)
             .map(|info| match info {

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -68,6 +68,21 @@ fn has_unknown_symbol_error(errors: &[CompileError], symbol: &str) -> bool {
     errors.iter().any(|err| err.message.contains(&needle))
 }
 
+#[test]
+fn test_ellipsis_abstract_method_outside_trait_is_type_error() {
+    let source = r#"
+model User:
+  def name(self) -> str: ...
+"#;
+    let errs = check_str_err(source, "abstract concrete method should fail typechecking");
+    assert!(
+        errs.iter().any(|err| err
+            .message
+            .contains("Method 'name' must have a body outside trait declarations")),
+        "expected concrete method body diagnostic, got: {errs:?}"
+    );
+}
+
 fn check_str_with_library_index(source: &str, library_index: LibraryManifestIndex) -> Result<(), Vec<CompileError>> {
     let tokens = lexer::lex(source)?;
     let ast = parser::parse(&tokens)?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -640,7 +640,7 @@ model User:
 
 
 trait Service:
-    def connect(self) -> None: ...
+    def connect(self) -> None
 
     def reset(self) -> None:
         pass

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/044_open_ended_trait_methods.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/044_open_ended_trait_methods.md
@@ -1,6 +1,6 @@
 # RFC 044: Open-Ended Trait Methods
 
-- **Status:** Draft
+- **Status:** Implemented
 - **Created:** 2026-03-27
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -10,7 +10,7 @@
 - **Issue:** https://github.com/dannys-code-corner/incan/issues/201
 - **RFC PR:** —
 - **Written against:** v0.2
-- **Shipped in:** —
+- **Shipped in:** v0.3
 
 ## Summary
 
@@ -199,9 +199,66 @@ The parser must distinguish between trait and non-trait contexts to determine if
 - **Formatter**: The formatter should handle both forms consistently (prefer no colon for new code)
 - **LSP / Tooling**: Hover and diagnostics should work for both forms
 
-## Unresolved questions
+## Implementation Plan
 
-- Should the formatter prefer one form over the other? (Recommendation: prefer no colon for new code)
-- Should lints warn about mixing both forms in the same trait? (Recommendation: no — both are valid)
+### Phase 1: RFC lifecycle and parser contract
 
-<!-- Rename this section to "Design Decisions" once all questions have been resolved. An RFC cannot move from Draft to Planned until no unresolved questions remain. -->
+- Resolve the RFC's settled formatter/lint recommendations into design decisions.
+- Make method parsing context-aware so body-less methods are accepted only in trait bodies.
+- Preserve `def name(...) -> T: ...` as a valid abstract trait method spelling.
+- Keep non-trait `def name(...) -> T` rejected at parse time.
+
+### Phase 2: Formatter, docs, and tooling surfaces
+
+- Format abstract trait methods without the `: ...` suffix for newly formatted code.
+- Keep default method bodies and docstring-bearing methods colon-delimited.
+- Update authored user-facing language documentation for trait method declarations.
+- Add release notes for the active development line.
+
+### Phase 3: Verification and closeout
+
+- Add focused parser tests for body-less trait methods and non-trait rejection.
+- Add formatter tests for the preferred body-less trait method style.
+- Run formatting and the repository pre-commit gate.
+- Bump the active `0.3.0-dev.N` version by one development increment.
+
+## Progress Checklist
+
+### Spec / design
+
+- [x] Resolve formatter preference: formatter output should prefer no colon for abstract trait methods.
+- [x] Resolve lint policy: no lint should warn about mixing no-colon and `: ...` abstract trait method spellings.
+
+### Parser / AST
+
+- [x] Parser: accept body-less method declarations in trait bodies.
+- [x] Parser: preserve `: ...` abstract method declarations in trait bodies.
+- [x] Parser: reject body-less method declarations in models, classes, enums, and newtypes.
+- [x] Parser: reject body-less method declarations followed by a docstring without a colon.
+
+### Formatter / LSP / Tooling
+
+- [x] Formatter: prefer `def method(...) -> T` for abstract trait methods.
+- [x] LSP/tooling: confirm existing method metadata still reports abstract methods correctly.
+
+### Typechecker / Lowering / Emission
+
+- [x] Typechecker: confirm trait obligations treat both abstract spellings identically.
+- [x] Lowering/emission: confirm no IR is generated for abstract trait requirements.
+
+### Tests
+
+- [x] Parser unit tests cover body-less trait methods and invalid non-trait body-less methods.
+- [x] Formatter tests cover the preferred no-colon abstract trait method output.
+- [x] Run targeted parser/formatter/typechecker verification.
+
+### Docs / release
+
+- [x] Update authored language docs for abstract trait method declarations.
+- [x] Add release notes entry for RFC 044.
+- [x] Bump active development version from `0.3.0-dev.40` to `0.3.0-dev.41`.
+
+## Design Decisions
+
+- Formatter output should prefer the no-colon spelling for abstract trait methods in newly formatted code.
+- Lints should not warn about mixing no-colon and `: ...` abstract trait method spellings inside the same trait because both forms are valid and semantically equivalent.

--- a/workspaces/docs-site/docs/language/explanation/derives_and_traits.md
+++ b/workspaces/docs-site/docs/language/explanation/derives_and_traits.md
@@ -59,7 +59,7 @@ Enums use the same adoption model when a closed set of variants should satisfy a
 
 ```incan
 trait Describable:
-    def describe(self) -> str: ...
+    def describe(self) -> str
 
 enum Outcome with Describable:
     Success

--- a/workspaces/docs-site/docs/language/explanation/traits_as_language_hooks.md
+++ b/workspaces/docs-site/docs/language/explanation/traits_as_language_hooks.md
@@ -68,7 +68,7 @@ For example, a type can expose one conversion hook for more than one target type
 
 ```incan
 trait Snapshot[T]:
-    def snapshot(self) -> T: ...
+    def snapshot(self) -> T
 
 model Reading with Snapshot[str], Snapshot[bytes]:
     value: int

--- a/workspaces/docs-site/docs/language/reference/derives_and_traits.md
+++ b/workspaces/docs-site/docs/language/reference/derives_and_traits.md
@@ -320,7 +320,7 @@ Explicit brackets are supported only for direct calls resolved as Incan function
 
 ## Traits (authoring)
 
-Traits define reusable capabilities. Traits are always abstract: you opt concrete types in with `with TraitName`, and you may also use the trait name itself directly in annotations. Methods can be required (`...`) or have defaults.
+Traits define reusable capabilities. Traits are always abstract: you opt concrete types in with `with TraitName`, and you may also use the trait name itself directly in annotations. Required methods may be written as a signature with no body; the older `: ...` spelling remains valid for compatibility. Methods with defaults still use a colon and an indented body.
 
 Models, classes, enums, and other concrete type declarations can adopt traits. Traits may adopt other traits with the same `with` syntax to form capability hierarchies. That means a narrower trait can refine a broader one, and any concrete adopter of the narrower trait is also accepted where the broader trait is expected.
 
@@ -339,7 +339,7 @@ def main() -> None:
 
 ```incan
 trait Renderable:
-    def render(self) -> str: ...
+    def render(self) -> str
 
 enum Token with Renderable:
     Text(str)
@@ -353,10 +353,10 @@ enum Token with Renderable:
 
 ```incan
 trait Collection[T]:
-    def first(self) -> T: ...
+    def first(self) -> T
 
 trait OrderedCollection[T] with Collection[T]:
-    def sorted(self) -> Self: ...
+    def sorted(self) -> Self
 
 def first_item(values: Collection[int]) -> int:
     return values.first()

--- a/workspaces/docs-site/docs/language/tutorials/book/11_traits_and_derives.md
+++ b/workspaces/docs-site/docs/language/tutorials/book/11_traits_and_derives.md
@@ -70,10 +70,10 @@ Traits can also refine other traits:
 
 ```incan
 trait Collection[T]:
-    def first(self) -> T: ...
+    def first(self) -> T
 
 trait OrderedCollection[T] with Collection[T]:
-    def sorted(self) -> Self: ...
+    def sorted(self) -> Self
 
 def first_item(values: Collection[int]) -> int:
     return values.first()

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -349,6 +349,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Runtime/Async**: `std.async.time` adds `timeout_join`, `timeout_join_ms`, and a must-use `TimeoutJoinOutcome` so spawned work can keep running after a deadline while callers retain the live `JoinHandle` for later observation or explicit abort (#417).
 - **Runtime/Async**: `std.async.sync.Barrier.wait()` now uses Incan-owned generation bookkeeping so cancelling a pending wait withdraws that participant and frees its arrival slot instead of corrupting barrier progress (#418).
 - **Language/Compiler**: Async semantic validation now warns when a direct async function or method call is not awaited, and the existing `await`-outside-async type error is routed through the same registry-backed async surface (#146).
+- **Language/Compiler**: RFC 044 lets abstract trait methods omit the trailing `: ...` marker while keeping the explicit spelling valid; body-less methods outside traits remain invalid (#201, RFC 044).
 - **Language/Compiler**: List and dict comprehensions now accept tuple-unpack iteration targets such as `for idx, name in enumerate(xs)`, matching ordinary `for` loop binding syntax (#483).
 - **Language/Compiler**: RFC 006 adds lazy `Generator[T]` values, including `yield`-based generator functions, full-clause generator expressions, iteration-protocol compatibility, and the minimum helper surface `.map()`, `.filter()`, `.take()`, and `.collect()` (#324, RFC 006).
 - **Language/Stdlib**: RFC 069 adds import-free `list.repeat(value, count)` for fixed-length list initialization. The compiler infers `list[T]`, enforces clone-compatible repeated values and `count: int`, lowers recognized calls to the stdlib helper, and raises `ValueError` with the bad count for negative runtime counts (#385, RFC 069).
@@ -369,6 +370,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Dependency policy**: The workspace now builds against Wasmtime `44.0.1` / Wasmtime WASI `44.0.1` and raises the Rust MSRV to `1.92`, matching Wasmtime 44's compiler requirement.
 - **Dependency policy**: Dependabot security alerts for the VS Code extension lockfile, docs-site Python pins, and Rust `rand` lock entries are remediated, while repo-owned GitHub Actions are moved to Node 24-compatible action releases (#475, #464).
 - **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.40`.
+- **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.41`.
 
 ## Known limitations (0.3)
 
@@ -390,6 +392,7 @@ The sections above are the release story. The list below is the detailed invento
 - Union types and type narrowing: [RFC 029]
 - Value enums: [RFC 032]
 - Variadic positional arguments and keyword capture: [RFC 038]
+- Open-ended trait methods: [RFC 044]
 - Computed properties: [RFC 046]
 - Checked contract metadata and interrogation tooling: [RFC 048]
 - Lightweight directed graph types: [RFC 047]


### PR DESCRIPTION
## Summary

This PR implements RFC 044 so abstract methods inside traits may be written as signature-only declarations, while the existing `: ...` spelling remains valid. The parser now distinguishes trait and concrete method contexts, the formatter prefers the no-colon abstract method style, docs and release notes describe the new surface, and the workspace development version advances to `0.3.0-dev.41`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Trait requirements can now be written as `def method(...) -> T` without `: ...`. The explicit `def method(...) -> T: ...` spelling still parses as the same abstract requirement. Body-less methods outside trait declarations remain invalid.
- **Internals**: `method_decl` is now context-aware for abstract body-less parsing. Concrete method owners still flow through typechecking, where explicit abstract spellings outside traits receive a typed diagnostic. Formatter output omits `: ...` for abstract method declarations.
- **Risks**: The parser context split touches every nominal method owner. Focused parser tests cover trait, model, class, enum, and newtype behavior; formatter and typechecker suites were run to catch downstream drift.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed on the rebased commit.
- `make smoke-test-fast` passed as part of the publish gate.
- Earlier focused checks included `cargo test -p incan_syntax parser::tests`, `cargo test format::tests`, `cargo test frontend::typechecker::tests`, and `mkdocs build --strict`.
- RFC lifecycle state: RFC 044 is `Implemented` and moved to `workspaces/docs-site/docs/RFCs/closed/implemented/044_open_ended_trait_methods.md`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s):
  - `workspaces/docs-site/docs/language/reference/derives_and_traits.md`
  - `workspaces/docs-site/docs/language/tutorials/book/11_traits_and_derives.md`
  - `workspaces/docs-site/docs/language/explanation/derives_and_traits.md`
  - `workspaces/docs-site/docs/language/explanation/traits_as_language_hooks.md`
  - `workspaces/docs-site/docs/release_notes/0_3.md`
  - `workspaces/docs-site/docs/RFCs/closed/implemented/044_open_ended_trait_methods.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #201