### PR TITLE
chore - make generated Rust trait-import retention metadata-driven (#447)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "byteorder",
  "clap",
@@ -1450,14 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,14 +1466,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "axum",
  "incan_core",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.42"
+version = "0.3.0-dev.43"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/incan_core/src/lang/traits.rs
+++ b/crates/incan_core/src/lang/traits.rs
@@ -174,6 +174,31 @@ pub fn as_str(id: TraitId) -> &'static str {
     info_for(id).canonical
 }
 
+/// Return canonical source-declared method names for builtin traits whose method set is compiler-observed.
+pub fn method_names(id: TraitId) -> &'static [&'static str] {
+    match id {
+        TraitId::Error => &["message", "source"],
+        TraitId::Debug
+        | TraitId::Display
+        | TraitId::Eq
+        | TraitId::PartialEq
+        | TraitId::Ord
+        | TraitId::PartialOrd
+        | TraitId::Hash
+        | TraitId::Clone
+        | TraitId::Default
+        | TraitId::From
+        | TraitId::Into
+        | TraitId::TryFrom
+        | TraitId::TryInto
+        | TraitId::Iterator
+        | TraitId::IntoIterator
+        | TraitId::Iterable
+        | TraitId::Sum
+        | TraitId::Awaitable => &[],
+    }
+}
+
 /// Return the full metadata entry for a builtin trait.
 ///
 /// The lookup is exhaustive over the closed enum, so adding a trait requires updating this match at compile time.

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -1731,7 +1731,7 @@ def main() -> None:
     #[test]
     fn generated_use_analysis_keeps_rust_extension_trait_imports() {
         use crate::backend::ir::decl::{
-            FunctionParam, IrFunction, IrImportItem, IrImportOrigin, IrImportQualifier, Visibility,
+            FunctionParam, IrFunction, IrImportItem, IrImportOrigin, IrImportQualifier, IrRustTraitImport, Visibility,
         };
         use crate::backend::ir::expr::{
             IrCallArg, IrCallArgKind, IrExprKind, MethodCallArgPolicy, VarAccess, VarRefKind,
@@ -1749,12 +1749,16 @@ def main() -> None:
                 IrImportItem {
                     name: String::from("Rng"),
                     alias: None,
-                    rust_trait_methods: vec![String::from("gen_range")],
+                    rust_trait_import: Some(IrRustTraitImport {
+                        trait_path: String::from("rand::Rng"),
+                        definition_path: None,
+                        methods: vec![String::from("gen_range")],
+                    }),
                 },
                 IrImportItem {
                     name: String::from("thread_rng"),
                     alias: None,
-                    rust_trait_methods: Vec::new(),
+                    rust_trait_import: None,
                 },
             ],
         }));
@@ -1839,6 +1843,106 @@ def main() -> None:
     }
 
     #[test]
+    fn generated_use_analysis_keeps_only_selected_same_name_rust_extension_trait_import() {
+        use crate::backend::ir::decl::{
+            FunctionParam, IrFunction, IrImportItem, IrImportOrigin, IrImportQualifier, IrRustTraitImport, Visibility,
+        };
+        use crate::backend::ir::expr::{IrExprKind, IrMethodDispatch, MethodCallArgPolicy, VarAccess, VarRefKind};
+        use crate::backend::ir::{IrDecl, IrDeclKind, IrProgram, IrStmt, IrStmtKind, IrType, Mutability, TypedExpr};
+
+        let mut program = IrProgram::new();
+        program.declarations.push(IrDecl::new(IrDeclKind::Import {
+            visibility: Visibility::Private,
+            origin: IrImportOrigin::Standard,
+            qualifier: IrImportQualifier::None,
+            path: vec![String::from("demo")],
+            alias: None,
+            items: vec![
+                IrImportItem {
+                    name: String::from("AlphaRender"),
+                    alias: None,
+                    rust_trait_import: Some(IrRustTraitImport {
+                        trait_path: String::from("demo::AlphaRender"),
+                        definition_path: None,
+                        methods: vec![String::from("render")],
+                    }),
+                },
+                IrImportItem {
+                    name: String::from("BetaRender"),
+                    alias: None,
+                    rust_trait_import: Some(IrRustTraitImport {
+                        trait_path: String::from("demo::BetaRender"),
+                        definition_path: None,
+                        methods: vec![String::from("render")],
+                    }),
+                },
+                IrImportItem {
+                    name: String::from("widget"),
+                    alias: None,
+                    rust_trait_import: None,
+                },
+            ],
+        }));
+        let widget_ty = IrType::Struct(String::from("demo::Widget"));
+        program.declarations.push(IrDecl::new(IrDeclKind::Function(IrFunction {
+            name: String::from("main"),
+            params: Vec::<FunctionParam>::new(),
+            return_type: IrType::Unit,
+            body: vec![
+                IrStmt::new(IrStmtKind::Let {
+                    name: String::from("widget"),
+                    ty: widget_ty.clone(),
+                    type_annotation: None,
+                    mutability: Mutability::Immutable,
+                    value: TypedExpr::new(
+                        IrExprKind::Var {
+                            name: String::from("widget"),
+                            access: VarAccess::Copy,
+                            ref_kind: VarRefKind::ExternalRustName,
+                        },
+                        widget_ty.clone(),
+                    ),
+                }),
+                IrStmt::new(IrStmtKind::Expr(TypedExpr::new(
+                    IrExprKind::MethodCall {
+                        receiver: Box::new(TypedExpr::new(
+                            IrExprKind::Var {
+                                name: String::from("widget"),
+                                access: VarAccess::Read,
+                                ref_kind: VarRefKind::Value,
+                            },
+                            widget_ty,
+                        )),
+                        method: String::from("render"),
+                        dispatch: Some(IrMethodDispatch::RustExtensionTraitImport {
+                            binding: String::from("AlphaRender"),
+                        }),
+                        type_args: Vec::new(),
+                        args: Vec::new(),
+                        callable_signature: None,
+                        arg_policy: MethodCallArgPolicy::Default,
+                    },
+                    IrType::String,
+                ))),
+            ],
+            is_async: false,
+            is_generator: false,
+            visibility: Visibility::Private,
+            type_params: Vec::new(),
+            is_extern: false,
+            rust_attributes: Vec::new(),
+            lint_allows: Vec::new(),
+        })));
+
+        let mut emitter = IrEmitter::new(&program.function_registry);
+        let code = must_ok(emitter.emit_program(&program));
+
+        assert!(code.contains("use demo::AlphaRender;"), "{code}");
+        assert!(!code.contains("use demo::BetaRender;"), "{code}");
+        assert_no_generated_unused_lint_allows(&code);
+    }
+
+    #[test]
     fn generated_use_analysis_keeps_rust_trait_candidates_without_metadata() {
         use crate::backend::ir::decl::{
             FunctionParam, IrFunction, IrImportItem, IrImportOrigin, IrImportQualifier, Visibility,
@@ -1859,12 +1963,12 @@ def main() -> None:
                 IrImportItem {
                     name: String::from("Rng"),
                     alias: None,
-                    rust_trait_methods: Vec::new(),
+                    rust_trait_import: None,
                 },
                 IrImportItem {
                     name: String::from("thread_rng"),
                     alias: None,
-                    rust_trait_methods: Vec::new(),
+                    rust_trait_import: None,
                 },
             ],
         }));

--- a/src/backend/ir/decl.rs
+++ b/src/backend/ir/decl.rs
@@ -155,16 +155,27 @@ pub enum IrImportQualifier {
     Super(usize),
 }
 
+/// Metadata for one Rust trait import that can participate in extension-method lookup.
+#[derive(Debug, Clone)]
+pub struct IrRustTraitImport {
+    /// Canonical import path used by Incan for this trait binding.
+    pub trait_path: String,
+    /// Resolved Rust definition path after re-export resolution, when available.
+    pub definition_path: Option<String>,
+    /// Method names this trait can place in Rust method-lookup scope.
+    pub methods: Vec<String>,
+}
+
 /// An item in a from ... import statement
 #[derive(Debug, Clone)]
 pub struct IrImportItem {
     pub name: String,
     pub alias: Option<String>,
-    /// Method names provided when this item is a Rust trait import.
+    /// Metadata provided when this item is a Rust trait import.
     ///
     /// Extension-trait imports can be used by Rust method lookup without appearing as identifiers in emitted tokens.
-    /// Codegen uses these method names to retain only trait imports that can satisfy observed method calls.
-    pub rust_trait_methods: Vec<String>,
+    /// Codegen uses this metadata to retain imports selected by frontend method-call analysis.
+    pub rust_trait_import: Option<IrRustTraitImport>,
 }
 
 /// IR trait definition

--- a/src/backend/ir/emit/decls/mod.rs
+++ b/src/backend/ir/emit/decls/mod.rs
@@ -378,7 +378,7 @@ impl<'a> IrEmitter<'a> {
                         || self.should_emit_import_binding(binding)
                         || self.should_emit_extension_trait_import(binding)
                         || (preserve_metadata_missing_trait_candidate
-                            && item.rust_trait_methods.is_empty()
+                            && item.rust_trait_import.is_none()
                             && item.name.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()))
                 })
                 .map(|item| {

--- a/src/backend/ir/emit/program.rs
+++ b/src/backend/ir/emit/program.rs
@@ -23,12 +23,15 @@ use quote::{format_ident, quote};
 use std::collections::{HashMap, HashSet};
 
 use incan_core::lang::surface::result_methods::ResultMethodId;
+use incan_core::lang::traits::{self as core_traits, TraitId};
 use incan_core::lang::{conventions, magic_methods};
 
 use super::super::decl::{
-    IrDeclKind, IrFunction, IrImportOrigin, IrImportQualifier, IrTraitBound, IrTypeParam, Visibility,
+    IrDeclKind, IrFunction, IrImportOrigin, IrImportQualifier, IrRustTraitImport, IrTraitBound, IrTypeParam, Visibility,
 };
-use super::super::expr::{IrDictEntry, IrExprKind, IrGeneratorClause, IrListEntry, MethodKind, Pattern, VarRefKind};
+use super::super::expr::{
+    IrDictEntry, IrExprKind, IrGeneratorClause, IrListEntry, IrMethodDispatch, MethodKind, Pattern, VarRefKind,
+};
 use super::super::stmt::AssignTarget;
 use super::super::types::{IR_UNION_TYPE_NAME, IrType};
 use super::super::{FunctionRegistry, FunctionSignature, IrDecl, IrProgram, IrStmt, IrStmtKind, TypedExpr};
@@ -222,7 +225,7 @@ struct GeneratedUseAnalyzer<'program> {
     declarations_by_name: HashMap<String, &'program IrDecl>,
     function_registry: &'program FunctionRegistry,
     impls_by_target: HashMap<String, Vec<&'program super::super::decl::IrImpl>>,
-    rust_extension_trait_imports_by_method: HashMap<String, Vec<String>>,
+    rust_extension_trait_imports: HashMap<String, IrRustTraitImport>,
     external_error_trait_types: HashSet<String>,
     preserve_public_items: bool,
     analysis: GeneratedUseAnalysis,
@@ -241,7 +244,7 @@ impl<'program> GeneratedUseAnalyzer<'program> {
             declarations_by_name: HashMap::new(),
             function_registry: &program.function_registry,
             impls_by_target: HashMap::new(),
-            rust_extension_trait_imports_by_method: HashMap::new(),
+            rust_extension_trait_imports: HashMap::new(),
             external_error_trait_types: external_error_trait_types.clone(),
             preserve_public_items,
             analysis: GeneratedUseAnalysis::default(),
@@ -291,17 +294,11 @@ impl<'program> GeneratedUseAnalyzer<'program> {
                     ..
                 } if matches!(origin, IrImportOrigin::Standard) && matches!(qualifier, IrImportQualifier::None) => {
                     for item in items {
-                        if item.rust_trait_methods.is_empty() {
+                        let Some(import) = &item.rust_trait_import else {
                             continue;
-                        }
+                        };
                         let binding = item.alias.as_ref().unwrap_or(&item.name).clone();
-                        for method in &item.rust_trait_methods {
-                            analyzer
-                                .rust_extension_trait_imports_by_method
-                                .entry(method.clone())
-                                .or_default()
-                                .push(binding.clone());
-                        }
+                        analyzer.rust_extension_trait_imports.insert(binding, import.clone());
                     }
                 }
                 IrDeclKind::Import { .. } => {}
@@ -735,10 +732,11 @@ impl<'program> GeneratedUseAnalyzer<'program> {
                 method,
                 args,
                 type_args,
+                dispatch,
                 ..
             } => {
                 self.scan_expr(receiver);
-                self.mark_rust_extension_trait_imports(receiver, method);
+                self.mark_rust_extension_trait_imports(receiver, method, dispatch.as_ref());
                 self.mark_stdlib_error_trait_import(receiver, method);
                 if let Some(type_name) = Self::nominal_type_name(&receiver.ty) {
                     self.analysis
@@ -1051,20 +1049,43 @@ impl<'program> GeneratedUseAnalyzer<'program> {
         }
     }
 
-    /// Mark Rust trait imports that can satisfy an observed extension-method call.
-    fn mark_rust_extension_trait_imports(&mut self, receiver: &TypedExpr, method: &str) {
+    /// Mark the Rust trait import selected for an observed extension-method call.
+    fn mark_rust_extension_trait_imports(
+        &mut self,
+        receiver: &TypedExpr,
+        method: &str,
+        dispatch: Option<&IrMethodDispatch>,
+    ) {
         if !self.receiver_can_use_rust_extension_trait(receiver) {
             return;
         }
-        let Some(bindings) = self.rust_extension_trait_imports_by_method.get(method).cloned() else {
+        if let Some(IrMethodDispatch::RustExtensionTraitImport { binding }) = dispatch {
+            if self.rust_extension_trait_imports.contains_key(binding) {
+                self.analysis.used_extension_trait_imports.insert(binding.clone());
+            }
+            return;
+        }
+        self.mark_unambiguous_rust_extension_trait_import(method);
+    }
+
+    /// Mark a trait import for metadata-free fallback only when the method has one possible imported trait.
+    fn mark_unambiguous_rust_extension_trait_import(&mut self, method: &str) {
+        let mut matches = self
+            .rust_extension_trait_imports
+            .iter()
+            .filter(|(_, import)| import.methods.iter().any(|candidate| candidate == method))
+            .map(|(binding, _)| binding.clone());
+        let Some(binding) = matches.next() else {
             return;
         };
-        self.analysis.used_extension_trait_imports.extend(bindings);
+        if matches.next().is_none() {
+            self.analysis.used_extension_trait_imports.insert(binding);
+        }
     }
 
     /// Mark the stdlib `Error` trait import required for Rust method lookup on imported error types.
     fn mark_stdlib_error_trait_import(&mut self, receiver: &TypedExpr, method: &str) {
-        if !matches!(method, "message" | "source") {
+        if !core_traits::method_names(TraitId::Error).contains(&method) {
             return;
         }
         let Some(type_name) = Self::nominal_type_name(&receiver.ty) else {

--- a/src/backend/ir/expr.rs
+++ b/src/backend/ir/expr.rs
@@ -609,6 +609,8 @@ impl BuiltinFn {
 pub enum IrMethodDispatch {
     /// Emit a fully-qualified trait method call.
     Trait { trait_path: String, type_args: Vec<IrType> },
+    /// Keep the emitted call as regular Rust method lookup while retaining this extension-trait import binding.
+    RustExtensionTraitImport { binding: String },
 }
 
 /// Known method kinds recognized by the Incan compiler.

--- a/src/backend/ir/lower/decl/imports.rs
+++ b/src/backend/ir/lower/decl/imports.rs
@@ -1,6 +1,6 @@
 //! Import declaration lowering.
 
-use super::super::super::decl::IrDeclKind;
+use super::super::super::decl::{IrDeclKind, IrRustTraitImport};
 use super::super::AstLowering;
 use crate::frontend::ast;
 use crate::frontend::module::canonicalize_source_module_segments;
@@ -68,16 +68,23 @@ impl AstLowering {
             .iter()
             .map(|item| {
                 let binding_name = item.alias.as_ref().unwrap_or(&item.name);
-                let rust_trait_methods = self
+                let rust_trait_import = self
                     .type_info
                     .as_ref()
-                    .and_then(|info| info.rust_trait_import_methods.get(binding_name))
-                    .map(|methods| methods.iter().cloned().collect())
-                    .unwrap_or_default();
+                    .and_then(|info| info.rust_trait_imports.get(binding_name))
+                    .map(|import| {
+                        let mut methods: Vec<_> = import.methods.iter().cloned().collect();
+                        methods.sort();
+                        IrRustTraitImport {
+                            trait_path: import.trait_path.clone(),
+                            definition_path: import.definition_path.clone(),
+                            methods,
+                        }
+                    });
                 super::super::super::decl::IrImportItem {
                     name: item.name.clone(),
                     alias: item.alias.clone(),
-                    rust_trait_methods,
+                    rust_trait_import,
                 }
             })
             .collect();

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -736,6 +736,14 @@ impl AstLowering {
                             trait_path,
                             type_args: type_args.iter().map(|ty| self.lower_resolved_type(ty)).collect(),
                         },
+                    })
+                    .or_else(|| {
+                        self.type_info
+                            .as_ref()
+                            .and_then(|info| info.rust_method_trait_import_use(expr_span))
+                            .map(|import_use| IrMethodDispatch::RustExtensionTraitImport {
+                                binding: import_use.binding.clone(),
+                            })
                     });
 
                 if let Some(policy) = numeric_resize_policy(&method_name)

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -2911,7 +2911,7 @@ impl TypeChecker {
     }
 
     /// Return the path suffix used when comparing re-exported Rust trait paths.
-    fn rust_trait_path_suffix(path: &str) -> &str {
+    pub(in crate::frontend::typechecker) fn rust_trait_path_suffix(path: &str) -> &str {
         path.split_once("::").map(|(_, suffix)| suffix).unwrap_or(path)
     }
 

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -12,6 +12,7 @@ use crate::frontend::typechecker::helpers::{
     collection_name, collection_type_id, generator_ty, is_frozen_bytes, is_frozen_str, is_intlike_for_index, list_ty,
     option_ty, string_method_return,
 };
+use crate::frontend::typechecker::type_info::{RustMethodTraitImportUse, RustTraitImportInfo};
 use incan_core::interop::{CoercionPolicy, RustCollectionFamily, RustItemKind};
 use incan_core::lang::conventions;
 use incan_core::lang::magic_methods;
@@ -1299,8 +1300,9 @@ impl TypeChecker {
         match &metadata.kind {
             RustItemKind::Type(_) => {
                 let Some(sig) = self.rust_method_signature(rust_path, method) else {
-                    // Metadata only covers inherent methods; trait-provided or extension methods are
-                    // not yet extracted. Stay permissive rather than false-positiving on valid calls.
+                    self.record_rust_extension_trait_import_for_call(&metadata, method, span);
+                    // Metadata only covers inherent methods plus direct trait impl summaries. Stay permissive rather
+                    // than false-positiving on valid calls when no unambiguous imported trait can be selected.
                     return Some(ResolvedType::Unknown);
                 };
                 if Self::rust_signature_has_receiver(&sig)
@@ -1333,6 +1335,68 @@ impl TypeChecker {
             // Stay permissive and let rustc catch genuine errors at compile time.
             _ => Some(ResolvedType::Unknown),
         }
+    }
+
+    /// Record the imported Rust extension trait needed for a method call when metadata proves a unique match.
+    ///
+    /// Rust method lookup needs the trait binding in scope even though the emitted call remains `receiver.method(...)`.
+    /// The typechecker has both receiver metadata and import metadata, so it is the narrowest layer that can select the
+    /// import without falling back to backend method-name heuristics.
+    fn record_rust_extension_trait_import_for_call(
+        &mut self,
+        receiver_metadata: &incan_core::interop::RustItemMetadata,
+        method: &str,
+        span: Span,
+    ) {
+        let RustItemKind::Type(type_info) = &receiver_metadata.kind else {
+            return;
+        };
+        let matches = self
+            .type_info
+            .rust_trait_imports
+            .iter()
+            .filter_map(|(binding, import)| {
+                Self::rust_trait_import_matches_receiver(type_info, import, method).map(|signature| {
+                    RustMethodTraitImportUse {
+                        binding: binding.clone(),
+                        trait_path: import.trait_path.clone(),
+                        method: method.to_string(),
+                        signature,
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        let [import_use] = matches.as_slice() else {
+            return;
+        };
+        self.type_info
+            .record_rust_method_trait_import_use(span, import_use.clone());
+    }
+
+    /// Return the trait method signature when `import` is implemented by `type_info` and declares `method`.
+    fn rust_trait_import_matches_receiver(
+        type_info: &incan_core::interop::RustTypeInfo,
+        import: &RustTraitImportInfo,
+        method: &str,
+    ) -> Option<Option<incan_core::interop::RustFunctionSig>> {
+        if !import.methods.contains(method) {
+            return None;
+        }
+        let trait_suffix = Self::rust_trait_path_suffix(&import.trait_path);
+        let implemented = type_info.implemented_traits.iter().any(|implemented| {
+            implemented.path == import.trait_path
+                || Some(implemented.path.as_str()) == import.definition_path.as_deref()
+                || Self::rust_trait_path_suffix(&implemented.path) == trait_suffix
+        });
+        implemented.then(|| Self::rust_trait_method_signature(import, method))
+    }
+
+    /// Return the imported trait method signature when metadata supplied it.
+    fn rust_trait_method_signature(
+        import: &RustTraitImportInfo,
+        method: &str,
+    ) -> Option<incan_core::interop::RustFunctionSig> {
+        import.method_signatures.get(method).cloned()
     }
 
     /// Check if a type is copyable.

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -12,6 +12,7 @@ use crate::frontend::module::{ExportedSymbol, canonicalize_source_module_segment
 use crate::frontend::symbols::*;
 use crate::frontend::testing_markers::{TestingMarkerSemantics, load_testing_marker_semantics};
 use crate::frontend::typechecker::TypeChecker;
+use crate::frontend::typechecker::type_info::RustTraitImportInfo;
 use crate::library_manifest::{
     AliasExport, ClassExport, ConstExport, EnumExport, EnumValueExport, EnumValueTypeExport, FieldExport,
     FunctionExport, LibraryManifest, MethodExport, ModelExport, NewtypeExport, ParamExport, ParamKindExport,
@@ -1531,17 +1532,19 @@ impl TypeChecker {
     fn define_rust_import_binding(&mut self, name: Ident, info: RustItemInfo, span: Span) {
         self.validate_root_namespace(&name, span);
         let mut trait_methods = HashSet::new();
+        let mut trait_method_signatures = std::collections::HashMap::new();
         if let Some(metadata) = &info.metadata
             && let RustItemKind::Trait(trait_info) = &metadata.kind
         {
-            trait_methods = trait_info
-                .items
-                .iter()
-                .filter_map(|item| match item {
-                    RustTraitAssoc::Function { name, .. } => Some(name.clone()),
-                    RustTraitAssoc::TypeAlias { .. } | RustTraitAssoc::Constant { .. } => None,
-                })
-                .collect();
+            for item in &trait_info.items {
+                match item {
+                    RustTraitAssoc::Function { name, signature } => {
+                        trait_methods.insert(name.clone());
+                        trait_method_signatures.insert(name.clone(), signature.clone());
+                    }
+                    RustTraitAssoc::TypeAlias { .. } | RustTraitAssoc::Constant { .. } => {}
+                }
+            }
         }
         if trait_methods.is_empty() {
             trait_methods.extend(
@@ -1551,9 +1554,18 @@ impl TypeChecker {
             );
         }
         if !trait_methods.is_empty() {
-            self.type_info
-                .rust_trait_import_methods
-                .insert(name.clone(), trait_methods);
+            self.type_info.rust_trait_imports.insert(
+                name.clone(),
+                RustTraitImportInfo {
+                    trait_path: info.path.clone(),
+                    definition_path: info
+                        .metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.definition_path.clone()),
+                    methods: trait_methods,
+                    method_signatures: trait_method_signatures,
+                },
+            );
         }
         self.define_rust_import_symbol(name, info, span);
     }

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -7415,6 +7415,84 @@ type JoinHandle[T] = rusttype RustJoinHandle[T] with Awaitable[T]
 
 #[cfg(feature = "rust_inspect")]
 #[test]
+fn test_rust_extension_trait_method_call_records_selected_import_binding() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from rust::demo import AlphaRender, BetaRender, Widget
+
+def f(w: Widget) -> None:
+  _ = w.render()
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
+    let mut checker = TypeChecker::new();
+    let tmp = seeded_rust_inspect_workspace()?;
+    let manifest_dir = tmp.path().to_path_buf();
+    checker.set_rust_inspect_manifest_dir(manifest_dir.clone());
+    for trait_name in ["AlphaRender", "BetaRender"] {
+        checker
+            .rust_inspect_cache
+            .insert_test_item(
+                &manifest_dir,
+                RustItemMetadata {
+                    canonical_path: format!("demo::{trait_name}"),
+                    definition_path: Some(format!("demo::{trait_name}")),
+                    visibility: RustVisibility::Public,
+                    kind: RustItemKind::Trait(RustTraitInfo {
+                        items: vec![RustTraitAssoc::Function {
+                            name: "render".to_string(),
+                            signature: RustFunctionSig {
+                                params: vec![RustParam {
+                                    name: Some("self".to_string()),
+                                    type_display: "&self".to_string(),
+                                }],
+                                return_type: "String".to_string(),
+                                is_async: false,
+                                is_unsafe: false,
+                            },
+                        }],
+                    }),
+                },
+            )
+            .map_err(|err| std::io::Error::other(format!("seed trait metadata: {err}")))?;
+    }
+    checker
+        .rust_inspect_cache
+        .insert_test_item(
+            &manifest_dir,
+            RustItemMetadata {
+                canonical_path: "demo::Widget".to_string(),
+                definition_path: Some("demo::Widget".to_string()),
+                visibility: RustVisibility::Public,
+                kind: RustItemKind::Type(RustTypeInfo {
+                    methods: Vec::new(),
+                    implemented_traits: vec![RustImplementedTrait {
+                        path: "demo::AlphaRender".to_string(),
+                    }],
+                    fields: Vec::new(),
+                    variants: Vec::new(),
+                }),
+            },
+        )
+        .map_err(|err| std::io::Error::other(format!("seed type metadata: {err}")))?;
+
+    checker
+        .check_program(&ast)
+        .map_err(|errs| std::io::Error::other(format!("typecheck failed: {errs:?}")))?;
+    let uses = &checker.type_info().rust_method_trait_import_uses;
+    assert!(
+        uses.values()
+            .any(|import_use| import_use.binding == "AlphaRender" && import_use.method == "render"),
+        "expected AlphaRender import use, got {uses:?}"
+    );
+    assert!(
+        !uses.values().any(|import_use| import_use.binding == "BetaRender"),
+        "BetaRender should not be selected for Widget.render(): {uses:?}"
+    );
+    Ok(())
+}
+
+#[cfg(feature = "rust_inspect")]
+#[test]
 fn test_rusttype_bodyless_rust_trait_forwarding_uses_metadata_and_skips_impl() -> Result<(), Box<dyn std::error::Error>>
 {
     let source = r#"

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use crate::frontend::ast::{ParamKind, Span};
 use crate::frontend::symbols::{CallableParam, NewtypePrimitiveConstraint, ResolvedType};
 use crate::frontend::testing_markers::TestingFixtureScope;
-use incan_core::interop::CoercionPolicy;
+use incan_core::interop::{CoercionPolicy, RustFunctionSig};
 
 use super::{ConstValue, const_eval};
 
@@ -95,11 +95,18 @@ pub struct TypeCheckInfo {
     /// Lowering consumes these decisions when an expression is used at an approved implicit-coercion site, such as a
     /// function argument, typed initializer, or model/class field initializer.
     pub validated_newtype_coercions: HashMap<(usize, usize), ValidatedNewtypeCoercionInfo>,
-    /// Rust trait imports keyed by the source binding name with the trait method names they can place in scope.
+    /// Rust trait imports keyed by the source binding name with the trait path and method names they can place in
+    /// scope.
     ///
-    /// Lowering carries this into IR import items so codegen can retain extension-trait imports that Rust method
-    /// lookup needs even when the generated Rust tokens do not otherwise mention the trait name.
-    pub rust_trait_import_methods: HashMap<String, HashSet<String>>,
+    /// Lowering carries this into IR import items so codegen can retain extension-trait imports when Rust method
+    /// lookup needs the trait in scope even though emitted call tokens do not otherwise mention the trait name.
+    pub rust_trait_imports: HashMap<String, RustTraitImportInfo>,
+    /// Rust extension-trait import selected for one Rust method call.
+    ///
+    /// Keyed by the full method-call expression span. Lowering attaches the binding to the corresponding IR method
+    /// call so generated-use analysis can retain the exact import instead of retaining every trait with the same
+    /// method name.
+    pub rust_method_trait_import_uses: HashMap<(usize, usize), RustMethodTraitImportUse>,
     /// Body-less rusttype Rust-trait adoptions proven by metadata and therefore satisfied by the backing type alias.
     ///
     /// Lowering must not emit an `impl Trait for Alias` for these entries because Rust coherence treats the alias as
@@ -166,6 +173,32 @@ pub struct ResolvedOperatorCall {
     pub method: String,
     /// The AST operator shape this call replaces.
     pub kind: ResolvedOperatorKind,
+}
+
+/// Metadata for one imported Rust trait binding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RustTraitImportInfo {
+    /// Canonical import path used by Incan for this trait binding.
+    pub trait_path: String,
+    /// Resolved Rust definition path after re-export resolution, when available.
+    pub definition_path: Option<String>,
+    /// Method names this trait can place in Rust method-lookup scope.
+    pub methods: HashSet<String>,
+    /// Method signatures this trait metadata provided, keyed by method name.
+    pub method_signatures: HashMap<String, RustFunctionSig>,
+}
+
+/// A typechecker-resolved Rust extension-trait import required by a method call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RustMethodTraitImportUse {
+    /// Local import binding to retain in generated Rust.
+    pub binding: String,
+    /// Trait path selected for the call.
+    pub trait_path: String,
+    /// Method name observed at the call site.
+    pub method: String,
+    /// Trait method signature, when metadata supplied it.
+    pub signature: Option<RustFunctionSig>,
 }
 
 /// A typechecker-resolved method call consumed by IR lowering.
@@ -460,6 +493,11 @@ impl TypeCheckInfo {
         self.resolved_method_calls.get(&(span.start, span.end))
     }
 
+    /// Return the Rust extension-trait import selected for the method call at `span`, if any.
+    pub fn rust_method_trait_import_use(&self, span: Span) -> Option<&RustMethodTraitImportUse> {
+        self.rust_method_trait_import_uses.get(&(span.start, span.end))
+    }
+
     /// Return custom iteration protocol metadata for `span`, if any.
     pub fn protocol_iteration(&self, span: Span) -> Option<&ProtocolIterationInfo> {
         self.protocol_iterations.get(&(span.start, span.end))
@@ -495,6 +533,12 @@ impl TypeCheckInfo {
                 dispatch,
             },
         );
+    }
+
+    /// Record that a Rust method call requires a specific imported extension trait in generated Rust scope.
+    pub(crate) fn record_rust_method_trait_import_use(&mut self, span: Span, import_use: RustMethodTraitImportUse) {
+        self.rust_method_trait_import_uses
+            .insert((span.start, span.end), import_use);
     }
 
     /// Record a custom `for` iteration protocol route.

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -406,6 +406,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Language/Interop**: Direct `list[T]` arguments passed to external Rust functions or methods can now satisfy `Vec<U>` parameters by mapping elements through Rust `.into()` at the call boundary, covering APIs such as Polars constructors that accept `Vec<Column>` from `Series` values (#128).
 - **Language/Compiler**: Multi-file web builds now retain private route-decorated handlers and the private models they use in dependency modules, so route registration works without forcing those declarations public (#117).
 - **Language/Compiler**: Stdlib import validation now rejects unknown names from known stdlib modules, imported stdlib static method calls preserve default arguments at the call site, union narrowing lowers chained `isinstance` branches without leaking raw `isinstance` calls or unit fallthroughs into generated Rust, and Rust interop accepts owned Incan values for shared borrowed generic parameters such as `&T` in both free-function and method-call positions (#499, #500, #501, #502, #506, #508).
+- **Language/Interop**: Generated Rust now retains extension-trait imports from typechecker import metadata and receiver trait metadata instead of backend method-name heuristics, so same-name methods from unrelated imported traits do not force unused trait imports (#447).
 - **Tooling**: `incan lock` now treats manifest projects as a project-wide lock surface, covering declared scripts and test harness dependency inputs so multi-entrypoint projects do not alternate stale-lock warnings between `incan test` and `incan run src/extra.incn` (#505).
 
 ### Documentation
@@ -421,6 +422,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Dependency policy**: Dependabot security alerts for the VS Code extension lockfile, docs-site Python pins, and Rust `rand` lock entries are remediated, while repo-owned GitHub Actions are moved to Node 24-compatible action releases (#475, #464).
 - **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.41`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.42`.
+- **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.43`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

This PR makes generated Rust extension-trait import retention metadata-driven. The typechecker now records Rust trait import metadata and selects the concrete extension-trait import for a method call when receiver metadata proves a unique trait match, so codegen can retain only the trait import Rust method lookup actually needs instead of retaining every imported trait that happens to declare the same method name.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Generated Rust no longer keeps unrelated same-name Rust extension-trait imports when metadata identifies the trait used by the receiver method call. This reduces avoidable unused-import warnings without changing the emitted method-call syntax.
- **Internals**: Rust trait import collection now stores trait path, definition path, method names, and method signatures by source binding. Method-call checking records a selected extension-trait import on the call span, lowering carries that binding into IR method dispatch, and generated-use analysis retains the exact binding. Builtin `Error` trait method names now come from canonical trait metadata instead of backend string literals.
- **Risks**: Rust interop method lookup remains intentionally permissive when metadata is unavailable or ambiguous. The main risk is an import-retention edge case for incomplete rust-inspect metadata, covered by keeping the existing unambiguous fallback path.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test generated_use_analysis --lib` passed.
- `cargo test test_rust_extension_trait_method_call_records_selected_import_binding --lib --features rust_inspect` passed.
- `make pre-commit` passed on the rebased commit, including 2266 nextest tests, rustdoc, clippy, cargo-deny, and smoke-test-fast.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #447