### PR TITLE
bugfix - make type aliases transparent for dicts and union patterns (#562)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "axum",
  "incan_core",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.47"
+version = "0.3.0-dev.48"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/frontend/typechecker/check_expr/match_.rs
+++ b/src/frontend/typechecker/check_expr/match_.rs
@@ -51,7 +51,7 @@ impl TypeChecker {
 
     /// Resolve the member type targeted by a union type pattern.
     fn union_pattern_member_type(&self, expected_ty: &ResolvedType, name: &str) -> Option<ResolvedType> {
-        let target_ty = resolve_type(&Type::Simple(name.to_string()), &self.symbols);
+        let target_ty = self.expand_type_aliases(resolve_type(&Type::Simple(name.to_string()), &self.symbols));
         let members = if let Some(members) = expected_ty.union_members() {
             members
         } else if let Some(inner) = expected_ty.option_inner_type() {
@@ -727,7 +727,8 @@ impl TypeChecker {
                         .option_inner_type()
                         .is_some_and(|inner| inner.union_members().is_some())
                 {
-                    resolve_type(&Type::Simple(name.clone()), &self.symbols).to_string()
+                    self.expand_type_aliases(resolve_type(&Type::Simple(name.clone()), &self.symbols))
+                        .to_string()
                 } else if name.contains("::") {
                     name.split("::").last().unwrap_or(name).to_string()
                 } else {

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -761,7 +761,9 @@ impl TypeChecker {
     /// Resolve the type argument used by a narrowing expression.
     fn resolve_narrowing_type_expr(&self, expr: &Spanned<Expr>) -> Option<ResolvedType> {
         match &expr.node {
-            Expr::Ident(name) => Some(resolve_type(&Type::Simple(name.clone()), &self.symbols)),
+            Expr::Ident(name) => {
+                Some(self.expand_type_aliases(resolve_type(&Type::Simple(name.clone()), &self.symbols)))
+            }
             Expr::Paren(inner) => self.resolve_narrowing_type_expr(inner),
             _ => None,
         }

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -128,6 +128,7 @@ impl TypeChecker {
                     span: decl.span,
                     scope: 0,
                 });
+                self.register_type_alias_target(a);
             }
             Declaration::Newtype(nt) => {
                 self.validate_root_namespace(&nt.name, decl.span);

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -71,6 +71,7 @@ use crate::frontend::ast::*;
 use crate::frontend::diagnostics::{CompileError, ErrorKind, errors};
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::module::{ExportedSymbol, exported_symbols};
+use crate::frontend::resolved_type_subst::{substitute_resolved_type, type_param_subst_map};
 use crate::frontend::surface_semantics::SurfaceContext;
 use crate::frontend::symbols::*;
 #[cfg(feature = "rust_inspect")]
@@ -111,6 +112,13 @@ pub(crate) struct LoopContext {
     pub expected_break_ty: Option<ResolvedType>,
     /// Types observed from `break` statements that contribute to the loop result.
     pub break_types: Vec<(ResolvedType, Span)>,
+}
+
+/// Resolved target for a source-level `type Alias = Target` declaration.
+#[derive(Debug, Clone)]
+pub(crate) struct TypeAliasTarget {
+    pub type_params: Vec<String>,
+    pub target: ResolvedType,
 }
 
 /// Declaration context that determines how `yield` expressions are interpreted.
@@ -169,6 +177,8 @@ pub struct TypeChecker {
     pub(crate) static_decls: Vec<(StaticDecl, Span)>,
     /// Collected module-level function declarations for static dependency analysis.
     pub(crate) local_function_decls: HashMap<String, FunctionDecl>,
+    /// Transparent source type aliases, keyed by their local type name.
+    pub(crate) type_aliases: HashMap<String, TypeAliasTarget>,
     /// Declaration-order index for each local static binding.
     pub(crate) static_decl_positions: HashMap<String, usize>,
     /// Const evaluation state machine.
@@ -272,6 +282,7 @@ impl TypeChecker {
             const_decls: HashMap::new(),
             static_decls: Vec::new(),
             local_function_decls: HashMap::new(),
+            type_aliases: HashMap::new(),
             static_decl_positions: HashMap::new(),
             const_eval_state: HashMap::new(),
             const_eval_cache: HashMap::new(),
@@ -2458,6 +2469,99 @@ impl TypeChecker {
         }
     }
 
+    /// Register the resolved target for a source-level type alias.
+    pub(crate) fn register_type_alias_target(&mut self, alias: &TypeAliasDecl) {
+        let type_params = alias
+            .type_params
+            .iter()
+            .map(|param| param.name.clone())
+            .collect::<Vec<_>>();
+        let target = self.resolve_type_checked(&alias.target);
+        self.type_aliases
+            .insert(alias.name.clone(), TypeAliasTarget { type_params, target });
+    }
+
+    /// Expand transparent source type aliases inside a resolved type.
+    fn expand_type_aliases(&self, ty: ResolvedType) -> ResolvedType {
+        let mut expanding = HashSet::new();
+        self.expand_type_aliases_inner(ty, &mut expanding)
+    }
+
+    /// Recursively expand alias leaves within one resolved type while preserving non-aliased structure.
+    fn expand_type_aliases_inner(&self, ty: ResolvedType, expanding: &mut HashSet<String>) -> ResolvedType {
+        match ty {
+            ResolvedType::Named(name) => self
+                .expand_named_type_alias(name.clone(), Vec::new(), expanding)
+                .unwrap_or(ResolvedType::Named(name)),
+            ResolvedType::Generic(name, args) => {
+                let expanded_args = args
+                    .into_iter()
+                    .map(|arg| self.expand_type_aliases_inner(arg, expanding))
+                    .collect::<Vec<_>>();
+                self.expand_named_type_alias(name.clone(), expanded_args.clone(), expanding)
+                    .unwrap_or(ResolvedType::Generic(name, expanded_args))
+            }
+            ResolvedType::Function(params, ret) => ResolvedType::Function(
+                params
+                    .into_iter()
+                    .map(|param| CallableParam {
+                        name: param.name,
+                        ty: self.expand_type_aliases_inner(param.ty, expanding),
+                        kind: param.kind,
+                        has_default: param.has_default,
+                    })
+                    .collect(),
+                Box::new(self.expand_type_aliases_inner(*ret, expanding)),
+            ),
+            ResolvedType::Tuple(items) => ResolvedType::Tuple(
+                items
+                    .into_iter()
+                    .map(|item| self.expand_type_aliases_inner(item, expanding))
+                    .collect(),
+            ),
+            ResolvedType::FrozenList(inner) => {
+                ResolvedType::FrozenList(Box::new(self.expand_type_aliases_inner(*inner, expanding)))
+            }
+            ResolvedType::FrozenDict(key, value) => ResolvedType::FrozenDict(
+                Box::new(self.expand_type_aliases_inner(*key, expanding)),
+                Box::new(self.expand_type_aliases_inner(*value, expanding)),
+            ),
+            ResolvedType::FrozenSet(inner) => {
+                ResolvedType::FrozenSet(Box::new(self.expand_type_aliases_inner(*inner, expanding)))
+            }
+            ResolvedType::Ref(inner) => ResolvedType::Ref(Box::new(self.expand_type_aliases_inner(*inner, expanding))),
+            ResolvedType::RefMut(inner) => {
+                ResolvedType::RefMut(Box::new(self.expand_type_aliases_inner(*inner, expanding)))
+            }
+            other => other,
+        }
+    }
+
+    /// Expand one named alias reference, applying generic arguments and stopping on alias cycles.
+    fn expand_named_type_alias(
+        &self,
+        name: String,
+        args: Vec<ResolvedType>,
+        expanding: &mut HashSet<String>,
+    ) -> Option<ResolvedType> {
+        let alias = self.type_aliases.get(&name)?;
+        if alias.type_params.len() != args.len() {
+            return None;
+        }
+        if !expanding.insert(name.clone()) {
+            return None;
+        }
+        let target = if alias.type_params.is_empty() {
+            alias.target.clone()
+        } else {
+            let subst = type_param_subst_map(&alias.type_params, &args);
+            substitute_resolved_type(&alias.target, &subst)
+        };
+        let expanded = self.expand_type_aliases_inner(target, expanding);
+        expanding.remove(&name);
+        Some(expanded)
+    }
+
     /// Resolve a type annotation and emit diagnostics for reserved or invalid type spellings.
     fn resolve_type_checked(&mut self, ty: &Spanned<Type>) -> ResolvedType {
         self.validate_stdlib_type_usage(ty);
@@ -2484,7 +2588,8 @@ impl TypeChecker {
                 .push(errors::rust_crate_root_used_as_type(name.as_str(), &info.path, ty.span));
             return ResolvedType::Unknown;
         }
-        resolve_type(&ty.node, &self.symbols)
+        let resolved = resolve_type(&ty.node, &self.symbols);
+        self.expand_type_aliases(resolved)
     }
 
     /// Return whether a simple type name is reserved for a parameterized numeric family.

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -2697,6 +2697,77 @@ def normalize(value: int | str) -> str:
 }
 
 #[test]
+fn test_issue562_type_aliases_are_transparent_for_dict_and_union_surfaces() -> Result<(), String> {
+    let source = r#"
+type FieldValue = str | bool | int | float | None
+type Fields = Dict[str, FieldValue]
+
+model Logger:
+  fields: Fields = {}
+
+  def copy_fields(self, extra: Fields) -> Fields:
+    mut merged: Fields = {}
+    for key in self.fields.keys():
+      merged[key] = self.fields[key]
+    for key in extra.keys():
+      merged[key] = extra[key]
+    return merged
+
+def to_text(value: FieldValue) -> str:
+  match value:
+    str(text) =>
+      return text
+    bool(flag) =>
+      if flag:
+        return "true"
+      return "false"
+    int(number) =>
+      return str(number)
+    float(number) =>
+      return str(number)
+    None =>
+      return "none"
+"#;
+    check_str(source).map_err(|errs| format!("{errs:?}"))
+}
+
+#[test]
+fn test_generic_type_alias_expands_in_dict_contexts() -> Result<(), String> {
+    let source = r#"
+type NamedValues[T] = Dict[str, T]
+
+def build() -> NamedValues[int]:
+  mut values: NamedValues[int] = {}
+  values["count"] = 1
+  return values
+"#;
+    check_str(source).map_err(|errs| format!("{errs:?}"))
+}
+
+#[test]
+fn test_type_alias_expands_in_narrowing_type_positions() -> Result<(), String> {
+    let source = r#"
+type Text = str
+type MaybeText = Text | int | None
+
+def normalize(value: MaybeText) -> str:
+  if isinstance(value, Text):
+    return value.upper()
+  return "missing"
+
+def describe(value: MaybeText) -> str:
+  match value:
+    Text(text) =>
+      return text.upper()
+    int(number) =>
+      return str(number)
+    None =>
+      return "missing"
+"#;
+    check_str(source).map_err(|errs| format!("{errs:?}"))
+}
+
+#[test]
 fn test_union_match_requires_exhaustive_type_patterns() {
     let source = r#"
 def normalize(value: int | str) -> str:

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4328,6 +4328,72 @@ def main() -> None:
     }
 
     #[test]
+    fn test_issue562_type_alias_dict_and_union_surfaces_compile_and_run() -> Result<(), Box<dyn std::error::Error>> {
+        let output = Command::new(incan_debug_binary())
+            .args([
+                "run",
+                "-c",
+                r#"
+type FieldValue = str | bool | int | float | None
+type Fields = Dict[str, FieldValue]
+
+model Logger:
+    fields: Fields = {}
+
+    def copy_fields(self, extra: Fields) -> Fields:
+        mut merged: Fields = {}
+        for key in self.fields.keys():
+            merged[key] = self.fields[key]
+        for key in extra.keys():
+            merged[key] = extra[key]
+        return merged
+
+def to_text(value: FieldValue) -> str:
+    match value:
+        str(text) =>
+            return text
+        bool(flag) =>
+            if flag:
+                return "true"
+            return "false"
+        int(number) =>
+            return str(number)
+        float(number) =>
+            return str(number)
+        None =>
+            return "none"
+
+def main() -> None:
+    logger = Logger(fields={"base": "one"})
+    merged = logger.copy_fields({"count": 7, "flag": True, "ratio": 2.5, "none": None})
+    println(to_text(merged["base"]))
+    println(to_text(merged["count"]))
+    println(to_text(merged["flag"]))
+    println(to_text(merged["ratio"]))
+    println(to_text(merged["none"]))
+"#,
+            ])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            output.status.success(),
+            "issue #562 alias transparency run-path regression failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = strip_ansi_escapes(&String::from_utf8_lossy(&output.stdout));
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            lines,
+            vec!["one", "7", "true", "2.5", "none"],
+            "unexpected issue #562 alias transparency output:\n{stdout}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_issue502_independent_union_narrowing_branches_compile_and_run() -> Result<(), Box<dyn std::error::Error>> {
         let output = Command::new(incan_debug_binary())
             .args([


### PR DESCRIPTION
## Summary

This PR fixes issue #562 by making source-level type aliases transparent in the affected typechecker surfaces. Alias-backed `Dict` types now work for empty literals, dictionary methods, indexing, assignment, and returns, and alias-backed union members now work in constructor patterns and narrowing type positions.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `type Fields = Dict[str, FieldValue]` behaves like its target for dict literals, methods, indexing, assignment, and returns. Union aliases such as `type FieldValue = str | bool | int | float | None` can be matched with constructor patterns.
- **Internals**: The typechecker records resolved source alias targets during collection, expands alias leaves during checked type resolution, applies generic alias substitutions, and shares alias expansion with `isinstance` narrowing and union pattern helper paths.
- **Risks**: This changes central type resolution behavior for source aliases. The expansion is intentionally cycle guarded and falls back for arity mismatches, but unusual recursive alias graphs remain worth watching.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test type_alias` passed after commit
- `make pre-commit` passed before commit on the same tree, including full tests, clippy, cargo-deny, smoke-test-fast, examples, and benchmark build smoke checks

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): N/A

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #562