### PR TITLE
bugfix - wrap long class trait adoption headers (#565)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "axum",
  "incan_core",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/incan_stdlib/stdlib/io.incn
+++ b/crates/incan_stdlib/stdlib/io.incn
@@ -99,7 +99,33 @@ pub enum Endian:
 
 
 @derive(Debug)
-pub class _BytesIO with BinaryReader, BinaryRead[u8], BinaryRead[i8], BinaryRead[u16], BinaryRead[i16], BinaryRead[u32], BinaryRead[i32], BinaryRead[u64], BinaryRead[i64], BinaryRead[u128], BinaryRead[i128], BinaryRead[f32], BinaryRead[f64], BinaryWrite[u8], BinaryWrite[i8], BinaryWrite[u16], BinaryWrite[i16], BinaryWrite[u32], BinaryWrite[i32], BinaryWrite[u64], BinaryWrite[i64], BinaryWrite[u128], BinaryWrite[i128], BinaryWrite[f32], BinaryWrite[f64]:
+pub class _BytesIO with (
+    BinaryReader,
+    BinaryRead[u8],
+    BinaryRead[i8],
+    BinaryRead[u16],
+    BinaryRead[i16],
+    BinaryRead[u32],
+    BinaryRead[i32],
+    BinaryRead[u64],
+    BinaryRead[i64],
+    BinaryRead[u128],
+    BinaryRead[i128],
+    BinaryRead[f32],
+    BinaryRead[f64],
+    BinaryWrite[u8],
+    BinaryWrite[i8],
+    BinaryWrite[u16],
+    BinaryWrite[i16],
+    BinaryWrite[u32],
+    BinaryWrite[i32],
+    BinaryWrite[u64],
+    BinaryWrite[i64],
+    BinaryWrite[u128],
+    BinaryWrite[i128],
+    BinaryWrite[f32],
+    BinaryWrite[f64],
+):
     """
     Writable and seekable byte stream over an in-memory buffer.
 

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -1624,6 +1624,27 @@ trait Combo with BoundedDataSet[int], DataSet[str]:
     }
 
     #[test]
+    fn test_parse_parenthesized_declaration_trait_adoptions() -> Result<(), Vec<CompileError>> {
+        let source = r#"
+class BinaryBuffer with (
+    BinaryReader,
+    BinaryRead[u8],
+    BinaryWrite[u8],
+):
+    handle: Cursor[bytes]
+"#;
+        let program = parse_str(source)?;
+        let class = require_class_decl(&program.declarations[0])?;
+        assert_eq!(class.traits.len(), 3);
+        assert_eq!(class.traits[0].node.name, "BinaryReader");
+        assert_eq!(class.traits[1].node.name, "BinaryRead");
+        assert_eq!(class.traits[1].node.type_args.len(), 1);
+        assert_eq!(class.traits[2].node.name, "BinaryWrite");
+        assert_eq!(class.traits[2].node.type_args.len(), 1);
+        Ok(())
+    }
+
+    #[test]
     fn test_parse_newtype_with_docstring() -> Result<(), Vec<CompileError>> {
         let source = r#"
 type UserId[T] = newtype int:

--- a/crates/incan_syntax/src/parser/types.rs
+++ b/crates/incan_syntax/src/parser/types.rs
@@ -110,8 +110,29 @@ impl<'a> Parser<'a> {
         Ok(Spanned::new(bound, Span::new(start, end)))
     }
 
-    /// Comma-separated supertrait bounds after `with` on a trait declaration.
+    /// Parse declaration-level trait adoption lists after `with`.
+    ///
+    /// Bare lists keep the original compact form (`with A, B`). Parenthesized lists (`with (A, B,)`) provide the
+    /// parseable multiline shape used by formatter output when a declaration header exceeds the target line length.
     fn trait_supertrait_list_spanned(&mut self) -> Result<Vec<Spanned<TraitBound>>, CompileError> {
+        if self.match_token(&TokenKind::Punctuation(PunctuationId::LParen)) {
+            let mut bounds = Vec::new();
+            loop {
+                bounds.push(self.trait_bound_spanned()?);
+                if !self.match_token(&TokenKind::Punctuation(PunctuationId::Comma)) {
+                    break;
+                }
+                if self.check(&TokenKind::Punctuation(PunctuationId::RParen)) {
+                    break;
+                }
+            }
+            self.expect(
+                &TokenKind::Punctuation(PunctuationId::RParen),
+                "Expected ')' after trait adoption list",
+            )?;
+            return Ok(bounds);
+        }
+
         let mut bounds = vec![self.trait_bound_spanned()?];
         while self.match_token(&TokenKind::Punctuation(PunctuationId::Comma)) {
             bounds.push(self.trait_bound_spanned()?);

--- a/src/format/formatter/declarations.rs
+++ b/src/format/formatter/declarations.rs
@@ -417,37 +417,16 @@ impl Formatter {
             self.format_decorator(&dec.node);
         }
 
-        self.write_visibility(class.visibility);
-        self.writer.write("class ");
-        self.writer.write(&class.name);
-        self.format_type_params(&class.type_params);
-
-        if let Some(base) = &class.extends {
-            self.writer.write(" extends ");
-            self.writer.write(base);
+        let checkpoint = self.writer.checkpoint();
+        self.write_class_header(class, false);
+        self.writer.write(":");
+        if !class.traits.is_empty() && self.writer.line_length_exceeded() {
+            self.writer.restore(checkpoint);
+            self.write_class_header(class, true);
+            self.writer.write(":");
         }
 
-        if !class.traits.is_empty() {
-            self.writer.write(" with ");
-            for (i, trait_name) in class.traits.iter().enumerate() {
-                if i > 0 {
-                    self.writer.write(", ");
-                }
-                self.writer.write(&trait_name.node.name);
-                if !trait_name.node.type_args.is_empty() {
-                    self.writer.write("[");
-                    for (j, arg) in trait_name.node.type_args.iter().enumerate() {
-                        if j > 0 {
-                            self.writer.write(", ");
-                        }
-                        self.format_type(&arg.node);
-                    }
-                    self.writer.write("]");
-                }
-            }
-        }
-
-        self.writer.writeln(":");
+        self.writer.newline();
         self.writer.indent();
 
         if let Some(docstring) = &class.docstring {
@@ -492,6 +471,28 @@ impl Formatter {
         }
 
         self.writer.dedent();
+    }
+
+    /// Write a class declaration header, optionally wrapping its trait adoption list.
+    fn write_class_header(&mut self, class: &ClassDecl, multiline_traits: bool) {
+        self.write_visibility(class.visibility);
+        self.writer.write("class ");
+        self.writer.write(&class.name);
+        self.format_type_params(&class.type_params);
+
+        if let Some(base) = &class.extends {
+            self.writer.write(" extends ");
+            self.writer.write(base);
+        }
+
+        if !class.traits.is_empty() {
+            self.writer.write(" with ");
+            if multiline_traits {
+                self.format_trait_bounds_multiline(&class.traits);
+            } else {
+                self.format_trait_bounds_inline(&class.traits);
+            }
+        }
     }
 
     /// Format a trait declaration, including same-trait method aliases.
@@ -1199,6 +1200,33 @@ impl Formatter {
             }
             self.writer.write("]");
         }
+    }
+
+    /// Format a comma-separated trait adoption list on the current line.
+    fn format_trait_bounds_inline(&mut self, bounds: &[Spanned<TraitBound>]) {
+        for (i, bound) in bounds.iter().enumerate() {
+            if i > 0 {
+                self.writer.write(", ");
+            }
+            self.format_trait_bound(&bound.node);
+        }
+    }
+
+    /// Format a parenthesized one-bound-per-line trait adoption list.
+    fn format_trait_bounds_multiline(&mut self, bounds: &[Spanned<TraitBound>]) {
+        let trailing_commas = self.writer.config().trailing_commas;
+        self.writer.write("(");
+        self.writer.newline();
+        self.writer.indent();
+        for (i, bound) in bounds.iter().enumerate() {
+            self.format_trait_bound(&bound.node);
+            if trailing_commas || i + 1 < bounds.len() {
+                self.writer.write(",");
+            }
+            self.writer.newline();
+        }
+        self.writer.dedent();
+        self.writer.write(")");
     }
 }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -488,6 +488,42 @@ def MixedName() -> int:
     }
 
     #[test]
+    fn test_format_source_wraps_long_class_trait_adoption_header() -> Result<(), FormatError> {
+        let source = r#"pub class _BytesIO with BinaryReader, BinaryRead[u8], BinaryRead[i8], BinaryRead[u16], BinaryRead[i16], BinaryRead[u32], BinaryRead[i32], BinaryRead[u64], BinaryRead[i64], BinaryWrite[u8], BinaryWrite[i8], BinaryWrite[u16], BinaryWrite[i16], BinaryWrite[u32], BinaryWrite[i32], BinaryWrite[u64], BinaryWrite[i64]:
+  handle: Cursor[bytes]
+"#;
+        let formatted = format_source(source)?;
+        let expected = r#"pub class _BytesIO with (
+    BinaryReader,
+    BinaryRead[u8],
+    BinaryRead[i8],
+    BinaryRead[u16],
+    BinaryRead[i16],
+    BinaryRead[u32],
+    BinaryRead[i32],
+    BinaryRead[u64],
+    BinaryRead[i64],
+    BinaryWrite[u8],
+    BinaryWrite[i8],
+    BinaryWrite[u16],
+    BinaryWrite[i16],
+    BinaryWrite[u32],
+    BinaryWrite[i32],
+    BinaryWrite[u64],
+    BinaryWrite[i64],
+):
+    handle: Cursor[bytes]
+"#;
+        assert_eq!(formatted, expected);
+        assert_eq!(format_source(&formatted)?, expected);
+        assert!(
+            formatted.lines().all(|line| line.len() <= 120),
+            "expected wrapped class trait adoption header to stay within 120 columns; got:\n{formatted}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_format_source_invalid_syntax() {
         let source = "def foo(";
         let result = format_source(source);

--- a/workspaces/docs-site/docs/language/reference/code_style.md
+++ b/workspaces/docs-site/docs/language/reference/code_style.md
@@ -56,7 +56,8 @@ def calculate(x: int) -> int:
 - Treat `120` characters as the target line length.
 - This is a best-effort target, not an absolute hard cap.
 - When a constructor call or ordinary call overflows, rewrite it vertically with one argument per line.
-- Some signatures, strings, and complex nested expressions may still require manual judgment.
+- When a class adopts many traits, use a parenthesized `with (...)` list with one trait per line.
+- Some strings and complex nested expressions may still require manual judgment.
 
 ```incan
 result = build_report(
@@ -65,6 +66,15 @@ result = build_report(
     include_lineage=true,
     include_statistics=true,
 )
+```
+
+```incan
+pub class Buffer with (
+    BinaryReader,
+    BinaryRead[u8],
+    BinaryWrite[u8],
+):
+    handle: Cursor[bytes]
 ```
 
 ### Naming

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -484,6 +484,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Language/Compiler**: Stdlib import validation now rejects unknown names from known stdlib modules, imported stdlib static method calls preserve default arguments at the call site, union narrowing lowers chained `isinstance` branches without leaking raw `isinstance` calls or unit fallthroughs into generated Rust, and Rust interop accepts owned Incan values for shared borrowed generic parameters such as `&T` in both free-function and method-call positions (#499, #500, #501, #502, #506, #508).
 - **Language/Interop**: Generated Rust now retains extension-trait imports from typechecker import metadata and receiver trait metadata instead of backend method-name heuristics, so same-name methods from unrelated imported traits do not force unused trait imports (#447).
 - **Tooling**: `incan lock` now treats manifest projects as a project-wide lock surface, covering declared scripts and test harness dependency inputs so multi-entrypoint projects do not alternate stale-lock warnings between `incan test` and `incan run src/extra.incn` (#505).
+- **Tooling**: `incan fmt` now wraps long class trait adoption headers into parseable parenthesized `with (...)` lists, keeping broad adoption surfaces such as `_BytesIO` readable and below the line-length target (#565).
 
 ### Documentation
 
@@ -504,6 +505,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.44`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.45`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.47`.
+- **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.48`.
 
 ## Known limitations (0.3)
 

--- a/workspaces/docs-site/docs/tooling/how-to/formatting.md
+++ b/workspaces/docs-site/docs/tooling/how-to/formatting.md
@@ -42,6 +42,7 @@ In particular, the current formatter contract includes:
 
 - `4`-space indentation
 - a `120`-character line-length target
+- wrapping for long class trait adoption headers into parenthesized one-trait-per-line `with (...)` lists
 - best-effort wrapping for long parenthesized logical expression chains at `and` / `or` breakpoints
 - top-level double-blank-line spacing only where the style guide permits it
 - preservation of one authored readability gap inside ordinary code blocks
@@ -123,7 +124,7 @@ Fix syntax errors before formatting.
 
 The `120`-character line length is a target, not a strict hard limit.
 The formatter does not yet rewrite every possible overflowing construct.
-Very long strings, signatures, fluent call chains, and some nested expressions may still require manual judgment.
+Very long strings, fluent call chains, and some nested expressions may still require manual judgment.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

This PR fixes issue #565 by making `incan fmt` wrap long class trait adoption headers into parenthesized multiline `with (...)` lists. The parser now accepts that formatter output for declaration-level trait adoptions, so wrapped class headers remain parseable and idempotent, and the broad `_BytesIO` stdlib adoption list no longer sits on a single overlong line.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan fmt` now wraps long class `with` trait adoption headers below the line-length target using a readable one-trait-per-line parenthesized list.
- **Internals**: Class header formatting speculates the inline form including the trailing colon, then restores and emits a multiline `with (...)` list when needed. The parser accepts parenthesized declaration trait adoption lists while preserving existing bare `with A, B` syntax.
- **Risks**: The parser helper is shared by declaration trait adoption surfaces, so malformed `with`-list diagnostics are the main edge to watch. Existing bare trait adoption syntax is covered and preserved.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant; covered by `make pre-commit` / `smoke-test-fast`)
- [x] `incan fmt --check .` (if relevant; covered by `make fmt` and pre-commit fmt-check)
- [x] Manual verification described below

Manual verification notes:

- `cargo test test_format_source_wraps_long_class_trait_adoption_header`
- `cargo test test_parse_parenthesized_declaration_trait_adoptions`
- `make fmt`
- `git diff --check`
- `mkdocs build --strict`
- `make pre-commit` passed, including 2341 nextest tests, clippy, cargo-deny, and `smoke-test-fast`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/tooling/how-to/formatting.md`, `workspaces/docs-site/docs/language/reference/code_style.md`, `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #565