### PR TITLE
chore - clarify std.uuid std.hash boundary (#338)

### DIFF
--- a/workspaces/docs-site/docs/language/reference/stdlib/uuid.md
+++ b/workspaces/docs-site/docs/language/reference/stdlib/uuid.md
@@ -1,6 +1,6 @@
 # `std.uuid`
 
-`std.uuid` provides RFC 9562 UUID values as ordinary Incan source-defined data. The module stores each `UUID` as a nominal `u128` wrapper and owns parsing, formatting, byte layout, version bits, and variant bits in Incan source. Rust interop is limited to primitive inputs for randomness, clock access, MD5, SHA-1, and UTF-8 string bytes.
+`std.uuid` provides RFC 9562 UUID values as ordinary Incan source-defined data. The module stores each `UUID` as a nominal `u128` wrapper and owns parsing, formatting, byte layout, version bits, and variant bits in Incan source. Rust interop is limited to primitive inputs for randomness, clock access, and UTF-8 string bytes; name-based UUID hashing dogfoods `std.hash`.
 
 ## Imports
 


### PR DESCRIPTION
## Summary

This PR updates the `std.uuid` reference docs to match the implementation after `std.hash` landed. UUID parsing, formatting, and generation remain source-defined in Incan; the docs now state that UUIDv3/v5 name-based hashing dogfoods `std.hash` instead of implying direct UUID-owned MD5/SHA-1 Rust interop.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: No runtime behavior changes. The UUID reference page now describes the actual dependency boundary accurately.
- **Internals**: No implementation changes. `std.uuid` already imports `md5` and `sha1` through `std.hash`, and the layering guard enforces that boundary.
- **Risks**: Low; this is a one-line documentation correction.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo fmt --all --check`
- `cargo test --test layering_guard std_uuid_namespace_stays_source_stdlib_only`
- `cargo test test_run_std_uuid_surface`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/reference/stdlib/uuid.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions

Refs #338