### PR TITLE
chore - tighten crate boundary ownership (#284)

### DIFF
--- a/crates/incan_core/src/lang/surface/types.rs
+++ b/crates/incan_core/src/lang/surface/types.rs
@@ -1,7 +1,10 @@
 //! Surface/runtime/interop types vocabulary.
 //!
-//! These types are part of the language surface (documented, user-facing), but are not “core”
+//! These types are part of the language surface (documented, user-facing), but are not "core"
 //! builtin types like `int`/`str` and do not belong in `lang::types::*` registries.
+//!
+//! Each entry carries explicit ownership metadata so stdlib/runtime-facing vocabulary can be filtered without
+//! hard-coded side tables.
 
 use crate::lang::registry::{LangItemInfo, RFC, RfcId, Since, Stability};
 
@@ -53,19 +56,86 @@ pub enum SurfaceTypeKind {
     Generic,
 }
 
+/// The implementation owner responsible for a surface type's semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SurfaceTypeOwner {
+    Runtime,
+    Stdlib,
+    Interop,
+}
+
+/// Coarse feature bucket used by compiler and tooling consumers that need grouped surface types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SurfaceTypeCategory {
+    AsyncSync,
+    AsyncTask,
+    AsyncChannel,
+    RustInterop,
+    Web,
+    Reflection,
+    Validation,
+}
+
+/// Ownership and import-scope metadata for a surface type spelling.
+#[derive(Debug, Clone, Copy)]
+pub struct SurfaceTypeOwnership {
+    pub owner: SurfaceTypeOwner,
+    pub category: SurfaceTypeCategory,
+    pub stdlib_module_path: Option<&'static str>,
+    pub rationale: &'static str,
+}
+
+/// Metadata for a surface type spelling.
 #[derive(Debug, Clone, Copy)]
 pub struct SurfaceTypeInfo {
     pub kind: SurfaceTypeKind,
+    pub ownership: SurfaceTypeOwnership,
     pub item: LangItemInfo<SurfaceTypeId>,
 }
+
+const RUNTIME_ASYNC_SYNC: SurfaceTypeOwnership = runtime(
+    "std.async.sync",
+    SurfaceTypeCategory::AsyncSync,
+    "Runtime-backed synchronization primitive re-exported through `std.async.sync`; it is not a language builtin.",
+);
+const RUNTIME_ASYNC_TASK: SurfaceTypeOwnership = runtime(
+    "std.async.task",
+    SurfaceTypeCategory::AsyncTask,
+    "Runtime task vocabulary surfaced through `std.async.task`; name lookup requires the stdlib module import.",
+);
+const RUNTIME_ASYNC_CHANNEL: SurfaceTypeOwnership = runtime(
+    "std.async.channel",
+    SurfaceTypeCategory::AsyncChannel,
+    "Runtime channel vocabulary surfaced through `std.async.channel`; name lookup requires the stdlib module import.",
+);
+const INTEROP_RUST: SurfaceTypeOwnership = interop(
+    SurfaceTypeCategory::RustInterop,
+    "Globally available Rust interop bridge type; no stdlib import owns its name.",
+);
+const STDLIB_WEB: SurfaceTypeOwnership = stdlib(
+    "std.web",
+    SurfaceTypeCategory::Web,
+    "Web stdlib facade type owned by `std.web`; it is predeclared in core only so compiler passes share a stable spelling.",
+);
+const STDLIB_REFLECTION: SurfaceTypeOwnership = stdlib(
+    "std.reflection",
+    SurfaceTypeCategory::Reflection,
+    "Reflection stdlib metadata type owned by `std.reflection`; core records the spelling for compiler-generated `__fields__()` results.",
+);
+const STDLIB_VALIDATION: SurfaceTypeOwnership = SurfaceTypeOwnership {
+    owner: SurfaceTypeOwner::Stdlib,
+    category: SurfaceTypeCategory::Validation,
+    stdlib_module_path: None,
+    rationale: "Globally available validated-newtype error type owned by the validation stdlib/runtime surface.",
+};
 
 pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     // Async primitives
     info(
         SurfaceTypeId::Mutex,
         "Mutex",
-        &[],
         SurfaceTypeKind::Generic,
+        RUNTIME_ASYNC_SYNC,
         "Async/runtime mutex.",
         RFC::_000,
         Since(0, 1),
@@ -73,8 +143,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::RwLock,
         "RwLock",
-        &[],
         SurfaceTypeKind::Generic,
+        RUNTIME_ASYNC_SYNC,
         "Async/runtime read-write lock.",
         RFC::_000,
         Since(0, 1),
@@ -82,8 +152,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Semaphore,
         "Semaphore",
-        &[],
         SurfaceTypeKind::Named,
+        RUNTIME_ASYNC_SYNC,
         "Async/runtime semaphore.",
         RFC::_000,
         Since(0, 1),
@@ -91,8 +161,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Barrier,
         "Barrier",
-        &[],
         SurfaceTypeKind::Named,
+        RUNTIME_ASYNC_SYNC,
         "Async/runtime barrier.",
         RFC::_000,
         Since(0, 1),
@@ -101,8 +171,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::JoinHandle,
         "JoinHandle",
-        &[],
         SurfaceTypeKind::Generic,
+        RUNTIME_ASYNC_TASK,
         "Handle to a spawned task.",
         RFC::_000,
         Since(0, 1),
@@ -110,8 +180,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::TaskJoinError,
         "TaskJoinError",
-        &[],
         SurfaceTypeKind::Named,
+        RUNTIME_ASYNC_TASK,
         "Error returned when a spawned task fails to join.",
         RFC::_000,
         Since(0, 1),
@@ -120,8 +190,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Sender,
         "Sender",
-        &[],
         SurfaceTypeKind::Generic,
+        RUNTIME_ASYNC_CHANNEL,
         "Bounded channel sender.",
         RFC::_000,
         Since(0, 1),
@@ -129,8 +199,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Receiver,
         "Receiver",
-        &[],
         SurfaceTypeKind::Generic,
+        RUNTIME_ASYNC_CHANNEL,
         "Bounded channel receiver.",
         RFC::_000,
         Since(0, 1),
@@ -138,8 +208,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::OneshotSender,
         "OneshotSender",
-        &[],
         SurfaceTypeKind::Generic,
+        RUNTIME_ASYNC_CHANNEL,
         "Oneshot channel sender.",
         RFC::_000,
         Since(0, 1),
@@ -147,8 +217,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::OneshotReceiver,
         "OneshotReceiver",
-        &[],
         SurfaceTypeKind::Generic,
+        RUNTIME_ASYNC_CHANNEL,
         "Oneshot channel receiver.",
         RFC::_000,
         Since(0, 1),
@@ -157,8 +227,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Vec,
         "Vec",
-        &[],
         SurfaceTypeKind::Generic,
+        INTEROP_RUST,
         "Rust interop `Vec<T>`.",
         RFC::_005,
         Since(0, 1),
@@ -166,8 +236,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::HashMap,
         "HashMap",
-        &[],
         SurfaceTypeKind::Generic,
+        INTEROP_RUST,
         "Rust interop `HashMap<K, V>`.",
         RFC::_005,
         Since(0, 1),
@@ -176,8 +246,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::App,
         "App",
-        &[],
         SurfaceTypeKind::Named,
+        STDLIB_WEB,
         "Web application handle for running an HTTP server.",
         RFC::_000,
         Since(0, 1),
@@ -185,8 +255,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Response,
         "Response",
-        &[],
         SurfaceTypeKind::Named,
+        STDLIB_WEB,
         "HTTP response builder for web handlers.",
         RFC::_000,
         Since(0, 1),
@@ -194,8 +264,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Html,
         "Html",
-        &[],
         SurfaceTypeKind::Named,
+        STDLIB_WEB,
         "HTML response wrapper for web handlers.",
         RFC::_000,
         Since(0, 1),
@@ -203,8 +273,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Json,
         "Json",
-        &[],
         SurfaceTypeKind::Generic,
+        STDLIB_WEB,
         "JSON response/extractor wrapper for web handlers.",
         RFC::_000,
         Since(0, 1),
@@ -212,8 +282,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Query,
         "Query",
-        &[],
         SurfaceTypeKind::Generic,
+        STDLIB_WEB,
         "Query-string extractor wrapper for web handlers.",
         RFC::_000,
         Since(0, 1),
@@ -221,8 +291,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Path,
         "Path",
-        &[],
         SurfaceTypeKind::Generic,
+        STDLIB_WEB,
         "Path-parameter extractor wrapper for web handlers.",
         RFC::_000,
         Since(0, 1),
@@ -230,8 +300,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Body,
         "Body",
-        &[],
         SurfaceTypeKind::Generic,
+        STDLIB_WEB,
         "Request body extractor wrapper for web handlers.",
         RFC::_000,
         Since(0, 1),
@@ -239,8 +309,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::Request,
         "Request",
-        &[],
         SurfaceTypeKind::Named,
+        STDLIB_WEB,
         "Full HTTP request access for web handlers.",
         RFC::_000,
         Since(0, 1),
@@ -248,8 +318,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::FieldInfo,
         "FieldInfo",
-        &[],
         SurfaceTypeKind::Named,
+        STDLIB_REFLECTION,
         "Field metadata record returned by __fields__().",
         RFC::_021,
         Since(0, 1),
@@ -257,8 +327,8 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
     info(
         SurfaceTypeId::ValidationError,
         "ValidationError",
-        &[],
         SurfaceTypeKind::Named,
+        STDLIB_VALIDATION,
         "Structured validation error used by validated newtypes.",
         RFC::_017,
         Since(0, 3),
@@ -283,42 +353,34 @@ pub const SEMAPHORE_PERMIT_TYPE_NAME: &str = "SemaphorePermit";
 /// (e.g. `App`, `Mutex`, `FieldInfo`). Rust interop types like `Vec`/`HashMap` remain globally
 /// available and return `None`.
 pub fn stdlib_module_path(id: SurfaceTypeId) -> Option<&'static str> {
-    match id {
-        // Async primitives
-        SurfaceTypeId::Mutex | SurfaceTypeId::RwLock | SurfaceTypeId::Semaphore | SurfaceTypeId::Barrier => {
-            Some("std.async.sync")
-        }
-
-        // Task handles
-        SurfaceTypeId::JoinHandle | SurfaceTypeId::TaskJoinError => Some("std.async.task"),
-
-        // Channels
-        SurfaceTypeId::Sender
-        | SurfaceTypeId::Receiver
-        | SurfaceTypeId::OneshotSender
-        | SurfaceTypeId::OneshotReceiver => Some("std.async.channel"),
-
-        // Web
-        SurfaceTypeId::App
-        | SurfaceTypeId::Response
-        | SurfaceTypeId::Html
-        | SurfaceTypeId::Json
-        | SurfaceTypeId::Query
-        | SurfaceTypeId::Path
-        | SurfaceTypeId::Body
-        | SurfaceTypeId::Request => Some("std.web"),
-
-        // Reflection
-        SurfaceTypeId::FieldInfo => Some("std.reflection"),
-
-        // Interop and validation types are globally available.
-        SurfaceTypeId::ValidationError | SurfaceTypeId::Vec | SurfaceTypeId::HashMap => None,
-    }
+    info_for(id).ownership.stdlib_module_path
 }
 
 /// Whether this surface type is globally available without an explicit import.
 pub fn is_global(id: SurfaceTypeId) -> bool {
     stdlib_module_path(id).is_none()
+}
+
+/// Return the implementation owner responsible for this surface type's semantics.
+#[must_use]
+pub fn owner(id: SurfaceTypeId) -> SurfaceTypeOwner {
+    info_for(id).ownership.owner
+}
+
+/// Return the coarse feature bucket for this surface type.
+#[must_use]
+pub fn category(id: SurfaceTypeId) -> SurfaceTypeCategory {
+    info_for(id).ownership.category
+}
+
+/// Iterate over all surface types with the given implementation owner.
+pub fn types_for_owner(owner: SurfaceTypeOwner) -> impl Iterator<Item = &'static SurfaceTypeInfo> {
+    SURFACE_TYPES.iter().filter(move |t| t.ownership.owner == owner)
+}
+
+/// Iterate over all surface types in the given feature bucket.
+pub fn types_in_category(category: SurfaceTypeCategory) -> impl Iterator<Item = &'static SurfaceTypeInfo> {
+    SURFACE_TYPES.iter().filter(move |t| t.ownership.category == category)
 }
 
 pub fn from_str(name: &str) -> Option<SurfaceTypeId> {
@@ -369,26 +431,66 @@ pub fn info_for(id: SurfaceTypeId) -> SurfaceTypeInfo {
     }
 }
 
+/// Build a surface type registry entry.
 const fn info(
     id: SurfaceTypeId,
     canonical: &'static str,
-    aliases: &'static [&'static str],
     kind: SurfaceTypeKind,
+    ownership: SurfaceTypeOwnership,
     description: &'static str,
     introduced_in_rfc: RfcId,
     since: Since,
 ) -> SurfaceTypeInfo {
     SurfaceTypeInfo {
         kind,
+        ownership,
         item: LangItemInfo {
             id,
             canonical,
-            aliases,
+            aliases: &[],
             description,
             introduced_in_rfc,
             since,
             stability: Stability::Stable,
             examples: &[],
         },
+    }
+}
+
+/// Build ownership metadata for a runtime-backed type exposed through a stdlib module.
+const fn runtime(
+    stdlib_module_path: &'static str,
+    category: SurfaceTypeCategory,
+    rationale: &'static str,
+) -> SurfaceTypeOwnership {
+    SurfaceTypeOwnership {
+        owner: SurfaceTypeOwner::Runtime,
+        category,
+        stdlib_module_path: Some(stdlib_module_path),
+        rationale,
+    }
+}
+
+/// Build ownership metadata for a stdlib-owned type that core keeps as shared vocabulary.
+const fn stdlib(
+    stdlib_module_path: &'static str,
+    category: SurfaceTypeCategory,
+    rationale: &'static str,
+) -> SurfaceTypeOwnership {
+    SurfaceTypeOwnership {
+        owner: SurfaceTypeOwner::Stdlib,
+        category,
+        stdlib_module_path: Some(stdlib_module_path),
+        rationale,
+    }
+}
+
+/// Build ownership metadata for a globally available Rust interop bridge type.
+const fn interop(category: SurfaceTypeCategory, rationale: &'static str) -> SurfaceTypeOwnership {
+    SurfaceTypeOwnership {
+        owner: SurfaceTypeOwner::Interop,
+        category,
+        stdlib_module_path: None,
+        rationale,
     }
 }

--- a/crates/incan_core/tests/lang_registry_guardrails.rs
+++ b/crates/incan_core/tests/lang_registry_guardrails.rs
@@ -8,6 +8,7 @@ use incan_core::lang::magic_methods;
 use incan_core::lang::operators;
 use incan_core::lang::punctuation;
 use incan_core::lang::registry::{RFC, Since};
+use incan_core::lang::surface::types::{SurfaceTypeCategory, SurfaceTypeId, SurfaceTypeOwner};
 use incan_core::lang::surface::{constructors, functions, types as surface_types};
 use incan_core::lang::traits;
 use incan_core::lang::types::{collections, numerics, stringlike};
@@ -312,6 +313,63 @@ fn surface_types_spellings_unique_and_resolvable() {
         from_str: surface_types::from_str,
         as_str: surface_types::as_str,
     });
+}
+
+#[test]
+fn surface_types_have_explicit_ownership_metadata() {
+    for info in surface_types::SURFACE_TYPES {
+        let id = info.item.id;
+
+        assert_eq!(surface_types::owner(id), info.ownership.owner);
+        assert_eq!(surface_types::category(id), info.ownership.category);
+        assert_eq!(surface_types::stdlib_module_path(id), info.ownership.stdlib_module_path);
+        assert!(
+            !info.ownership.rationale.trim().is_empty(),
+            "surface type {:?} must explain why incan_core owns its spelling",
+            id
+        );
+    }
+
+    let globally_available: Vec<SurfaceTypeId> = surface_types::SURFACE_TYPES
+        .iter()
+        .filter(|info| surface_types::is_global(info.item.id))
+        .map(|info| info.item.id)
+        .collect();
+    assert_eq!(
+        globally_available,
+        vec![
+            SurfaceTypeId::Vec,
+            SurfaceTypeId::HashMap,
+            SurfaceTypeId::ValidationError
+        ]
+    );
+
+    let interop_types: Vec<SurfaceTypeId> = surface_types::types_for_owner(SurfaceTypeOwner::Interop)
+        .map(|info| info.item.id)
+        .collect();
+    assert_eq!(interop_types, vec![SurfaceTypeId::Vec, SurfaceTypeId::HashMap]);
+
+    let web_types: Vec<SurfaceTypeId> = surface_types::types_in_category(SurfaceTypeCategory::Web)
+        .map(|info| info.item.id)
+        .collect();
+    assert_eq!(
+        web_types,
+        vec![
+            SurfaceTypeId::App,
+            SurfaceTypeId::Response,
+            SurfaceTypeId::Html,
+            SurfaceTypeId::Json,
+            SurfaceTypeId::Query,
+            SurfaceTypeId::Path,
+            SurfaceTypeId::Body,
+            SurfaceTypeId::Request,
+        ]
+    );
+
+    let validation_types: Vec<SurfaceTypeId> = surface_types::types_in_category(SurfaceTypeCategory::Validation)
+        .map(|info| info.item.id)
+        .collect();
+    assert_eq!(validation_types, vec![SurfaceTypeId::ValidationError]);
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/crates/incan_derive/README.md
+++ b/crates/incan_derive/README.md
@@ -4,6 +4,8 @@ Derive macros for the Incan programming language standard library.
 
 This crate provides procedural macros that generate boilerplate implementations for Incan language features. These macros are automatically used by the Incan compiler when you use decorators like `@derive(...)` in your Incan code.
 
+This crate is toolchain-locked to the Incan compiler and `incan_stdlib`. Its macros are exported because Rust procedural macro crates must export proc macros, not because they are intended as an independently stable public macro toolkit.
+
 ## Purpose
 
 When you write:
@@ -118,6 +120,10 @@ The compiler automatically:
 4. Ensures both `incan_stdlib` and `incan_derive` are in scope
 
 You should never need to use these macros directly - the compiler handles it.
+
+### Toolchain-locked boundary
+
+`incan_derive` is an implementation companion for generated Rust. Changes to macro names, generated helper methods, and trait wiring should follow the compiler and `incan_stdlib` together. If a behavior becomes part of the user-facing language contract, document it in the Incan language or stdlib docs first; keep this crate focused on the Rust expansion required to implement that contract.
 
 ## Development
 

--- a/crates/incan_derive/src/lib.rs
+++ b/crates/incan_derive/src/lib.rs
@@ -5,6 +5,10 @@
 //! - `FieldInfo`: Generates `HasFieldInfo` trait implementation for reflection
 //! - `IncanReflect`: Alias for IncanClass (for clarity in generated code)
 //! - `IncanJson`: Generates JSON serialization helpers
+//!
+//! This crate is a toolchain-locked implementation companion to `incan_stdlib` and compiler-generated Rust. Its macros
+//! are public only because Rust requires proc macros to be exported from a proc-macro crate; downstream code should not
+//! treat them as an independent stable macro toolkit.
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/crates/incan_stdlib/README.md
+++ b/crates/incan_stdlib/README.md
@@ -8,6 +8,8 @@ This crate provides the runtime support that all Incan-compiled programs depend 
 
 When you write Incan code with models, classes, and decorators, the compiler generates Rust code that leverages this standard library. Think of it as the bridge between Incan's Python-like ergonomics and Rust's performance.
 
+The user-facing contract is the Incan `std.*` surface declared by the stdlib stubs under `stdlib/`. The Rust modules under `src/` are the generated-code runtime backing for that surface. Some modules are stable support crates for generated Rust, while others are temporary host implementations that should not be treated as independent public APIs.
+
 ## What's Inside
 
 ### Core Traits
@@ -64,6 +66,12 @@ Enables JSON serialization support. Adds dependencies on `serde` and `serde_json
 
 **Enabled when**: Your Incan code imports and derives `std.serde.json`
 
+### `web` (optional)
+
+Enables the current Axum-backed host runtime for generated Incan web programs.
+
+**Boundary**: `incan_stdlib::web` is transitional generated-code support. It provides route registration, response helpers, and `App::run` while the Incan-owned `std.web` runtime surface is still maturing. Do not treat it as a stable standalone web framework API unless that contract is first reflected in the Incan stdlib stubs and language documentation.
+
 ## Architecture Notes
 
 ### Incan stdlib stubs
@@ -76,6 +84,16 @@ These files define the user-facing `std.*` API surface and are parsed by the com
 For `std.testing`, this also includes marker semantics metadata consumed by `incan test` discovery/execution.
 The Rust runtime in `src/testing.rs` only provides irreducible host boundaries declared via `@rust.extern`.
 The language `assert` statement is always available without importing `std.testing`; the stdlib assertion helpers mirror that behavior for call-style assertions and unwrap-style helpers.
+
+### Transitional web runtime
+
+The web runtime is deliberately quarantined in `src/web.rs`. It re-exports a small set of Axum types, collects routes through `inventory`, and starts a Tokio/Axum server for generated programs. That is a compiler/runtime implementation bridge, not the final ownership model for `std.web`.
+
+Changes to this module should keep the generated-code boundary explicit: add stable user-facing behavior in the Incan stdlib stubs first, then update the Rust backing only where host integration is still required.
+
+### Internal generated-code support
+
+The `__private` module re-exports host crates needed by generated Rust. It is toolchain-locked to the compiler and may change with generated code. It is not part of the Incan language stdlib.
 
 ### Why a Separate Crate?
 

--- a/crates/incan_stdlib/src/lib.rs
+++ b/crates/incan_stdlib/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //! This crate provides traits and utilities that generated Incan code depends on, including reflection capabilities,
 //! JSON serialization helpers, and numeric operations.
+//!
+//! The stable boundary for Incan users is the `std.*` API declared by the Incan stdlib stubs. Rust modules in this
+//! crate are runtime support for compiler-generated Rust and may contain transitional host implementations while the
+//! corresponding Incan-language stdlib surface is still being built.
 
 #![deny(clippy::unwrap_used)]
 

--- a/crates/incan_stdlib/src/web.rs
+++ b/crates/incan_stdlib/src/web.rs
@@ -2,6 +2,11 @@
 //!
 //! Web route registration is inventory-driven. The compiler/proc-macro layer emits `inventory::submit!` calls
 //! containing `RouteEntry` records, and `App::run` builds the router from those records at runtime.
+//!
+//! This module is a transitional host-runtime boundary, not a stable general-purpose web framework API. It exists so
+//! generated Incan web programs have a concrete Rust target while the `std.web` surface and runtime ownership model
+//! are still settling. Public items here should be treated as generated-code support unless the Incan stdlib stubs and
+//! language docs explicitly expose them.
 
 // FIXME: this module need to be rewritten in incan once the appropriate RFCs are implemented
 
@@ -13,7 +18,7 @@ use axum::response::{Html as AxumHtmlInner, IntoResponse, Response as AxumRawRes
 use tokio::runtime::Runtime;
 
 // Re-export axum types so stdlib Incan modules can import them via `incan_stdlib::web::Json`,
-// `incan_stdlib::web::Html`, etc. These are the canonical "web response" types for Incan programs.
+// `incan_stdlib::web::Html`, etc. These are transitional generated-code targets for the current host runtime.
 pub use axum::Json;
 pub use axum::response::Html;
 
@@ -54,6 +59,9 @@ impl RouteEntry {
 inventory::collect!(RouteEntry);
 
 /// Minimal application handle for generated web programs.
+///
+/// This handle is part of the transitional web runtime. It is intentionally small and should not be extended as a
+/// general stable application framework without first moving that contract into the Incan stdlib surface.
 #[derive(Default)]
 pub struct App {}
 

--- a/crates/incan_web_macros/README.md
+++ b/crates/incan_web_macros/README.md
@@ -1,0 +1,23 @@
+# incan_web_macros
+
+Procedural macros for the transitional Incan web runtime.
+
+This crate supports compiler-generated Rust that targets `incan_stdlib::web`. It is toolchain-locked to the Incan compiler and stdlib runtime crate; it is not a standalone public web framework API.
+
+## Boundary
+
+The macros here generate Axum/inventory wiring for Incan web programs:
+
+- `#[route(...)]` registers generated route handlers with `incan_stdlib::web::RouteEntry`.
+- `#[derive(IntoResponse)]` delegates response conversion for tuple newtypes.
+- `#[derive(FromRequestParts)]` delegates request extraction for tuple newtypes.
+
+Those expansions are part of the current host-runtime bridge. If `std.web` changes ownership or moves more behavior into Incan source, these macros may change with the compiler.
+
+## Development
+
+Keep changes aligned with `crates/incan_stdlib/src/web.rs` and generated web code. Do not add reusable routing abstractions here unless the corresponding Incan stdlib surface has been defined first.
+
+## License
+
+Apache 2.0

--- a/crates/incan_web_macros/src/lib.rs
+++ b/crates/incan_web_macros/src/lib.rs
@@ -1,3 +1,8 @@
+//! Procedural macros for the transitional Incan web runtime.
+//!
+//! This crate is toolchain-locked to `incan_stdlib::web` and compiler-generated Rust. It is not a standalone routing
+//! framework API; macro output may change whenever the compiler/runtime contract changes.
+
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};

--- a/crates/rust_inspect/README.md
+++ b/crates/rust_inspect/README.md
@@ -8,6 +8,8 @@ This crate is the compiler-side boundary for looking up Rust function/type metad
 - extract `RustItemMetadata` for canonical Rust paths
 - cache extracted items so compiler hot paths can read metadata without re-extracting it
 
+`rust_inspect` is toolchain-locked to the Incan compiler. Treat it as staged interop-preparation infrastructure, not as a reusable crate API for downstream programs.
+
 ## Purpose
 
 Incan needs Rust-side signatures and item shapes for some interop checks:
@@ -41,6 +43,7 @@ The intended contract is:
 - `prewarm(...)` may perform expensive extraction
 - `get(...)` should be cache-only
 - compiler/typechecker hot paths should prefer cached reads over fresh extraction
+- workspace loading is owned by explicit preparation/cache code, not by semantic checks as a side effect
 
 ## Architecture Notes
 
@@ -72,6 +75,8 @@ Keeping it separate makes that boundary explicit.
 ### Not a stable public contract
 
 This crate is an internal compiler subsystem. The API may change as Incan settles the right architecture for Rust inspection. In particular, cache layout, fidelity reporting, and workspace loading strategy should be treated as implementation details unless explicitly documented otherwise.
+
+The stable architectural rule is the phase boundary: extraction happens before hot semantic/codegen paths need the data, and those paths consume cached metadata or report a miss.
 
 ### Internal module layout
 

--- a/crates/rust_inspect/src/cache.rs
+++ b/crates/rust_inspect/src/cache.rs
@@ -1,4 +1,7 @@
 //! In-memory cache: one loaded workspace per manifest directory, plus per-item metadata.
+//!
+//! The cache is the boundary that keeps rust-analyzer/Cargo extraction out of compiler hot paths. Preparation code may
+//! call `get_or_extract`; ordinary semantic/codegen consumers should use cache-only reads through `Inspector::get`.
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -26,6 +29,9 @@ const INSPECTOR_VERSION: &str = env!("CARGO_PKG_VERSION");
 ///
 /// The workspace is loaded at most once per canonical manifest directory; item metadata is stored per `(workspace_root,
 /// canonical_path)` and reused without re-querying salsa.
+///
+/// This type is internal plumbing for the toolchain-locked inspection subsystem. Its persistence format and negative
+/// lookup behavior are implementation details unless promoted through the crate-level API.
 ///
 /// The entire cache is protected by one mutex so `RustWorkspace` (which is not `Sync` because of the retained `Vfs`)
 /// never has to live inside `Arc` for cross-thread sharing.

--- a/crates/rust_inspect/src/lib.rs
+++ b/crates/rust_inspect/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //! The `Inspector` API separates eager extraction (`prewarm`) from cache-only reads (`get`) so compiler hot paths can
 //! remain extraction-free.
+//!
+//! This crate is a toolchain-locked compiler subsystem. It is responsible for staged Rust interop preparation and
+//! metadata cache access, not for ambient semantic analysis. Callers should make workspace loading and extraction
+//! explicit before typechecking/codegen paths ask for cached metadata.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -80,6 +84,9 @@ impl Inspector {
     }
 
     /// Create an inspector bound to one generated lock workspace.
+    ///
+    /// The workspace should be compiler-managed, usually the generated lock workspace used for Rust interop
+    /// preparation rather than the user's live application tree.
     pub fn new(config: InspectorConfig) -> Self {
         Self {
             config,
@@ -90,7 +97,8 @@ impl Inspector {
     /// Eagerly extract/cache metadata for the supplied canonical query paths.
     ///
     /// This is the expensive path. Callers should do this in explicit preparation phases rather than semantic hot
-    /// loops.
+    /// loops. A missing item that is stable enough to cache negatively is skipped here so later cache-only lookups can
+    /// report the miss without reloading the Rust workspace.
     pub fn prewarm<I>(&self, canonical_paths: I, progress: &(dyn Fn(String) + Sync)) -> Result<(), InspectError>
     where
         I: IntoIterator<Item = String>,

--- a/crates/rust_inspect/src/loader.rs
+++ b/crates/rust_inspect/src/loader.rs
@@ -1,4 +1,7 @@
 //! Load a Cargo tree into rust-analyzer's `RootDatabase`.
+//!
+//! This module is intentionally behind the rust-inspect preparation/cache boundary. It owns the unstable rust-analyzer
+//! embedding details so parser/typechecker/codegen code does not load Cargo workspaces directly.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -51,7 +54,8 @@ impl RustWorkspace {
 
     /// Load the Cargo project rooted at `manifest_dir` (directory containing `Cargo.toml`).
     ///
-    /// `progress` is forwarded to rust-analyzer while discovering workspace members.
+    /// `progress` is forwarded to rust-analyzer while discovering workspace members. Call this only from explicit
+    /// inspection preparation paths, not from ordinary semantic lookups.
     pub fn load(manifest_dir: &Path, progress: &(dyn Fn(String) + Sync)) -> Result<Self, RustMetadataError> {
         Self::load_with_options(manifest_dir, progress, false)
     }

--- a/workspaces/docs-site/docs/contributing/explanation/architecture.md
+++ b/workspaces/docs-site/docs/contributing/explanation/architecture.md
@@ -159,6 +159,26 @@ Runtime crates (used by generated Rust programs, not the compiler)
         - Proc-macro derives to generate impls for stdlib traits
 ```
 
+## Workspace Crate Boundary Policy
+
+Workspace crates are not interchangeable buckets for compiler code. Treat each crate as one of these ownership categories:
+
+- **Stable contract crates**: `incan_core`, `incan_syntax`, `incan_semantics_core`, and `incan_vocab`. These crates hold shared language contracts used across compiler, tooling, library manifests, and generated-package boundaries. Keep them deterministic, dependency-light, and explicit about what is stable.
+- **Compiler/toolchain implementation crates**: `incan`, `incan_semantics_stdlib`, and `rust_inspect`. These crates own compiler orchestration, stdlib semantics packs, and Rust metadata preparation. They may evolve with the toolchain and should not be treated as general runtime APIs.
+- **Runtime-only crates**: `incan_stdlib`, `incan_derive`, and `incan_web_macros`. These crates back generated Rust programs and runtime behavior. The compiler must not depend on them in normal builds.
+- **Transitional runtime surfaces**: the current `incan_stdlib::web` backing plus related macro glue. Keep transitional runtime code quarantined behind runtime-only crates until it is either stabilized or replaced by Incan-authored library code.
+
+The useful distinction is stable contract versus implementation detail, not "more crates" versus "fewer crates." A new crate boundary is justified when it protects a real contract: syntax shared with formatter/LSP, pure semantic policy shared with runtime, a semantics-pack interface, a library manifest ABI, or a staged interop subsystem. It is not justified when it only hides a pile of toolchain internals behind a new package name.
+
+When moving code, preserve these rules:
+
+- Language policy that both compiler and runtime must share belongs in `incan_core` or another stable contract crate.
+- Syntax shapes, parser diagnostics, and AST vocabulary belong in `incan_syntax`; compiler-only name resolution and typechecking stay out of that crate.
+- Surface semantics packs return descriptors through `incan_semantics_core`; they do not call compiler frontend/backend code directly.
+- Runtime facades, proc macros, web glue, panics, allocation-heavy wrappers, and generated-program helpers stay in runtime-only crates.
+- Rust interop metadata loading stays staged and cache-oriented in `rust_inspect`; semantic hot paths should read prepared metadata rather than performing hidden workspace extraction.
+- If a type looks stdlib-owned (`Mutex`, `JoinHandle`, `App`, `Response`, etc.), do not add more core-owned surface metadata without an explicit rationale. Prefer library-defined ownership when the current manifest and semantics-pack machinery can express it.
+
 ## Semantic Core
 
 Incan has a **semantic core** crate (`incan_core`) that holds pure, deterministic helpers shared by the compiler and
@@ -170,6 +190,8 @@ runtime, without creating dependency cycles.
 - **Constraints**: pure/deterministic (no IO, no global state) and no dependencies on compiler crates.
 - **Stdlib registry**: `incan_core::lang::stdlib::STDLIB_NAMESPACES` drives stdlib import validation, stub path resolution,
   unknown-module hints, and import-activated language features (soft keywords like `async`/`await`).
+
+`incan_core` should own language-wide policy, not runtime implementations. Existing stdlib-facing surface type metadata is a compatibility boundary; new work should either justify why the metadata is truly language-core policy or push ownership toward library-defined declarations/semantics packs.
 
 See crate-level documentation in `crates/incan_core` for the contract, extension checklist,
 and drift-prevention expectations; tests in `tests/semantic_core_*` serve as the source of truth
@@ -317,9 +339,9 @@ descriptors represent compiler behavior patterns, not individual keywords.
 | `ir/decl.rs`        | IR declarations (`IrDecl`)                      |
 | `project.rs`        | Cargo project scaffolding and generation        |
 
-### Rust inspect subsystem (`src/rust_inspect/`)
+### Rust inspect subsystem (`crates/rust_inspect/`, re-exported through `src/rust_inspect/`)
 
-`rust_inspect/` powers RFC 041 interop checks that need Rust-side signatures and item shapes.
+`rust_inspect` is a staged interop subsystem for checks that need Rust-side signatures and item shapes. It is toolchain-locked implementation code, not a stable language contract crate.
 
 | Module         | Purpose                                                              |
 | -------------- | -------------------------------------------------------------------- |
@@ -328,6 +350,8 @@ descriptors represent compiler behavior patterns, not individual keywords.
 | `loader.rs`    | Rust workspace loading and crate graph setup for metadata extraction |
 | `extractor.rs` | rust-analyzer-backed extraction of item signatures and method shapes |
 | `error.rs`     | Typed metadata load/extract error surface                            |
+
+Keep Rust inspection as explicit preparation followed by cache reads. CLI/LSP/project setup may prepare the inspection workspace and prewarm metadata; parser/typechecker/lowering paths should not silently trigger expensive Rust workspace loading.
 
 #### Expression Emission (`src/backend/ir/emit/expressions/`)
 

--- a/workspaces/docs-site/docs/contributing/explanation/layering.md
+++ b/workspaces/docs-site/docs/contributing/explanation/layering.md
@@ -4,6 +4,7 @@ This repository follows a strict dependency direction to keep semantics shared a
 compiler and the runtime:
 
 - `incan` (compiler) may depend on `incan_core`.
+- `incan` may depend on `incan_syntax`, `incan_semantics_core`, `incan_semantics_stdlib`, and optional `rust_inspect` for compiler/toolchain work.
 - `incan` must **not** depend on `incan_stdlib` except as a **dev-dependency** for parity tests.
 - `incan_stdlib` depends on `incan_core`.
 - Generated user programs depend on `incan_stdlib`.
@@ -11,12 +12,29 @@ compiler and the runtime:
 ```mermaid
 flowchart TD
   incanCompiler["incan (compiler)"] --> incanCore["incan_core"]
+  incanCompiler --> incanSyntax["incan_syntax"]
+  incanCompiler --> semanticsCore["incan_semantics_core"]
+  incanCompiler --> semanticsStdlib["incan_semantics_stdlib"]
+  incanCompiler -. optional CLI/LSP interop .-> rustInspect["rust_inspect"]
+  incanSyntax --> incanCore
+  semanticsStdlib --> semanticsCore
   incanStdlib["incan_stdlib"] --> incanCore
   generatedProgram["generated program"] --> incanStdlib
+  generatedProgram --> incanDerive["incan_derive"]
+  generatedProgram --> incanWebMacros["incan_web_macros"]
 ```
 
 CI/Test guardrails enforce that `incan` keeps `incan_stdlib` out of its normal dependencies. If you need runtime helpers
 inside tests, add them under `[dev-dependencies]` only.
+
+## Workspace crate categories
+
+Use this policy when deciding where new code belongs:
+
+- **Stable contracts**: `incan_core`, `incan_syntax`, `incan_semantics_core`, and `incan_vocab`. Other layers build on these crates. Keep them deterministic, dependency-light, and free of runtime side effects.
+- **Compiler/toolchain implementation**: `incan`, `incan_semantics_stdlib`, and `rust_inspect`. These crates are tied to the current compiler/tooling. They may depend on stable contracts but should not become runtime APIs.
+- **Runtime-only implementation**: `incan_stdlib`, `incan_derive`, and `incan_web_macros`. Generated Rust programs use these crates. The compiler may generate references to them but must not depend on them in normal builds.
+- **Transitional runtime surfaces**: current `incan_stdlib::web` and related macro glue. This runtime code is not yet a stable long-term contract. Keep it quarantined and avoid treating it as compiler-owned policy.
 
 ## Why we do this
 
@@ -32,49 +50,86 @@ We want one “source of truth” for language behavior so the compiler and runt
 
 **`incan_core`**:
 
-    - Pure helpers that define *meaning/policy* (e.g., string indexing/slicing rules, numeric promotion, canonical error
-      message constants).
-    - Central registries for language vocabulary and stdlib wiring (for example `incan_core::lang::stdlib::STDLIB_NAMESPACES`
-      and keyword metadata used by the lexer/parser).
-    - Must be deterministic and side-effect free.
-    - Should not depend on compiler internals (AST, spans, lexer/parser state).
+- Pure helpers that define *meaning/policy* (e.g., string indexing/slicing rules, numeric promotion, canonical error message constants).
+- Central registries for language vocabulary and stdlib wiring (for example `incan_core::lang::stdlib::STDLIB_NAMESPACES` and keyword metadata used by the lexer/parser).
+- Must be deterministic and side-effect free.
+- Should not depend on compiler internals (AST, spans, lexer/parser state).
+- Should not gain new stdlib-owned runtime surface types unless the type metadata is truly shared language policy.
+
+**`incan_syntax`**:
+
+- Lexer, parser, AST, and syntax diagnostics shared by compiler, formatter, LSP, and future tooling.
+- May use language vocabulary from stable contract crates.
+- Must not perform name resolution, typechecking, lowering, Rust interop loading, or runtime behavior.
+
+**`incan_semantics_core`**:
+
+- Stable action-descriptor and semantics-pack contracts that compiler stages can consume.
+- Owns behavior descriptors, not compiler execution. Packs describe what to do; compiler stages decide how to do it.
+
+**`incan_semantics_stdlib`**:
+
+- Stdlib semantics-pack implementation for current built-in library surfaces.
+- Toolchain-locked implementation crate, not a stable external API.
+- Should return descriptors and canonical targets instead of reaching into compiler internals.
+
+**`rust_inspect`**:
+
+- Dedicated Rust metadata preparation, extraction, and caching subsystem.
+- Allowed behind compiler/tooling features for Rust interop.
+- Should remain explicit and staged: prepare/prewarm metadata at CLI/LSP/project boundaries, then read cached metadata in semantic paths.
 
 **`incan_stdlib`**:
 
-    - Runtime helpers used by generated Rust code.
-    - Includes facades that generated code imports (for example `incan_stdlib::r#async` backing the `std.async` namespace).
-    - Should delegate behavior to `incan_core` for policy/consistency, and implement runtime-only actions (like
-      panicking) using the shared error messages/taxonomy.
+- Runtime helpers used by generated Rust code.
+- Includes facades that generated code imports (for example `incan_stdlib::r#async` backing the `std.async` namespace).
+- Should delegate behavior to `incan_core` for policy/consistency, and implement runtime-only actions (like panicking) using the shared error messages/taxonomy.
+- May contain transitional implementation modules, but those modules must not become compiler dependencies.
+
+**`incan_derive` / `incan_web_macros`**:
+
+- Runtime-side macro support for generated Rust programs.
+- Must not become a backchannel for compiler logic.
+- Web macro/runtime glue is transitional until the web surface has a stable long-term ownership model.
 
 **`incan` (compiler)**:
 
-    - Parsing, typing, lowering, codegen, diagnostics.
-    - May use `incan_core` to implement checks/const-eval and to keep error text aligned.
-    - Must not use `incan_stdlib` in normal builds; only in tests for parity.
+- Parsing, typing, lowering, codegen, diagnostics.
+- May use stable contract crates to implement checks/const-eval and to keep error text aligned.
+- Must not use runtime-only crates in normal builds; only `incan_stdlib` as a dev-dependency for parity tests.
 
 ## Allowed / forbidden dependencies
 
 **Allowed**:
 
-    - `incan` → `incan_core` (normal dependency)
-    - `incan_stdlib` → `incan_core` (normal dependency)
-    - `incan` → `incan_stdlib` (dev-dependency only, for tests)
+- `incan` → `incan_core`, `incan_syntax`, `incan_semantics_core`, `incan_semantics_stdlib`, `incan_vocab` as normal compiler/toolchain dependencies.
+- `incan` → `rust_inspect` behind the `rust_inspect`/CLI/LSP interop path.
+- `incan_stdlib` → `incan_core` as a normal dependency.
+- `incan` → `incan_stdlib` as a dev-dependency only, for tests.
 
-***Forbidden**:
+**Forbidden**:
 
-    - `incan` → `incan_stdlib` in `[dependencies]` (this breaks layering)
-    - `incan_core` → `incan` or `incan_stdlib`
+- `incan` → `incan_stdlib` in `[dependencies]` (this breaks layering).
+- `incan` → `incan_derive` or `incan_web_macros` in normal dependencies.
+- `incan_core`, `incan_syntax`, or `incan_semantics_core` → compiler/toolchain/runtime implementation crates.
+- Runtime crates calling back into compiler crates.
 
 ## Common pitfalls
 
 - Adding a “quick helper” in `incan_stdlib` and calling it from the compiler.
     - Fix: move the policy/logic to `incan_core` and keep only runtime glue (panics, wrappers) in `incan_stdlib`.
 
+- Adding another stdlib-specific surface type to `incan_core` because similar metadata already exists there.
+    - Fix: decide whether the type is true language policy or library-owned surface. Prefer library-defined ownership when possible, and document the exception when it must stay core-owned.
+
 - Emitting direct Rust operations that bypass shared semantics (e.g., slicing Rust `String` by byte indices).
     - Fix: emit calls to `incan_stdlib` wrappers which themselves delegate to `incan_core`.
 
 - Duplicating error messages as string literals in multiple places.
     - Fix: put canonical text in `incan_core` and reuse it from both compiler and runtime.
+
+- Loading Rust metadata opportunistically from typechecking or lowering.
+    - Fix: prewarm through the explicit `rust_inspect` preparation path and keep semantic lookups cache-oriented.
 
 ## Guardrails (how it is enforced)
 

--- a/workspaces/docs-site/docs/contributing/tutorials/book/01_architecture_tour.md
+++ b/workspaces/docs-site/docs/contributing/tutorials/book/01_architecture_tour.md
@@ -21,6 +21,8 @@ At a high level, the compiler/toolchain splits into:
 - **Project generation**: writes a Cargo project, builds/runs it
 - **Tooling**: formatter, LSP, test runner, and other developer-facing workflows
 
+Workspace crates split across stable contracts, compiler/toolchain implementation, and runtime-only implementation. Keep that split in mind before adding a dependency: generated programs may use runtime crates, but compiler code should normally consume stable contract crates and toolchain crates only.
+
 ## Where to look in the repository
 
 You can orient yourself with these anchors:
@@ -28,6 +30,16 @@ You can orient yourself with these anchors:
 - `crates/incan_syntax/`:
     - shared lexer/parser/AST/diagnostics
     - used by compiler, formatter, and LSP to avoid drift
+- `crates/incan_core/`:
+    - pure language policy and registries shared across compiler/runtime boundaries
+- `crates/incan_semantics_core/` and `crates/incan_semantics_stdlib/`:
+    - descriptor contracts plus current stdlib semantics-pack implementation
+- `crates/incan_vocab/`:
+    - stable library manifest/desugarer contract for import-activated library DSLs
+- `crates/rust_inspect/`:
+    - staged Rust metadata preparation/cache subsystem for Rust interop
+- `crates/incan_stdlib/`, `crates/incan_derive/`, and `crates/incan_web_macros/`:
+    - runtime-only support used by generated Rust programs
 - `src/frontend/`:
     - module resolution (`module.rs`)
     - typechecker (`typechecker/`)
@@ -44,6 +56,7 @@ You can orient yourself with these anchors:
 If you want the deep version (module layout, key types, entry points), read:
 
 - [Architecture](../../explanation/architecture.md)
+- [Layering rules](../../explanation/layering.md)
 
 ## Contributor workflow: “touch points”
 

--- a/workspaces/docs-site/docs/contributing/tutorials/book/02_layering_and_boundaries.md
+++ b/workspaces/docs-site/docs/contributing/tutorials/book/02_layering_and_boundaries.md
@@ -24,6 +24,9 @@ In practice, the patterns you want are:
 
 - **`incan_syntax` is shared**: lexer/parser/AST/diagnostics are reused by compiler, formatter, and LSP.
 - **`incan_core` is a semantic core**: shared, pure semantics and registries that must not drift.
+- **`incan_semantics_core` is the descriptor contract**: semantics packs describe compiler actions without calling compiler internals.
+- **`incan_semantics_stdlib` is implementation**: current stdlib packs are toolchain-locked, not general runtime APIs.
+- **`rust_inspect` is staged interop**: prepare/prewarm Rust metadata explicitly, then use cache-oriented reads in semantic paths.
 - **Compiler crates should not depend on runtime crates**: runtime is for generated programs, not for the compiler.
 
 ## A common failure mode
@@ -33,6 +36,12 @@ You add a feature, it “works” in the CLI, but:
 - the formatter prints it differently,
 - the LSP can’t parse it,
 - or the language reference/keywords drift from implementation.
+
+Another failure mode is treating runtime convenience as compiler policy:
+
+- adding a helper to `incan_stdlib` and calling it from `incan`,
+- putting stdlib-owned runtime types into `incan_core` without a clear language-policy reason,
+- or making `rust_inspect` do hidden workspace loading from a semantic hot path.
 
 When you feel tempted to “just implement it in the CLI”:
 

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -374,6 +374,7 @@ The sections above are the release story. The list below is the detailed invento
 ### Documentation
 
 - **Docs**: Added explanation pages for compile-time vs runtime behavior and Rust-shaped confidence, with navigation links and evaluator-guide cross-links for Python and Rust users.
+- **Contributor docs**: Workspace crate boundaries are now classified as stable contracts, compiler/toolchain implementation, runtime-only implementation, and transitional runtime surfaces. The docs also call out explicit ownership metadata for shared surface types, staged Rust interop inspection, and the quarantined `std.web` host-runtime bridge (#284).
 
 ### Versioning and release track
 


### PR DESCRIPTION
## Summary

This PR tightens Incan crate-boundary ownership by making shared surface-type ownership explicit in `incan_core`, documenting stable-contract versus runtime/toolchain crate categories, and clarifying that current `std.web` runtime glue is transitional generated-code support rather than a standalone public framework API.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: No language syntax or runtime behavior changes. This is contributor-facing ownership and boundary clarification.
- **Internals**: `SurfaceTypeInfo` now carries `SurfaceTypeOwnership` with owner, category, import scope, and rationale; `stdlib_module_path` and global-surface checks are registry-driven from that metadata. Contributor docs classify crates as stable contracts, compiler/toolchain implementation, runtime-only implementation, or transitional runtime surfaces.
- **Risks**: Low behavioral risk, but the new metadata becomes a maintenance point for future shared surface types. The guardrail test enforces explicit owner/category/rationale coverage and preserves global/imported surface expectations.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed on the rebased branch before the final upstream rebase: `2166 tests run: 2166 passed`, clippy passed, cargo-deny passed, and `smoke-test-fast` passed.
- After rebasing onto the latest `origin/main`, reran focused checks:
  - `git diff --check origin/main...HEAD` passed.
  - `cargo test -p incan_core surface_types_have_explicit_ownership_metadata` passed.
  - `cargo test -p incan_stdlib -p rust_inspect -p incan_web_macros -p incan_derive` passed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/contributing/explanation/architecture.md`
- Link(s): `workspaces/docs-site/docs/contributing/explanation/layering.md`
- Link(s): `workspaces/docs-site/docs/contributing/tutorials/book/01_architecture_tour.md`
- Link(s): `workspaces/docs-site/docs/contributing/tutorials/book/02_layering_and_boundaries.md`
- Link(s): `crates/incan_stdlib/README.md`
- Link(s): `crates/rust_inspect/README.md`
- Link(s): `crates/incan_derive/README.md`
- Link(s): `crates/incan_web_macros/README.md`
- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #284