### PR TITLE
bugfix - allow serde derives to satisfy JSON trait methods (#585)

### DIFF
--- a/src/backend/ir/lower/decl/methods.rs
+++ b/src/backend/ir/lower/decl/methods.rs
@@ -688,6 +688,25 @@ impl AstLowering {
         }
     }
 
+    /// Return whether a required trait method is supplied by a backend derive instead of by a source method body.
+    ///
+    /// Serde JSON derives implement the Rust-side conversion hooks during codegen. Imported stdlib trait declarations
+    /// still make those hooks visible to lowering, so this keeps the trait impl obligation aligned with the backend
+    /// expansion without making all missing stdlib trait methods optional.
+    fn backend_default_trait_method(trait_name: &str, method_name: &str) -> bool {
+        let short_name = trait_name
+            .rsplit(['.', ':'])
+            .find(|segment| !segment.is_empty())
+            .unwrap_or(trait_name);
+        matches!(
+            (short_name, method_name),
+            ("Serialize", "to_json")
+                | ("JsonSerialize", "to_json")
+                | ("Deserialize", "from_json")
+                | ("JsonDeserialize", "from_json")
+        )
+    }
+
     /// Return whether a method is safe to emit into an imported trait impl when the trait declaration is missing.
     fn method_matches_imported_trait_without_decl(&self, method: &ast::MethodDecl, trait_name: &str) -> bool {
         if method.trait_target.is_some() {
@@ -942,6 +961,12 @@ impl AstLowering {
                 // Otherwise, expand a default method body into the impl (RFC 000: defaults may assume adopter fields).
                 if trait_method.node.body.is_some() {
                     methods.push(self.lower_impl_method_for_trait(&trait_method.node, Some(&type_param_names))?);
+                    continue;
+                }
+
+                // Some stdlib traits expose source-level obligations that are intentionally satisfied by backend
+                // derive expansion. Keep collecting ordinary missing-method errors for all other traits.
+                if Self::backend_default_trait_method(trait_name, method_name) {
                     continue;
                 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10196,6 +10196,45 @@ def main() -> None:
     }
 
     #[test]
+    fn direct_std_json_deserialize_derive_runs_through_incan_surface() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let main_path = write_project_files(
+            tmp.path(),
+            "[project]\nname = \"direct_std_json_deserialize_derive\"\nversion = \"0.3.0-dev.1\"\n",
+            r#"from std.serde.json import Deserialize
+
+@derive(Deserialize)
+model Payload:
+  value: int
+
+def main() -> None:
+  match Payload.from_json('{"value":7}'):
+    case Ok(payload):
+      println(f"{payload.value}")
+    case Err(err):
+      println(err)
+"#,
+        )?;
+
+        let output = Command::new(incan_bin_path())
+            .arg("run")
+            .arg(&main_path)
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+
+        assert!(
+            output.status.success(),
+            "expected directly imported Deserialize.from_json to run successfully through Incan source.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout.lines().next(), Some("7"));
+        Ok(())
+    }
+
+    #[test]
     fn generated_runtime_helpers_support_frozen_float_list_min_max() -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;
         let main_path = write_project_files(


### PR DESCRIPTION
## Summary

This PR fixes direct `@derive(Deserialize)` use from `std.serde.json` so lowering accepts the backend-synthesized JSON trait implementation instead of reporting a missing required trait method.

Closes #585.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `from std.serde.json import Deserialize` plus `@derive(Deserialize)` now runs through the Incan surface and exposes `Payload.from_json(...)` without a lowering error.
- **Internals**: Lowering recognizes serde JSON `Serialize`/`Deserialize` methods as backend-synthesized trait methods when a trait declaration is present, instead of treating them as missing user-authored implementations.
- **Risks**: The exception is intentionally narrow; a regression would most likely affect serde JSON derive lowering. Ordinary required trait methods should still error when not implemented.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit`
- Added regression coverage: `direct_std_json_deserialize_derive_runs_through_incan_surface`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
