### PR TITLE
feature - enforce requires-incan toolchain constraints (#401)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.48"
+version = "0.3.0-dev.49"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -29,9 +29,9 @@ use crate::manifest::ProjectManifest;
 
 use super::common::{
     CargoPolicy, build_source_map, cargo_command_flags, collect_inline_rust_imports, collect_modules,
-    collect_project_requirements, format_dependency_error, imported_module_deps_for_with_index,
-    merge_project_requirement_dependencies, module_key_index, resolve_project_root,
-    typecheck_modules_with_import_graph, validate_output_dir,
+    collect_project_requirements, enforce_project_toolchain_constraint, format_dependency_error,
+    imported_module_deps_for_with_index, merge_project_requirement_dependencies, module_key_index,
+    resolve_project_root, typecheck_modules_with_import_graph, validate_output_dir,
 };
 #[cfg(feature = "rust_inspect")]
 use super::common::{collect_rust_inspect_query_paths, ensure_rust_inspect_workspace, prewarm_rust_inspect_workspace};
@@ -414,6 +414,13 @@ fn prepare_project(
             .map_err(|e| CliError::failure(format!("failed to determine current directory: {e}")))?
             .join(file_path)
     };
+    let path = normalized_file_path.as_path();
+    let inferred_project_root = resolve_project_root(path);
+    let manifest = ProjectManifest::discover(&inferred_project_root).map_err(|e| CliError::failure(e.to_string()))?;
+    if let Some(manifest) = manifest.as_ref() {
+        enforce_project_toolchain_constraint(manifest)?;
+    }
+
     let normalized_file_path_str = normalized_file_path.to_string_lossy().to_string();
     let modules = collect_modules(&normalized_file_path_str)?;
     let rust_extern_contexts = collect_rust_extern_contexts(&modules);
@@ -423,9 +430,6 @@ fn prepare_project(
     };
 
     let dep_modules = &modules[..modules.len() - 1];
-    let path = normalized_file_path.as_path();
-    let inferred_project_root = resolve_project_root(path);
-    let manifest = ProjectManifest::discover(&inferred_project_root).map_err(|e| CliError::failure(e.to_string()))?;
     let project_root = manifest
         .as_ref()
         .map(|manifest| manifest.project_root().to_path_buf())
@@ -635,6 +639,7 @@ pub fn build_library(
             "No incan.toml found for `incan build --lib` (run `incan init` first)",
         ));
     };
+    enforce_project_toolchain_constraint(&manifest)?;
 
     let lib_entry = validate_library_entrypoint(&manifest)?;
     let lib_entry_str = lib_entry.to_string_lossy().to_string();

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -27,6 +27,7 @@ use crate::frontend::{ast_walk, diagnostics, lexer, parser, typechecker, vocab_d
 use crate::lockfile::CargoFeatureSelection;
 use crate::manifest::ProjectManifest;
 use crate::manifest::{DependencySource, DependencySpec};
+use crate::project_lifecycle::toolchain::ToolchainConstraintSet;
 #[cfg(feature = "rust_inspect")]
 use crate::rust_inspect::{Inspector, InspectorConfig};
 use incan_core::lang::{
@@ -130,6 +131,18 @@ impl CargoPolicy {
             self.locked = true;
         }
     }
+}
+
+/// Enforce the project-level `requires-incan` constraint for a project-aware command.
+pub(crate) fn enforce_project_toolchain_constraint(manifest: &ProjectManifest) -> CliResult<()> {
+    enforce_toolchain_constraints(&ToolchainConstraintSet::from_project_manifest(manifest))
+}
+
+/// Enforce an already-resolved effective `requires-incan` constraint set.
+pub(crate) fn enforce_toolchain_constraints(constraints: &ToolchainConstraintSet) -> CliResult<()> {
+    constraints
+        .enforce_current()
+        .map_err(|error| CliError::failure(error.to_string()))
 }
 
 /// Resolve one boolean policy input with CLI enable/disable flags over env defaults.

--- a/src/cli/commands/lifecycle.rs
+++ b/src/cli/commands/lifecycle.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use clap::ValueEnum;
-use serde_json::json;
+use serde_json::{Value as JsonValue, json};
 use toml_edit::{DocumentMut, value};
 
 use crate::cli::{CliError, CliResult, ExitCode};
@@ -21,6 +21,7 @@ use crate::manifest::{
     render_dependency_overlay_manifest,
 };
 use crate::project_lifecycle::env::{EnvConfigError, EnvConfigSet, EnvRunPreview, ResolvedEnv, resolve_cwd};
+use crate::project_lifecycle::toolchain::{ToolchainCompatibility, ToolchainConstraintSet};
 use crate::project_lifecycle::version::{VersionBump, VersionChange, VersionRequest};
 
 /// CLI spelling of version bumps accepted by `incan version`.
@@ -151,7 +152,7 @@ pub fn env_show(env_name: Option<&str>, format: EnvOutputFormat, project: Option
         Some(env_name) => {
             let resolved = context.config.resolve_env(env_name).map_err(env_config_error_to_cli)?;
             match format {
-                EnvOutputFormat::Text => print_resolved_env(&resolved, &context.project_root),
+                EnvOutputFormat::Text => print_resolved_env(&resolved, &context.project_root)?,
                 EnvOutputFormat::Json => print_resolved_env_json(&resolved, &context.project_root)?,
             }
         }
@@ -180,12 +181,13 @@ pub fn env_run(
         .config
         .resolve_run_preview(&context.project_root, env_name, script, extra_args)
         .map_err(env_config_error_to_cli)?;
-    reject_recursive_env_run(&preview)?;
 
     if dry_run {
-        print_run_preview(&preview);
+        print_run_preview(&preview)?;
         return Ok(ExitCode::SUCCESS);
     }
+    crate::cli::commands::common::enforce_toolchain_constraints(&preview.resolved_env.requires_incan)?;
+    reject_recursive_env_run(&preview)?;
 
     let Some((program, args)) = preview.argv.split_first() else {
         return Err(CliError::failure(format!(
@@ -459,9 +461,22 @@ fn extend_active_invocation_stack(current: Option<&str>, next_marker: &str) -> S
 }
 
 /// Print one resolved environment in the human-oriented text format.
-fn print_resolved_env(resolved: &ResolvedEnv, project_root: &Path) {
+fn print_resolved_env(resolved: &ResolvedEnv, project_root: &Path) -> CliResult<()> {
+    let compatibility = toolchain_compatibility(&resolved.requires_incan)?;
     println!("{}", resolved.name);
     println!("  overlay chain: {}", resolved.overlay_chain.join(" -> "));
+    println!(
+        "  requires-incan: {}",
+        compatibility
+            .effective_requirement
+            .as_deref()
+            .unwrap_or("unconstrained")
+    );
+    println!(
+        "  active Incan: {} ({})",
+        compatibility.active_version,
+        toolchain_status(&compatibility)
+    );
     println!("  cwd: {}", display_cwd(project_root, resolved.cwd.as_deref()));
     println!("  env vars: {}", resolved.env_vars.len());
     println!("  scripts: {}", resolved.scripts.len());
@@ -480,13 +495,16 @@ fn print_resolved_env(resolved: &ResolvedEnv, project_root: &Path) {
     print_named_value_section("Dev Dependencies", &resolved.dev_dependencies, |name, value| {
         format!("{name:<16} {}", value_to_display_string(value))
     });
+    Ok(())
 }
 
 /// Print one resolved environment as JSON.
 fn print_resolved_env_json(resolved: &ResolvedEnv, project_root: &Path) -> CliResult<()> {
+    let compatibility = toolchain_compatibility(&resolved.requires_incan)?;
     print_json(&json!({
         "env": resolved.name,
         "overlay_chain": resolved.overlay_chain,
+        "requires_incan": toolchain_json(&compatibility),
         "cwd": resolve_cwd(project_root, resolved.cwd.as_deref()).display().to_string(),
         "env_vars": resolved.env_vars,
         "scripts": resolved.scripts,
@@ -496,16 +514,32 @@ fn print_resolved_env_json(resolved: &ResolvedEnv, project_root: &Path) -> CliRe
 }
 
 /// Print the dry-run preview for `incan env run`.
-fn print_run_preview(preview: &EnvRunPreview) {
+fn print_run_preview(preview: &EnvRunPreview) -> CliResult<()> {
+    let compatibility = toolchain_compatibility(&preview.resolved_env.requires_incan)?;
     println!("env: {}", preview.env);
+    println!(
+        "requires-incan: {}",
+        compatibility
+            .effective_requirement
+            .as_deref()
+            .unwrap_or("unconstrained")
+    );
+    println!(
+        "active Incan: {} ({})",
+        compatibility.active_version,
+        toolchain_status(&compatibility)
+    );
     println!("cwd: {}", preview.cwd.display());
     println!("env-vars:");
     print_map(&preview.env_vars);
     println!("command: {}", shell_join(&preview.argv));
+    Ok(())
 }
 
 struct EnvSummary {
     name: String,
+    requires_incan: String,
+    toolchain_status: String,
     cwd: String,
     env_vars: usize,
     scripts: usize,
@@ -528,6 +562,8 @@ fn print_env_overview_json(context: &EnvContext) -> CliResult<()> {
             .into_iter()
             .map(|summary| json!({
                 "name": summary.name,
+                "requires_incan": summary.requires_incan,
+                "toolchain_status": summary.toolchain_status,
                 "cwd": summary.cwd,
                 "env_vars": summary.env_vars,
                 "scripts": summary.scripts,
@@ -546,8 +582,15 @@ fn resolve_env_summaries(context: &EnvContext) -> CliResult<Vec<EnvSummary>> {
         .into_iter()
         .map(|name| {
             let resolved = context.config.resolve_env(&name).map_err(env_config_error_to_cli)?;
+            let compatibility = toolchain_compatibility(&resolved.requires_incan)?;
             Ok(EnvSummary {
                 name: resolved.name,
+                requires_incan: compatibility
+                    .effective_requirement
+                    .as_deref()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "unconstrained".to_string()),
+                toolchain_status: toolchain_status(&compatibility).to_string(),
                 cwd: display_cwd(&context.project_root, resolved.cwd.as_deref()),
                 env_vars: resolved.env_vars.len(),
                 scripts: resolved.scripts.len(),
@@ -572,6 +615,18 @@ fn print_summary_table(summaries: &[EnvSummary]) {
         .max()
         .unwrap_or(3)
         .max("Cwd".len());
+    let requires_width = summaries
+        .iter()
+        .map(|summary| summary.requires_incan.len())
+        .max()
+        .unwrap_or(15)
+        .max("Requires Incan".len());
+    let toolchain_width = summaries
+        .iter()
+        .map(|summary| summary.toolchain_status.len())
+        .max()
+        .unwrap_or(10)
+        .max("Toolchain".len());
     let env_vars_width = summaries
         .iter()
         .map(|summary| summary.env_vars.to_string().len())
@@ -598,17 +653,19 @@ fn print_summary_table(summaries: &[EnvSummary]) {
         .max("Dev Dependencies".len());
 
     println!(
-        "{:<name_width$}  {:<cwd_width$}  {:>env_vars_width$}  {:>scripts_width$}  {:>deps_width$}  {:>dev_deps_width$}",
-        "Name", "Cwd", "Env Vars", "Scripts", "Dependencies", "Dev Dependencies",
+        "{:<name_width$}  {:<requires_width$}  {:<toolchain_width$}  {:<cwd_width$}  {:>env_vars_width$}  {:>scripts_width$}  {:>deps_width$}  {:>dev_deps_width$}",
+        "Name", "Requires Incan", "Toolchain", "Cwd", "Env Vars", "Scripts", "Dependencies", "Dev Dependencies",
     );
     println!(
-        "{:-<name_width$}  {:-<cwd_width$}  {:-<env_vars_width$}  {:-<scripts_width$}  {:-<deps_width$}  {:-<dev_deps_width$}",
-        "", "", "", "", "", "",
+        "{:-<name_width$}  {:-<requires_width$}  {:-<toolchain_width$}  {:-<cwd_width$}  {:-<env_vars_width$}  {:-<scripts_width$}  {:-<deps_width$}  {:-<dev_deps_width$}",
+        "", "", "", "", "", "", "", "",
     );
     for summary in summaries {
         println!(
-            "{:<name_width$}  {:<cwd_width$}  {:>env_vars_width$}  {:>scripts_width$}  {:>deps_width$}  {:>dev_deps_width$}",
+            "{:<name_width$}  {:<requires_width$}  {:<toolchain_width$}  {:<cwd_width$}  {:>env_vars_width$}  {:>scripts_width$}  {:>deps_width$}  {:>dev_deps_width$}",
             summary.name,
+            summary.requires_incan,
+            summary.toolchain_status,
             summary.cwd,
             summary.env_vars,
             summary.scripts,
@@ -616,6 +673,41 @@ fn print_summary_table(summaries: &[EnvSummary]) {
             summary.dev_dependencies,
         );
     }
+}
+
+/// Compute current-toolchain compatibility for CLI display.
+fn toolchain_compatibility(constraints: &ToolchainConstraintSet) -> CliResult<ToolchainCompatibility> {
+    constraints
+        .compatibility_current()
+        .map_err(|error| CliError::failure(error.to_string()))
+}
+
+/// Render the compact compatibility status used in text tables.
+fn toolchain_status(compatibility: &ToolchainCompatibility) -> &'static str {
+    if compatibility.effective_requirement.is_none() {
+        "unconstrained"
+    } else if compatibility.satisfied {
+        "satisfied"
+    } else {
+        "unsatisfied"
+    }
+}
+
+/// Render toolchain compatibility as JSON.
+fn toolchain_json(compatibility: &ToolchainCompatibility) -> JsonValue {
+    json!({
+        "active_version": compatibility.active_version,
+        "effective": compatibility.effective_requirement.as_deref(),
+        "satisfied": compatibility.satisfied,
+        "layers": compatibility
+            .layers
+            .iter()
+            .map(|layer| json!({
+                "source": layer.source.as_str(),
+                "requirement": layer.requirement.as_str(),
+            }))
+            .collect::<Vec<_>>(),
+    })
 }
 
 /// Print one named string map section in text output.
@@ -761,6 +853,7 @@ mod tests {
             resolved_env: ResolvedEnv {
                 name: "unit".to_string(),
                 overlay_chain: vec![],
+                requires_incan: ToolchainConstraintSet::new(),
                 cwd: None,
                 env_vars: BTreeMap::new(),
                 scripts: BTreeMap::new(),
@@ -781,5 +874,45 @@ mod tests {
             vec!["default:run".to_string(), "unit:test".to_string()]
         );
         assert!(active_stack_contains(Some(&stack), "unit:test"));
+    }
+
+    #[test]
+    fn env_run_rejects_unsatisfied_requires_incan_before_spawning() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        fs::write(
+            tmp.path().join(MANIFEST_FILENAME),
+            r#"
+            [project]
+            name = "demo"
+            version = "0.1.0"
+
+            [tool.incan.envs.release]
+            requires-incan = ">999.0.0"
+
+            [tool.incan.envs.release.scripts]
+            probe = ["incan", "--version"]
+            "#,
+        )?;
+
+        let previous = env::current_dir()?;
+        env::set_current_dir(tmp.path())?;
+        let result = env_run("release", "probe", false, &[], None);
+        env::set_current_dir(previous)?;
+
+        let error = match result {
+            Ok(exit_code) => return Err(format!("expected requires-incan failure, got {exit_code:?}").into()),
+            Err(error) => error,
+        };
+        assert!(
+            error.message.contains("does not satisfy requires-incan"),
+            "expected requires-incan failure, got: {}",
+            error.message
+        );
+        assert!(
+            error.message.contains("env.release.requires-incan"),
+            "expected env layer in diagnostic, got: {}",
+            error.message
+        );
+        Ok(())
     }
 }

--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -24,8 +24,8 @@ use crate::manifest::ProjectManifest;
 
 use super::common::{
     CargoPolicy, ProjectRequirements, build_source_map, cargo_command_flags, cargo_lockfile_flags,
-    collect_inline_rust_imports, collect_modules, collect_project_requirements, format_dependency_error,
-    merge_project_requirement_dependencies,
+    collect_inline_rust_imports, collect_modules, collect_project_requirements, enforce_project_toolchain_constraint,
+    format_dependency_error, merge_project_requirement_dependencies,
 };
 #[cfg(feature = "rust_inspect")]
 use super::common::{collect_rust_inspect_query_paths, ensure_rust_inspect_workspace, prewarm_rust_inspect_workspace};
@@ -47,6 +47,7 @@ pub fn lock_project(
     let manifest = ProjectManifest::discover(&start_dir)
         .map_err(|e| CliError::failure(e.to_string()))?
         .ok_or_else(|| CliError::failure("No incan.toml found (run `incan init`)"))?;
+    enforce_project_toolchain_constraint(&manifest)?;
 
     let cargo_features = CargoFeatureSelection {
         cargo_features,

--- a/src/cli/test_runner/mod.rs
+++ b/src/cli/test_runner/mod.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::cli::commands::common::CargoPolicy;
 use crate::cli::{CliError, CliResult, ExitCode};
+use crate::manifest::ProjectManifest;
 
 mod discovery;
 mod execution;
@@ -193,6 +194,19 @@ fn stable_id_root(path: &Path) -> PathBuf {
     } else {
         canonical
     }
+}
+
+/// Discover and enforce project-level toolchain constraints for a test path, when it belongs to a project.
+fn enforce_test_path_toolchain_constraint(path: &Path) -> CliResult<()> {
+    let start = if path.is_file() {
+        path.parent().unwrap_or_else(|| Path::new("."))
+    } else {
+        path
+    };
+    if let Some(manifest) = ProjectManifest::discover(start).map_err(|error| CliError::failure(error.to_string()))? {
+        crate::cli::commands::common::enforce_project_toolchain_constraint(&manifest)?;
+    }
+    Ok(())
 }
 
 /// Stable test identifier used by `-k`, `--list`, and machine-readable reports.
@@ -1047,6 +1061,7 @@ pub fn run_tests(config: TestRunConfig<'_>) -> CliResult<ExitCode> {
     let jobs = jobs.max(1);
 
     let path = Path::new(path);
+    enforce_test_path_toolchain_constraint(path)?;
     let stable_id_root = stable_id_root(path);
     let test_files = discover_test_files(path);
     let eval_context = CollectionEvalContext::new(test_features.into_iter().collect());

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -8,6 +8,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use toml_edit::{Array as EditArray, Document, DocumentMut, Item, Table, Value as EditValue};
 
@@ -259,6 +260,9 @@ pub struct EnvSection {
     /// Env names to apply before this env.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extends: Vec<String>,
+    /// Required Incan toolchain version requirement for this env.
+    #[serde(rename = "requires-incan", skip_serializing_if = "Option::is_none")]
+    pub requires_incan: Option<String>,
     /// Skip implicit `default` inclusion when resolving this env.
     #[serde(default, skip_serializing_if = "is_false")]
     pub detached: bool,
@@ -758,6 +762,7 @@ fn parse_manifest_content(content: &str, path: &Path) -> Result<ProjectManifest,
         .unwrap_or_default();
 
     validate_package_collisions(&rust_dependencies, &rust_dev_dependencies, path)?;
+    validate_requires_incan_constraints(&raw, &spans, path)?;
 
     if let Some(vocab) = &raw.vocab {
         if let Some(crate_path) = &vocab.crate_path {
@@ -787,6 +792,56 @@ fn parse_manifest_content(content: &str, path: &Path) -> Result<ProjectManifest,
         rust_dependencies: rust_dependencies.specs,
         rust_dev_dependencies: rust_dev_dependencies.specs,
     })
+}
+
+/// Validate every `requires-incan` string in the manifest before command-specific policy checks run.
+fn validate_requires_incan_constraints(
+    raw: &RawManifest,
+    spans: &ManifestSpans<'_>,
+    path: &Path,
+) -> Result<(), ManifestError> {
+    if let Some(requirement) = raw
+        .project
+        .as_ref()
+        .and_then(|project| project.requires_incan.as_deref())
+    {
+        validate_requires_incan_requirement(requirement, path, spans.entry_location(&["project"], "requires-incan"))?;
+    }
+
+    if let Some(envs) = raw
+        .tool
+        .as_ref()
+        .and_then(|tool| tool.incan.as_ref())
+        .map(|incan| &incan.envs)
+    {
+        for (env_name, env) in envs {
+            if let Some(requirement) = env.requires_incan.as_deref() {
+                validate_requires_incan_requirement(
+                    requirement,
+                    path,
+                    spans.entry_location(&["tool", "incan", "envs", env_name.as_str()], "requires-incan"),
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate one SemVer requirement string from a `requires-incan` field.
+fn validate_requires_incan_requirement(
+    requirement: &str,
+    path: &Path,
+    location: Option<ManifestLocation>,
+) -> Result<(), ManifestError> {
+    VersionReq::parse(requirement).map_err(|error| {
+        manifest_invalid(
+            path,
+            location,
+            format!("invalid requires-incan constraint `{requirement}`: {error}"),
+        )
+    })?;
+    Ok(())
 }
 
 /// Serialize one resolved Rust dependency spec back into the canonical TOML table shape.

--- a/src/project_lifecycle/env.rs
+++ b/src/project_lifecycle/env.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use toml::Value;
 
 use crate::manifest::{EnvSection, ProjectManifest};
+use crate::project_lifecycle::toolchain::ToolchainConstraintSet;
 
 /// Display label used for the project-level overlay in resolved chains.
 pub const PROJECT_BASE_OVERLAY: &str = "project";
@@ -25,6 +26,8 @@ pub struct EnvConfigSet {
 /// A deterministic overlay of fields that can participate in environment resolution.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct EnvOverlay {
+    /// Effective Incan toolchain constraints contributed by the project and env overlays.
+    pub requires_incan: ToolchainConstraintSet,
     /// Working directory for scripts. Relative paths are interpreted against the project root.
     pub cwd: Option<String>,
     /// Environment variables to inject into the script process.
@@ -44,6 +47,8 @@ pub struct ResolvedEnv {
     pub name: String,
     /// Overlay labels in application order, beginning with the project base overlay.
     pub overlay_chain: Vec<String>,
+    /// Effective Incan toolchain constraints after project/env overlay resolution.
+    pub requires_incan: ToolchainConstraintSet,
     /// Final working directory, if any env overlay defined it.
     pub cwd: Option<String>,
     /// Final environment variable map after deterministic overlay merging.
@@ -99,6 +104,7 @@ impl EnvConfigSet {
     pub fn from_manifest(manifest: &ProjectManifest) -> Self {
         Self {
             base: EnvOverlay {
+                requires_incan: ToolchainConstraintSet::from_project_manifest(manifest),
                 dependencies: manifest.env_base_dependency_overlay(),
                 dev_dependencies: manifest.env_base_dev_dependency_overlay(),
                 ..EnvOverlay::default()
@@ -154,6 +160,7 @@ impl EnvConfigSet {
         Ok(ResolvedEnv {
             name: name.to_string(),
             overlay_chain: state.chain,
+            requires_incan: state.overlay.requires_incan,
             cwd: state.overlay.cwd,
             env_vars: state.overlay.env_vars,
             scripts: state.overlay.scripts,
@@ -233,7 +240,7 @@ impl EnvConfigSet {
 
         state.stack.pop();
         if let Some(env) = env {
-            state.overlay.apply_env(env);
+            state.overlay.apply_env(name, env);
         }
         state.chain.push(name.to_string());
         Ok(())
@@ -242,7 +249,11 @@ impl EnvConfigSet {
 
 impl EnvOverlay {
     /// Apply one configured env table on top of this overlay using RFC 015 merge rules.
-    fn apply_env(&mut self, env: &EnvSection) {
+    fn apply_env(&mut self, name: &str, env: &EnvSection) {
+        if let Some(requirement) = &env.requires_incan {
+            self.requires_incan
+                .push(format!("env.{name}.requires-incan"), requirement.clone());
+        }
         if let Some(cwd) = &env.cwd {
             self.cwd = Some(cwd.clone());
         }
@@ -696,6 +707,59 @@ mod tests {
             ]
         );
         assert_eq!(preview.env_vars.get("INCAN_NO_BANNER").map(String::as_str), Some("1"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_project_and_env_toolchain_constraints_in_overlay_order() -> Result<(), Box<dyn std::error::Error>> {
+        let config = parse_config(
+            r#"
+            [project]
+            requires-incan = ">=0.3,<0.5"
+
+            [tool.incan.envs.default]
+            requires-incan = ">=0.3,<0.4"
+
+            [tool.incan.envs.release]
+            requires-incan = ">=0.3.1,<0.4"
+            "#,
+        )?;
+
+        let resolved = config.resolve_env("release")?;
+
+        assert_eq!(
+            resolved
+                .requires_incan
+                .layers()
+                .iter()
+                .map(|layer| (layer.source.as_str(), layer.requirement.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("project.requires-incan", ">=0.3,<0.5"),
+                ("env.default.requires-incan", ">=0.3,<0.4"),
+                ("env.release.requires-incan", ">=0.3.1,<0.4"),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_project_requires_incan_is_manifest_error() -> Result<(), Box<dyn std::error::Error>> {
+        let error = match ProjectManifest::from_str(
+            r#"
+            [project]
+            requires-incan = "not semver"
+            "#,
+            Path::new("incan.toml"),
+        ) {
+            Ok(manifest) => return Err(format!("expected manifest error, parsed {manifest:?}").into()),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("invalid requires-incan constraint"),
+            "expected requires-incan parse diagnostic, got: {error}"
+        );
         Ok(())
     }
 

--- a/src/project_lifecycle/mod.rs
+++ b/src/project_lifecycle/mod.rs
@@ -4,4 +4,5 @@
 //! live outside this boundary so the policy can be tested independently.
 
 pub mod env;
+pub mod toolchain;
 pub mod version;

--- a/src/project_lifecycle/toolchain.rs
+++ b/src/project_lifecycle/toolchain.rs
@@ -1,0 +1,299 @@
+//! Incan toolchain compatibility policy for project lifecycle commands.
+//!
+//! `requires-incan` is an execution guard, not dependency resolution. This module keeps the pure SemVer compatibility
+//! checks separate from CLI command orchestration so project-aware commands can enforce the same policy consistently.
+
+use semver::{Prerelease, Version, VersionReq};
+
+use crate::manifest::ProjectManifest;
+
+/// One manifest layer that contributed a `requires-incan` constraint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolchainConstraintLayer {
+    /// Human-readable source label used in diagnostics and inspection output.
+    pub source: String,
+    /// Raw SemVer requirement string as authored in `incan.toml`.
+    pub requirement: String,
+}
+
+impl ToolchainConstraintLayer {
+    /// Build one named constraint layer.
+    #[must_use]
+    pub fn new(source: impl Into<String>, requirement: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            requirement: requirement.into(),
+        }
+    }
+}
+
+/// Effective toolchain constraints after project/env overlays have been resolved.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolchainConstraintSet {
+    layers: Vec<ToolchainConstraintLayer>,
+}
+
+impl ToolchainConstraintSet {
+    /// Create an empty, unconstrained set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a set from already-labeled constraint layers.
+    #[must_use]
+    pub fn from_layers(layers: impl IntoIterator<Item = ToolchainConstraintLayer>) -> Self {
+        Self {
+            layers: layers.into_iter().collect(),
+        }
+    }
+
+    /// Build the project-level baseline from `[project].requires-incan`, if present.
+    #[must_use]
+    pub fn from_project_manifest(manifest: &ProjectManifest) -> Self {
+        let mut constraints = Self::new();
+        if let Some(requirement) = manifest
+            .project
+            .as_ref()
+            .and_then(|project| project.requires_incan.as_deref())
+        {
+            constraints.push("project.requires-incan", requirement);
+        }
+        constraints
+    }
+
+    /// Add one authored constraint layer.
+    pub fn push(&mut self, source: impl Into<String>, requirement: impl Into<String>) {
+        self.layers.push(ToolchainConstraintLayer::new(source, requirement));
+    }
+
+    /// Extend this set with all layers from another set.
+    pub fn extend(&mut self, other: ToolchainConstraintSet) {
+        self.layers.extend(other.layers);
+    }
+
+    /// Borrow all contributing layers.
+    #[must_use]
+    pub fn layers(&self) -> &[ToolchainConstraintLayer] {
+        &self.layers
+    }
+
+    /// Return whether no layer declared a constraint.
+    #[must_use]
+    pub fn is_unconstrained(&self) -> bool {
+        self.layers.is_empty()
+    }
+
+    /// Render the effective constraint for display.
+    #[must_use]
+    pub fn effective_requirement_display(&self) -> String {
+        if self.layers.is_empty() {
+            "unconstrained".to_string()
+        } else {
+            self.layers
+                .iter()
+                .map(|layer| layer.requirement.as_str())
+                .collect::<Vec<_>>()
+                .join(" && ")
+        }
+    }
+
+    /// Check the active compiler version from [`crate::version::INCAN_VERSION`].
+    pub fn compatibility_current(&self) -> Result<ToolchainCompatibility, ToolchainConstraintError> {
+        self.compatibility_with(crate::version::INCAN_VERSION)
+    }
+
+    /// Check compatibility against one SemVer version string.
+    pub fn compatibility_with(&self, active_version: &str) -> Result<ToolchainCompatibility, ToolchainConstraintError> {
+        let active =
+            Version::parse(active_version).map_err(|source| ToolchainConstraintError::InvalidActiveVersion {
+                version: active_version.to_string(),
+                message: source.to_string(),
+            })?;
+
+        let parsed = self
+            .layers
+            .iter()
+            .map(|layer| {
+                VersionReq::parse(&layer.requirement).map_err(|source| ToolchainConstraintError::InvalidRequirement {
+                    source: layer.source.clone(),
+                    requirement: layer.requirement.clone(),
+                    message: source.to_string(),
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let satisfied = parsed
+            .iter()
+            .all(|requirement| requirement_matches_active_toolchain(requirement, &active));
+
+        Ok(ToolchainCompatibility {
+            active_version: active_version.to_string(),
+            effective_requirement: (!self.layers.is_empty()).then(|| self.effective_requirement_display()),
+            satisfied,
+            layers: self.layers.clone(),
+        })
+    }
+
+    /// Fail if the active compiler version does not satisfy this effective constraint.
+    pub fn enforce_current(&self) -> Result<(), ToolchainConstraintError> {
+        let compatibility = self.compatibility_current()?;
+        if compatibility.satisfied {
+            Ok(())
+        } else {
+            Err(ToolchainConstraintError::Unsatisfied(compatibility))
+        }
+    }
+}
+
+/// Compatibility result for inspection commands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolchainCompatibility {
+    /// Active compiler version string.
+    pub active_version: String,
+    /// Effective constraint display string, or `None` when unconstrained.
+    pub effective_requirement: Option<String>,
+    /// Whether the active compiler satisfies every contributing layer.
+    pub satisfied: bool,
+    /// Contributing project/env layers.
+    pub layers: Vec<ToolchainConstraintLayer>,
+}
+
+/// Errors emitted while parsing or enforcing toolchain constraints.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolchainConstraintError {
+    /// The compiler's own package version is not a valid SemVer version.
+    InvalidActiveVersion {
+        /// Invalid active version string.
+        version: String,
+        /// SemVer parser message.
+        message: String,
+    },
+    /// One manifest-authored `requires-incan` value is malformed.
+    InvalidRequirement {
+        /// Manifest layer label.
+        source: String,
+        /// Authored requirement string.
+        requirement: String,
+        /// SemVer parser message.
+        message: String,
+    },
+    /// The active compiler does not satisfy the effective requirement.
+    Unsatisfied(ToolchainCompatibility),
+}
+
+impl std::fmt::Display for ToolchainConstraintError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidActiveVersion { version, message } => {
+                write!(f, "invalid active Incan version `{version}`: {message}")
+            }
+            Self::InvalidRequirement {
+                source,
+                requirement,
+                message,
+            } => {
+                write!(
+                    f,
+                    "invalid requires-incan constraint `{requirement}` from {source}: {message}"
+                )
+            }
+            Self::Unsatisfied(compatibility) => {
+                writeln!(
+                    f,
+                    "active Incan toolchain {} does not satisfy requires-incan {}",
+                    compatibility.active_version,
+                    compatibility
+                        .effective_requirement
+                        .as_deref()
+                        .unwrap_or("unconstrained")
+                )?;
+                writeln!(f)?;
+                writeln!(f, "contributing constraints:")?;
+                for layer in &compatibility.layers {
+                    writeln!(f, "  - {}: {}", layer.source, layer.requirement)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ToolchainConstraintError {}
+
+/// Return whether a requirement matches the active toolchain.
+///
+/// Incan dev builds are published as SemVer prereleases such as `0.3.0-dev.48`. For lifecycle compatibility, a dev
+/// build is allowed to satisfy a range that admits its release-core version (`0.3.0`) so projects can write the normal
+/// line constraint `>=0.3,<0.4` while the line is still in development.
+fn requirement_matches_active_toolchain(requirement: &VersionReq, active: &Version) -> bool {
+    if requirement.matches(active) {
+        return true;
+    }
+    if active.pre.is_empty() {
+        return false;
+    }
+
+    let mut release_core = active.clone();
+    release_core.pre = Prerelease::EMPTY;
+    requirement.matches(&release_core)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ToolchainConstraintError, ToolchainConstraintSet};
+
+    #[test]
+    fn unconstrained_set_is_satisfied() -> Result<(), Box<dyn std::error::Error>> {
+        let compatibility = ToolchainConstraintSet::new().compatibility_with("0.3.0-dev.48")?;
+
+        assert!(compatibility.satisfied);
+        assert_eq!(compatibility.effective_requirement, None);
+        Ok(())
+    }
+
+    #[test]
+    fn release_line_requirement_matches_dev_toolchain() -> Result<(), Box<dyn std::error::Error>> {
+        let mut constraints = ToolchainConstraintSet::new();
+        constraints.push("project.requires-incan", ">=0.3,<0.4");
+
+        let compatibility = constraints.compatibility_with("0.3.0-dev.48")?;
+
+        assert!(compatibility.satisfied);
+        assert_eq!(compatibility.effective_requirement.as_deref(), Some(">=0.3,<0.4"));
+        Ok(())
+    }
+
+    #[test]
+    fn all_layers_must_match_active_toolchain() -> Result<(), Box<dyn std::error::Error>> {
+        let mut constraints = ToolchainConstraintSet::new();
+        constraints.push("project.requires-incan", ">=0.3,<0.5");
+        constraints.push("env.release.requires-incan", ">=0.4,<0.5");
+
+        let compatibility = constraints.compatibility_with("0.3.0-dev.48")?;
+
+        assert!(!compatibility.satisfied);
+        assert_eq!(
+            compatibility.effective_requirement.as_deref(),
+            Some(">=0.3,<0.5 && >=0.4,<0.5")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_layer_is_reported_with_source() {
+        let mut constraints = ToolchainConstraintSet::new();
+        constraints.push("project.requires-incan", "not semver");
+
+        let error = match constraints.compatibility_with("0.3.0-dev.48") {
+            Ok(compatibility) => panic!("expected malformed constraint, got {compatibility:?}"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            ToolchainConstraintError::InvalidRequirement { ref source, .. }
+                if source == "project.requires-incan"
+        ));
+    }
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -72,6 +72,147 @@ main = "src/main.incn"
 }
 
 #[test]
+fn requires_incan_allows_compatible_project_commands() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir)?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        r#"[project]
+name = "compatible_toolchain_guard"
+version = "0.1.0"
+requires-incan = ">=0.3,<0.4"
+
+[project.scripts]
+main = "src/main.incn"
+"#,
+    )?;
+    let main_path = src_dir.join("main.incn");
+    fs::write(
+        &main_path,
+        r#"def main() -> None:
+  println("cli lifecycle ok")
+"#,
+    )?;
+
+    let output = run_incan(
+        tmp.path(),
+        &["lock", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(&output, "incan lock with compatible requires-incan");
+
+    Ok(())
+}
+
+#[test]
+fn requires_incan_rejects_project_aware_commands() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let project_root = tmp.path();
+    let src_dir = project_root.join("src");
+    let tests_dir = project_root.join("tests");
+    fs::create_dir_all(&src_dir)?;
+    fs::create_dir_all(&tests_dir)?;
+    fs::write(
+        project_root.join("incan.toml"),
+        r#"[project]
+name = "toolchain_guard"
+version = "0.1.0"
+requires-incan = ">999.0.0"
+
+[project.scripts]
+main = "src/main.incn"
+"#,
+    )?;
+    fs::write(
+        src_dir.join("main.incn"),
+        r#"def main() -> None:
+  println("should not run")
+"#,
+    )?;
+    fs::write(
+        tests_dir.join("test_main.incn"),
+        r#"from std.testing import test
+
+@test
+def test_guard() -> None:
+  assert True
+"#,
+    )?;
+
+    let cases = vec![
+        (vec!["lock"], "incan lock"),
+        (vec!["build", "src/main.incn"], "incan build"),
+        (vec!["run"], "incan run"),
+        (vec!["test"], "incan test"),
+    ];
+
+    for (args, context) in cases {
+        let output = run_incan(project_root, &args)?;
+        assert_failure(&output, context);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("does not satisfy requires-incan"),
+            "{context} should reject incompatible requires-incan, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("project.requires-incan"),
+            "{context} should name the project constraint layer, got:\n{stderr}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn env_requires_incan_is_reported_and_enforced_for_env_run() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let project_root = tmp.path();
+    fs::write(
+        project_root.join("incan.toml"),
+        r#"[project]
+name = "env_toolchain_guard"
+version = "0.1.0"
+
+[tool.incan.envs.release]
+requires-incan = ">999.0.0"
+
+[tool.incan.envs.release.scripts]
+probe = ["incan", "--version"]
+"#,
+    )?;
+
+    let show_output = run_incan(project_root, &["env", "show", "release"])?;
+    assert_success(&show_output, "incan env show release");
+    let show_stdout = String::from_utf8_lossy(&show_output.stdout);
+    assert!(
+        show_stdout.contains("requires-incan: >999.0.0"),
+        "env show should report effective constraint, got:\n{show_stdout}"
+    );
+    assert!(
+        show_stdout.contains("unsatisfied"),
+        "env show should report compatibility state, got:\n{show_stdout}"
+    );
+
+    let dry_run_output = run_incan(project_root, &["env", "run", "release", "probe", "--dry-run"])?;
+    assert_success(&dry_run_output, "incan env run release probe --dry-run");
+    let dry_run_stdout = String::from_utf8_lossy(&dry_run_output.stdout);
+    assert!(
+        dry_run_stdout.contains("active Incan:") && dry_run_stdout.contains("unsatisfied"),
+        "env dry-run should surface unsatisfied compatibility without spawning, got:\n{dry_run_stdout}"
+    );
+
+    let run_output = run_incan(project_root, &["env", "run", "release", "probe"])?;
+    assert_failure(&run_output, "incan env run release probe");
+    let stderr = String::from_utf8_lossy(&run_output.stderr);
+    assert!(
+        stderr.contains("env.release.requires-incan"),
+        "env run should name the env constraint layer, got:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn init_creates_project_scaffold_with_expected_content() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let project_dir = tmp.path().join("generated_app");

--- a/workspaces/docs-site/docs/language/how-to/project_lifecycle.md
+++ b/workspaces/docs-site/docs/language/how-to/project_lifecycle.md
@@ -111,6 +111,36 @@ incan version --set 1.2.0
 
 `incan version` changes the project version, not the compiler or toolchain version. Toolchain requirements stay in `requires-incan`, and compiler releases are maintained separately from your app or library.
 
+## Set the required Incan toolchain
+
+Use `[project].requires-incan` when a project needs a particular Incan release line:
+
+```toml
+[project]
+name = "greeter"
+version = "0.1.0"
+requires-incan = ">=0.3,<0.4"
+```
+
+Project-aware execution commands enforce this before they do real work. If the active compiler is incompatible, `incan run`, `incan build`, `incan test`, `incan lock`, and `incan env run` fail with the active version and the requirement that rejected it. Plain single-file or inline commands outside a project do not use `requires-incan`.
+
+You can make a named env stricter for release or CI workflows:
+
+```toml
+[tool.incan.envs.ci]
+requires-incan = ">=0.3,<0.4"
+
+[tool.incan.envs.ci.scripts]
+test = ["incan", "test", "--locked"]
+```
+
+Inspect the effective requirement before running the script:
+
+```bash
+incan env show ci
+incan env run ci test --dry-run
+```
+
 ## Define repeatable environments
 
 Use `incan env` when a project has commands that should always run with the same arguments, working directory, or environment variables.

--- a/workspaces/docs-site/docs/language/reference/project_lifecycle.md
+++ b/workspaces/docs-site/docs/language/reference/project_lifecycle.md
@@ -108,6 +108,21 @@ Both `incan new` and `incan init` accept metadata flags:
 
 `incan init --name greeter --version 0.1.0` writes the core project keys, `readme = "README.md"`, and a default `main` script. Metadata flags or interactive answers populate optional fields such as `description`, `authors`, and `license`.
 
+### Toolchain requirements
+
+`requires-incan` is an executable compatibility guard. Project-aware execution commands enforce it before doing build, test, lock, or env-script work:
+
+```toml
+[project]
+name = "greeter"
+version = "0.1.0"
+requires-incan = ">=0.3,<0.4"
+```
+
+If the active compiler is outside the range, `incan run` in project mode, `incan build`, `incan test`, `incan lock`, and `incan env run` fail early with a diagnostic that names the active compiler version and the contributing constraint layers. Single-file and inline commands without a discovered `incan.toml` remain manifest-free and do not infer a requirement.
+
+Development compilers identify themselves with prerelease versions such as `0.3.0-dev.49`. For lifecycle compatibility, that development build is treated as part of the `0.3` line, so a requirement such as `>=0.3,<0.4` admits it.
+
 ## `[project.scripts]`
 
 `[project.scripts]` maps script names to Incan source files:
@@ -206,6 +221,7 @@ test = ["incan", "test", "tests/"]
 
 [tool.incan.envs.ci]
 extends = ["unit"]
+requires-incan = ">=0.3,<0.4"
 
 [tool.incan.envs.ci.scripts]
 test = ["incan", "test", "--locked", "tests/"]
@@ -251,10 +267,15 @@ Typical pattern:
 | Field      | Type                  | Meaning                                                                     |
 | ---------- | --------------------- | --------------------------------------------------------------------------- |
 | `extends`  | list of strings       | Other environments to merge before this one                                 |
+| `requires-incan` | string          | Additional Incan toolchain requirement for this env                         |
 | `detached` | bool                  | Do not include `default` automatically                                      |
 | `cwd`      | string                | Working directory for scripts, relative to the project root unless absolute |
 | `env-vars` | table                 | Environment variables to inject into the process                            |
 | `scripts`  | table of string lists | Script names mapped to argv lists                                           |
+
+An env-level `requires-incan` is combined with the project requirement and any inherited env requirements. This can make an automation env stricter than day-to-day development without weakening the project baseline. Use `incan env show <env>` or `incan env run <env> <script> --dry-run` to inspect the effective requirement and current compatibility before running the script.
+
+RFC 073 also reserves declarative environment matrices, but matrix expansion is not part of the `0.3` lifecycle implementation. Named envs resolve one configuration unless a later release documents matrix support.
 
 Dependency overlay tables may also be used for environment-specific dependencies:
 

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -524,6 +524,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Language/Interop**: Generated Rust now retains extension-trait imports from typechecker import metadata and receiver trait metadata instead of backend method-name heuristics, so same-name methods from unrelated imported traits do not force unused trait imports (#447).
 - **Tooling**: `incan lock` now treats manifest projects as a project-wide lock surface, covering declared scripts and test harness dependency inputs so multi-entrypoint projects do not alternate stale-lock warnings between `incan test` and `incan run src/extra.incn` (#505).
 - **Tooling**: `incan fmt` now wraps long class trait adoption headers into parseable parenthesized `with (...)` lists, keeping broad adoption surfaces such as `_BytesIO` readable and below the line-length target (#565).
+- **Tooling**: Project-aware commands now enforce `[project].requires-incan`, env-level `requires-incan` can narrow named environment workflows, and `incan env show` / `env run --dry-run` report the effective toolchain compatibility before scripts run; RFC 073 matrix expansion remains deferred beyond `0.3` (#401, RFC 073).
 
 ### Documentation
 
@@ -546,6 +547,7 @@ The sections above are the release story. The list below is the detailed invento
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.46`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.47`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.48`.
+- **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.49`.
 
 ## Known limitations (0.3)
 

--- a/workspaces/docs-site/docs/tooling/reference/project_configuration.md
+++ b/workspaces/docs-site/docs/tooling/reference/project_configuration.md
@@ -35,6 +35,8 @@ readme = "README.md"
 requires-incan = ">=0.2"
 ```
 
+`requires-incan` is enforced by project-aware execution commands. If the active compiler does not satisfy the requirement, `incan run` in project mode, `incan build`, `incan test`, `incan lock`, and `incan env run` fail before compiling, locking, or launching scripts. Single-file or inline commands without a discovered project manifest do not infer a toolchain requirement.
+
 ### `[project.scripts]`
 
 Named entry points for CLI commands:
@@ -91,6 +93,7 @@ test = ["incan", "test", "tests/"]
 
 [tool.incan.envs.release]
 extends = ["default"]
+requires-incan = ">=0.3,<0.4"
 env-vars = { INCAN_FANCY_ERRORS = "1" }
 
 [tool.incan.envs.release.scripts]
@@ -102,10 +105,15 @@ Fields:
 | Field      | Type                  | Description                                                                 |
 | ---------- | --------------------- | --------------------------------------------------------------------------- |
 | `extends`  | list of strings       | Other environments to merge before this one                                 |
+| `requires-incan` | string          | Additional Incan toolchain requirement for this env                         |
 | `detached` | bool                  | Do not include `default` automatically                                      |
 | `cwd`      | string                | Working directory for scripts, relative to the project root unless absolute |
 | `env-vars` | table                 | Environment variables to inject into the process                            |
 | `scripts`  | table of string lists | Script names mapped to argv lists                                           |
+
+Env-level `requires-incan` narrows the project requirement for that environment. `incan env show <env>` and `incan env run <env> <script> --dry-run` display the effective requirement and whether the active compiler satisfies it; actual `incan env run` execution rejects unsatisfied constraints before spawning the script.
+
+Environment matrices from RFC 073 remain deferred beyond `0.3`; ordinary named envs may declare `requires-incan`, but matrix expansion is not available yet.
 
 Use the environment with:
 


### PR DESCRIPTION
## Summary

This PR implements the `0.3` `requires-incan` slice tracked by issue #401. Project-aware lifecycle commands now validate `[project].requires-incan` before build, test, lock, run, or env-script execution; named envs can add narrower `requires-incan` layers; and env inspection/dry-run output reports the effective toolchain compatibility without blocking read-only inspection. RFC 073 remains broader than this PR: matrix-expanded environments are explicitly deferred beyond `0.3`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan run` in project mode, `incan build`, `incan test`, `incan lock`, and actual `incan env run` execution now fail early when the active Incan version does not satisfy the effective `requires-incan` constraints. `incan env show` and `incan env run --dry-run` show the effective requirement and whether the current toolchain satisfies it.
- **Internals**: Added a pure project-lifecycle toolchain constraint model, manifest validation for project/env `requires-incan` strings, shared CLI enforcement helpers, env overlay accumulation of constraint layers, and JSON/text compatibility rendering for env inspection.
- **Risks**: This changes project-aware command startup behavior for projects that opt into `requires-incan`. The dev-prerelease policy intentionally treats `0.3.0-dev.N` as satisfying release-line ranges such as `>=0.3,<0.4`, so future release-versioning changes should keep that compatibility rule in mind.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make fmt`
- `cargo test toolchain --lib`
- `cargo test requires_incan --lib`
- `cargo test --test cli_integration requires_incan -- --nocapture`
- `cargo test lifecycle --lib`
- `mkdocs build --strict` from `workspaces/docs-site`
- `make pre-commit TEST_CMD='cargo nextest run --all --status-level all --retries 2'` passed after rebasing onto `origin/main` at `737259cd` (2365 nextest tests passed, then clippy, cargo-deny, smoke-test-fast, examples, and benchmark build smoke).
- Post-commit focused reruns passed: `cargo test requires_incan --lib` and `cargo test --test cli_integration requires_incan -- --nocapture`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/tooling/reference/project_configuration.md`, `workspaces/docs-site/docs/language/reference/project_lifecycle.md`, `workspaces/docs-site/docs/language/how-to/project_lifecycle.md`, `workspaces/docs-site/docs/release_notes/0_3.md`

RFC lifecycle note: RFC 073 is still Draft and its matrix-expansion scope remains deferred. This PR completes the issue #401 `0.3` `requires-incan` slice only.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #401