### PR TITLE
bugfix - use Rust trait metadata for decode argument shape (#612)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc0"
+version = "0.3.0-rc1"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -233,6 +233,34 @@ impl<'a> IrEmitter<'a> {
         )
     }
 
+    /// Return whether an argument expression already emits Rust reference-shaped tokens.
+    ///
+    /// The frontend keeps `bytes.as_slice()` typed as `bytes` because Incan does not expose Rust slice types directly.
+    /// During Rust emission, however, that call is already a borrowed view. External fallback borrowing must not wrap
+    /// it again or Rust receives `&&[u8]`.
+    fn method_arg_already_has_reference_shape(arg: &TypedExpr) -> bool {
+        if Self::method_arg_already_borrowed_for_ref_param(&arg.ty) {
+            return true;
+        }
+        let IrExprKind::MethodCall {
+            receiver, method, args, ..
+        } = &arg.kind
+        else {
+            return false;
+        };
+        if !args.is_empty() {
+            return false;
+        }
+        match method.as_str() {
+            "as_slice" => matches!(&receiver.ty, IrType::Bytes | IrType::StaticBytes | IrType::FrozenBytes),
+            "as_bytes" | "as_str" => matches!(
+                &receiver.ty,
+                IrType::String | IrType::StaticStr | IrType::FrozenStr | IrType::StrRef
+            ),
+            _ => false,
+        }
+    }
+
     /// Emit method-call arguments with Rust-boundary borrowing and union wrapping applied from callable metadata.
     fn emit_method_call_args(
         &self,
@@ -395,6 +423,7 @@ impl<'a> IrEmitter<'a> {
                     } else if external_method_shape
                         && idx == 0
                         && Self::method_arg_needs_fallback_borrow(method, &arg.ty)
+                        && !Self::method_arg_already_has_reference_shape(arg)
                     {
                         emitted = quote! { &#emitted };
                     }
@@ -420,6 +449,7 @@ impl<'a> IrEmitter<'a> {
                     && !external_param_planned
                     && idx == 0
                     && Self::method_arg_needs_fallback_borrow(method, &arg.ty)
+                    && !Self::method_arg_already_has_reference_shape(arg)
                 {
                     return Ok(quote! { &#emitted });
                 }
@@ -427,7 +457,7 @@ impl<'a> IrEmitter<'a> {
                     match &param.ty {
                         IrType::Ref(_) if matches!(base_use_site, ValueUseSite::MethodArg) => {}
                         IrType::Ref(_) => match &arg.ty {
-                            _ if Self::method_arg_already_borrowed_for_ref_param(&arg.ty) => {}
+                            _ if Self::method_arg_already_has_reference_shape(arg) => {}
                             _ => emitted = quote! { &#emitted },
                         },
                         IrType::RefMut(_) => match &arg.ty {

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -233,32 +233,9 @@ impl<'a> IrEmitter<'a> {
         )
     }
 
-    /// Return whether an argument expression already emits Rust reference-shaped tokens.
-    ///
-    /// The frontend keeps `bytes.as_slice()` typed as `bytes` because Incan does not expose Rust slice types directly.
-    /// During Rust emission, however, that call is already a borrowed view. External fallback borrowing must not wrap
-    /// it again or Rust receives `&&[u8]`.
+    /// Return whether an argument expression already has Rust reference shape in IR.
     fn method_arg_already_has_reference_shape(arg: &TypedExpr) -> bool {
-        if Self::method_arg_already_borrowed_for_ref_param(&arg.ty) {
-            return true;
-        }
-        let IrExprKind::MethodCall {
-            receiver, method, args, ..
-        } = &arg.kind
-        else {
-            return false;
-        };
-        if !args.is_empty() {
-            return false;
-        }
-        match method.as_str() {
-            "as_slice" => matches!(&receiver.ty, IrType::Bytes | IrType::StaticBytes | IrType::FrozenBytes),
-            "as_bytes" | "as_str" => matches!(
-                &receiver.ty,
-                IrType::String | IrType::StaticStr | IrType::FrozenStr | IrType::StrRef
-            ),
-            _ => false,
-        }
+        Self::method_arg_already_borrowed_for_ref_param(&arg.ty)
     }
 
     /// Emit method-call arguments with Rust-boundary borrowing and union wrapping applied from callable metadata.
@@ -437,21 +414,6 @@ impl<'a> IrEmitter<'a> {
                         self.external_list_arg_element_coercion(arg, Some(&param.ty), emitted.clone())
                 {
                     emitted = coerced;
-                }
-                if external_method_shape
-                    && !external_param_planned
-                    && idx == 0
-                    && Self::method_arg_needs_fallback_mut_borrow(method, &arg.ty)
-                {
-                    return Ok(quote! { &mut #emitted });
-                }
-                if external_method_shape
-                    && !external_param_planned
-                    && idx == 0
-                    && Self::method_arg_needs_fallback_borrow(method, &arg.ty)
-                    && !Self::method_arg_already_has_reference_shape(arg)
-                {
-                    return Ok(quote! { &#emitted });
                 }
                 if !external_param_planned {
                     match &param.ty {

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -1104,6 +1104,20 @@ mod tests {
     use crate::backend::ir::{FunctionParam, FunctionRegistry, FunctionSignature, Mutability};
     use incan_core::lang::traits::{self as core_traits, TraitId};
 
+    fn prost_decode_signature(return_type: IrType) -> FunctionSignature {
+        FunctionSignature {
+            params: vec![FunctionParam {
+                name: "buf".to_string(),
+                ty: IrType::Generic("Buf".to_string()),
+                mutability: Mutability::Immutable,
+                is_self: false,
+                kind: crate::frontend::ast::ParamKind::Normal,
+                default: None,
+            }],
+            return_type,
+        }
+    }
+
     #[test]
     fn type_name_associated_call_does_not_borrow_string_arguments() -> Result<(), String> {
         let registry = FunctionRegistry::new();
@@ -1295,10 +1309,14 @@ mod tests {
     }
 
     #[test]
-    fn external_decode_fallback_keeps_explicit_slice_argument_shape() -> Result<(), String> {
+    fn external_decode_metadata_keeps_explicit_slice_argument_shape() -> Result<(), String> {
         let registry = FunctionRegistry::new();
         let emitter = IrEmitter::new(&registry);
         let descriptor_set = IrType::Struct("prost_types::FileDescriptorSet".to_string());
+        let result_ty = IrType::Result(
+            Box::new(descriptor_set.clone()),
+            Box::new(IrType::Struct("prost::DecodeError".to_string())),
+        );
         let expr = TypedExpr::new(
             IrExprKind::MethodCall {
                 receiver: Box::new(TypedExpr::new(
@@ -1335,13 +1353,10 @@ mod tests {
                         IrType::Bytes,
                     ),
                 }],
-                callable_signature: None,
+                callable_signature: Some(prost_decode_signature(result_ty.clone())),
                 arg_policy: MethodCallArgPolicy::Default,
             },
-            IrType::Result(
-                Box::new(descriptor_set),
-                Box::new(IrType::Struct("prost::DecodeError".to_string())),
-            ),
+            result_ty,
         );
 
         let emitted = emitter
@@ -1354,7 +1369,73 @@ mod tests {
         );
         assert!(
             !rendered.contains("FileDescriptorSet :: decode (& data . as_slice ())"),
-            "decode fallback must not add a second borrow to explicit slice arguments, got `{rendered}`"
+            "decode metadata must not add a fallback borrow to explicit slice arguments, got `{rendered}`"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn external_decode_metadata_keeps_explicit_rust_vec_slice_argument_shape() -> Result<(), String> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let descriptor_set = IrType::Struct("prost_types::FileDescriptorSet".to_string());
+        let result_ty = IrType::Result(
+            Box::new(descriptor_set.clone()),
+            Box::new(IrType::Struct("prost::DecodeError".to_string())),
+        );
+        let expr = TypedExpr::new(
+            IrExprKind::MethodCall {
+                receiver: Box::new(TypedExpr::new(
+                    IrExprKind::Var {
+                        name: "FileDescriptorSet".to_string(),
+                        access: VarAccess::Copy,
+                        ref_kind: VarRefKind::ExternalRustName,
+                    },
+                    descriptor_set.clone(),
+                )),
+                method: "decode".to_string(),
+                dispatch: None,
+                type_args: Vec::new(),
+                args: vec![IrCallArg {
+                    name: None,
+                    kind: IrCallArgKind::Positional,
+                    expr: TypedExpr::new(
+                        IrExprKind::MethodCall {
+                            receiver: Box::new(TypedExpr::new(
+                                IrExprKind::Var {
+                                    name: "encoded".to_string(),
+                                    access: VarAccess::Read,
+                                    ref_kind: VarRefKind::Value,
+                                },
+                                IrType::Struct("alloc::vec::Vec<u8>".to_string()),
+                            )),
+                            method: "as_slice".to_string(),
+                            dispatch: None,
+                            type_args: Vec::new(),
+                            args: Vec::new(),
+                            callable_signature: None,
+                            arg_policy: MethodCallArgPolicy::Default,
+                        },
+                        IrType::Bytes,
+                    ),
+                }],
+                callable_signature: Some(prost_decode_signature(result_ty.clone())),
+                arg_policy: MethodCallArgPolicy::Default,
+            },
+            result_ty,
+        );
+
+        let emitted = emitter
+            .emit_expr(&expr)
+            .map_err(|err| format!("expected successful expression emission, got {err:?}"))?;
+        let rendered = emitted.to_string();
+        assert!(
+            rendered.contains("FileDescriptorSet :: decode (encoded . as_slice ())"),
+            "explicit Rust Vec slice arguments should be passed through, got `{rendered}`"
+        );
+        assert!(
+            !rendered.contains("FileDescriptorSet :: decode (& encoded . as_slice ())"),
+            "decode metadata must not add a fallback borrow to explicit Rust Vec slice arguments, got `{rendered}`"
         );
         Ok(())
     }

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -1295,6 +1295,121 @@ mod tests {
     }
 
     #[test]
+    fn external_decode_fallback_keeps_explicit_slice_argument_shape() -> Result<(), String> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let descriptor_set = IrType::Struct("prost_types::FileDescriptorSet".to_string());
+        let expr = TypedExpr::new(
+            IrExprKind::MethodCall {
+                receiver: Box::new(TypedExpr::new(
+                    IrExprKind::Var {
+                        name: "FileDescriptorSet".to_string(),
+                        access: VarAccess::Copy,
+                        ref_kind: VarRefKind::ExternalRustName,
+                    },
+                    descriptor_set.clone(),
+                )),
+                method: "decode".to_string(),
+                dispatch: None,
+                type_args: Vec::new(),
+                args: vec![IrCallArg {
+                    name: None,
+                    kind: IrCallArgKind::Positional,
+                    expr: TypedExpr::new(
+                        IrExprKind::MethodCall {
+                            receiver: Box::new(TypedExpr::new(
+                                IrExprKind::Var {
+                                    name: "data".to_string(),
+                                    access: VarAccess::Read,
+                                    ref_kind: VarRefKind::Value,
+                                },
+                                IrType::Bytes,
+                            )),
+                            method: "as_slice".to_string(),
+                            dispatch: None,
+                            type_args: Vec::new(),
+                            args: Vec::new(),
+                            callable_signature: None,
+                            arg_policy: MethodCallArgPolicy::Default,
+                        },
+                        IrType::Bytes,
+                    ),
+                }],
+                callable_signature: None,
+                arg_policy: MethodCallArgPolicy::Default,
+            },
+            IrType::Result(
+                Box::new(descriptor_set),
+                Box::new(IrType::Struct("prost::DecodeError".to_string())),
+            ),
+        );
+
+        let emitted = emitter
+            .emit_expr(&expr)
+            .map_err(|err| format!("expected successful expression emission, got {err:?}"))?;
+        let rendered = emitted.to_string();
+        assert!(
+            rendered.contains("FileDescriptorSet :: decode (data . as_slice ())"),
+            "explicit slice arguments should be passed through, got `{rendered}`"
+        );
+        assert!(
+            !rendered.contains("FileDescriptorSet :: decode (& data . as_slice ())"),
+            "decode fallback must not add a second borrow to explicit slice arguments, got `{rendered}`"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn external_decode_fallback_still_borrows_owned_bytes_argument() -> Result<(), String> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let descriptor_set = IrType::Struct("prost_types::FileDescriptorSet".to_string());
+        let expr = TypedExpr::new(
+            IrExprKind::MethodCall {
+                receiver: Box::new(TypedExpr::new(
+                    IrExprKind::Var {
+                        name: "FileDescriptorSet".to_string(),
+                        access: VarAccess::Copy,
+                        ref_kind: VarRefKind::ExternalRustName,
+                    },
+                    descriptor_set.clone(),
+                )),
+                method: "decode".to_string(),
+                dispatch: None,
+                type_args: Vec::new(),
+                args: vec![IrCallArg {
+                    name: None,
+                    kind: IrCallArgKind::Positional,
+                    expr: TypedExpr::new(
+                        IrExprKind::Var {
+                            name: "data".to_string(),
+                            access: VarAccess::Read,
+                            ref_kind: VarRefKind::Value,
+                        },
+                        IrType::Bytes,
+                    ),
+                }],
+                callable_signature: None,
+                arg_policy: MethodCallArgPolicy::Default,
+            },
+            IrType::Result(
+                Box::new(descriptor_set),
+                Box::new(IrType::Struct("prost::DecodeError".to_string())),
+            ),
+        );
+
+        let emitted = emitter
+            .emit_expr(&expr)
+            .map_err(|err| format!("expected successful expression emission, got {err:?}"))?;
+        let rendered = emitted.to_string();
+        assert!(
+            rendered.contains("FileDescriptorSet :: decode (& data)"),
+            "owned bytes should still use the decode fallback borrow, got `{rendered}`"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn interop_try_adapter_emits_question_mark() -> Result<(), String> {
         let registry = FunctionRegistry::new();
         let emitter = IrEmitter::new(&registry);

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -1342,7 +1342,23 @@ impl TypeChecker {
         if preserves_lookup_arg_shape {
             self.type_info.record_regular_method_arg_shape(receiver_span, method);
         }
-        let metadata = self.rust_item_metadata_for_path(rust_path)?;
+        let Some(metadata) = self.rust_item_metadata_for_path(rust_path) else {
+            if let Some(import_use) = self.record_unique_rust_trait_import_for_unresolved_receiver_call(method, span)
+                && let Some(sig) = import_use.signature.as_ref()
+            {
+                let callable_display = format!("rust::{rust_path}.{method}");
+                let ret = self.validate_rust_method_call(
+                    callable_display.as_str(),
+                    sig,
+                    args,
+                    arg_types,
+                    preserves_lookup_arg_shape,
+                    span,
+                );
+                return Some(Self::substitute_rust_self_type(ret, rust_path));
+            }
+            return None;
+        };
         match &metadata.kind {
             RustItemKind::Type(_) => {
                 let Some(sig) = self.rust_method_signature(rust_path, method) else {
@@ -1429,6 +1445,38 @@ impl TypeChecker {
         let [import_use] = matches.as_slice() else {
             return None;
         };
+        self.type_info
+            .record_rust_method_trait_import_use(span, import_use.clone());
+        Some(import_use.clone())
+    }
+
+    /// Record a unique imported Rust trait method when receiver metadata is unavailable.
+    ///
+    /// rust-inspect can miss generated or re-export-heavy concrete types while still extracting the imported trait's
+    /// signature. In that case the trait signature is enough for call-site parameter shape metadata; rustc remains the
+    /// authority on whether the receiver type actually implements the trait.
+    fn record_unique_rust_trait_import_for_unresolved_receiver_call(
+        &mut self,
+        method: &str,
+        span: Span,
+    ) -> Option<RustMethodTraitImportUse> {
+        let matches = self
+            .type_info
+            .rust
+            .trait_imports
+            .iter()
+            .filter(|(_, import)| import.methods.contains(method))
+            .map(|(binding, import)| RustMethodTraitImportUse {
+                binding: binding.clone(),
+                trait_path: import.trait_path.clone(),
+                method: method.to_string(),
+                signature: Self::rust_trait_method_signature(import, method),
+            })
+            .collect::<Vec<_>>();
+        let [import_use] = matches.as_slice() else {
+            return None;
+        };
+        import_use.signature.as_ref()?;
         self.type_info
             .record_rust_method_trait_import_use(span, import_use.clone());
         Some(import_use.clone())

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -999,6 +999,8 @@ mod validate_rust_function_call_tests {
         let checker = TypeChecker::new();
 
         assert!(checker.rust_arg_matches_boundary(&ResolvedType::Named("Payload".to_string()), "T",));
+        assert!(checker.rust_arg_matches_boundary(&ResolvedType::Bytes, "impl Buf"));
+        assert!(checker.rust_arg_matches_boundary(&ResolvedType::Bytes, "implBuf"));
         assert!(checker.rust_arg_matches_boundary(&ResolvedType::Named("Payload".to_string()), "&T",));
         assert!(checker.rust_arg_matches_boundary(&ResolvedType::Named("Payload".to_string()), "&TValue",));
     }
@@ -1042,6 +1044,54 @@ mod validate_rust_function_call_tests {
                 .get(&(span.start, span.end))
                 .is_some_and(|params| params.len() == 1 && params[0].ty == ResolvedType::TypeVar("T".to_string())),
             "expected Rust by-value generic method param shape to be recorded, got {:?}",
+            checker.type_info.calls.call_site_callable_params
+        );
+    }
+
+    #[test]
+    fn validate_rust_method_call_records_by_value_impl_trait_param_shape() {
+        let mut checker = TypeChecker::new();
+        let span = Span::new(30, 40);
+        let arg_expr = Spanned::new(Expr::Ident("encoded".to_string()), span);
+        let args = [CallArg::Positional(arg_expr)];
+        let arg_types = [ResolvedType::Bytes];
+        let sig = RustFunctionSig {
+            params: vec![RustParam {
+                name: Some("buf".to_string()),
+                type_display: "implBuf".to_string(),
+            }],
+            return_type: "demo::FileDescriptorSet".to_string(),
+            is_async: false,
+            is_unsafe: false,
+        };
+
+        let _ = checker.validate_rust_method_call(
+            "rust::demo::FileDescriptorSet.decode",
+            &sig,
+            &args,
+            &arg_types,
+            false,
+            span,
+        );
+
+        assert!(
+            checker.errors.is_empty(),
+            "expected by-value impl Trait Rust param to accept bytes without borrow coercion, got {:?}",
+            checker.errors
+        );
+        assert!(
+            checker.type_info.rust.arg_coercions.is_empty(),
+            "expected by-value impl Trait Rust param to avoid borrow coercion, got {:?}",
+            checker.type_info.rust.arg_coercions
+        );
+        assert!(
+            checker
+                .type_info
+                .calls
+                .call_site_callable_params
+                .get(&(span.start, span.end))
+                .is_some_and(|params| params.len() == 1 && params[0].ty == ResolvedType::TypeVar("implBuf".to_string())),
+            "expected Rust by-value impl Trait method param shape to be recorded, got {:?}",
             checker.type_info.calls.call_site_callable_params
         );
     }

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -789,6 +789,36 @@ impl TypeChecker {
         normalized.strip_prefix('&').map(|inner| (false, inner))
     }
 
+    /// Remove Rust lifetime labels that decorate borrowed display types.
+    ///
+    /// rust-analyzer commonly prints borrowed method parameters as `&'h str` or `&'a [u8]`. The typechecker only needs
+    /// the ownership shape and payload type, so erase the lifetime after `&` before whitespace normalization turns it
+    /// into an unparseable token such as `&'hstr`.
+    fn strip_borrow_lifetimes(rust_ty: &str) -> String {
+        let mut out = String::with_capacity(rust_ty.len());
+        let mut chars = rust_ty.chars().peekable();
+        while let Some(ch) = chars.next() {
+            out.push(ch);
+            if ch != '&' {
+                continue;
+            }
+            while matches!(chars.peek(), Some(next) if next.is_whitespace()) {
+                out.push(chars.next().expect("peeked whitespace should exist"));
+            }
+            if !matches!(chars.peek(), Some('\'')) {
+                continue;
+            }
+            chars.next();
+            while matches!(chars.peek(), Some(next) if next.is_ascii_alphanumeric() || *next == '_') {
+                chars.next();
+            }
+            while matches!(chars.peek(), Some(next) if next.is_whitespace()) {
+                chars.next();
+            }
+        }
+        out
+    }
+
     /// Map structured rust-inspect [`RustTypeShape`] into a [`ResolvedType`] for field access and pattern typing.
     ///
     /// `Option`/`Result` become [`ResolvedType::Generic`] with constructor names `Option` and `Result`. Concrete paths
@@ -860,7 +890,8 @@ impl TypeChecker {
     /// for one or both type arguments. Prefer precise typing from Incan surfaces over relying on this heuristic.
     pub(crate) fn resolved_type_from_rust_display(&self, rust_ty: &str) -> ResolvedType {
         let trimmed = rust_ty.trim();
-        let no_lifetimes = trimmed.replace("'static ", "").replace("'_", "").replace(' ', "");
+        let no_lifetimes = Self::strip_borrow_lifetimes(trimmed);
+        let no_lifetimes = no_lifetimes.replace("'static ", "").replace("'_", "").replace(' ', "");
         let normalized = no_lifetimes.trim_start_matches("::").to_string();
         if let Some(Symbol {
             kind: SymbolKind::RustItem(info),
@@ -949,9 +980,18 @@ impl TypeChecker {
         }
     }
 
-    /// Return a Rust generic type-parameter name when the display is the simple identifier form rust-analyzer uses
-    /// for params like `T` or `U`.
+    /// Return a Rust generic parameter display when rust-analyzer reports a by-value generic boundary.
+    ///
+    /// Plain type parameters appear as `T` or `U`. Anonymous `impl Trait` parameters can arrive with whitespace erased,
+    /// such as `implBuf` for `impl Buf`; those still carry by-value shape and must not be treated as borrowed Rust
+    /// boundary targets.
     pub(crate) fn rust_display_type_var_name(normalized: &str) -> Option<&str> {
+        if let Some(tail) = normalized.strip_prefix("impl")
+            && !tail.is_empty()
+            && (tail.contains("::") || tail.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()))
+        {
+            return Some(normalized);
+        }
         if normalized.len() == 1 && normalized.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()) {
             Some(normalized)
         } else {
@@ -966,7 +1006,8 @@ impl TypeChecker {
     /// borrowed Rust boundary so emission can pass `&arg` instead of moving an owned `String` or `Vec<u8>`.
     pub(crate) fn resolved_param_type_from_rust_display(&self, rust_ty: &str) -> ResolvedType {
         let trimmed = rust_ty.trim();
-        let no_lifetimes = trimmed.replace("'static ", "").replace("'_", "").replace(' ', "");
+        let no_lifetimes = Self::strip_borrow_lifetimes(trimmed);
+        let no_lifetimes = no_lifetimes.replace("'static ", "").replace("'_", "").replace(' ', "");
         let normalized = no_lifetimes.trim_start_matches("::").to_string();
         if let Some(name) = Self::rust_display_type_var_name(normalized.as_str()) {
             return ResolvedType::TypeVar(name.to_string());

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -915,6 +915,7 @@ impl TypeChecker {
             };
         }
         match normalized.as_str() {
+            "{unknown}" => ResolvedType::Unknown,
             "bool" => ResolvedType::Bool,
             "f64" => ResolvedType::Float,
             "i64" => ResolvedType::Int,

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -2511,6 +2511,8 @@ fn test_resolved_type_from_builtin_borrowed_displays_stays_stable() {
     let checker = TypeChecker::new();
     assert_eq!(checker.resolved_type_from_rust_display("&str"), ResolvedType::Str);
     assert_eq!(checker.resolved_type_from_rust_display("&[u8]"), ResolvedType::Bytes);
+    assert_eq!(checker.resolved_type_from_rust_display("&'h str"), ResolvedType::Str);
+    assert_eq!(checker.resolved_type_from_rust_display("&'h [u8]"), ResolvedType::Bytes);
 }
 
 #[test]
@@ -2523,6 +2525,18 @@ fn test_resolved_param_type_from_builtin_borrowed_displays_preserves_ref_payload
     assert_eq!(
         checker.resolved_param_type_from_rust_display("&[u8]"),
         ResolvedType::Ref(Box::new(ResolvedType::Bytes)),
+    );
+    assert_eq!(
+        checker.resolved_param_type_from_rust_display("&'h str"),
+        ResolvedType::Ref(Box::new(ResolvedType::Str)),
+    );
+    assert_eq!(
+        checker.resolved_param_type_from_rust_display("&'h [u8]"),
+        ResolvedType::Ref(Box::new(ResolvedType::Bytes)),
+    );
+    assert_eq!(
+        checker.resolved_param_type_from_rust_display("&'h mut demo::Thing"),
+        ResolvedType::RefMut(Box::new(ResolvedType::RustPath("demo::Thing".to_string()))),
     );
 }
 
@@ -8057,10 +8071,10 @@ def f(w: Widget) -> None:
 #[test]
 fn test_rust_extension_trait_associated_call_records_param_shape() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
-from rust::demo import Cursor, FileDescriptorSet, Message
+from rust::demo import FileDescriptorSet, Message
 
-def f(cursor: Cursor) -> None:
-  _ = FileDescriptorSet.decode(cursor)
+def f(encoded: bytes) -> None:
+  _ = FileDescriptorSet.decode(encoded.as_slice())
 "#;
     let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
     let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
@@ -8082,7 +8096,7 @@ def f(cursor: Cursor) -> None:
                         signature: RustFunctionSig {
                             params: vec![RustParam {
                                 name: Some("buf".to_string()),
-                                type_display: "T".to_string(),
+                                type_display: "implBuf".to_string(),
                             }],
                             return_type: "Self".to_string(),
                             is_async: false,
@@ -8093,7 +8107,7 @@ def f(cursor: Cursor) -> None:
             },
         )
         .map_err(|err| std::io::Error::other(format!("seed trait metadata: {err}")))?;
-    for path in ["demo::Cursor", "demo::FileDescriptorSet"] {
+    for path in ["demo::FileDescriptorSet"] {
         checker
             .rust_inspect_cache
             .insert_test_item(
@@ -8134,9 +8148,14 @@ def f(cursor: Cursor) -> None:
             .calls
             .call_site_callable_params
             .values()
-            .any(|params| params.len() == 1 && params[0].ty == ResolvedType::TypeVar("T".to_string())),
+            .any(|params| params.len() == 1 && params[0].ty == ResolvedType::TypeVar("implBuf".to_string())),
         "expected trait-provided decode parameter shape to be recorded, got {:?}",
         checker.type_info().calls.call_site_callable_params
+    );
+    assert!(
+        checker.type_info().rust.arg_coercions.is_empty(),
+        "expected trait-provided impl Trait decode to avoid borrow coercions, got {:?}",
+        checker.type_info().rust.arg_coercions
     );
     Ok(())
 }

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3025,6 +3025,15 @@ fn test_rust_metadata_lookup_path_rejects_unknown_placeholder() {
     assert_eq!(TypeChecker::rust_metadata_lookup_path("{unknown}"), None);
 }
 
+#[test]
+fn test_rust_display_unknown_placeholder_resolves_unknown() {
+    let checker = TypeChecker::new();
+    assert_eq!(
+        checker.resolved_type_from_rust_display("{unknown}"),
+        ResolvedType::Unknown
+    );
+}
+
 #[cfg(feature = "rust_inspect")]
 #[test]
 fn test_rust_item_metadata_lookup_reuses_cached_nominal_item_for_instantiated_rust_path()
@@ -8155,6 +8164,75 @@ def f(encoded: bytes) -> None:
     assert!(
         checker.type_info().rust.arg_coercions.is_empty(),
         "expected trait-provided impl Trait decode to avoid borrow coercions, got {:?}",
+        checker.type_info().rust.arg_coercions
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rust_extension_trait_associated_call_records_param_shape_without_receiver_metadata()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from rust::demo import Message
+from rust::datafusion_substrait::substrait::proto import Plan as ConsumerPlan
+
+def f(encoded: bytes) -> None:
+  _ = ConsumerPlan.decode(encoded.as_slice())
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
+    let mut checker = TypeChecker::new();
+    let tmp = seeded_rust_inspect_workspace()?;
+    let manifest_dir = tmp.path().to_path_buf();
+    checker.set_rust_inspect_manifest_dir(manifest_dir.clone());
+    checker
+        .rust_inspect_cache
+        .insert_test_item(
+            &manifest_dir,
+            RustItemMetadata {
+                canonical_path: "demo::Message".to_string(),
+                definition_path: Some("demo::Message".to_string()),
+                visibility: RustVisibility::Public,
+                kind: RustItemKind::Trait(RustTraitInfo {
+                    items: vec![RustTraitAssoc::Function {
+                        name: "decode".to_string(),
+                        signature: RustFunctionSig {
+                            params: vec![RustParam {
+                                name: Some("buf".to_string()),
+                                type_display: "implBuf".to_string(),
+                            }],
+                            return_type: "Self".to_string(),
+                            is_async: false,
+                            is_unsafe: false,
+                        },
+                    }],
+                }),
+            },
+        )
+        .map_err(|err| std::io::Error::other(format!("seed trait metadata: {err}")))?;
+
+    checker
+        .check_program(&ast)
+        .map_err(|errs| std::io::Error::other(format!("typecheck failed: {errs:?}")))?;
+    let uses = &checker.type_info().rust.method_trait_import_uses;
+    assert!(
+        uses.values()
+            .any(|import_use| import_use.binding == "Message" && import_use.method == "decode"),
+        "expected Message import use for unresolved receiver metadata, got {uses:?}"
+    );
+    assert!(
+        checker
+            .type_info()
+            .calls
+            .call_site_callable_params
+            .values()
+            .any(|params| params.len() == 1 && params[0].ty == ResolvedType::TypeVar("implBuf".to_string())),
+        "expected trait-provided decode parameter shape without receiver metadata, got {:?}",
+        checker.type_info().calls.call_site_callable_params
+    );
+    assert!(
+        checker.type_info().rust.arg_coercions.is_empty(),
+        "expected unresolved receiver trait signature to avoid borrow coercions, got {:?}",
         checker.type_info().rust.arg_coercions
     );
     Ok(())

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -780,11 +780,11 @@ pub struct DecodeError;
 pub struct FileDescriptorSet;
 
 pub trait Message: Sized {
-    fn decode<T: DecodeBuf>(_buf: T) -> Result<Self, DecodeError>;
+    fn decode(_buf: impl DecodeBuf) -> Result<Self, DecodeError>;
 }
 
 impl Message for FileDescriptorSet {
-    fn decode<T: DecodeBuf>(_buf: T) -> Result<Self, DecodeError> {
+    fn decode(_buf: impl DecodeBuf) -> Result<Self, DecodeError> {
         Ok(Self)
     }
 }
@@ -804,6 +804,100 @@ impl Message for FileDescriptorSet {
     assert!(
         stdout.contains("ok"),
         "expected trait-provided by-value generic decode helper output, got:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn run_accepts_cross_crate_trait_decode_slice_param_issue612() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "cli_cross_crate_trait_decode_project",
+        r#"
+
+[rust-dependencies]
+prost = { path = "rust/prost" }
+prost-types = { path = "rust/prost-types" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::prost import Message
+from rust::prost_types import FileDescriptorSet
+
+
+def main() -> None:
+  encoded = b"abc"
+  match FileDescriptorSet.decode(encoded.as_slice()):
+    Ok(_) => println("ok")
+    Err(_) => println("err")
+"#,
+    )?;
+    let prost_src = tmp.path().join("rust").join("prost").join("src");
+    fs::create_dir_all(&prost_src)?;
+    fs::write(
+        prost_src.parent().ok_or("prost src has no parent")?.join("Cargo.toml"),
+        r#"[package]
+name = "prost"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        prost_src.join("lib.rs"),
+        r#"pub trait Buf {}
+
+impl Buf for &[u8] {}
+
+pub struct DecodeError;
+
+pub trait Message: Sized {
+    fn decode(_buf: impl Buf) -> Result<Self, DecodeError>;
+}
+"#,
+    )?;
+    let prost_types_src = tmp.path().join("rust").join("prost-types").join("src");
+    fs::create_dir_all(&prost_types_src)?;
+    fs::write(
+        prost_types_src
+            .parent()
+            .ok_or("prost-types src has no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "prost-types"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+prost = { path = "../prost" }
+"#,
+    )?;
+    fs::write(
+        prost_types_src.join("lib.rs"),
+        r#"pub struct FileDescriptorSet;
+
+impl prost::Message for FileDescriptorSet {
+    fn decode(_buf: impl prost::Buf) -> Result<Self, prost::DecodeError> {
+        Ok(Self)
+    }
+}
+"#,
+    )?;
+
+    let output = run_incan(
+        tmp.path(),
+        &["run", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+
+    assert_success(
+        &output,
+        "incan run with cross-crate trait-provided decode over explicit slice",
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("ok"),
+        "expected cross-crate trait-provided decode helper output, got:\n{stdout}"
     );
     Ok(())
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -824,11 +824,12 @@ prost-types = { path = "rust/prost-types" }
     fs::write(
         &main_path,
         r#"from rust::prost import Message
-from rust::prost_types import FileDescriptorSet
+from rust::prost_types import FileDescriptorSet, ProducerPlan
 
 
 def main() -> None:
-  encoded = b"abc"
+  producer = ProducerPlan.new()
+  encoded = producer.encode_to_vec()
   match FileDescriptorSet.decode(encoded.as_slice()):
     Ok(_) => println("ok")
     Err(_) => println("err")
@@ -875,7 +876,19 @@ prost = { path = "../prost" }
     )?;
     fs::write(
         prost_types_src.join("lib.rs"),
-        r#"pub struct FileDescriptorSet;
+        r#"pub struct ProducerPlan;
+
+impl ProducerPlan {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn encode_to_vec(&self) -> Vec<u8> {
+        b"abc".to_vec()
+    }
+}
+
+pub struct FileDescriptorSet;
 
 impl prost::Message for FileDescriptorSet {
     fn decode(_buf: impl prost::Buf) -> Result<Self, prost::DecodeError> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -46,16 +46,21 @@ fn strip_ansi_escapes(text: &str) -> String {
     out
 }
 
-static RUNTIME_ERROR_PROJECT_COUNTER: AtomicU64 = AtomicU64::new(0);
+static TEST_PROJECT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Create a throwaway project name that does not collide under parallel nextest workers.
+///
+/// Several CLI tests rely on the default `target/incan/<name>` output location. The generated project name includes
+/// both the current process id and a local counter so those tests do not trample each other's generated Cargo projects.
+fn unique_test_project_name(prefix: &str) -> String {
+    let unique = TEST_PROJECT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}_{}_{}", std::process::id(), unique)
+}
 
 /// Create a minimal throwaway Incan project for end-to-end runtime error assertions.
-///
-/// The generated project name includes both the current process id and a local counter so parallel nextest workers do
-/// not trample each other's `target/incan/<name>` outputs.
 fn write_runtime_error_project(source: &str) -> Result<(tempfile::TempDir, PathBuf), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
-    let unique = RUNTIME_ERROR_PROJECT_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let project_name = format!("runtime_error_contract_{}_{}", std::process::id(), unique);
+    let project_name = unique_test_project_name("runtime_error_contract");
     let src_dir = tmp.path().join("src");
     fs::create_dir_all(&src_dir)?;
     fs::write(
@@ -12886,10 +12891,13 @@ pub def small_key_map_bytes() -> bytes:
         );
 
         let consumer_root = tmp.path().join("ordinal_keys_consumer");
+        let consumer_name = unique_test_project_name("ordinal_keys_consumer");
         std::fs::create_dir_all(consumer_root.join("src"))?;
         std::fs::write(
             consumer_root.join("incan.toml"),
-            "[project]\nname = \"consumer\"\n\n[dependencies]\nordinal_keys = { path = \"../ordinal_keys_lib\" }\n",
+            format!(
+                "[project]\nname = \"{consumer_name}\"\n\n[dependencies]\nordinal_keys = {{ path = \"../ordinal_keys_lib\" }}\n"
+            ),
         )?;
         let consumer_main = consumer_root.join("src/main.incn");
         std::fs::write(
@@ -13282,9 +13290,12 @@ pub def projection(name: str, target: str) -> str:
         );
 
         let consumer_root = tmp.path().join("nested_consumer");
+        let consumer_name = unique_test_project_name("nested_consumer");
         let consumer_main = write_project_files(
             &consumer_root,
-            "[project]\nname = \"consumer\"\n\n[dependencies]\nnested = { path = \"../nested_vocab_project\" }\n",
+            &format!(
+                "[project]\nname = \"{consumer_name}\"\n\n[dependencies]\nnested = {{ path = \"../nested_vocab_project\" }}\n"
+            ),
             r#"import pub::nested
 
 def main() -> None:


### PR DESCRIPTION
## Summary

This PR prepares `v0.3.0-rc1` from `release/v0.3` and fixes #612 by making trait-provided Rust method calls use imported trait signature metadata when concrete receiver metadata is unavailable. The important behavior is that InQL's real `ConsumerPlan.decode(encoded.as_slice())` path now emits `ConsumerPlan::decode(encoded.as_slice())`, not `ConsumerPlan::decode(&encoded.as_slice())`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `FileDescriptorSet.decode(encoded.as_slice())` and the real InQL `ConsumerPlan.decode(encoded.as_slice())` path lower to Rust associated calls without adding a second borrow.
- **Internals**: The frontend now records a unique imported Rust trait method use, including its signature, for unresolved receiver-associated calls. The backend then uses that callable parameter metadata to decide argument shape instead of hardcoding view methods such as `as_slice`.
- **Fallback behavior**: The legacy method-name fallback only applies when no callable parameter metadata exists; metadata wins whenever it is available.
- **Risks**: Trait-method fallback is intentionally conservative: ambiguous imported traits or traits without signature metadata do not get treated as metadata-backed calls.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (covered through smoke-test-fast)
- [x] `incan fmt --check .` (covered through pre-commit)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed, including 2445 nextest tests, clippy, cargo-deny, and the chained `smoke-test-fast` example/benchmark smoke suite.
- `git diff --check` passed.
- Focused checks passed for the #612 backend decode tests, the new unresolved-receiver trait metadata test, `{unknown}` Rust display normalization, the strengthened cross-crate CLI test, and the prior value-enum regression.
- Real InQL verification without the localized #612 workaround passed in `<scratch-path>`:
  - `make build incan`
  - `make test incan` — 88 passed
  - `make ci incan`
- The generated InQL Rust at `target/lib/src/session/datafusion_backend.rs` contains `ConsumerPlan::decode(encoded.as_slice())`.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #612