### PR TITLE
chore - ship Rust ABI metadata in library manifests (#262)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "byteorder",
  "clap",
@@ -1450,14 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,14 +1466,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "axum",
  "incan_core",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/rust_inspect/README.md
+++ b/crates/rust_inspect/README.md
@@ -42,8 +42,10 @@ The intended contract is:
 
 - `prewarm(...)` may perform expensive extraction
 - `get(...)` should be cache-only
-- compiler/typechecker hot paths should prefer cached reads over fresh extraction
 - workspace loading is owned by explicit preparation/cache code, not by semantic checks as a side effect
+- published-library consumers should prefer shipped `.incnlib` Rust ABI metadata over workspace inspection
+- `rust_inspect` remains the producer-side ABI capture and local/fallback inspection backend
+- compiler/typechecker fallback paths should prefer cached reads over fresh extraction
 
 ## Architecture Notes
 

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -3,7 +3,7 @@
 //! This module handles the full compilation flow: module collection, type checking, codegen configuration, dependency
 //! resolution, project generation, and Cargo build/run.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -22,6 +22,8 @@ use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::module::canonicalize_source_module_segments;
 use crate::frontend::{diagnostics, typechecker};
 use crate::library_manifest::LibraryManifest;
+#[cfg(feature = "rust_inspect")]
+use crate::library_manifest::LibraryRustAbi;
 use crate::lockfile::CargoFeatureSelection;
 use crate::manifest::ProjectManifest;
 
@@ -36,6 +38,8 @@ use super::common::{collect_rust_inspect_query_paths, ensure_rust_inspect_worksp
 use super::lock::{LockResolutionRequest, resolve_lock_payload};
 use super::vocab_extraction::{PendingDesugarerArtifact, collect_library_vocab_metadata};
 use crate::cli::prelude::ParsedModule;
+#[cfg(feature = "rust_inspect")]
+use crate::rust_inspect::{InspectError, Inspector, InspectorConfig};
 
 // ============================================================================
 // Project Preparation (shared between build and run)
@@ -154,6 +158,46 @@ fn collect_rust_extern_contexts(modules: &[ParsedModule]) -> Vec<RustExternDeclC
         }
     }
     contexts
+}
+
+#[cfg(feature = "rust_inspect")]
+/// Collect canonical Rust metadata paths that must be shipped in a library manifest's ABI payload.
+fn collect_library_rust_abi_query_paths(
+    modules: &[ParsedModule],
+    rust_extern_contexts: &[RustExternDeclContext],
+) -> Vec<String> {
+    let mut paths: BTreeSet<String> = collect_rust_inspect_query_paths(modules).into_iter().collect();
+    for context in rust_extern_contexts {
+        paths.insert(format!("{}::{}", context.rust_module_path, context.item_name));
+    }
+    paths.into_iter().collect()
+}
+
+#[cfg(feature = "rust_inspect")]
+/// Read prewarmed Rust metadata from the generated inspect workspace and package it as manifest ABI.
+fn collect_library_rust_abi(
+    rust_inspect_manifest_dir: &Path,
+    query_paths: &[String],
+) -> CliResult<Option<LibraryRustAbi>> {
+    if query_paths.is_empty() {
+        return Ok(None);
+    }
+
+    let inspector = Inspector::new(InspectorConfig::new(rust_inspect_manifest_dir.to_path_buf()));
+    let mut items = Vec::new();
+    for path in query_paths {
+        match inspector.get(path) {
+            Ok(result) => items.push((*result.metadata).clone()),
+            Err(InspectError::MetadataMiss { .. }) => {}
+            Err(err) => {
+                return Err(CliError::failure(format!(
+                    "failed to read Rust ABI metadata for `{path}` from {}: {err}",
+                    rust_inspect_manifest_dir.display()
+                )));
+            }
+        }
+    }
+    Ok(LibraryRustAbi::from_items(items))
 }
 
 fn classify_rust_extern_build_failure(
@@ -467,7 +511,7 @@ fn prepare_project(
     };
     merge_project_requirement_dependencies(&mut resolved, &project_requirements)?;
     #[cfg(feature = "rust_inspect")]
-    let metadata_query_paths = collect_rust_inspect_query_paths(&modules);
+    let metadata_query_paths = collect_library_rust_abi_query_paths(&modules, &rust_extern_contexts);
 
     // Resolve lock payload before moving deps into generator (borrows resolved)
     let lock_payload = resolve_lock_payload(LockResolutionRequest {
@@ -652,7 +696,7 @@ pub fn build_library(
     };
     merge_project_requirement_dependencies(&mut resolved, &project_requirements)?;
     #[cfg(feature = "rust_inspect")]
-    let metadata_query_paths = collect_rust_inspect_query_paths(&modules);
+    let metadata_query_paths = collect_library_rust_abi_query_paths(&modules, &rust_extern_contexts);
 
     let lock_payload_for_typecheck = resolve_lock_payload(LockResolutionRequest {
         project_root: &project_root,
@@ -787,6 +831,10 @@ pub fn build_library(
         }),
         modules: api_metadata_modules,
     });
+    #[cfg(feature = "rust_inspect")]
+    {
+        library_manifest.rust_abi = collect_library_rust_abi(&rust_inspect_manifest_dir, &metadata_query_paths)?;
+    }
     let mut pending_desugarer_artifact: Option<PendingDesugarerArtifact> = None;
 
     if let Some(vocab_extraction) = collect_library_vocab_metadata(&manifest, &project_root)? {
@@ -813,8 +861,6 @@ pub fn build_library(
     generator.set_include_dev_dependencies(false);
     generator.set_rust_edition(manifest.build.as_ref().and_then(|build| build.rust_edition.clone()));
     #[cfg(feature = "rust_inspect")]
-    let metadata_query_paths = collect_rust_inspect_query_paths(&modules);
-
     let lock_payload = resolve_lock_payload(LockResolutionRequest {
         project_root: &project_root,
         project_name: project_name.as_str(),
@@ -1002,6 +1048,32 @@ mod tests {
         };
         assert!(rendered.contains("Rust backing item"));
         assert!(rendered.contains("incan_stdlib::testing::fail"));
+    }
+
+    #[cfg(feature = "rust_inspect")]
+    #[test]
+    fn library_rust_abi_query_paths_include_rust_extern_backing_items() -> Result<(), Box<dyn std::error::Error>> {
+        let source =
+            "rust.module(\"incan_stdlib::num\")\n@rust.extern\npub def gcd_i64(a: int, b: int) -> int:\n  ...\n";
+        let tokens = lexer::lex(source).map_err(|errs| format!("lex errors: {errs:?}"))?;
+        let ast = parser::parse(&tokens).map_err(|errs| format!("parse errors: {errs:?}"))?;
+        let module = ParsedModule {
+            name: "lib".to_string(),
+            path_segments: vec!["lib".to_string()],
+            file_path: PathBuf::from("src/lib.incn"),
+            source: source.to_string(),
+            ast,
+        };
+
+        let modules = vec![module];
+        let contexts = collect_rust_extern_contexts(&modules);
+        let paths = collect_library_rust_abi_query_paths(&modules, &contexts);
+
+        assert!(
+            paths.iter().any(|path| path == "incan_stdlib::num::gcd_i64"),
+            "expected rust.extern backing item in ABI query paths, got: {paths:?}"
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/frontend/library_manifest_index.rs
+++ b/src/frontend/library_manifest_index.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::library_manifest::{LibraryManifest, LibraryManifestError};
 use crate::manifest::{DependencySource, DependencySpec, ProjectManifest};
+use incan_core::interop::RustItemMetadata;
 use incan_vocab::{CargoDependency, CargoDependencySource, KeywordActivation, KeywordRegistration, KeywordSpec};
 use serde::Deserialize;
 
@@ -164,6 +165,27 @@ impl LibraryManifestIndex {
             LibraryManifestIndexEntry::Loaded { metadata, .. } => Some(metadata),
             LibraryManifestIndexEntry::Failed(_) => None,
         }
+    }
+
+    /// Return shipped Rust ABI metadata from loaded dependency manifests.
+    ///
+    /// This is the consumer hot-path lookup for Rust-backed symbols published by `.incnlib` artifacts. It deliberately
+    /// searches deterministic dependency-key order so duplicate metadata across dependencies is stable.
+    pub(crate) fn rust_abi_item(&self, canonical_path: &str) -> Option<RustItemMetadata> {
+        let mut keys: Vec<&String> = self.entries.keys().collect();
+        keys.sort();
+        for key in keys {
+            let Some(LibraryManifestIndexEntry::Loaded { manifest, .. }) = self.entries.get(key) else {
+                continue;
+            };
+            let Some(abi) = manifest.rust_abi.as_ref() else {
+                continue;
+            };
+            if let Some(item) = abi.get(canonical_path) {
+                return Some(item.clone());
+            }
+        }
+        None
     }
 
     /// Build path-based Cargo dependencies for all successfully loaded library artifacts.

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -392,9 +392,13 @@ impl TypeChecker {
     }
 
     #[cfg(feature = "rust_inspect")]
+    /// Return Rust item metadata, preferring shipped dependency ABI over rust-inspect cache reads.
     pub(crate) fn rust_item_metadata_for_path(&self, canonical_path: &str) -> Option<RustItemMetadata> {
         let canonical_path = Self::normalize_rust_namespace_path(canonical_path);
-        let lookup_path = Self::rust_inspect_lookup_path(canonical_path)?;
+        let lookup_path = Self::rust_metadata_lookup_path(canonical_path)?;
+        if let Some(metadata) = self.library_manifests.rust_abi_item(lookup_path) {
+            return Some(metadata);
+        }
         let dir = self.rust_inspect_manifest_dir.as_ref()?;
         match self.rust_inspect_cache.get_cached(dir, lookup_path) {
             Ok(Some(hit)) => Some((*hit.metadata).clone()),
@@ -411,9 +415,13 @@ impl TypeChecker {
     }
 
     #[cfg(feature = "rust_inspect")]
+    /// Return Rust item metadata, falling back to extraction only after shipped ABI and cache-only reads miss.
     pub(crate) fn rust_item_metadata_for_path_blocking(&self, canonical_path: &str) -> Option<RustItemMetadata> {
         let canonical_path = Self::normalize_rust_namespace_path(canonical_path);
-        let lookup_path = Self::rust_inspect_lookup_path(canonical_path)?;
+        let lookup_path = Self::rust_metadata_lookup_path(canonical_path)?;
+        if let Some(metadata) = self.library_manifests.rust_abi_item(lookup_path) {
+            return Some(metadata);
+        }
         let dir = self.rust_inspect_manifest_dir.as_ref()?;
         // stdlib interop paths are conventionally stable and intentionally stay cache-only.
         if lookup_path.starts_with("incan_stdlib::") {
@@ -444,13 +452,17 @@ impl TypeChecker {
     }
 
     #[cfg(not(feature = "rust_inspect"))]
-    pub(crate) fn rust_item_metadata_for_path(&self, _canonical_path: &str) -> Option<RustItemMetadata> {
-        None
+    /// Return Rust item metadata from shipped dependency ABI when rust-inspect support is not compiled in.
+    pub(crate) fn rust_item_metadata_for_path(&self, canonical_path: &str) -> Option<RustItemMetadata> {
+        let canonical_path = Self::normalize_rust_namespace_path(canonical_path);
+        let lookup_path = Self::rust_metadata_lookup_path(canonical_path)?;
+        self.library_manifests.rust_abi_item(lookup_path)
     }
 
     #[cfg(not(feature = "rust_inspect"))]
-    pub(crate) fn rust_item_metadata_for_path_blocking(&self, _canonical_path: &str) -> Option<RustItemMetadata> {
-        None
+    /// Return Rust item metadata from shipped dependency ABI when rust-inspect support is not compiled in.
+    pub(crate) fn rust_item_metadata_for_path_blocking(&self, canonical_path: &str) -> Option<RustItemMetadata> {
+        self.rust_item_metadata_for_path(canonical_path)
     }
 
     fn split_top_level_generic_args(args: &str) -> Vec<&str> {
@@ -480,14 +492,20 @@ impl TypeChecker {
     /// rust-analyzer metadata is keyed by the item path (`foo::Bar`), not by instantiated spellings like
     /// `foo::Bar<T>` or placeholder displays like `{unknown}`. This strips outer generic instantiation from a Rust
     /// path while rejecting obviously non-item spellings before hitting the metadata cache/extractor.
-    #[cfg(feature = "rust_inspect")]
-    fn rust_inspect_lookup_path(canonical_path: &str) -> Option<&str> {
-        crate::rust_inspect::Inspector::normalize_lookup_path(canonical_path)
-    }
-
-    #[cfg(not(feature = "rust_inspect"))]
-    fn rust_inspect_lookup_path(_canonical_path: &str) -> Option<&str> {
-        None
+    fn rust_metadata_lookup_path(canonical_path: &str) -> Option<&str> {
+        let trimmed = canonical_path.trim();
+        if trimmed.is_empty() || trimmed == "{unknown}" {
+            return None;
+        }
+        let had_generics = trimmed.contains('<');
+        let base = trimmed.split_once('<').map_or(trimmed, |(base, _)| base);
+        if had_generics && !base.contains("::") {
+            return None;
+        }
+        if base.is_empty() || base.contains(['{', '}', '(', ')', '[', ']', ',', ' ']) {
+            return None;
+        }
+        Some(base)
     }
 
     /// Strip the synthetic `rust::` namespace prefix used in Incan source paths.

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -13,13 +13,12 @@ use crate::frontend::testing_markers::TestingFixtureScope;
 use crate::frontend::{lexer, parser};
 use crate::library_manifest::{
     ClassExport, ConstExport, EnumExport, EnumValueExport, EnumValueTypeExport, EnumVariantExport, FunctionExport,
-    LibraryContractMetadata, LibraryExports, LibraryManifest, MethodExport, ModelExport, ParamExport, ParamKindExport,
-    PartialExport, PartialPresetExport, PartialTargetKindExport, PresetValueExport, ReceiverExport, StaticExport,
-    TraitExport, TypeBoundExport, TypeParamExport, TypeRef,
+    LibraryContractMetadata, LibraryExports, LibraryManifest, LibraryRustAbi, MethodExport, ModelExport, ParamExport,
+    ParamKindExport, PartialExport, PartialPresetExport, PartialTargetKindExport, PresetValueExport, ReceiverExport,
+    StaticExport, TraitExport, TypeBoundExport, TypeParamExport, TypeRef,
 };
 #[cfg(feature = "rust_inspect")]
 use crate::rust_inspect::{Inspector, InspectorConfig, write_borrowed_param_probe_crate, write_substrait_probe_crate};
-#[cfg(feature = "rust_inspect")]
 use incan_core::interop::{
     RustFieldInfo, RustFunctionSig, RustImplementedTrait, RustItemKind, RustItemMetadata, RustMethodSig, RustParam,
     RustTraitAssoc, RustTraitInfo, RustTypeInfo, RustTypeShape, RustVariantInfo, RustVisibility,
@@ -100,6 +99,51 @@ fn synthetic_artifact_root(name: &str) -> PathBuf {
     root.push("target");
     root.push("lib");
     root
+}
+
+fn library_index_with_rust_abi_item(name: &str, metadata: RustItemMetadata) -> LibraryManifestIndex {
+    let mut manifest = LibraryManifest::new("runtime_facade", "0.1.0");
+    manifest.rust_abi = LibraryRustAbi::from_items(vec![metadata]);
+    LibraryManifestIndex::from_entries(HashMap::from([(
+        "runtime_facade".to_string(),
+        LibraryManifestIndexEntry::Loaded {
+            manifest: Box::new(manifest),
+            metadata: LibraryArtifactMetadata::from_crate_root(
+                "runtime_facade",
+                "runtime_facade",
+                synthetic_artifact_root(name),
+            ),
+        },
+    )]))
+}
+
+#[test]
+fn rust_item_metadata_prefers_shipped_library_abi() {
+    let manifest_metadata = RustItemMetadata {
+        canonical_path: "demo_runtime::parse".to_string(),
+        definition_path: Some("demo_runtime::parse".to_string()),
+        visibility: RustVisibility::Public,
+        kind: RustItemKind::Function(RustFunctionSig {
+            params: vec![RustParam {
+                name: Some("source".to_string()),
+                type_display: "&str".to_string(),
+            }],
+            return_type: "demo_runtime::Plan".to_string(),
+            is_async: false,
+            is_unsafe: false,
+        }),
+    };
+
+    let mut checker = TypeChecker::new();
+    checker.set_library_manifest_index(library_index_with_rust_abi_item(
+        "demo_runtime_parse",
+        manifest_metadata.clone(),
+    ));
+
+    let Some(actual) = checker.rust_item_metadata_for_path("rust::demo_runtime::parse") else {
+        panic!("expected shipped Rust ABI metadata");
+    };
+    assert_eq!(actual, manifest_metadata);
 }
 
 fn clone_trait_name() -> String {
@@ -1405,6 +1449,7 @@ fn library_index_with_mylib_exports() -> LibraryManifestIndex {
         vocab: None,
         soft_keywords: Default::default(),
         contract_metadata: LibraryContractMetadata::default(),
+        rust_abi: None,
     };
 
     LibraryManifestIndex::from_entries(HashMap::from([(
@@ -1447,6 +1492,7 @@ fn library_index_with_trait_export() -> LibraryManifestIndex {
         vocab: None,
         soft_keywords: Default::default(),
         contract_metadata: LibraryContractMetadata::default(),
+        rust_abi: None,
     };
 
     LibraryManifestIndex::from_entries(HashMap::from([(
@@ -1585,6 +1631,7 @@ fn library_index_with_rfc025_trait_adoptions() -> LibraryManifestIndex {
         vocab: None,
         soft_keywords: Default::default(),
         contract_metadata: LibraryContractMetadata::default(),
+        rust_abi: None,
     };
 
     LibraryManifestIndex::from_entries(HashMap::from([(
@@ -1805,6 +1852,7 @@ fn library_index_with_pub_boundary_type_fidelity_exports() -> LibraryManifestInd
         vocab: None,
         soft_keywords: Default::default(),
         contract_metadata: LibraryContractMetadata::default(),
+        rust_abi: None,
     };
 
     LibraryManifestIndex::from_entries(HashMap::from([(
@@ -2777,23 +2825,21 @@ fn test_rust_inspect_function_signature_preserves_borrowed_rust_path_param() -> 
     Ok(())
 }
 
-#[cfg(feature = "rust_inspect")]
 #[test]
-fn test_rust_inspect_lookup_path_strips_outer_generic_instantiation() {
+fn test_rust_metadata_lookup_path_strips_outer_generic_instantiation() {
     assert_eq!(
-        TypeChecker::rust_inspect_lookup_path("incan_stdlib::r#async::channel::SendError<T>"),
+        TypeChecker::rust_metadata_lookup_path("incan_stdlib::r#async::channel::SendError<T>"),
         Some("incan_stdlib::r#async::channel::SendError")
     );
     assert_eq!(
-        TypeChecker::rust_inspect_lookup_path("Result<(),incan_stdlib::r#async::channel::SendError<T>>"),
+        TypeChecker::rust_metadata_lookup_path("Result<(),incan_stdlib::r#async::channel::SendError<T>>"),
         None
     );
 }
 
-#[cfg(feature = "rust_inspect")]
 #[test]
-fn test_rust_inspect_lookup_path_rejects_unknown_placeholder() {
-    assert_eq!(TypeChecker::rust_inspect_lookup_path("{unknown}"), None);
+fn test_rust_metadata_lookup_path_rejects_unknown_placeholder() {
+    assert_eq!(TypeChecker::rust_metadata_lookup_path("{unknown}"), None);
 }
 
 #[cfg(feature = "rust_inspect")]

--- a/src/library_manifest/mod.rs
+++ b/src/library_manifest/mod.rs
@@ -20,3 +20,6 @@ pub(crate) use type_refs::type_ref_from_resolved;
 
 /// Stable on-disk format version for `.incnlib` manifests.
 pub const LIBRARY_MANIFEST_FORMAT: u32 = 1;
+
+/// Stable schema version for Rust ABI metadata embedded in `.incnlib` manifests.
+pub const RUST_ABI_SCHEMA_VERSION: u32 = 1;

--- a/src/library_manifest/model.rs
+++ b/src/library_manifest/model.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use super::type_refs::type_ref_from_resolved;
 use super::validation::validate_raw_manifest;
 use super::wire::RawLibraryManifest;
-use super::{DslSurface, LIBRARY_MANIFEST_FORMAT, VocabKeywordRegistration, VocabProviderManifest};
+use super::{
+    DslSurface, LIBRARY_MANIFEST_FORMAT, RUST_ABI_SCHEMA_VERSION, VocabKeywordRegistration, VocabProviderManifest,
+};
 use crate::frontend::api_metadata::CheckedApiMetadataPackage;
 use crate::frontend::contract_metadata::ContractMetadataPackage as ModelContractMetadataPackage;
 use crate::frontend::library_exports::{
@@ -16,6 +18,7 @@ use crate::frontend::library_exports::{
     CheckedTypeBound, CheckedTypeParam,
 };
 use crate::frontend::symbols::{CallableParam, ValueEnumBacking, ValueEnumValue};
+use incan_core::interop::RustItemMetadata;
 
 /// Errors surfaced while reading, writing, parsing, serializing, or validating `.incnlib` manifests.
 #[derive(Debug, thiserror::Error)]
@@ -60,6 +63,8 @@ pub struct LibraryManifest {
     pub soft_keywords: SoftKeywordExports,
     /// Optional RFC 048 checked metadata embedded in the manifest.
     pub contract_metadata: LibraryContractMetadata,
+    /// Optional Rust-backed ABI metadata captured at library publication time.
+    pub rust_abi: Option<LibraryRustAbi>,
 }
 
 /// Public library exports grouped by declaration kind.
@@ -161,6 +166,47 @@ pub struct LibraryContractMetadata {
     /// Checked public API metadata extracted from the producer source.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api: Option<CheckedApiMetadataPackage>,
+}
+
+/// Versioned Rust ABI payload persisted into `.incnlib`.
+///
+/// The payload stores the same backend-neutral metadata shape that `rust_inspect` extracts, but ships it with the
+/// library artifact so consumers can resolve Rust-backed imports without loading the producer workspace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LibraryRustAbi {
+    /// Serialized ABI schema version.
+    #[serde(default = "default_rust_abi_schema_version")]
+    pub schema_version: u32,
+    /// Canonical Rust item metadata keyed by `RustItemMetadata::canonical_path`.
+    #[serde(default)]
+    pub items: Vec<RustItemMetadata>,
+}
+
+/// Default Rust ABI schema version for manifest payloads that predate explicit serde fields.
+fn default_rust_abi_schema_version() -> u32 {
+    RUST_ABI_SCHEMA_VERSION
+}
+
+impl LibraryRustAbi {
+    /// Build a deterministic ABI payload from extracted Rust metadata.
+    pub fn from_items(mut items: Vec<RustItemMetadata>) -> Option<Self> {
+        items.sort_by(|left, right| left.canonical_path.cmp(&right.canonical_path));
+        items.dedup_by(|left, right| left.canonical_path == right.canonical_path);
+        if items.is_empty() {
+            return None;
+        }
+        Some(Self {
+            schema_version: RUST_ABI_SCHEMA_VERSION,
+            items,
+        })
+    }
+
+    /// Return metadata for one canonical Rust path.
+    pub fn get(&self, canonical_path: &str) -> Option<&RustItemMetadata> {
+        self.items.iter().find(|item| {
+            item.canonical_path == canonical_path || item.definition_path.as_deref() == Some(canonical_path)
+        })
+    }
 }
 
 /// Soft keywords that become active when the library is imported.
@@ -488,6 +534,7 @@ impl LibraryManifest {
             vocab: None,
             soft_keywords: SoftKeywordExports::default(),
             contract_metadata: LibraryContractMetadata::default(),
+            rust_abi: None,
         }
     }
 

--- a/src/library_manifest/tests.rs
+++ b/src/library_manifest/tests.rs
@@ -103,6 +103,35 @@ fn manifest_io_round_trip_preserves_partial_exports() -> Result<(), Box<dyn std:
 }
 
 #[test]
+fn manifest_io_round_trip_preserves_rust_abi_metadata() -> Result<(), Box<dyn std::error::Error>> {
+    use incan_core::interop::{RustFunctionSig, RustItemKind, RustItemMetadata, RustParam, RustVisibility};
+
+    let mut manifest = LibraryManifest::new("mylib", "0.1.0");
+    manifest.rust_abi = LibraryRustAbi::from_items(vec![RustItemMetadata {
+        canonical_path: "mylib_runtime::parse".to_string(),
+        definition_path: Some("mylib_runtime::parse".to_string()),
+        visibility: RustVisibility::Public,
+        kind: RustItemKind::Function(RustFunctionSig {
+            params: vec![RustParam {
+                name: Some("source".to_string()),
+                type_display: "&str".to_string(),
+            }],
+            return_type: "Result<mylib_runtime::Plan, mylib_runtime::Error>".to_string(),
+            is_async: true,
+            is_unsafe: false,
+        }),
+    }]);
+
+    let tmp = tempfile::tempdir()?;
+    let path = tmp.path().join("mylib.incnlib");
+    manifest.write_to_path(&path)?;
+    let loaded = LibraryManifest::read_from_path(&path)?;
+
+    assert_eq!(loaded, manifest);
+    Ok(())
+}
+
+#[test]
 fn manifest_validation_rejects_invalid_partial_exports() -> Result<(), Box<dyn std::error::Error>> {
     let mut base = LibraryManifest::new("mylib", "0.1.0");
     base.exports.partials.push(PartialExport {
@@ -148,6 +177,65 @@ fn manifest_validation_rejects_invalid_partial_exports() -> Result<(), Box<dyn s
         );
     }
     Ok(())
+}
+
+#[test]
+fn manifest_validation_rejects_duplicate_rust_abi_paths() -> Result<(), Box<dyn std::error::Error>> {
+    use incan_core::interop::{RustItemKind, RustItemMetadata, RustModuleInfo, RustVisibility};
+
+    let duplicate = RustItemMetadata {
+        canonical_path: "mylib_runtime::Plan".to_string(),
+        definition_path: None,
+        visibility: RustVisibility::Public,
+        kind: RustItemKind::Module(RustModuleInfo { children: Vec::new() }),
+    };
+    let raw = format!(
+        r#"{{
+  "name": "mylib",
+  "version": "0.1.0",
+  "incan_version": "{}",
+  "manifest_format": {},
+  "exports": {{}},
+  "soft_keywords": {{}},
+  "rust_abi": {{
+    "schema_version": {},
+    "items": [{}, {}]
+  }}
+}}"#,
+        crate::version::INCAN_VERSION,
+        LIBRARY_MANIFEST_FORMAT,
+        RUST_ABI_SCHEMA_VERSION,
+        serde_json::to_string(&duplicate)?,
+        serde_json::to_string(&duplicate)?
+    );
+
+    let err = LibraryManifest::from_json_str(&raw);
+    assert!(err.is_err(), "expected duplicate Rust ABI metadata to fail");
+    Ok(())
+}
+
+#[test]
+fn manifest_validation_rejects_unsupported_rust_abi_schema_version() {
+    let raw = format!(
+        r#"{{
+  "name": "mylib",
+  "version": "0.1.0",
+  "incan_version": "{}",
+  "manifest_format": {},
+  "exports": {{}},
+  "soft_keywords": {{}},
+  "rust_abi": {{
+    "schema_version": {},
+    "items": []
+  }}
+}}"#,
+        crate::version::INCAN_VERSION,
+        LIBRARY_MANIFEST_FORMAT,
+        RUST_ABI_SCHEMA_VERSION + 1
+    );
+
+    let err = LibraryManifest::from_json_str(&raw);
+    assert!(err.is_err(), "expected unsupported Rust ABI schema to fail");
 }
 
 #[test]

--- a/src/library_manifest/validation.rs
+++ b/src/library_manifest/validation.rs
@@ -13,7 +13,7 @@ use semver::Version;
 use super::wire::{RawLibraryExports, RawLibraryManifest};
 use super::{
     EnumExport, EnumValueExport, EnumValueTypeExport, LIBRARY_MANIFEST_FORMAT, LibraryManifestError, ParamExport,
-    ParamKindExport, PartialExport, VocabProviderManifest,
+    ParamKindExport, PartialExport, RUST_ABI_SCHEMA_VERSION, VocabProviderManifest,
 };
 use crate::frontend::contract_metadata::CONTRACT_METADATA_SCHEMA_VERSION;
 
@@ -23,8 +23,37 @@ pub(super) fn validate_raw_manifest(raw: &RawLibraryManifest) -> Result<(), Libr
     validate_callable_param_exports(&raw.exports)?;
     validate_value_enum_exports(&raw.exports)?;
     validate_contract_metadata(raw)?;
+    validate_rust_abi(raw)?;
     validate_vocab_payload(raw)?;
     validate_soft_keyword_activations(raw)?;
+    Ok(())
+}
+
+/// Validate embedded Rust ABI metadata before consumers use it as a hot-path lookup source.
+fn validate_rust_abi(raw: &RawLibraryManifest) -> Result<(), LibraryManifestError> {
+    let Some(abi) = &raw.rust_abi else {
+        return Ok(());
+    };
+    if abi.schema_version != RUST_ABI_SCHEMA_VERSION {
+        return Err(LibraryManifestError::Invalid(format!(
+            "rust_abi.schema_version {} is unsupported (expected {})",
+            abi.schema_version, RUST_ABI_SCHEMA_VERSION
+        )));
+    }
+    let mut paths = HashSet::new();
+    for item in &abi.items {
+        if item.canonical_path.trim().is_empty() {
+            return Err(LibraryManifestError::Invalid(
+                "rust_abi.items canonical_path cannot be empty".to_string(),
+            ));
+        }
+        if !paths.insert(item.canonical_path.as_str()) {
+            return Err(LibraryManifestError::Invalid(format!(
+                "rust_abi.items contains duplicate canonical path `{}`",
+                item.canonical_path
+            )));
+        }
+    }
     Ok(())
 }
 

--- a/src/library_manifest/wire.rs
+++ b/src/library_manifest/wire.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     AliasExport, ClassExport, ConstExport, DslSurface, EnumExport, FunctionExport, LibraryContractMetadata,
-    LibraryExports, LibraryManifest, LibraryManifestError, ModelExport, NewtypeExport, PartialExport,
+    LibraryExports, LibraryManifest, LibraryManifestError, LibraryRustAbi, ModelExport, NewtypeExport, PartialExport,
     SoftKeywordActivation, SoftKeywordExports, StaticExport, TraitExport, TypeAliasExport, VocabDesugarerArtifact,
     VocabExports, VocabKeywordRegistration, VocabProviderManifest,
 };
@@ -24,6 +24,8 @@ pub(super) struct RawLibraryManifest {
     pub(super) soft_keywords: RawSoftKeywordExports,
     #[serde(default)]
     pub(super) contract_metadata: LibraryContractMetadata,
+    #[serde(default)]
+    pub(super) rust_abi: Option<LibraryRustAbi>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -105,6 +107,7 @@ impl RawLibraryManifest {
                 activations: semantic.soft_keywords.activations.clone(),
             },
             contract_metadata: semantic.contract_metadata.clone(),
+            rust_abi: semantic.rust_abi.clone(),
         }
     }
 
@@ -140,6 +143,7 @@ impl RawLibraryManifest {
                 activations: self.soft_keywords.activations,
             },
             contract_metadata: self.contract_metadata,
+            rust_abi: self.rust_abi,
         })
     }
 }

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/031_library_system_phase1.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/031_library_system_phase1.md
@@ -138,7 +138,7 @@ $ incan build
 
 A library produces two artifacts during `incan build --lib`:
 
-1. **Type manifest** (`.incnlib`) — a JSON file containing everything the typechecker needs: exported models, classes, functions, traits, enums, type aliases, and soft keyword declarations. Generated from the library's checked public API — never hand-written.
+1. **Type manifest** (`.incnlib`) — a JSON file containing everything the typechecker needs: exported models, classes, functions, traits, enums, type aliases, soft keyword declarations, checked contract metadata, and shipped Rust ABI metadata for Rust-backed items. Generated from the library's checked public API and Rust ABI extraction during `build --lib` — never hand-written.
 
 2. **Generated Rust crate** — the library's `.incn` source lowered to Rust source plus `Cargo.toml`, ready for `cargo` to compile and link against. The Phase 1 artifact ships generated `.rs` source, not a compiled `.rlib`, so the artifact remains target-independent and compatible with the consumer's toolchain.
 
@@ -173,9 +173,15 @@ Manifest:
     activations: list[SoftKeywordActivation]
       # Extracted from the library's vocab crate (RFC 027) during build --lib.
       # Never hand-authored.
+
+  rust_abi:
+    schema_version: int               # Rust ABI schema version
+    items: list[RustItemMetadata]     # Canonical Rust item signatures captured during build --lib
 ```
 
 The manifest is serialized as JSON for Phase 1 because it is human-readable, debuggable, and requires no extra dependencies. Implementations should isolate the encoding behind a stable manifest read/write boundary so the on-disk format may evolve later without changing the language contract. The semantic contract is the manifest schema, not JSON as a forever format.
+
+Consumers use embedded `rust_abi` metadata before falling back to workspace inspection. That keeps published-library Rust-backed signatures deterministic: the producer captures the Rust ABI once, ships it in `.incnlib`, and consumers do not need to inspect the producer workspace on compiler hot paths.
 
 `TypeRef` is recursive: it must support plain named types, applied generics, optionals, results/unions, and nested combinations. Bounds belong at the declarations that introduce type parameters, not on every individual use site, so exported generic types and exported generic functions must carry their type parameters plus bound metadata alongside the recursive `TypeRef` tree.
 

--- a/workspaces/docs-site/docs/language/how-to/rust_interop.md
+++ b/workspaces/docs-site/docs/language/how-to/rust_interop.md
@@ -224,6 +224,12 @@ adopted Rust trait. In that case Incan treats the alias as already satisfying th
 the Incan-facing async contract, but Rust `Future` bridge emission still needs safe pin-projection and output-mapping
 metadata before it can replace handwritten Rust adapters.
 
+## Published libraries and shipped ABI metadata
+
+When a library exposes Rust-backed items, run `incan build --lib` before another project consumes it through `pub::`. The generated `.incnlib` embeds a versioned Rust ABI payload containing the canonical Rust item signatures captured during the producer build.
+
+Consumers load that shipped ABI metadata first for Rust-backed imported symbols. `rust_inspect` remains available for producer capture, local workspace imports, and explicit fallback/debug paths, but a packaged dependency should not require consumer-side workspace inspection for signatures that were already published in its `.incnlib`.
+
 ### Qualified backing paths
 
 When a `rust::` import binds a Rust module (or other namespace), you can name a concrete type inside it with `::` after that binding:


### PR DESCRIPTION
## Summary

This PR converges Rust-backed library imports on shipped ABI metadata by adding a versioned `rust_abi` payload to `.incnlib`, emitting it during `incan build --lib`, and making consumer typechecking prefer that manifest payload before falling back to `rust_inspect`. It also documents the published-library ABI model and bumps the workspace version to `0.3.0-dev.43` after rebasing onto current `main`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Published libraries that expose Rust-backed items now embed canonical Rust item signatures in their `.incnlib`; consumers load that ABI first instead of requiring producer workspace inspection for already-published signatures.
- **Internals**: Added `LibraryRustAbi` with schema validation, manifest wire round-tripping, producer-side ABI collection from the prewarmed rust-inspect workspace, deterministic dependency lookup through `LibraryManifestIndex`, and ABI-first typechecker metadata lookup including no-`rust_inspect` builds.
- **Risks**: The ABI payload schema is new and touches manifest compatibility. The highest-risk path is stale or incomplete producer metadata, so the PR validates schema versions, duplicate paths, and covered `@rust.extern` backing item collection.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo check` after resolving rebase conflicts onto `origin/main`
- `make pre-commit` after final rebase: formatting, rustdoc coverage, 2269/2269 tests, clippy, cargo-deny
- `make pre-commit` continued through smoke-test-fast: web and nested examples, 57 checked examples, 34 runnable examples, 8 benchmark build checks

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/how-to/rust_interop.md`, `workspaces/docs-site/docs/RFCs/closed/implemented/031_library_system_phase1.md`, `crates/rust_inspect/README.md`
- RFC lifecycle state: RFC 031 was already under `closed/implemented`; this PR updates the implemented artifact description only.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #262