### PR TITLE
chore - group typechecker lowering artifacts (#283)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "byteorder",
  "clap",
@@ -1450,14 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,14 +1466,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "axum",
  "incan_core",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.43"
+version = "0.3.0-dev.44"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/lower/decl/helpers.rs
+++ b/src/backend/ir/lower/decl/helpers.rs
@@ -167,7 +167,7 @@ impl AstLowering {
             || self
                 .type_info
                 .as_ref()
-                .is_some_and(|info| info.trait_type_params.contains_key(name))
+                .is_some_and(|info| info.traits.type_params.contains_key(name))
     }
 
     /// Lower an annotation like `Collection[int]` to a Rust trait bound shape.
@@ -418,7 +418,7 @@ impl AstLowering {
         if let Some(traits) = self
             .type_info
             .as_ref()
-            .and_then(|info| info.derivable_modules.get(&key))
+            .and_then(|info| info.derivations.derivable_modules.get(&key))
         {
             return Some(traits.clone());
         }
@@ -431,7 +431,7 @@ impl AstLowering {
         if let Some(paths) = self
             .type_info
             .as_ref()
-            .and_then(|info| info.trait_rust_derive_paths.get(&key))
+            .and_then(|info| info.derivations.trait_rust_derive_paths.get(&key))
         {
             return paths.clone();
         }
@@ -447,13 +447,14 @@ impl AstLowering {
         if self
             .type_info
             .as_ref()
-            .and_then(|info| info.derivable_modules.get(&module_key))
+            .and_then(|info| info.derivations.derivable_modules.get(&module_key))
             .is_some_and(|traits| traits.iter().any(|candidate| candidate == trait_name))
         {
             return true;
         }
         if self.type_info.as_ref().is_some_and(|info| {
-            info.trait_rust_derive_paths
+            info.derivations
+                .trait_rust_derive_paths
                 .contains_key(&format!("{module_key}.{trait_name}"))
         }) {
             return true;

--- a/src/backend/ir/lower/decl/imports.rs
+++ b/src/backend/ir/lower/decl/imports.rs
@@ -71,7 +71,7 @@ impl AstLowering {
                 let rust_trait_import = self
                     .type_info
                     .as_ref()
-                    .and_then(|info| info.rust_trait_imports.get(binding_name))
+                    .and_then(|info| info.rust.trait_imports.get(binding_name))
                     .map(|import| {
                         let mut methods: Vec<_> = import.methods.iter().cloned().collect();
                         methods.sort();

--- a/src/backend/ir/lower/decl/methods.rs
+++ b/src/backend/ir/lower/decl/methods.rs
@@ -106,7 +106,7 @@ impl AstLowering {
         }
         self.type_info
             .as_ref()
-            .and_then(|info| info.trait_type_params.get(trait_name).cloned())
+            .and_then(|info| info.traits.type_params.get(trait_name).cloned())
     }
 
     /// Infer the concrete trait arguments for `impl Trait<...> for Type<...>` from the adopter's leading type params.
@@ -148,7 +148,7 @@ impl AstLowering {
         let Some(type_info) = &self.type_info else {
             return;
         };
-        let Some(direct_supertraits) = type_info.trait_direct_supertraits.get(trait_name) else {
+        let Some(direct_supertraits) = type_info.traits.direct_supertraits.get(trait_name) else {
             return;
         };
         let Some(param_names) = self.trait_type_param_names(trait_name) else {
@@ -210,7 +210,8 @@ impl AstLowering {
         trait_name: &str,
     ) -> bool {
         self.type_info.as_ref().is_some_and(|info| {
-            info.rusttype_forwarded_trait_adoptions
+            info.rust
+                .rusttype_forwarded_trait_adoptions
                 .contains(&(type_name.to_string(), trait_name.to_string()))
         })
     }
@@ -302,7 +303,8 @@ impl AstLowering {
         let mut out = Vec::new();
         for method in methods {
             let Some(binding) = self.type_info.as_ref().and_then(|info| {
-                info.decorated_method_bindings
+                info.declarations
+                    .decorated_method_bindings
                     .get(&(type_name.to_string(), method.node.name.clone()))
                     .cloned()
             }) else {
@@ -337,7 +339,8 @@ impl AstLowering {
         type_param_names: Option<&HashSet<&str>>,
     ) -> Result<Vec<IrFunction>, LoweringError> {
         if self.type_info.as_ref().is_some_and(|info| {
-            info.decorated_method_bindings
+            info.declarations
+                .decorated_method_bindings
                 .contains_key(&(owner.to_string(), method.name.clone()))
         }) {
             let original = self.lower_method_named_with_type_params(
@@ -361,7 +364,8 @@ impl AstLowering {
         method: &ast::MethodDecl,
     ) -> Result<IrFunction, LoweringError> {
         let Some(binding) = self.type_info.as_ref().and_then(|info| {
-            info.decorated_method_bindings
+            info.declarations
+                .decorated_method_bindings
                 .get(&(owner.to_string(), method.name.clone()))
                 .cloned()
         }) else {
@@ -465,7 +469,8 @@ impl AstLowering {
         method: &ast::MethodDecl,
     ) -> Result<IrFunction, LoweringError> {
         let Some(binding) = self.type_info.as_ref().and_then(|info| {
-            info.decorated_method_bindings
+            info.declarations
+                .decorated_method_bindings
                 .get(&(owner.to_string(), method.name.clone()))
                 .cloned()
         }) else {

--- a/src/backend/ir/lower/decl/traits.rs
+++ b/src/backend/ir/lower/decl/traits.rs
@@ -158,7 +158,7 @@ impl AstLowering {
         let supertraits: Vec<(String, Vec<IrType>)> = if let Some(ti) = self
             .type_info
             .as_ref()
-            .and_then(|info| info.trait_direct_supertraits.get(&t.name))
+            .and_then(|info| info.traits.direct_supertraits.get(&t.name))
         {
             ti.iter()
                 .map(|(name, args)| self.lower_supertrait_from_resolved(name, args))

--- a/src/backend/ir/lower/expr/calls.rs
+++ b/src/backend/ir/lower/expr/calls.rs
@@ -1145,6 +1145,7 @@ impl AstLowering {
     ) -> Vec<IrType> {
         if let Some(info) = self.type_info.as_ref()
             && let Some(resolved) = info
+                .calls
                 .call_site_monomorph_type_args
                 .get(&(call_span.start, call_span.end))
         {
@@ -1920,7 +1921,7 @@ mod tests {
     fn lower_method_call_wraps_args_with_rust_arg_coercion() -> Result<(), String> {
         let arg_span = Span::new(10, 20);
         let mut type_info = TypeCheckInfo::default();
-        type_info.rust_arg_coercions.insert(
+        type_info.rust.arg_coercions.insert(
             (arg_span.start, arg_span.end),
             RustArgCoercionInfo {
                 rust_target_type: "&str".to_string(),
@@ -1965,7 +1966,7 @@ mod tests {
         let arg_span = Span::new(10, 17);
         let mut type_info = TypeCheckInfo::default();
         type_info.record_regular_method_arg_shape(receiver_span, "get");
-        type_info.rust_arg_coercions.insert(
+        type_info.rust.arg_coercions.insert(
             (arg_span.start, arg_span.end),
             RustArgCoercionInfo {
                 rust_target_type: "&Q".to_string(),

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -108,7 +108,11 @@ impl AstLowering {
             },
             _ => return None,
         };
-        type_info.awaitable_delegation_fields.get(type_name).cloned()
+        type_info
+            .expressions
+            .awaitable_delegation_fields
+            .get(type_name)
+            .cloned()
     }
 
     /// Lower a block race arm, treating a trailing expression statement as the arm value.

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -957,7 +957,7 @@ impl AstLowering {
                     let ir_underlying = self
                         .type_info
                         .as_ref()
-                        .and_then(|ti| ti.rusttype_canonical_rust_paths.get(&n.name))
+                        .and_then(|ti| ti.rust.rusttype_canonical_paths.get(&n.name))
                         .cloned()
                         .map(IrType::Struct)
                         .unwrap_or_else(|| self.lower_type(&n.underlying.node));
@@ -1037,7 +1037,7 @@ impl AstLowering {
                 let return_type = self
                     .type_info
                     .as_ref()
-                    .and_then(|info| info.decorated_function_bindings.get(&f.name))
+                    .and_then(|info| info.declarations.decorated_function_bindings.get(&f.name))
                     .and_then(|binding| match &binding.ty {
                         crate::frontend::symbols::ResolvedType::Function(_, ret) => Some(self.lower_resolved_type(ret)),
                         _ => None,
@@ -1052,7 +1052,7 @@ impl AstLowering {
                 if self
                     .type_info
                     .as_ref()
-                    .is_some_and(|info| info.decorated_function_bindings.contains_key(&f.name))
+                    .is_some_and(|info| info.declarations.decorated_function_bindings.contains_key(&f.name))
                 {
                     let original_name = Self::decorator_original_function_name(&f.name);
                     let original_return_type =
@@ -1502,7 +1502,7 @@ impl AstLowering {
         let Some(binding) = self
             .type_info
             .as_ref()
-            .and_then(|info| info.decorated_function_bindings.get(&f.name).cloned())
+            .and_then(|info| info.declarations.decorated_function_bindings.get(&f.name).cloned())
         else {
             return Ok(vec![self.lower_declaration(&ast::Declaration::Function(f.clone()))?]);
         };

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -1997,6 +1997,7 @@ impl TypeChecker {
             });
             if let Some(field_name) = realization_field {
                 self.type_info
+                    .expressions
                     .awaitable_delegation_fields
                     .insert(type_name.to_string(), field_name);
             } else {
@@ -2283,10 +2284,10 @@ impl TypeChecker {
             info.ty = expected_ty.clone();
         }
 
-        if let Some(binding) = self.type_info.static_bindings.get_mut(&static_decl.name) {
+        if let Some(binding) = self.type_info.declarations.static_bindings.get_mut(&static_decl.name) {
             binding.is_imported = false;
         } else {
-            self.type_info.static_bindings.insert(
+            self.type_info.declarations.static_bindings.insert(
                 static_decl.name.clone(),
                 super::StaticBindingInfo { is_imported: false },
             );
@@ -2972,6 +2973,7 @@ impl TypeChecker {
             let trait_definition_path = trait_metadata.and_then(|metadata| metadata.definition_path.as_deref());
             if Self::rust_type_metadata_implements_trait(&backing_metadata, trait_path, trait_definition_path) {
                 self.type_info
+                    .rust
                     .rusttype_forwarded_trait_adoptions
                     .insert((nt.name.clone(), trait_bound.name.clone()));
             } else {
@@ -3048,7 +3050,8 @@ impl TypeChecker {
             && let Some(path) = &rusttype_path
         {
             self.type_info
-                .rusttype_canonical_rust_paths
+                .rust
+                .rusttype_canonical_paths
                 .insert(nt.name.clone(), path.clone());
         }
         if !nt.is_rusttype && !nt.interop_edges.is_empty() {
@@ -3587,7 +3590,7 @@ impl TypeChecker {
         if let Some(symbol_id) = self.symbols.lookup(&func.name)
             && let Some(symbol) = self.symbols.get_mut(symbol_id)
         {
-            self.type_info.decorated_function_bindings.insert(
+            self.type_info.declarations.decorated_function_bindings.insert(
                 func.name.clone(),
                 DecoratedFunctionBindingInfo { ty: binding_ty.clone() },
             );
@@ -3629,7 +3632,7 @@ impl TypeChecker {
         let Some((_receiver, surface_params)) = params.split_first() else {
             return;
         };
-        self.type_info.decorated_method_bindings.insert(
+        self.type_info.declarations.decorated_method_bindings.insert(
             (owner.to_string(), method.name.clone()),
             DecoratedMethodBindingInfo {
                 unbound_ty: binding_ty,
@@ -3867,7 +3870,7 @@ impl TypeChecker {
                 .filter(|param| self.testing_fixture_names.contains(&param.node.name))
                 .map(|param| param.node.name.clone())
                 .collect();
-            self.type_info.testing_fixtures.insert(
+            self.type_info.testing.fixtures.insert(
                 func.name.clone(),
                 TestingFixtureInfo {
                     scope: args.scope,

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -1353,7 +1353,8 @@ impl TypeChecker {
         };
         let matches = self
             .type_info
-            .rust_trait_imports
+            .rust
+            .trait_imports
             .iter()
             .filter_map(|(binding, import)| {
                 Self::rust_trait_import_matches_receiver(type_info, import, method).map(|signature| {
@@ -1967,7 +1968,7 @@ impl TypeChecker {
         // ---- `&str` → `String` (Incan `str` = Rust `String`) ----
         let is_borrowed_str = normalized == "&str" || (normalized.starts_with("&'") && normalized.ends_with("str"));
         if is_borrowed_str && matches!(incan_ret, ResolvedType::Str) {
-            self.type_info.rust_return_coercions.insert(
+            self.type_info.rust.return_coercions.insert(
                 (span.start, span.end),
                 crate::frontend::typechecker::RustArgCoercionInfo {
                     rust_target_type: "String".to_string(),
@@ -1980,7 +1981,7 @@ impl TypeChecker {
         // ---- `&[u8]` → `Vec<u8>` (Incan `bytes` = Rust `Vec<u8>`) ----
         let is_borrowed_bytes = normalized == "&[u8]" || (normalized.starts_with("&'") && normalized.ends_with("[u8]"));
         if is_borrowed_bytes && matches!(incan_ret, ResolvedType::Bytes) {
-            self.type_info.rust_return_coercions.insert(
+            self.type_info.rust.return_coercions.insert(
                 (span.start, span.end),
                 crate::frontend::typechecker::RustArgCoercionInfo {
                     rust_target_type: "Vec<u8>".to_string(),
@@ -2459,6 +2460,7 @@ impl TypeChecker {
                 ));
             }
             self.type_info
+                .expressions
                 .ident_kinds
                 .insert((base.span.start, base.span.end), IdentKind::TypeName);
             return self.check_builtin_list_repeat_call(args, span);

--- a/src/frontend/typechecker/check_expr/basics.rs
+++ b/src/frontend/typechecker/check_expr/basics.rs
@@ -76,6 +76,7 @@ impl TypeChecker {
                     self.errors
                         .push(errors::rust_item_not_public(name, meta.canonical_path.as_str(), span));
                     self.type_info
+                        .expressions
                         .ident_kinds
                         .insert((span.start, span.end), IdentKind::RustImport);
                     return ResolvedType::Unknown;
@@ -122,7 +123,10 @@ impl TypeChecker {
             }
         };
 
-        self.type_info.ident_kinds.insert((span.start, span.end), kind);
+        self.type_info
+            .expressions
+            .ident_kinds
+            .insert((span.start, span.end), kind);
         ty
     }
 

--- a/src/frontend/typechecker/check_expr/calls.rs
+++ b/src/frontend/typechecker/check_expr/calls.rs
@@ -112,6 +112,7 @@ impl TypeChecker {
                 if let Some(fields) = ctor_fields {
                     self.record_expr_type(callee.span, self_ty.clone());
                     self.type_info
+                        .expressions
                         .ident_kinds
                         .insert((callee.span.start, callee.span.end), IdentKind::TypeName);
                     self.check_model_or_class_constructor_call(&owner_name, &fields, args, span);
@@ -154,6 +155,7 @@ impl TypeChecker {
                         }
                         self.record_expr_type(callee.span, ResolvedType::Named(name.clone()));
                         self.type_info
+                            .expressions
                             .ident_kinds
                             .insert((callee.span.start, callee.span.end), IdentKind::TypeName);
                         return self.check_constructor(name, args, span);
@@ -179,6 +181,7 @@ impl TypeChecker {
                                     self.resolved_function_type_from_rust_sig(sig, false),
                                 );
                                 self.type_info
+                                    .expressions
                                     .ident_kinds
                                     .insert((callee.span.start, callee.span.end), IdentKind::RustImport);
                             }
@@ -231,6 +234,7 @@ impl TypeChecker {
                 let constructor_ty = self.check_model_or_class_constructor_call(name, &fields, args, span);
                 self.record_expr_type(callee.span, ResolvedType::Named(name.clone()));
                 self.type_info
+                    .expressions
                     .ident_kinds
                     .insert((callee.span.start, callee.span.end), IdentKind::TypeName);
                 if in_scope && let Some(tid) = surface_types::from_str(name) {

--- a/src/frontend/typechecker/check_expr/calls/generic_bounds.rs
+++ b/src/frontend/typechecker/check_expr/calls/generic_bounds.rs
@@ -100,6 +100,7 @@ impl TypeChecker {
         }
     }
 
+    /// Record explicit call-site generic arguments after every type parameter has a concrete resolved type.
     fn record_call_site_monomorph_if_complete(
         &mut self,
         call_span: Span,
@@ -117,6 +118,7 @@ impl TypeChecker {
             out.push(ty.clone());
         }
         self.type_info
+            .calls
             .call_site_monomorph_type_args
             .insert((call_span.start, call_span.end), out);
     }
@@ -135,7 +137,7 @@ impl TypeChecker {
     /// - Validates value arguments against the specialized formals, then runs [`Self::infer_type_param_bindings`] so
     ///   remaining type parameters are filled from argument types.
     /// - Enforces explicit `with` bounds, requires every method type parameter to be concretely bound when brackets
-    ///   were present, and records `TypeCheckInfo::call_site_monomorph_type_args` for lowering.
+    ///   were present, and records `TypeCheckInfo::calls.call_site_monomorph_type_args` for lowering.
     ///
     /// # Parameters
     ///

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -359,7 +359,7 @@ impl TypeChecker {
             match self.rust_arg_boundary_match(arg_ty, param.type_display.as_str()) {
                 RustArgBoundaryMatch::Exact => {}
                 RustArgBoundaryMatch::Coercion(kind) => {
-                    self.type_info.rust_arg_coercions.insert(
+                    self.type_info.rust.arg_coercions.insert(
                         (arg_expr.span.start, arg_expr.span.end),
                         RustArgCoercionInfo {
                             rust_target_type: normalized,
@@ -404,7 +404,7 @@ impl TypeChecker {
             match self.rust_arg_boundary_match(arg_ty, param.type_display.as_str()) {
                 RustArgBoundaryMatch::Exact => {}
                 RustArgBoundaryMatch::Coercion(kind) => {
-                    self.type_info.rust_arg_coercions.insert(
+                    self.type_info.rust.arg_coercions.insert(
                         (arg_expr.span.start, arg_expr.span.end),
                         RustArgCoercionInfo {
                             rust_target_type: normalized,
@@ -662,9 +662,9 @@ mod validate_rust_function_call_tests {
             checker.errors
         );
         assert!(
-            checker.type_info.rust_arg_coercions.is_empty(),
+            checker.type_info.rust.arg_coercions.is_empty(),
             "expected lookup-preserving rust method call to preserve arg shape without coercion, got {:?}",
-            checker.type_info.rust_arg_coercions
+            checker.type_info.rust.arg_coercions
         );
     }
 
@@ -706,9 +706,9 @@ mod validate_rust_function_call_tests {
             checker.errors
         );
         assert!(
-            checker.type_info.rust_arg_coercions.is_empty(),
+            checker.type_info.rust.arg_coercions.is_empty(),
             "expected lookup-preserving generic probe to preserve arg shape without coercion, got {:?}",
-            checker.type_info.rust_arg_coercions
+            checker.type_info.rust.arg_coercions
         );
     }
 
@@ -768,7 +768,8 @@ mod validate_rust_function_call_tests {
         assert!(
             checker
                 .type_info
-                .rust_arg_coercions
+                .rust
+                .arg_coercions
                 .contains_key(&(span.start, span.end)),
             "expected rust arg coercion metadata for borrowed String boundary"
         );
@@ -922,7 +923,8 @@ mod validate_rust_function_call_tests {
         assert!(
             checker
                 .type_info
-                .rust_arg_coercions
+                .rust
+                .arg_coercions
                 .contains_key(&(span.start, span.end)),
             "expected rust arg coercion metadata for rusttype target boundary"
         );
@@ -996,7 +998,8 @@ mod validate_rust_function_call_tests {
         assert!(
             checker
                 .type_info
-                .rust_arg_coercions
+                .rust
+                .arg_coercions
                 .contains_key(&(span.start, span.end)),
             "expected rust arg coercion metadata for rust method boundary"
         );

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -420,7 +420,7 @@ impl TypeChecker {
         self.static_decls.push((static_decl.clone(), span));
 
         let ty = self.resolve_type_checked(&static_decl.ty);
-        self.type_info.static_bindings.insert(
+        self.type_info.declarations.static_bindings.insert(
             static_decl.name.clone(),
             crate::frontend::typechecker::StaticBindingInfo { is_imported: false },
         );

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -518,7 +518,7 @@ impl TypeChecker {
             if self.symbols.lookup(alias).is_none() {
                 self.validate_root_namespace(alias, span);
                 if matches!(imported_kind, SymbolKind::Static(_)) {
-                    self.type_info.static_bindings.insert(
+                    self.type_info.declarations.static_bindings.insert(
                         alias.clone(),
                         crate::frontend::typechecker::StaticBindingInfo { is_imported: true },
                     );
@@ -984,7 +984,7 @@ impl TypeChecker {
         self.remap_symbol_kind_with_import_aliases(&mut kind, imported_type_aliases);
 
         if matches!(kind, SymbolKind::Static(_)) {
-            self.type_info.static_bindings.insert(
+            self.type_info.declarations.static_bindings.insert(
                 local_name.clone(),
                 crate::frontend::typechecker::StaticBindingInfo { is_imported: true },
             );
@@ -1554,7 +1554,7 @@ impl TypeChecker {
             );
         }
         if !trait_methods.is_empty() {
-            self.type_info.rust_trait_imports.insert(
+            self.type_info.rust.trait_imports.insert(
                 name.clone(),
                 RustTraitImportInfo {
                     trait_path: info.path.clone(),
@@ -1648,7 +1648,7 @@ impl TypeChecker {
             touched_static = true;
         }
         if touched_static {
-            self.type_info.static_bindings.insert(
+            self.type_info.declarations.static_bindings.insert(
                 name.to_string(),
                 crate::frontend::typechecker::StaticBindingInfo { is_imported: true },
             );

--- a/src/frontend/typechecker/const_eval.rs
+++ b/src/frontend/typechecker/const_eval.rs
@@ -104,9 +104,12 @@ impl TypeChecker {
         };
 
         // Publish classification for downstream stages.
-        self.type_info.const_kinds.insert(konst.name.clone(), result.kind);
+        self.type_info
+            .consts
+            .const_kinds
+            .insert(konst.name.clone(), result.kind);
         if let Some(val) = result.value.clone() {
-            self.type_info.const_values.insert(konst.name.clone(), val);
+            self.type_info.consts.const_values.insert(konst.name.clone(), val);
         }
 
         // If an annotation exists, require compatibility.

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -950,13 +950,17 @@ impl TypeChecker {
         &self.type_info
     }
 
+    /// Record the resolved type for one expression span in the lowering-facing expression artifact map.
     pub(crate) fn record_expr_type(&mut self, span: Span, ty: ResolvedType) {
-        self.type_info.expr_types.insert((span.start, span.end), ty);
+        self.type_info.expressions.expr_types.insert((span.start, span.end), ty);
     }
 
     /// Record a typechecker-proven unpack binding plan for backend lowering.
     pub(crate) fn record_fixed_unpack_plan(&mut self, span: Span, plan: FixedUnpackPlan) {
-        self.type_info.fixed_unpack_plans.insert((span.start, span.end), plan);
+        self.type_info
+            .calls
+            .fixed_unpack_plans
+            .insert((span.start, span.end), plan);
     }
 
     /// Look up a type by name and return its [`TypeInfo`], if known.
@@ -1307,17 +1311,19 @@ impl TypeChecker {
     /// This records all visible trait symbols (local and imported), not just traits declared in the current module,
     /// so lowering can resolve supertrait graphs and generic trait arity across module boundaries.
     fn record_trait_metadata_for_lowering(&mut self) {
-        self.type_info.trait_direct_supertraits.clear();
-        self.type_info.trait_type_params.clear();
-        self.type_info.derivable_modules = self.dependency_derivable_modules.clone();
-        self.type_info.trait_rust_derive_paths = self.dependency_trait_rust_derive_paths.clone();
+        self.type_info.traits.direct_supertraits.clear();
+        self.type_info.traits.type_params.clear();
+        self.type_info.derivations.derivable_modules = self.dependency_derivable_modules.clone();
+        self.type_info.derivations.trait_rust_derive_paths = self.dependency_trait_rust_derive_paths.clone();
         for sym in self.symbols.all_symbols() {
             if let SymbolKind::Trait(info) = &sym.kind {
                 self.type_info
-                    .trait_direct_supertraits
+                    .traits
+                    .direct_supertraits
                     .insert(sym.name.clone(), info.supertraits.clone());
                 self.type_info
-                    .trait_type_params
+                    .traits
+                    .type_params
                     .insert(sym.name.clone(), info.type_params.clone());
             }
         }

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -2115,14 +2115,14 @@ def f() -> None:
         .map_err(|errs| std::io::Error::other(format!("check_program failed: {errs:?}")))?;
     let info = checker.type_info();
     assert!(
-        info.expr_types.values().any(|t| {
+        info.expressions.expr_types.values().any(|t| {
             matches!(
                 t,
                 ResolvedType::RustPath(p) if p == "std::time::Instant"
             )
         }),
         "expected RustPath(std::time::Instant) in expr types, got {:?}",
-        info.expr_types
+        info.expressions.expr_types
     );
     Ok(())
 }
@@ -3046,11 +3046,12 @@ def f() -> None:
     })?;
     let info = checker.type_info();
     assert!(
-        info.expr_types
+        info.expressions
+            .expr_types
             .values()
             .any(|t| matches!(t, ResolvedType::Function(params, _) if params.is_empty())),
         "expected associated function field access to resolve to a callable type, got {:?}",
-        info.expr_types
+        info.expressions.expr_types
     );
     Ok(())
 }
@@ -3072,11 +3073,12 @@ def f(words: HashSet[str]) -> None:
         .map_err(|errs| std::io::Error::other(format!("expected imported HashMap lookup to typecheck: {errs:?}")))?;
     let info = checker.type_info();
     assert!(
-        info.regular_method_arg_shape_preserving_calls
+        info.rust
+            .regular_method_arg_shape_preserving_calls
             .iter()
             .any(|(_, _, method)| method == "contains"),
         "expected HashSet.contains lookup to record preserved method arg shape, got {:?}",
-        info.regular_method_arg_shape_preserving_calls
+        info.rust.regular_method_arg_shape_preserving_calls
     );
     Ok(())
 }
@@ -3322,11 +3324,12 @@ def render[T](value: Label[T]) -> str:
     })?;
     let info = checker.type_info();
     assert!(
-        info.rust_return_coercions
+        info.rust
+            .return_coercions
             .values()
             .any(|c| c.rust_target_type == "String" && matches!(c.target_type, ResolvedType::Str)),
         "expected rust return coercion (&str -> String) for generic rusttype method call, got {:?}",
-        info.rust_return_coercions
+        info.rust.return_coercions
     );
     Ok(())
 }
@@ -4161,12 +4164,15 @@ def describe(u: User) -> None:
         .map_err(|errs| std::io::Error::other(format!("check_program failed: {errs:?}")))?;
     let info = checker.type_info();
     assert!(
-        info.expr_types.values().any(|t| matches!(t, ResolvedType::Str)),
+        info.expressions
+            .expr_types
+            .values()
+            .any(|t| matches!(t, ResolvedType::Str)),
         "expected __class_name__() to resolve to str, got {:?}",
-        info.expr_types
+        info.expressions.expr_types
     );
     assert!(
-        info.expr_types.values().any(|t| {
+        info.expressions.expr_types.values().any(|t| {
             matches!(
                 t,
                 ResolvedType::FrozenList(inner)
@@ -4174,7 +4180,7 @@ def describe(u: User) -> None:
             )
         }),
         "expected __fields__() to resolve to FrozenList[FieldInfo], got {:?}",
-        info.expr_types
+        info.expressions.expr_types
     );
     Ok(())
 }
@@ -4200,12 +4206,15 @@ def describe(u: User) -> None:
         .map_err(|errs| std::io::Error::other(format!("check_program failed: {errs:?}")))?;
     let info = checker.type_info();
     assert!(
-        info.expr_types.values().any(|t| matches!(t, ResolvedType::FrozenStr)),
+        info.expressions
+            .expr_types
+            .values()
+            .any(|t| matches!(t, ResolvedType::FrozenStr)),
         "expected FieldInfo.name/type_name access to resolve to FrozenStr, got {:?}",
-        info.expr_types
+        info.expressions.expr_types
     );
     assert!(
-        info.expr_types.values().any(|t| {
+        info.expressions.expr_types.values().any(|t| {
             matches!(
                 t,
                 ResolvedType::Generic(name, args)
@@ -4216,10 +4225,10 @@ def describe(u: User) -> None:
             )
         }),
         "expected FieldInfo.alias access to resolve to Option[FrozenStr], got {:?}",
-        info.expr_types
+        info.expressions.expr_types
     );
     assert!(
-        info.expr_types.values().any(|t| {
+        info.expressions.expr_types.values().any(|t| {
             matches!(
                 t,
                 ResolvedType::FrozenDict(key, value)
@@ -4228,12 +4237,15 @@ def describe(u: User) -> None:
             )
         }),
         "expected FieldInfo.extra access to resolve to FrozenDict[FrozenStr, FrozenStr], got {:?}",
-        info.expr_types
+        info.expressions.expr_types
     );
     assert!(
-        info.expr_types.values().any(|t| matches!(t, ResolvedType::Bool)),
+        info.expressions
+            .expr_types
+            .values()
+            .any(|t| matches!(t, ResolvedType::Bool)),
         "expected FieldInfo.has_default access to resolve to bool, got {:?}",
-        info.expr_types
+        info.expressions.expr_types
     );
     Ok(())
 }
@@ -5074,9 +5086,10 @@ def f(account: Account) -> int:
     let ast = parser::parse(&tokens).map_err(|errs| format!("{errs:?}"))?;
     let mut checker = TypeChecker::new();
     checker.check_program(&ast).map_err(|errs| format!("{errs:?}"))?;
-    assert_eq!(checker.type_info.computed_property_accesses.len(), 1);
+    assert_eq!(checker.type_info.expressions.computed_property_accesses.len(), 1);
     let access = checker
         .type_info
+        .expressions
         .computed_property_accesses
         .values()
         .next()
@@ -7524,7 +7537,7 @@ def f(w: Widget) -> None:
     checker
         .check_program(&ast)
         .map_err(|errs| std::io::Error::other(format!("typecheck failed: {errs:?}")))?;
-    let uses = &checker.type_info().rust_method_trait_import_uses;
+    let uses = &checker.type_info().rust.method_trait_import_uses;
     assert!(
         uses.values()
             .any(|import_use| import_use.binding == "AlphaRender" && import_use.method == "render"),
@@ -7590,6 +7603,7 @@ type Thing = rusttype RustThing with Labelled
     assert!(
         checker
             .type_info()
+            .rust
             .rusttype_forwarded_trait_adoptions
             .contains(&("Thing".to_string(), "Labelled".to_string())),
         "expected metadata-proven rusttype forwarding to be recorded"
@@ -9567,7 +9581,7 @@ def main() -> None:
     checker
         .check_program(&ast)
         .map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
-    let coercions = &checker.type_info().validated_newtype_coercions;
+    let coercions = &checker.type_info().expressions.validated_newtype_coercions;
 
     assert!(
         coercions.values().any(|info| {
@@ -9712,7 +9726,7 @@ def main() -> None:
     checker
         .check_program(&ast)
         .map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
-    let coercions = &checker.type_info().validated_newtype_coercions;
+    let coercions = &checker.type_info().expressions.validated_newtype_coercions;
     assert!(
         coercions.values().any(|info| {
             info.target_type == ResolvedType::Named("PositiveInt".to_string())
@@ -10177,12 +10191,12 @@ model Cell[T] with ExternBox:
 
     let type_info = checker.type_info();
     assert_eq!(
-        type_info.trait_type_params.get("ExternBox"),
+        type_info.traits.type_params.get("ExternBox"),
         Some(&vec!["T".to_string()]),
         "Imported trait type params should be available to lowering metadata"
     );
     assert_eq!(
-        type_info.trait_direct_supertraits.get("ExternBox"),
+        type_info.traits.direct_supertraits.get("ExternBox"),
         Some(&Vec::new()),
         "Imported trait supertraits should be recorded even when empty"
     );
@@ -10334,11 +10348,12 @@ def main() -> None:
     assert!(
         checker
             .type_info()
+            .calls
             .resolved_operator_calls
             .values()
             .any(|call| call.method == "__add__" && call.kind == ResolvedOperatorKind::Binary),
         "expected + to resolve to __add__, got {:?}",
-        checker.type_info().resolved_operator_calls
+        checker.type_info().calls.resolved_operator_calls
     );
     Ok(())
 }
@@ -10495,11 +10510,12 @@ def main() -> None:
     assert!(
         checker
             .type_info()
+            .calls
             .resolved_operator_calls
             .values()
             .any(|call| call.method == "__add__" && call.kind == ResolvedOperatorKind::Binary),
         "expected compound assignment to resolve to __add__, got {:?}",
-        checker.type_info().resolved_operator_calls
+        checker.type_info().calls.resolved_operator_calls
     );
     Ok(())
 }
@@ -10550,11 +10566,12 @@ def main() -> int:
     assert!(
         checker
             .type_info()
+            .calls
             .resolved_operator_calls
             .values()
             .any(|call| call.method == "__getitem__" && call.kind == ResolvedOperatorKind::Index),
         "expected indexing to resolve to __getitem__, got {:?}",
-        checker.type_info().resolved_operator_calls
+        checker.type_info().calls.resolved_operator_calls
     );
     Ok(())
 }
@@ -10581,11 +10598,12 @@ def main() -> None:
     assert!(
         checker
             .type_info()
+            .calls
             .resolved_operator_calls
             .values()
             .any(|call| call.method == "__setitem__" && call.kind == ResolvedOperatorKind::IndexAssign),
         "expected index assignment to resolve to __setitem__, got {:?}",
-        checker.type_info().resolved_operator_calls
+        checker.type_info().calls.resolved_operator_calls
     );
     Ok(())
 }
@@ -10652,6 +10670,7 @@ def main() -> None:
 
     let calls: Vec<_> = checker
         .type_info()
+        .calls
         .resolved_operator_calls
         .values()
         .map(|call| (call.method.as_str(), call.kind))
@@ -10666,19 +10685,20 @@ def main() -> None:
             calls.contains(&expected),
             "expected RFC 068 hook {:?}, got {:?}",
             expected,
-            checker.type_info().resolved_operator_calls
+            checker.type_info().calls.resolved_operator_calls
         );
     }
     assert!(
         checker
             .type_info()
-            .protocol_iterations
+            .protocols
+            .iterations
             .values()
             .any(|info| info.iter_method == "__iter__"
                 && info.next_method == "__next__"
                 && info.item_type == ResolvedType::Int),
         "expected custom iteration metadata, got {:?}",
-        checker.type_info().protocol_iterations
+        checker.type_info().protocols.iterations
     );
     Ok(())
 }
@@ -11118,6 +11138,7 @@ def main() -> None:
 
     let resolved: Vec<_> = checker
         .type_info()
+        .calls
         .resolved_operator_calls
         .values()
         .map(|call| call.method.as_str())
@@ -11136,7 +11157,7 @@ def main() -> None:
         assert!(
             resolved.contains(&expected),
             "expected {expected} to resolve in {:?}",
-            checker.type_info().resolved_operator_calls
+            checker.type_info().calls.resolved_operator_calls
         );
     }
 

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -14,8 +14,9 @@ use super::{ConstValue, const_eval};
 
 /// Capture reusable typechecking output for later compiler stages.
 ///
-/// This struct is the bridge that lets backend lowering/codegen **consume the typechecker’s view** of the program,
-/// rather than re-deriving types and semantics from the AST.
+/// This struct is the bridge that lets backend lowering/codegen consume the typechecker’s view of the program rather
+/// than re-deriving types and semantics from the AST. The bridge is intentionally grouped by consumer contract: each
+/// field names a semantic artifact family instead of exposing one flat collection of unrelated side channels.
 ///
 /// ## Notes
 /// - Expression types are keyed by `(span.start, span.end)` so downstream code can look them up without holding AST
@@ -35,17 +36,45 @@ use super::{ConstValue, const_eval};
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct TypeCheckInfo {
+    /// Trait hierarchy metadata consumed by trait impl and default-method lowering.
+    pub traits: TraitArtifacts,
+    /// Derive expansion metadata imported from dependency modules and manifests.
+    pub derivations: DerivationArtifacts,
+    /// Expression-local resolution facts keyed by source spans.
+    pub expressions: ExpressionArtifacts,
+    /// Const evaluation facts needed by runtime and emission boundaries.
+    pub consts: ConstArtifacts,
+    /// Rust interop decisions that must be preserved exactly across lowering.
+    pub rust: RustInteropArtifacts,
+    /// Declaration-level binding rewrites and visibility facts consumed by lowering.
+    pub declarations: DeclarationArtifacts,
+    /// Call-site semantic decisions selected by the typechecker.
+    pub calls: CallArtifacts,
+    /// Test-runner and fixture metadata extracted during typechecking.
+    pub testing: TestingArtifacts,
+    /// Custom protocol decisions that lower into explicit runtime calls.
+    pub protocols: ProtocolArtifacts,
+}
+
+/// Trait hierarchy metadata consumed by trait impl and default-method lowering.
+#[derive(Debug, Default, Clone)]
+pub struct TraitArtifacts {
     /// RFC 042: Direct supertraits per trait name, copied from
     /// [`TraitInfo::supertraits`](crate::frontend::symbols::TraitInfo::supertraits) for IR lowering.
     ///
     /// Lowering does not retain the typechecker symbol table; this snapshot supplies resolved supertrait type
     /// arguments after a successful check.
-    pub trait_direct_supertraits: HashMap<String, Vec<(String, Vec<ResolvedType>)>>,
+    pub direct_supertraits: HashMap<String, Vec<(String, Vec<ResolvedType>)>>,
     /// RFC 042: Trait type parameter names keyed by trait name for lowering-time generic substitution.
     ///
     /// Includes locally-declared and imported traits so backend lowering can handle cross-module trait hierarchies
     /// without relying on local AST declarations.
-    pub trait_type_params: HashMap<String, Vec<String>>,
+    pub type_params: HashMap<String, Vec<String>>,
+}
+
+/// Derive expansion metadata imported from dependency modules and manifests.
+#[derive(Debug, Default, Clone)]
+pub struct DerivationArtifacts {
     /// RFC 024: Imported derivable modules keyed by source module path, such as `yaml` or `formats.yaml`.
     ///
     /// Values are the trait names listed in the module's `__derives__` metadata. Lowering consumes this so
@@ -56,10 +85,11 @@ pub struct TypeCheckInfo {
     /// The typechecker owns this because dependency modules are already imported and validated there. Lowering should
     /// not re-run module resolution or assume RFC 024 metadata only exists in stdlib source.
     pub trait_rust_derive_paths: HashMap<String, Vec<String>>,
-    /// `rusttype` Incan name → canonical Rust path string (`substrait::proto::type::Binary`), when the checker
-    /// resolved the underlying type to [`ResolvedType::RustPath`]. Used by lowering so `m::T` spellings emit full
-    /// paths without re-running import resolution.
-    pub rusttype_canonical_rust_paths: HashMap<String, String>,
+}
+
+/// Expression-local resolution facts keyed by source spans.
+#[derive(Debug, Default, Clone)]
+pub struct ExpressionArtifacts {
     /// Map from expression span (start,end) -> resolved type.
     pub expr_types: HashMap<(usize, usize), ResolvedType>,
     /// Type names that implement `Awaitable[T]` by delegating to one concrete awaitable field.
@@ -72,11 +102,6 @@ pub struct TypeCheckInfo {
     /// Lowering/emission can use this to distinguish `obj.field` storage reads from `obj.property` getter calls while
     /// still consuming the same resolved expression type map for the property return type.
     pub computed_property_accesses: HashMap<(usize, usize), ComputedPropertyAccessInfo>,
-    /// RFC 038: unpack operands whose static shape has been proven by call binding.
-    ///
-    /// Lowering consumes these plans to rewrite fixed/static unpack operands into ordinary IR call arguments. This
-    /// keeps backend emission from re-deriving the frontend's binding decision from raw IR shape.
-    pub fixed_unpack_plans: HashMap<(usize, usize), FixedUnpackPlan>,
     /// Map from identifier expression span (start,end) -> how it resolved (value vs type vs module).
     ///
     /// This exists so downstream stages (IR lowering/codegen) can reliably distinguish:
@@ -84,29 +109,43 @@ pub struct TypeCheckInfo {
     /// - `Type.method(...)` where `Type` is a type name (emits `Type::method(...)` in Rust), and
     /// - imported placeholders (e.g. `from rust::... import Foo`) which are not value bindings.
     pub ident_kinds: HashMap<(usize, usize), IdentKind>,
-    /// Const category classification (RFC 008): const name -> kind.
-    pub const_kinds: HashMap<String, const_eval::ConstKind>,
-    /// Computed const values (when available), keyed by const name.
-    pub const_values: HashMap<String, ConstValue>,
-    /// Rust-boundary coercion decisions keyed by argument expression span.
-    pub rust_arg_coercions: HashMap<(usize, usize), RustArgCoercionInfo>,
     /// RFC 017 validated-newtype coercion decisions keyed by source expression span.
     ///
     /// Lowering consumes these decisions when an expression is used at an approved implicit-coercion site, such as a
     /// function argument, typed initializer, or model/class field initializer.
     pub validated_newtype_coercions: HashMap<(usize, usize), ValidatedNewtypeCoercionInfo>,
+}
+
+/// Const evaluation facts needed by runtime and emission boundaries.
+#[derive(Debug, Default, Clone)]
+pub struct ConstArtifacts {
+    /// Const category classification (RFC 008): const name -> kind.
+    pub const_kinds: HashMap<String, const_eval::ConstKind>,
+    /// Computed const values (when available), keyed by const name.
+    pub const_values: HashMap<String, ConstValue>,
+}
+
+/// Rust interop decisions that must be preserved exactly across lowering.
+#[derive(Debug, Default, Clone)]
+pub struct RustInteropArtifacts {
+    /// `rusttype` Incan name → canonical Rust path string (`substrait::proto::type::Binary`), when the checker
+    /// resolved the underlying type to [`ResolvedType::RustPath`]. Used by lowering so `m::T` spellings emit full
+    /// paths without re-running import resolution.
+    pub rusttype_canonical_paths: HashMap<String, String>,
+    /// Rust-boundary coercion decisions keyed by argument expression span.
+    pub arg_coercions: HashMap<(usize, usize), RustArgCoercionInfo>,
     /// Rust trait imports keyed by the source binding name with the trait path and method names they can place in
     /// scope.
     ///
     /// Lowering carries this into IR import items so codegen can retain extension-trait imports when Rust method
     /// lookup needs the trait in scope even though emitted call tokens do not otherwise mention the trait name.
-    pub rust_trait_imports: HashMap<String, RustTraitImportInfo>,
+    pub trait_imports: HashMap<String, RustTraitImportInfo>,
     /// Rust extension-trait import selected for one Rust method call.
     ///
     /// Keyed by the full method-call expression span. Lowering attaches the binding to the corresponding IR method
     /// call so generated-use analysis can retain the exact import instead of retaining every trait with the same
     /// method name.
-    pub rust_method_trait_import_uses: HashMap<(usize, usize), RustMethodTraitImportUse>,
+    pub method_trait_import_uses: HashMap<(usize, usize), RustMethodTraitImportUse>,
     /// Body-less rusttype Rust-trait adoptions proven by metadata and therefore satisfied by the backing type alias.
     ///
     /// Lowering must not emit an `impl Trait for Alias` for these entries because Rust coherence treats the alias as
@@ -116,18 +155,33 @@ pub struct TypeCheckInfo {
     ///
     /// Populated when metadata shows a `rusttype` method's actual Rust return type requires coercion to the
     /// Incan-declared type (e.g. `&str` → `String` for a method declared `-> str`).
-    pub rust_return_coercions: HashMap<(usize, usize), RustArgCoercionInfo>,
+    pub return_coercions: HashMap<(usize, usize), RustArgCoercionInfo>,
     /// Regular method calls whose arguments must keep Rust method-call lookup shape.
     ///
     /// Keyed by `(receiver_span.start, receiver_span.end, method_name)` so lowering can preserve borrow-sensitive
     /// lookup calls like `HashMap.get(key)` without re-querying rust-inspect metadata in the backend.
     pub regular_method_arg_shape_preserving_calls: HashSet<(usize, usize, String)>,
+}
+
+/// Declaration-level binding rewrites and visibility facts consumed by lowering.
+#[derive(Debug, Default, Clone)]
+pub struct DeclarationArtifacts {
     /// Module-visible static bindings keyed by local name for lowering/runtime emission.
     pub static_bindings: HashMap<String, StaticBindingInfo>,
     /// RFC 036: Module-visible function names whose declaration was rebound through a user-defined decorator chain.
     pub decorated_function_bindings: HashMap<String, DecoratedFunctionBindingInfo>,
     /// RFC 036: Method names whose declaration was rebound through a user-defined decorator chain.
     pub decorated_method_bindings: HashMap<(String, String), DecoratedMethodBindingInfo>,
+}
+
+/// Call-site semantic decisions selected by the typechecker.
+#[derive(Debug, Default, Clone)]
+pub struct CallArtifacts {
+    /// RFC 038: unpack operands whose static shape has been proven by call binding.
+    ///
+    /// Lowering consumes these plans to rewrite fixed/static unpack operands into ordinary IR call arguments. This
+    /// keeps backend emission from re-deriving the frontend's binding decision from raw IR shape.
+    pub fixed_unpack_plans: HashMap<(usize, usize), FixedUnpackPlan>,
     /// RFC 054: For call expressions that used explicit bracketed type arguments, maps the **full call expression
     /// span** `(start, end)` to the final monomorphized type arguments in callee type-parameter order.
     ///
@@ -155,15 +209,25 @@ pub struct TypeCheckInfo {
     /// Lowering consumes this for calls whose selected method lives in a trait impl rather than an inherent Rust impl.
     /// This keeps codegen from re-deriving dispatch from method names or argument shapes.
     pub resolved_method_calls: HashMap<(usize, usize), ResolvedMethodCall>,
+}
+
+/// Test-runner and fixture metadata extracted during typechecking.
+#[derive(Debug, Default, Clone)]
+pub struct TestingArtifacts {
     /// `std.testing.fixture` declarations resolved during typechecking.
     ///
     /// A successful typecheck guarantees async fixture entries have exactly one top-level `yield value` boundary.
-    pub testing_fixtures: HashMap<String, TestingFixtureInfo>,
+    pub fixtures: HashMap<String, TestingFixtureInfo>,
+}
+
+/// Custom protocol decisions that lower into explicit runtime calls.
+#[derive(Debug, Default, Clone)]
+pub struct ProtocolArtifacts {
     /// RFC 068: Custom `for` iteration protocol choices keyed by iterable expression span.
     ///
     /// Lowering consumes this so a structural `__iter__` / `__next__` pair can become an explicit loop that calls the
     /// resolved hooks without relying on Rust's `IntoIterator`.
-    pub protocol_iterations: HashMap<(usize, usize), ProtocolIterationInfo>,
+    pub iterations: HashMap<(usize, usize), ProtocolIterationInfo>,
 }
 
 /// A typechecker-resolved user-defined operator call consumed by IR lowering.
@@ -383,17 +447,17 @@ pub struct TestingFixtureInfo {
 impl TypeCheckInfo {
     /// Return the resolved type recorded for the expression at `span`, if any.
     pub fn expr_type(&self, span: Span) -> Option<&ResolvedType> {
-        self.expr_types.get(&(span.start, span.end))
+        self.expressions.expr_types.get(&(span.start, span.end))
     }
 
     /// Return computed-property metadata for a field-access expression, if that access resolved to a property.
     pub fn computed_property_access(&self, span: Span) -> Option<&ComputedPropertyAccessInfo> {
-        self.computed_property_accesses.get(&(span.start, span.end))
+        self.expressions.computed_property_accesses.get(&(span.start, span.end))
     }
 
     /// Record that a field-access expression resolved to a computed property read.
     pub(crate) fn record_computed_property_access(&mut self, span: Span, owner_type: &str, property: &str) {
-        self.computed_property_accesses.insert(
+        self.expressions.computed_property_accesses.insert(
             (span.start, span.end),
             ComputedPropertyAccessInfo {
                 owner_type: owner_type.to_string(),
@@ -404,52 +468,56 @@ impl TypeCheckInfo {
 
     /// Return the RFC 038 fixed/static unpack plan recorded for an unpack operand, if any.
     pub fn fixed_unpack_plan(&self, span: Span) -> Option<&FixedUnpackPlan> {
-        self.fixed_unpack_plans.get(&(span.start, span.end))
+        self.calls.fixed_unpack_plans.get(&(span.start, span.end))
     }
 
     /// Return how the identifier expression at `span` resolved in the symbol table.
     pub fn ident_kind(&self, span: Span) -> Option<IdentKind> {
-        self.ident_kinds.get(&(span.start, span.end)).copied()
+        self.expressions.ident_kinds.get(&(span.start, span.end)).copied()
     }
 
     /// Return static-binding metadata for `name`, if the checker recorded one.
     pub fn static_binding(&self, name: &str) -> Option<&StaticBindingInfo> {
-        self.static_bindings.get(name)
+        self.declarations.static_bindings.get(name)
     }
 
     /// Return frontend fixture metadata for `name`, if the declaration was marked with `@fixture`.
     pub fn testing_fixture(&self, name: &str) -> Option<&TestingFixtureInfo> {
-        self.testing_fixtures.get(name)
+        self.testing.fixtures.get(name)
     }
 
     /// Return the computed const value for `name`, when const evaluation succeeded.
     pub fn const_value(&self, name: &str) -> Option<&ConstValue> {
-        self.const_values.get(name)
+        self.consts.const_values.get(name)
     }
 
     /// Return the recorded Rust-boundary argument coercion for the expression at `span`, if any.
     pub fn rust_arg_coercion(&self, span: Span) -> Option<&RustArgCoercionInfo> {
-        self.rust_arg_coercions.get(&(span.start, span.end))
+        self.rust.arg_coercions.get(&(span.start, span.end))
     }
 
     /// Return the validated-newtype coercion recorded for the expression at `span`, if any.
     pub fn validated_newtype_coercion(&self, span: Span) -> Option<&ValidatedNewtypeCoercionInfo> {
-        self.validated_newtype_coercions.get(&(span.start, span.end))
+        self.expressions
+            .validated_newtype_coercions
+            .get(&(span.start, span.end))
     }
 
     /// Record a typechecker-approved validated-newtype coercion for a source expression span.
     pub(crate) fn record_validated_newtype_coercion(&mut self, span: Span, info: ValidatedNewtypeCoercionInfo) {
-        self.validated_newtype_coercions.insert((span.start, span.end), info);
+        self.expressions
+            .validated_newtype_coercions
+            .insert((span.start, span.end), info);
     }
 
     /// Return the recorded return coercion for the call expression at `span`, if any.
     pub fn rust_return_coercion(&self, span: Span) -> Option<&RustArgCoercionInfo> {
-        self.rust_return_coercions.get(&(span.start, span.end))
+        self.rust.return_coercions.get(&(span.start, span.end))
     }
 
     /// Whether lowering should preserve Rust method-call lookup argument shape for this receiver/method pair.
     pub fn preserves_regular_method_arg_shape(&self, receiver_span: Span, method: &str) -> bool {
-        self.regular_method_arg_shape_preserving_calls.contains(&(
+        self.rust.regular_method_arg_shape_preserving_calls.contains(&(
             receiver_span.start,
             receiver_span.end,
             method.to_string(),
@@ -458,7 +526,7 @@ impl TypeCheckInfo {
 
     /// Record that lowering should preserve Rust method-call lookup argument shape for this receiver/method pair.
     pub(crate) fn record_regular_method_arg_shape(&mut self, receiver_span: Span, method: &str) {
-        self.regular_method_arg_shape_preserving_calls.insert((
+        self.rust.regular_method_arg_shape_preserving_calls.insert((
             receiver_span.start,
             receiver_span.end,
             method.to_string(),
@@ -467,7 +535,8 @@ impl TypeCheckInfo {
 
     /// Return rest-aware callable metadata recorded for the full call expression span, if any.
     pub fn call_site_callable_params(&self, span: Span) -> Option<&[CallableParam]> {
-        self.call_site_callable_params
+        self.calls
+            .call_site_callable_params
             .get(&(span.start, span.end))
             .map(Vec::as_slice)
     }
@@ -478,29 +547,30 @@ impl TypeCheckInfo {
             .iter()
             .any(|param| param.kind != ParamKind::Normal || callable_param_needs_boundary_snapshot(&param.ty))
         {
-            self.call_site_callable_params
+            self.calls
+                .call_site_callable_params
                 .insert((span.start, span.end), params.to_vec());
         }
     }
 
     /// Return a typechecker-resolved user-defined operator call for `span`, if any.
     pub fn resolved_operator_call(&self, span: Span) -> Option<&ResolvedOperatorCall> {
-        self.resolved_operator_calls.get(&(span.start, span.end))
+        self.calls.resolved_operator_calls.get(&(span.start, span.end))
     }
 
     /// Return a typechecker-resolved method call for `span`, if any.
     pub fn resolved_method_call(&self, span: Span) -> Option<&ResolvedMethodCall> {
-        self.resolved_method_calls.get(&(span.start, span.end))
+        self.calls.resolved_method_calls.get(&(span.start, span.end))
     }
 
     /// Return the Rust extension-trait import selected for the method call at `span`, if any.
     pub fn rust_method_trait_import_use(&self, span: Span) -> Option<&RustMethodTraitImportUse> {
-        self.rust_method_trait_import_uses.get(&(span.start, span.end))
+        self.rust.method_trait_import_uses.get(&(span.start, span.end))
     }
 
     /// Return custom iteration protocol metadata for `span`, if any.
     pub fn protocol_iteration(&self, span: Span) -> Option<&ProtocolIterationInfo> {
-        self.protocol_iterations.get(&(span.start, span.end))
+        self.protocols.iterations.get(&(span.start, span.end))
     }
 
     /// Record a user-defined operator call that lowering should emit as a direct dunder method call.
@@ -510,7 +580,7 @@ impl TypeCheckInfo {
         method: impl Into<String>,
         kind: ResolvedOperatorKind,
     ) {
-        self.resolved_operator_calls.insert(
+        self.calls.resolved_operator_calls.insert(
             (span.start, span.end),
             ResolvedOperatorCall {
                 method: method.into(),
@@ -526,7 +596,7 @@ impl TypeCheckInfo {
         method: impl Into<String>,
         dispatch: ResolvedMethodDispatch,
     ) {
-        self.resolved_method_calls.insert(
+        self.calls.resolved_method_calls.insert(
             (span.start, span.end),
             ResolvedMethodCall {
                 method: method.into(),
@@ -537,13 +607,14 @@ impl TypeCheckInfo {
 
     /// Record that a Rust method call requires a specific imported extension trait in generated Rust scope.
     pub(crate) fn record_rust_method_trait_import_use(&mut self, span: Span, import_use: RustMethodTraitImportUse) {
-        self.rust_method_trait_import_uses
+        self.rust
+            .method_trait_import_uses
             .insert((span.start, span.end), import_use);
     }
 
     /// Record a custom `for` iteration protocol route.
     pub(crate) fn record_protocol_iteration(&mut self, span: Span, info: ProtocolIterationInfo) {
-        self.protocol_iterations.insert((span.start, span.end), info);
+        self.protocols.iterations.insert((span.start, span.end), info);
     }
 }
 

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -423,6 +423,8 @@ The sections above are the release story. The list below is the detailed invento
 - **Project metadata**: Workspace package metadata, Cargo lock entries, stdlib version-check docs, and checked-in pro example lockfiles now identify the development line as `0.3.0-dev.41`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.42`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.43`.
+- **Compiler internals**: Typechecker lowering metadata is grouped into explicit semantic artifact families instead of one flat `TypeCheckInfo` payload, narrowing the backend-facing contract without changing language behavior (#283).
+- **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.44`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

This PR narrows issue #283 to the backend-facing typechecker artifact boundary by turning `TypeCheckInfo` into an aggregate of explicit semantic artifact families. Typechecker producers and IR lowering/codegen consumers now exchange grouped artifacts for traits, derivations, expressions, consts, Rust interop, declarations, calls, testing metadata, and protocol decisions instead of one flat side-channel payload.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: No language behavior changes are intended. The release notes and package metadata now identify the development line as `0.3.0-dev.44`.
- **Internals**: `TypeCheckInfo` now groups backend-facing typechecker output into named artifact structs, and frontend producers plus lowering consumers were migrated to that contract or existing accessors.
- **Risks**: This touches many artifact producer/consumer paths; the main risk is a missed migration for a rarely used lowering decision. Focused lowering tests and the full pre-commit gate passed after fixing rustdoc coverage findings.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed, including full test suite, clippy, cargo-deny, smoke-test-fast, examples, and benchmark build smoke checks.
- `cargo test backend::ir::lower::expr::calls` passed after the final commit.
- `git diff --check origin/main...HEAD` passed after the final commit.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #283