### PR TITLE
bugfix - fix generic constructors and Rust struct construction (#604, #605)

### DIFF
--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -1254,6 +1254,16 @@ pub fn rust_item_shape_not_supported(path: &str, description: &str, span: Span) 
     .with_note("RFC 041 intentionally limits which Rust item shapes are typechecked directly")
 }
 
+/// A Rust import is being used as a constructor, but the compiler lacks enough metadata to emit valid Rust.
+pub fn rust_constructor_metadata_unavailable(path: &str, span: Span) -> CompileError {
+    CompileError::type_error(
+        format!("Cannot construct imported Rust item `rust::{path}` without constructor metadata"),
+        span,
+    )
+    .with_hint("Use an associated Rust constructor method, a helper function, or refresh Rust metadata for this item")
+    .with_note("Named-field Rust structs require field metadata so Incan can emit a Rust struct literal")
+}
+
 /// `type X = rusttype Y` requires `Y` to resolve to a Rust-origin imported item.
 pub fn rusttype_requires_rust_backing(type_name: &str, span: Span) -> CompileError {
     CompileError::type_error(

--- a/crates/rust_inspect/src/extractor.rs
+++ b/crates/rust_inspect/src/extractor.rs
@@ -717,7 +717,6 @@ fn collect_public_fields(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget, cra
                 type_shape,
             });
         }
-        collected.sort_by(|a, b| a.name.cmp(&b.name));
         return collected;
     }
 
@@ -736,7 +735,6 @@ fn collect_public_fields(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget, cra
             type_shape,
         });
     }
-    fields.sort_by(|a, b| a.name.cmp(&b.name));
     fields
 }
 
@@ -1043,6 +1041,37 @@ impl Labelled for Thing {}
             "expected direct Labelled impl in metadata, got {:?}",
             info.implemented_traits
         );
+        Ok(())
+    }
+
+    #[test]
+    fn type_metadata_preserves_struct_field_declaration_order() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        fs::create_dir_all(tmp.path().join("src"))?;
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            r#"[package]
+name = "demo_field_order_probe"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )?;
+        fs::write(
+            tmp.path().join("src/lib.rs"),
+            r#"pub struct Pair {
+    pub zeta: i64,
+    pub alpha: i64,
+}
+"#,
+        )?;
+
+        let workspace = RustWorkspace::load(tmp.path(), &|_| ())?;
+        let metadata = extract_rust_item(&workspace, "demo_field_order_probe::Pair")?;
+        let RustItemKind::Type(info) = metadata.kind else {
+            return Err(std::io::Error::other("expected type metadata").into());
+        };
+        let fields = info.fields.iter().map(|field| field.name.as_str()).collect::<Vec<_>>();
+        assert_eq!(fields, ["zeta", "alpha"]);
         Ok(())
     }
 }

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -3441,6 +3441,117 @@ pub def forward(value: Thing) -> None:
 
     #[cfg(feature = "rust_inspect")]
     #[test]
+    fn test_codegen_emits_named_field_struct_literal_for_imported_rust_type_constructor()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::frontend::typechecker::TypeChecker;
+        use incan_core::interop::{
+            RustFieldInfo, RustItemKind, RustItemMetadata, RustTypeInfo, RustTypeShape, RustVisibility,
+        };
+
+        let source = r#"
+from rust::demo import Pair
+
+pub def make_pair() -> Pair:
+  return Pair(1, 2)
+"#;
+        let tokens = must_ok(lexer::lex(source));
+        let ast = must_ok(parser::parse(&tokens));
+
+        let tmp = seeded_rust_inspect_workspace()?;
+        let manifest_dir = tmp.path().to_path_buf();
+        let mut tc = TypeChecker::new();
+        tc.set_rust_inspect_manifest_dir(manifest_dir.clone());
+        tc.rust_inspect_cache
+            .insert_test_item(
+                &manifest_dir,
+                RustItemMetadata {
+                    canonical_path: "demo::Pair".to_string(),
+                    definition_path: Some("demo::Pair".to_string()),
+                    visibility: RustVisibility::Public,
+                    kind: RustItemKind::Type(RustTypeInfo {
+                        methods: Vec::new(),
+                        implemented_traits: Vec::new(),
+                        fields: vec![
+                            RustFieldInfo {
+                                name: "zeta".to_string(),
+                                type_display: "i64".to_string(),
+                                type_shape: RustTypeShape::Int,
+                            },
+                            RustFieldInfo {
+                                name: "alpha".to_string(),
+                                type_display: "i64".to_string(),
+                                type_shape: RustTypeShape::Int,
+                            },
+                        ],
+                        variants: Vec::new(),
+                    }),
+                },
+            )
+            .map_err(|e| std::io::Error::other(format!("seed rust-inspect type: {e}")))?;
+        tc.check_program(&ast)
+            .map_err(|errs| std::io::Error::other(format!("typecheck failed: {errs:?}")))?;
+
+        let mut lowering = AstLowering::new_with_type_info(tc.type_info().clone());
+        let ir_program = lowering
+            .lower_program(&ast)
+            .map_err(|err| std::io::Error::other(format!("lowering failed: {err:?}")))?;
+        let mut emitter = IrEmitter::new(&ir_program.function_registry);
+        let code = emitter
+            .emit_program(&ir_program)
+            .map_err(|err| std::io::Error::other(format!("emit failed: {err:?}")))?;
+
+        assert!(
+            code.contains("Pair {") && code.contains("zeta: 1") && code.contains("alpha: 2"),
+            "expected named-field Rust struct literal in generated code; got:\n{code}"
+        );
+        assert!(
+            !code.contains("Pair(1, 2)"),
+            "imported named-field Rust structs must not emit tuple-style constructors; got:\n{code}"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "rust_inspect")]
+    #[test]
+    fn test_codegen_uses_source_field_names_for_metadata_free_rust_type_constructor()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::frontend::typechecker::TypeChecker;
+
+        let source = r#"
+from rust::demo import Pair
+
+pub def make_pair() -> Pair:
+  return Pair(zeta=1, alpha=2)
+"#;
+        let tokens = must_ok(lexer::lex(source));
+        let ast = must_ok(parser::parse(&tokens));
+
+        let mut tc = TypeChecker::new();
+        tc.check_program(&ast)
+            .map_err(|errs| std::io::Error::other(format!("typecheck failed: {errs:?}")))?;
+
+        let mut lowering = AstLowering::new_with_type_info(tc.type_info().clone());
+        let ir_program = lowering
+            .lower_program(&ast)
+            .map_err(|err| std::io::Error::other(format!("lowering failed: {err:?}")))?;
+        let mut emitter = IrEmitter::new(&ir_program.function_registry);
+        let code = emitter
+            .emit_program(&ir_program)
+            .map_err(|err| std::io::Error::other(format!("emit failed: {err:?}")))?;
+
+        assert!(
+            code.contains("Pair {") && code.contains("zeta: 1") && code.contains("alpha: 2"),
+            "expected source-named Rust struct literal in generated code; got:\n{code}"
+        );
+        assert!(
+            !code.contains("Pair(zeta = 1, alpha = 2)") && !code.contains("Pair(1, 2)"),
+            "metadata-free named Rust constructors must not emit call syntax; got:\n{code}"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "rust_inspect")]
+    #[test]
     fn test_codegen_borrows_rust_backed_method_args_from_metadata() -> Result<(), Box<dyn std::error::Error>> {
         use crate::frontend::typechecker::TypeChecker;
         use incan_core::interop::{

--- a/src/backend/ir/lower/expr/calls.rs
+++ b/src/backend/ir/lower/expr/calls.rs
@@ -1493,6 +1493,33 @@ impl AstLowering {
             if is_known_struct || is_resolved_type_name {
                 return self.lower_constructor_call(&constructor_name, type_args, args, call_span);
             }
+
+            if let Some(field_names) = self
+                .type_info
+                .as_ref()
+                .and_then(|info| info.rust_named_field_constructor_fields(call_span))
+                .map(|fields| fields.to_vec())
+            {
+                let lowered_args = self.lower_call_args(args)?;
+                let fields = field_names
+                    .into_iter()
+                    .zip(lowered_args)
+                    .map(|(field_name, arg)| (field_name, arg.expr))
+                    .collect();
+                let expr_ty = self
+                    .type_info
+                    .as_ref()
+                    .and_then(|info| info.expr_type(call_span))
+                    .map(|ty| self.lower_resolved_type(ty))
+                    .unwrap_or(IrType::Unknown);
+                return Ok((
+                    IrExprKind::Struct {
+                        name: name.clone(),
+                        fields,
+                    },
+                    expr_ty,
+                ));
+            }
         }
 
         let imported_callee_path = match &f.node {

--- a/src/frontend/typechecker/check_expr/calls.rs
+++ b/src/frontend/typechecker/check_expr/calls.rs
@@ -8,10 +8,12 @@ use crate::frontend::diagnostics::errors;
 use crate::frontend::resolved_type_subst::substitute_resolved_type;
 use crate::frontend::symbols::{FieldInfo, ResolvedType, SymbolKind, TypeInfo};
 use crate::frontend::typechecker::IdentKind;
+use incan_core::interop::{RustFieldInfo, RustItemKind, RustTypeInfo};
 use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::keywords::{self, KeywordId};
 use incan_core::lang::stdlib;
 use incan_core::lang::surface::types::{self as surface_types, SurfaceTypeId};
+use std::collections::{HashMap, HashSet};
 
 use super::TypeChecker;
 
@@ -20,6 +22,16 @@ mod builtins;
 mod constructors;
 mod generic_bounds;
 mod rust_boundary;
+
+fn rust_path_last_segment_looks_like_type(path: &str) -> bool {
+    path.rsplit("::")
+        .next()
+        .unwrap_or(path)
+        .trim_start_matches("r#")
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_uppercase())
+}
 
 impl TypeChecker {
     /// Type-check a call expression after parsing has identified the callee, explicit type arguments, and value
@@ -180,8 +192,9 @@ impl TypeChecker {
                                 return self.check_constructor(name, args, span);
                             }
                         }
-                        let explicit_constructor_ty =
-                            self.explicit_constructor_result_type(name, &type_info, type_args, span);
+                        let explicit_constructor_context =
+                            self.explicit_constructor_type_context(name, &type_info, type_args, span);
+                        let explicit_constructor_ty = explicit_constructor_context.as_ref().map(|(ty, _)| ty.clone());
                         if let TypeInfo::Model(model) = &type_info
                             && model
                                 .derives
@@ -207,9 +220,14 @@ impl TypeChecker {
                             TypeInfo::Class(info) => Some(info.fields.clone()),
                             _ => None,
                         };
-                        let Some(fields) = ctor_fields else {
+                        let Some(mut fields) = ctor_fields else {
                             return ResolvedType::Unknown;
                         };
+                        if let Some((_, type_bindings)) = &explicit_constructor_context {
+                            for field in fields.values_mut() {
+                                field.ty = substitute_resolved_type(&field.ty, type_bindings);
+                            }
+                        }
                         let constructor_ty = self.check_model_or_class_constructor_call(name, &fields, args, span);
                         self.record_expr_type(callee.span, ResolvedType::Named(name.clone()));
                         self.type_info
@@ -228,22 +246,68 @@ impl TypeChecker {
                             self.check_call_args(args);
                             return ResolvedType::Unknown;
                         }
-                        if let Some(meta) = &info.metadata
-                            && let incan_core::interop::RustItemKind::Function(sig) = &meta.kind
-                        {
-                            let error_count_before = self.errors.len();
-                            let result = self.validate_rust_function_call(info.path.as_str(), sig, args, span);
-                            if self.errors.len() == error_count_before {
-                                self.record_expr_type(
-                                    callee.span,
-                                    self.resolved_function_type_from_rust_sig(sig, false),
-                                );
-                                self.type_info
-                                    .expressions
-                                    .ident_kinds
-                                    .insert((callee.span.start, callee.span.end), IdentKind::RustImport);
+                        if let Some(meta) = &info.metadata {
+                            match &meta.kind {
+                                RustItemKind::Function(sig) => {
+                                    let error_count_before = self.errors.len();
+                                    let result = self.validate_rust_function_call(info.path.as_str(), sig, args, span);
+                                    if self.errors.len() == error_count_before {
+                                        self.record_expr_type(
+                                            callee.span,
+                                            self.resolved_function_type_from_rust_sig(sig, false),
+                                        );
+                                        self.type_info
+                                            .expressions
+                                            .ident_kinds
+                                            .insert((callee.span.start, callee.span.end), IdentKind::RustImport);
+                                    }
+                                    return result;
+                                }
+                                RustItemKind::Type(type_info) if !type_info.fields.is_empty() => {
+                                    let error_count_before = self.errors.len();
+                                    let result = self.check_rust_named_field_constructor_call(
+                                        info.path.as_str(),
+                                        type_info,
+                                        args,
+                                        span,
+                                    );
+                                    if self.errors.len() == error_count_before {
+                                        self.record_expr_type(callee.span, ResolvedType::RustPath(info.path.clone()));
+                                        self.type_info
+                                            .expressions
+                                            .ident_kinds
+                                            .insert((callee.span.start, callee.span.end), IdentKind::RustImport);
+                                    }
+                                    return result;
+                                }
+                                RustItemKind::Type(_) => {
+                                    self.check_call_args(args);
+                                    self.errors
+                                        .push(errors::rust_constructor_metadata_unavailable(info.path.as_str(), span));
+                                    return ResolvedType::Unknown;
+                                }
+                                RustItemKind::Unsupported { description } => {
+                                    self.check_call_args(args);
+                                    self.errors.push(errors::rust_item_shape_not_supported(
+                                        info.path.as_str(),
+                                        description.as_str(),
+                                        span,
+                                    ));
+                                    return ResolvedType::Unknown;
+                                }
+                                _ => {
+                                    self.check_call_args(args);
+                                    self.errors
+                                        .push(errors::rust_constructor_metadata_unavailable(info.path.as_str(), span));
+                                    return ResolvedType::Unknown;
+                                }
                             }
-                            return result;
+                        } else if rust_path_last_segment_looks_like_type(info.path.as_str()) {
+                            return self.check_metadata_free_rust_named_field_constructor_call(
+                                info.path.as_str(),
+                                args,
+                                span,
+                            );
                         }
                     }
                     // RFC 042: traits are abstract — reject `TraitName(...)` constructor syntax.
@@ -344,6 +408,166 @@ impl TypeChecker {
                 ResolvedType::Unknown
             }
         }
+    }
+
+    /// Type-check a call to an imported Rust named-field struct using rust-inspect field metadata.
+    fn check_rust_named_field_constructor_call(
+        &mut self,
+        path: &str,
+        type_info: &RustTypeInfo,
+        args: &[CallArg],
+        span: Span,
+    ) -> ResolvedType {
+        let fields_by_name: HashMap<&str, &RustFieldInfo> = type_info
+            .fields
+            .iter()
+            .map(|field| (field.name.as_str(), field))
+            .collect();
+        let mut selected_fields = Vec::with_capacity(args.len());
+        let mut provided = HashSet::new();
+        let mut positional_index = 0usize;
+        let mut has_shape_error = false;
+        let mut emitted_arity_error = false;
+
+        for arg in args {
+            match arg {
+                CallArg::Positional(expr) => {
+                    let Some(field) = type_info.fields.get(positional_index) else {
+                        self.check_expr(expr);
+                        if !emitted_arity_error {
+                            self.errors
+                                .push(errors::builtin_arity(path, type_info.fields.len(), args.len(), span));
+                            emitted_arity_error = true;
+                        }
+                        has_shape_error = true;
+                        continue;
+                    };
+                    positional_index += 1;
+                    self.check_rust_struct_field_expr(field, expr);
+                    if !provided.insert(field.name.clone()) {
+                        self.errors.push(errors::duplicate_constructor_field(
+                            path,
+                            field.name.as_str(),
+                            expr.span,
+                        ));
+                        has_shape_error = true;
+                        continue;
+                    }
+                    selected_fields.push(field.name.clone());
+                }
+                CallArg::Named(field_name, expr) => {
+                    let Some(field) = fields_by_name.get(field_name.as_str()) else {
+                        self.check_expr(expr);
+                        self.errors.push(errors::missing_field(path, field_name, expr.span));
+                        has_shape_error = true;
+                        continue;
+                    };
+                    self.check_rust_struct_field_expr(field, expr);
+                    if !provided.insert(field.name.clone()) {
+                        self.errors.push(errors::duplicate_constructor_field(
+                            path,
+                            field.name.as_str(),
+                            expr.span,
+                        ));
+                        has_shape_error = true;
+                        continue;
+                    }
+                    selected_fields.push(field.name.clone());
+                }
+                CallArg::PositionalUnpack(expr) | CallArg::KeywordUnpack(expr) => {
+                    self.check_expr(expr);
+                    if !emitted_arity_error {
+                        self.errors
+                            .push(errors::builtin_arity(path, type_info.fields.len(), args.len(), span));
+                        emitted_arity_error = true;
+                    }
+                    has_shape_error = true;
+                }
+            }
+        }
+
+        for field in &type_info.fields {
+            if !provided.contains(&field.name) {
+                self.errors.push(errors::missing_required_constructor_field(
+                    path,
+                    field.name.as_str(),
+                    span,
+                ));
+                has_shape_error = true;
+            }
+        }
+
+        if !has_shape_error {
+            self.type_info
+                .record_rust_named_field_constructor_fields(span, selected_fields);
+        }
+        ResolvedType::RustPath(path.to_string())
+    }
+
+    /// Type-check a Rust type-shaped constructor when metadata is unavailable but source names every field.
+    ///
+    /// Metadata is still required for positional construction because field order must come from Rust. Named source
+    /// arguments already carry the field names lowering needs, so this path can preserve InQL/Substrait-style protobuf
+    /// constructors without emitting invalid tuple calls.
+    fn check_metadata_free_rust_named_field_constructor_call(
+        &mut self,
+        path: &str,
+        args: &[CallArg],
+        span: Span,
+    ) -> ResolvedType {
+        let mut selected_fields = Vec::with_capacity(args.len());
+        let mut provided = HashSet::new();
+        let mut has_shape_error = false;
+        let mut emitted_metadata_error = false;
+
+        for arg in args {
+            match arg {
+                CallArg::Named(field_name, expr) => {
+                    self.check_expr(expr);
+                    if !provided.insert(field_name.clone()) {
+                        self.errors.push(errors::duplicate_constructor_field(
+                            path,
+                            field_name.as_str(),
+                            expr.span,
+                        ));
+                        has_shape_error = true;
+                        continue;
+                    }
+                    selected_fields.push(field_name.clone());
+                }
+                CallArg::Positional(expr) => {
+                    self.check_expr(expr);
+                    if !emitted_metadata_error {
+                        self.errors
+                            .push(errors::rust_constructor_metadata_unavailable(path, span));
+                        emitted_metadata_error = true;
+                    }
+                    has_shape_error = true;
+                }
+                CallArg::PositionalUnpack(expr) | CallArg::KeywordUnpack(expr) => {
+                    self.check_expr(expr);
+                    if !emitted_metadata_error {
+                        self.errors
+                            .push(errors::rust_constructor_metadata_unavailable(path, span));
+                        emitted_metadata_error = true;
+                    }
+                    has_shape_error = true;
+                }
+            }
+        }
+
+        if !has_shape_error {
+            self.type_info
+                .record_rust_named_field_constructor_fields(span, selected_fields);
+            return ResolvedType::RustPath(path.to_string());
+        }
+        ResolvedType::Unknown
+    }
+
+    /// Type-check a Rust struct field argument with the metadata-provided target type as context.
+    fn check_rust_struct_field_expr(&mut self, field: &RustFieldInfo, expr: &Spanned<Expr>) -> ResolvedType {
+        let expected = self.resolved_type_from_rust_shape(&field.type_shape);
+        self.check_expr_with_expected(expr, Some(&expected))
     }
 
     /// Type-check RFC 047 graph direct constructors (`DiGraph[T]()`, `Dag[T]()`, `MultiDiGraph[T]()`).

--- a/src/frontend/typechecker/check_expr/calls/constructors.rs
+++ b/src/frontend/typechecker/check_expr/calls/constructors.rs
@@ -3,6 +3,7 @@
 use super::TypeChecker;
 use crate::frontend::ast::{CallArg, Expr, ParamKind, Span, Spanned, Type};
 use crate::frontend::diagnostics::errors;
+use crate::frontend::resolved_type_subst::type_param_subst_map_call_site;
 use crate::frontend::symbols::{CallableParam, FieldInfo, ResolvedType, SymbolKind, TypeInfo, ValueEnumInfo};
 use crate::frontend::typechecker::helpers::option_ty;
 use incan_core::lang::surface::types::{self as surface_types, SurfaceTypeId};
@@ -223,14 +224,14 @@ impl TypeChecker {
         self.constructor_result_type_with_bindings(name, &std::collections::HashMap::new())
     }
 
-    /// Compute a constructor result type from explicit call-site type arguments.
-    pub(in crate::frontend::typechecker::check_expr::calls) fn explicit_constructor_result_type(
+    /// Resolve explicit constructor type arguments and build the type-parameter bindings they imply.
+    pub(in crate::frontend::typechecker::check_expr::calls) fn explicit_constructor_type_context(
         &mut self,
         name: &str,
         type_info: &TypeInfo,
         type_args: &[Spanned<Type>],
         span: Span,
-    ) -> Option<ResolvedType> {
+    ) -> Option<(ResolvedType, std::collections::HashMap<String, ResolvedType>)> {
         if type_args.is_empty() {
             return None;
         }
@@ -248,12 +249,11 @@ impl TypeChecker {
                 type_args.len(),
                 span,
             ));
-            return Some(ResolvedType::Unknown);
+            return Some((ResolvedType::Unknown, std::collections::HashMap::new()));
         }
-        Some(ResolvedType::Generic(
-            name.to_string(),
-            type_args.iter().map(|ty| self.resolve_type_checked(ty)).collect(),
-        ))
+        let resolved_args: Vec<ResolvedType> = type_args.iter().map(|ty| self.resolve_type_checked(ty)).collect();
+        let bindings = type_param_subst_map_call_site(type_params, &resolved_args);
+        Some((ResolvedType::Generic(name.to_string(), resolved_args), bindings))
     }
 
     /// Compute the constructor result surface type, substituting any generic bindings inferred from constructor fields.

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -18,7 +18,7 @@ mod stdlib_imports;
 
 use self::decl_helpers::{
     collect_fields, collect_method_aliases, collect_method_overloads, collect_methods_from_overloads,
-    collect_properties, inject_validate_methods,
+    collect_properties, inject_validate_methods, owner_resolved_type, resolve_declared_type, type_param_name_set,
 };
 
 type InheritedMembers = (
@@ -441,7 +441,7 @@ impl TypeChecker {
 
     /// Register a model declaration with its fields, methods, and derived traits.
     fn collect_model(&mut self, model: &ModelDecl, span: Span) {
-        let fields = collect_fields(&model.fields, self, &model.name);
+        let fields = collect_fields(&model.fields, self, &model.name, &model.type_params);
         let properties = collect_properties(&model.properties, self, Some(&model.name), &model.type_params);
         let mut method_overloads =
             collect_method_overloads(&model.methods, self, Some(&model.name), &model.type_params);
@@ -459,7 +459,8 @@ impl TypeChecker {
         );
         let method_aliases = collect_method_aliases(&model.method_aliases, &mut methods, &mut method_overloads);
         self.collect_method_partials(&model.name, &model.method_partials, &mut methods, &mut method_overloads);
-        let mut trait_adoptions = self.collect_trait_adoption_infos(&model.traits);
+        let mut trait_adoptions =
+            self.collect_trait_adoption_infos(&model.traits, Some(&model.name), &model.type_params);
         trait_adoptions.extend(self.collect_derive_trait_adoption_infos(&derives));
 
         self.symbols.define(Symbol {
@@ -485,7 +486,7 @@ impl TypeChecker {
         let (mut fields, mut properties, mut methods, mut method_overloads) = self.inherit_from_parent(&class.extends);
 
         // Add own fields (can override inherited ones)
-        fields.extend(collect_fields(&class.fields, self, &class.name));
+        fields.extend(collect_fields(&class.fields, self, &class.name, &class.type_params));
         properties.extend(collect_properties(
             &class.properties,
             self,
@@ -502,7 +503,8 @@ impl TypeChecker {
         let derives = self.extract_derive_names(&class.decorators);
         let method_aliases = collect_method_aliases(&class.method_aliases, &mut methods, &mut method_overloads);
         self.collect_method_partials(&class.name, &class.method_partials, &mut methods, &mut method_overloads);
-        let mut trait_adoptions = self.collect_trait_adoption_infos(&class.traits);
+        let mut trait_adoptions =
+            self.collect_trait_adoption_infos(&class.traits, Some(&class.name), &class.type_params);
         trait_adoptions.extend(self.collect_derive_trait_adoption_infos(&derives));
 
         self.symbols.define(Symbol {
@@ -541,7 +543,14 @@ impl TypeChecker {
     }
 
     /// Resolve direct trait adoptions, retaining generic trait arguments for later dispatch checks.
-    fn collect_trait_adoption_infos(&mut self, traits: &[Spanned<TraitBound>]) -> Vec<TypeBoundInfo> {
+    fn collect_trait_adoption_infos(
+        &mut self,
+        traits: &[Spanned<TraitBound>],
+        owner_name: Option<&str>,
+        owner_type_params: &[TypeParam],
+    ) -> Vec<TypeBoundInfo> {
+        let active_type_params = type_param_name_set(owner_type_params, &[]);
+        let owner_self_ty = owner_name.map(|name| owner_resolved_type(name, owner_type_params));
         traits
             .iter()
             .map(|trait_ref| {
@@ -553,7 +562,9 @@ impl TypeChecker {
                         .node
                         .type_args
                         .iter()
-                        .map(|arg| self.resolve_type_checked(arg))
+                        .map(|arg| {
+                            resolve_declared_type(self, arg, &active_type_params, owner_name, owner_self_ty.as_ref())
+                        })
                         .collect(),
                     module_path,
                 }
@@ -1002,7 +1013,7 @@ impl TypeChecker {
                     .map(|target| (rebinding.node.name.clone(), target))
             })
             .collect();
-        let trait_adoptions = self.collect_trait_adoption_infos(&nt.traits);
+        let trait_adoptions = self.collect_trait_adoption_infos(&nt.traits, Some(&nt.name), &nt.type_params);
 
         // Define a placeholder symbol FIRST so methods can reference the newtype name
         self.symbols.define(Symbol {
@@ -1117,7 +1128,7 @@ impl TypeChecker {
                 .collect(),
         });
 
-        let mut trait_adoptions = self.collect_trait_adoption_infos(&en.traits);
+        let mut trait_adoptions = self.collect_trait_adoption_infos(&en.traits, Some(&en.name), &en.type_params);
         trait_adoptions.extend(self.collect_derive_trait_adoption_infos(&derives));
         self.symbols.define(Symbol {
             name: en.name.clone(),

--- a/src/frontend/typechecker/collect/decl_helpers.rs
+++ b/src/frontend/typechecker/collect/decl_helpers.rs
@@ -1,6 +1,6 @@
 //! Collection helpers for the first pass (fields/methods + derive-driven injections).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::frontend::ast::*;
 use crate::frontend::symbols::{CallableParam, FieldInfo, MethodInfo, PropertyInfo, ResolvedType, TypeBoundInfo};
@@ -11,7 +11,7 @@ use incan_core::lang::derives::{self, DeriveId};
 ///
 /// During first-pass collection the owner type symbol is not yet registered, so simple self-references like `->
 /// Session` would otherwise fall back to `TypeVar("Session")`.
-fn owner_resolved_type(owner_name: &str, owner_type_params: &[TypeParam]) -> ResolvedType {
+pub(super) fn owner_resolved_type(owner_name: &str, owner_type_params: &[TypeParam]) -> ResolvedType {
     if owner_type_params.is_empty() {
         return ResolvedType::Named(owner_name.to_string());
     }
@@ -106,13 +106,85 @@ fn resolve_owner_self_reference(
     }
 }
 
+pub(super) fn type_param_name_set(
+    owner_type_params: &[TypeParam],
+    method_type_params: &[TypeParam],
+) -> HashSet<String> {
+    owner_type_params
+        .iter()
+        .chain(method_type_params.iter())
+        .map(|param| param.name.clone())
+        .collect()
+}
+
+fn shadow_declared_type_params(ty: ResolvedType, type_param_names: &HashSet<String>) -> ResolvedType {
+    match ty {
+        ResolvedType::Named(name) | ResolvedType::TypeVar(name) if type_param_names.contains(&name) => {
+            ResolvedType::TypeVar(name)
+        }
+        ResolvedType::Generic(name, args) => ResolvedType::Generic(
+            name,
+            args.into_iter()
+                .map(|arg| shadow_declared_type_params(arg, type_param_names))
+                .collect(),
+        ),
+        ResolvedType::Function(params, ret) => ResolvedType::Function(
+            params
+                .into_iter()
+                .map(|param| CallableParam {
+                    name: param.name,
+                    ty: shadow_declared_type_params(param.ty, type_param_names),
+                    kind: param.kind,
+                    has_default: param.has_default,
+                })
+                .collect(),
+            Box::new(shadow_declared_type_params(*ret, type_param_names)),
+        ),
+        ResolvedType::Tuple(items) => ResolvedType::Tuple(
+            items
+                .into_iter()
+                .map(|item| shadow_declared_type_params(item, type_param_names))
+                .collect(),
+        ),
+        ResolvedType::FrozenList(inner) => {
+            ResolvedType::FrozenList(Box::new(shadow_declared_type_params(*inner, type_param_names)))
+        }
+        ResolvedType::FrozenSet(inner) => {
+            ResolvedType::FrozenSet(Box::new(shadow_declared_type_params(*inner, type_param_names)))
+        }
+        ResolvedType::FrozenDict(key, value) => ResolvedType::FrozenDict(
+            Box::new(shadow_declared_type_params(*key, type_param_names)),
+            Box::new(shadow_declared_type_params(*value, type_param_names)),
+        ),
+        ResolvedType::Ref(inner) => ResolvedType::Ref(Box::new(shadow_declared_type_params(*inner, type_param_names))),
+        ResolvedType::RefMut(inner) => {
+            ResolvedType::RefMut(Box::new(shadow_declared_type_params(*inner, type_param_names)))
+        }
+        other => other,
+    }
+}
+
+pub(super) fn resolve_declared_type(
+    checker: &mut TypeChecker,
+    ty: &Spanned<Type>,
+    type_param_names: &HashSet<String>,
+    owner_name: Option<&str>,
+    owner_self_ty: Option<&ResolvedType>,
+) -> ResolvedType {
+    let resolved = checker.resolve_type_checked(ty);
+    let resolved = shadow_declared_type_params(resolved, type_param_names);
+    resolve_owner_self_reference(resolved, owner_name, owner_self_ty)
+}
+
 /// Build method symbol metadata from one declared method while resolving owner `Self` references.
 fn method_info_from_decl(
     method: &Spanned<MethodDecl>,
     checker: &mut TypeChecker,
     owner_name: Option<&str>,
+    owner_type_params: &[TypeParam],
     owner_self_ty: Option<&ResolvedType>,
 ) -> MethodInfo {
+    let active_type_params = type_param_name_set(owner_type_params, &method.node.type_params);
     let type_params: Vec<String> = method.node.type_params.iter().map(|tp| tp.name.clone()).collect();
     let type_param_bounds: HashMap<String, Vec<String>> = method
         .node
@@ -144,11 +216,7 @@ fn method_info_from_decl(
                             .type_args
                             .iter()
                             .map(|type_arg| {
-                                resolve_owner_self_reference(
-                                    checker.resolve_type_checked(type_arg),
-                                    owner_name,
-                                    owner_self_ty,
-                                )
+                                resolve_declared_type(checker, type_arg, &active_type_params, owner_name, owner_self_ty)
                             })
                             .collect(),
                         module_path: checker.trait_bound_module_path(&bound.name),
@@ -164,14 +232,16 @@ fn method_info_from_decl(
         .map(|p| {
             CallableParam::named_with_default(
                 p.node.name.clone(),
-                resolve_owner_self_reference(checker.resolve_type_checked(&p.node.ty), owner_name, owner_self_ty),
+                resolve_declared_type(checker, &p.node.ty, &active_type_params, owner_name, owner_self_ty),
                 p.node.kind,
                 p.node.default.is_some(),
             )
         })
         .collect();
-    let return_type = resolve_owner_self_reference(
-        checker.resolve_type_checked(&method.node.return_type),
+    let return_type = resolve_declared_type(
+        checker,
+        &method.node.return_type,
+        &active_type_params,
         owner_name,
         owner_self_ty,
     );
@@ -182,9 +252,7 @@ fn method_info_from_decl(
             .node
             .type_args
             .iter()
-            .map(|type_arg| {
-                resolve_owner_self_reference(checker.resolve_type_checked(type_arg), owner_name, owner_self_ty)
-            })
+            .map(|type_arg| resolve_declared_type(checker, type_arg, &active_type_params, owner_name, owner_self_ty))
             .collect(),
         module_path: checker.trait_bound_module_path(&target.node.name),
     });
@@ -219,6 +287,7 @@ pub(super) fn collect_method_overloads(
                 method,
                 checker,
                 owner_name,
+                owner_type_params,
                 owner_self_ty.as_ref(),
             ));
     }
@@ -293,14 +362,23 @@ pub(super) fn collect_fields(
     fields: &[Spanned<FieldDecl>],
     checker: &mut TypeChecker,
     owner: &str,
+    owner_type_params: &[TypeParam],
 ) -> HashMap<String, FieldInfo> {
+    let owner_self_ty = owner_resolved_type(owner, owner_type_params);
+    let active_type_params = type_param_name_set(owner_type_params, &[]);
     fields
         .iter()
         .map(|f| {
             (
                 f.node.name.clone(),
                 FieldInfo {
-                    ty: checker.resolve_type_checked(&f.node.ty),
+                    ty: resolve_declared_type(
+                        checker,
+                        &f.node.ty,
+                        &active_type_params,
+                        Some(owner),
+                        Some(&owner_self_ty),
+                    ),
                     visibility: f.node.visibility,
                     owner: Some(owner.to_string()),
                     has_default: f.node.default.is_some(),
@@ -320,14 +398,17 @@ pub(super) fn collect_properties(
     owner_type_params: &[TypeParam],
 ) -> HashMap<String, PropertyInfo> {
     let owner_self_ty = owner_name.map(|name| owner_resolved_type(name, owner_type_params));
+    let active_type_params = type_param_name_set(owner_type_params, &[]);
     properties
         .iter()
         .map(|property| {
             (
                 property.node.name.clone(),
                 PropertyInfo {
-                    return_type: resolve_owner_self_reference(
-                        checker.resolve_type_checked(&property.node.return_type),
+                    return_type: resolve_declared_type(
+                        checker,
+                        &property.node.return_type,
+                        &active_type_params,
                         owner_name,
                         owner_self_ty.as_ref(),
                     ),

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3308,6 +3308,44 @@ def f() -> None:
     Ok(())
 }
 
+#[test]
+fn test_imported_rust_type_like_constructor_without_metadata_is_rejected() {
+    let source = r#"
+from rust::std::ops import Range
+
+def f() -> None:
+  _ = Range(1, 3)
+"#;
+    let errs = check_str_err(source, "expected Rust constructor metadata diagnostic");
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("Cannot construct imported Rust item") && e.message.contains("std::ops::Range")),
+        "expected Rust constructor metadata diagnostic, got {errs:?}"
+    );
+}
+
+#[test]
+fn test_imported_rust_function_without_metadata_stays_permissive() {
+    let source = r#"
+from rust::std::fs import read_to_string
+
+def f() -> None:
+  _ = read_to_string("input.csv")
+"#;
+    assert!(check_str(source).is_ok());
+}
+
+#[test]
+fn test_imported_rust_named_constructor_without_metadata_stays_permissive() {
+    let source = r#"
+from rust::std::ops import Range
+
+def f() -> None:
+  _ = Range(start=1, end=3)
+"#;
+    assert!(check_str(source).is_ok());
+}
+
 /// Field access on a Rust type that isn't a known inherent associated function should be permissive
 /// (metadata only covers inherent methods, not consts, type aliases, or trait-provided items).
 #[test]
@@ -7507,6 +7545,25 @@ pub def get_value[T](boxed: Boxed[T]) -> T:
 }
 
 #[test]
+fn test_explicit_generic_model_constructor_args_specialize_field_types() {
+    let source = r#"
+pub trait Iterator[T]:
+  def __next__(mut self) -> Option[T]: ...
+
+  def zip[U](self, other: Iterator[U]) -> Iterator[tuple[T, U]]:
+    return ZipIterator[T, Self, U, Iterator[U]](left=self, right=other)
+
+pub model ZipIterator[T, Left with Iterator[T], U, Right with Iterator[U]] with Iterator[tuple[T, U]]:
+  left: Left
+  right: Right
+
+  def __next__(mut self) -> Option[tuple[T, U]]:
+    return None
+"#;
+    assert!(check_str(source).is_ok());
+}
+
+#[test]
 fn test_generic_class_field_access_substitutes_nested_field_type() {
     let source = r#"
 pub class Boxed[T]:
@@ -7514,6 +7571,29 @@ pub class Boxed[T]:
 
 pub def get_values[T](boxed: Boxed[T]) -> List[T]:
   return boxed.values
+"#;
+    assert!(check_str(source).is_ok());
+}
+
+#[test]
+fn test_generic_model_field_type_params_shadow_value_variants() {
+    let source = r#"
+pub enum JoinSide:
+  Left
+  Right
+
+pub trait Iterator[T]:
+  def __next__(mut self) -> Option[T]: ...
+
+  def zip[U](self, other: Iterator[U]) -> Iterator[tuple[T, U]]:
+    return ZipIterator[T, Self, U, Iterator[U]](left=self, right=other)
+
+pub model ZipIterator[T, Left with Iterator[T], U, Right with Iterator[U]] with Iterator[tuple[T, U]]:
+  left: Left
+  right: Right
+
+  def __next__(mut self) -> Option[tuple[T, U]]:
+    return None
 "#;
     assert!(check_str(source).is_ok());
 }

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -166,6 +166,12 @@ pub struct RustInteropArtifacts {
     /// Keyed by `(receiver_span.start, receiver_span.end, method_name)` so lowering can preserve borrow-sensitive
     /// lookup calls like `HashMap.get(key)` without re-querying rust-inspect metadata in the backend.
     pub regular_method_arg_shape_preserving_calls: HashSet<(usize, usize, String)>,
+    /// Imported Rust named-field struct constructor calls keyed by full call-expression span.
+    ///
+    /// The frontend resolves positional source arguments against rust-inspect field metadata. Lowering consumes the
+    /// resolved field names so `Range(1, 3)` can emit `Range { start: 1, end: 3 }` instead of an invalid tuple-style
+    /// Rust constructor.
+    pub named_field_constructor_fields: HashMap<(usize, usize), Vec<String>>,
 }
 
 /// Declaration-level binding rewrites and visibility facts consumed by lowering.
@@ -554,6 +560,21 @@ impl TypeCheckInfo {
             receiver_span.end,
             method.to_string(),
         ));
+    }
+
+    /// Return the Rust struct field names selected for this named-field constructor call, if any.
+    pub fn rust_named_field_constructor_fields(&self, span: Span) -> Option<&[String]> {
+        self.rust
+            .named_field_constructor_fields
+            .get(&(span.start, span.end))
+            .map(Vec::as_slice)
+    }
+
+    /// Record the Rust struct field names selected for a named-field constructor call.
+    pub(crate) fn record_rust_named_field_constructor_fields(&mut self, span: Span, fields: Vec<String>) {
+        self.rust
+            .named_field_constructor_fields
+            .insert((span.start, span.end), fields);
     }
 
     /// Return rest-aware callable metadata recorded for the full call expression span, if any.


### PR DESCRIPTION
## Summary

This PR fixes two InQL-blocking compiler regressions: explicit generic model constructors now validate fields with call-site type argument substitutions, and imported Rust named-field struct constructors now lower as Rust struct literals instead of invalid positional calls. It also preserves Rust field declaration order in rust-inspect metadata and keeps metadata-free named Rust constructors usable by lowering source field names while still rejecting metadata-free positional construction.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Incan code using explicit generic constructors like the stdlib `ZipIterator[...]` path no longer misvalidates generic fields against ambient symbols, and InQL-style named Rust protobuf constructors now emit valid Rust struct literals.
- **Internals**: Constructor typechecking now carries explicit type-parameter bindings into field validation. Declaration collection resolves owner type-parameter names before ambient symbols across fields, properties, methods, and trait adoptions. Rust constructor lowering records frontend-selected field names and uses rust-inspect declaration order or source-named fields when metadata is unavailable.
- **Risks**: The Rust interop fallback intentionally remains permissive for metadata-free lower-case Rust calls, but metadata-free type-shaped positional construction is now rejected until field order can be proven.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` reached `✓ Pre-commit checks passed (full)`: fmt-check, rustdoc, 2399/2399 tests, clippy, and cargo-deny passed. Its trailing `smoke-test-fast` phase initially hit local disk exhaustion.
- Cleaned this worktree's generated `target` artifacts and reran `make smoke-test-fast`: passed.
- `cargo build -p incan`: passed before commit.
- Focused #604/#605 regression tests cover explicit generic constructor substitution, type-parameter shadowing, metadata-backed Rust named constructors, metadata-free named constructors, metadata-free Rust functions, and metadata-free positional rejection.
- InQL `make build incan` now gets past #604/#605 and stops on separate InQL v0.3 source update diagnostics.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): …

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #604
Closes #605
