### PR TITLE
bugfix - preserve by-value generic Rust call arguments (#609)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "axum",
  "incan_core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-dev.50"
+version = "0.3.0-dev.51"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -332,19 +332,14 @@ impl<'a> IrEmitter<'a> {
                 );
                 let external_call_arg_shape = matches!(base_use_site, ValueUseSite::ExternalCallArg { .. });
                 let arg_use_site = match (base_use_site, param) {
-                    (ValueUseSite::ExternalCallArg { .. }, Some(param)) if !matches!(&param.ty, IrType::Generic(_)) => {
-                        ValueUseSite::ExternalCallArg {
-                            target_ty: Some(&param.ty),
-                        }
-                    }
+                    (ValueUseSite::ExternalCallArg { .. }, Some(param)) => ValueUseSite::ExternalCallArg {
+                        target_ty: Some(&param.ty),
+                    },
                     (ValueUseSite::IncanCallArg { in_return, .. }, Some(param)) => ValueUseSite::IncanCallArg {
                         target_ty: Some(&param.ty),
                         callee_param: Some(param),
                         in_return,
                     },
-                    _ if external_method_shape && matches!(param.map(|param| &param.ty), Some(IrType::Generic(_))) => {
-                        ValueUseSite::MethodArg
-                    }
                     _ => base_use_site,
                 };
                 let previous_qualify = if *from_default {

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -1228,6 +1228,73 @@ mod tests {
     }
 
     #[test]
+    fn external_decode_with_generic_by_value_signature_does_not_borrow_argument() -> Result<(), String> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let descriptor_set = IrType::Struct("prost_types::FileDescriptorSet".to_string());
+        let expr = TypedExpr::new(
+            IrExprKind::MethodCall {
+                receiver: Box::new(TypedExpr::new(
+                    IrExprKind::Var {
+                        name: "FileDescriptorSet".to_string(),
+                        access: VarAccess::Copy,
+                        ref_kind: VarRefKind::ExternalRustName,
+                    },
+                    descriptor_set.clone(),
+                )),
+                method: "decode".to_string(),
+                dispatch: None,
+                type_args: Vec::new(),
+                args: vec![IrCallArg {
+                    name: None,
+                    kind: IrCallArgKind::Positional,
+                    expr: TypedExpr::new(
+                        IrExprKind::Var {
+                            name: "cursor".to_string(),
+                            access: VarAccess::Move,
+                            ref_kind: VarRefKind::Value,
+                        },
+                        IrType::Struct("std::io::Cursor<Vec<u8>>".to_string()),
+                    ),
+                }],
+                callable_signature: Some(FunctionSignature {
+                    params: vec![FunctionParam {
+                        name: "buf".to_string(),
+                        ty: IrType::Generic("Buf".to_string()),
+                        mutability: Mutability::Immutable,
+                        is_self: false,
+                        kind: crate::frontend::ast::ParamKind::Normal,
+                        default: None,
+                    }],
+                    return_type: IrType::Result(
+                        Box::new(descriptor_set.clone()),
+                        Box::new(IrType::Struct("prost::DecodeError".to_string())),
+                    ),
+                }),
+                arg_policy: MethodCallArgPolicy::Default,
+            },
+            IrType::Result(
+                Box::new(descriptor_set),
+                Box::new(IrType::Struct("prost::DecodeError".to_string())),
+            ),
+        );
+
+        let emitted = emitter
+            .emit_expr(&expr)
+            .map_err(|err| format!("expected successful expression emission, got {err:?}"))?;
+        let rendered = emitted.to_string();
+        assert!(
+            rendered.contains("FileDescriptorSet :: decode (cursor)"),
+            "generic by-value Rust method params must pass the value directly, got `{rendered}`"
+        );
+        assert!(
+            !rendered.contains("FileDescriptorSet :: decode (& cursor)"),
+            "generic by-value Rust method params must not borrow the argument, got `{rendered}`"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn interop_try_adapter_emits_question_mark() -> Result<(), String> {
         let registry = FunctionRegistry::new();
         let emitter = IrEmitter::new(&registry);

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -269,6 +269,9 @@ impl TypeChecker {
     /// boundary adapters.
     fn rust_arg_boundary_match(&self, arg_ty: &ResolvedType, rust_param_ty: &str) -> RustArgBoundaryMatch {
         let normalized = rust_param_ty.replace(' ', "");
+        if Self::rust_display_type_var_name(normalized.as_str()).is_some() {
+            return RustArgBoundaryMatch::Exact;
+        }
         let borrowed_shared = matches!(Self::rust_display_borrow_kind(normalized.as_str()), Some((false, _)));
         if let Some((is_mut, inner)) = Self::rust_display_borrow_kind(normalized.as_str()) {
             if Self::is_rust_generic_type_param_display(inner)
@@ -331,7 +334,12 @@ impl TypeChecker {
                 CallableParam::positional(self.resolved_param_type_from_rust_display(param.type_display.as_str()))
             })
             .collect();
-        self.type_info.record_call_site_callable_params(span, &params);
+        // Plain Rust type variables carry by-value shape, but they are not ordinary borrow-boundary snapshots.
+        if params.iter().any(|param| matches!(param.ty, ResolvedType::TypeVar(_))) {
+            self.type_info.record_call_site_callable_params_exact(span, &params);
+        } else {
+            self.type_info.record_call_site_callable_params(span, &params);
+        }
     }
 
     /// Return whether a lookup-style Rust method should preserve the probe argument's emitted shape.
@@ -990,8 +998,52 @@ mod validate_rust_function_call_tests {
     fn borrowed_generic_rust_function_param_accepts_owned_incan_value() {
         let checker = TypeChecker::new();
 
+        assert!(checker.rust_arg_matches_boundary(&ResolvedType::Named("Payload".to_string()), "T",));
         assert!(checker.rust_arg_matches_boundary(&ResolvedType::Named("Payload".to_string()), "&T",));
         assert!(checker.rust_arg_matches_boundary(&ResolvedType::Named("Payload".to_string()), "&TValue",));
+    }
+
+    #[test]
+    fn validate_rust_method_call_records_by_value_generic_param_shape() {
+        let mut checker = TypeChecker::new();
+        let span = Span::new(30, 40);
+        let arg_expr = Spanned::new(Expr::Ident("cursor".to_string()), span);
+        let args = [CallArg::Positional(arg_expr)];
+        let arg_types = [ResolvedType::RustPath("std::io::Cursor<Vec<u8>>".to_string())];
+        let sig = RustFunctionSig {
+            params: vec![RustParam {
+                name: Some("buf".to_string()),
+                type_display: "T".to_string(),
+            }],
+            return_type: "demo::FileDescriptorSet".to_string(),
+            is_async: false,
+            is_unsafe: false,
+        };
+
+        let _ = checker.validate_rust_method_call(
+            "rust::demo::FileDescriptorSet.decode",
+            &sig,
+            &args,
+            &arg_types,
+            false,
+            span,
+        );
+
+        assert!(
+            checker.errors.is_empty(),
+            "expected by-value Rust generic param to accept the owned argument, got {:?}",
+            checker.errors
+        );
+        assert!(
+            checker
+                .type_info
+                .calls
+                .call_site_callable_params
+                .get(&(span.start, span.end))
+                .is_some_and(|params| params.len() == 1 && params[0].ty == ResolvedType::TypeVar("T".to_string())),
+            "expected Rust by-value generic method param shape to be recorded, got {:?}",
+            checker.type_info.calls.call_site_callable_params
+        );
     }
 
     #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -663,6 +663,76 @@ edition = "2021"
 }
 
 #[test]
+fn run_accepts_by_value_generic_decode_rust_param_issue609() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "cli_by_value_generic_decode_project",
+        r#"
+
+[rust-dependencies]
+decode_helper = { path = "rust/decode_helper" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::decode_helper import FileDescriptorSet
+from rust::std::io import Cursor
+
+
+def main() -> None:
+  mut cursor = Cursor.new(b"abc")
+  match FileDescriptorSet.decode(cursor):
+    Ok(_) => println("ok")
+    Err(_) => println("err")
+"#,
+    )?;
+    let helper_src = tmp.path().join("rust").join("decode_helper").join("src");
+    fs::create_dir_all(&helper_src)?;
+    fs::write(
+        helper_src
+            .parent()
+            .ok_or("helper src has no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "decode_helper"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        helper_src.join("lib.rs"),
+        r#"pub trait DecodeBuf {}
+
+impl DecodeBuf for std::io::Cursor<Vec<u8>> {}
+
+pub struct DecodeError;
+
+pub struct FileDescriptorSet;
+
+impl FileDescriptorSet {
+    pub fn decode<T: DecodeBuf>(_buf: T) -> Result<Self, DecodeError> {
+        Ok(Self)
+    }
+}
+"#,
+    )?;
+
+    let output = run_incan(
+        tmp.path(),
+        &["run", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+
+    assert_success(&output, "incan run with by-value generic decode Rust param");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("ok"),
+        "expected by-value generic decode helper output, got:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn build_locked_rejects_stale_lockfile() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "cli_locked_project", "")?;

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -593,6 +593,8 @@ The sections above are the release story. The list below is the detailed invento
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.48`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.49`.
 - **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.50`.
+- **Compiler/Rust interop**: Metadata-backed external Rust calls now preserve inspected generic by-value parameters, so prost-style `decode<T: Buf>(buf: T)` calls pass owned cursors directly instead of generating an invalid shared borrow (#609).
+- **Project metadata**: Workspace package metadata and Cargo lock entries now identify the development line as `0.3.0-dev.51`.
 
 ## Known limitations (0.3)
 


### PR DESCRIPTION
## Summary

This PR fixes Rust interop call emission for metadata-backed associated functions whose inspected signature takes a generic parameter by value, such as `decode<T: Buf>(buf: T)`. The typechecker now preserves plain Rust type variables as exact by-value call-site parameters and the backend honors that explicit external signature, so owned cursor arguments are passed directly instead of being fallback-borrowed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Rust interop calls to prost-style decode methods, for example `FileDescriptorSet.decode(cursor)`, now pass owned cursor values directly when the Rust signature accepts `T: Buf` by value.
- **Internals**: Rust boundary matching now treats direct Rust type variables as exact by-value parameter matches, records exact call-site parameter shape only when inspected params contain `TypeVar`, and method emission keeps explicit external generic params on the external call-arg path.
- **Risks**: The touched paths affect Rust interop argument shaping. The main risk is a regression in borrow/coercion decisions for external Rust calls; focused regressions and the full local gate cover the by-value generic path and adjacent Rust interop behavior.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed after the final commit, including formatting, rustdoc, 2435 nextest tests, LSP focused tests, clippy, cargo-deny, and smoke-test-fast.
- Focused regression coverage added for frontend Rust boundary metadata, backend method emission, and an end-to-end CLI project using a local `decode<T: DecodeBuf>(T)` helper crate.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #609