### PR TITLE
bugfix - fix v0.3 rc2 release regressions (#615, #616, #617)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc1"
+version = "0.3.0-rc2"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/decl.rs
+++ b/src/backend/ir/decl.rs
@@ -57,6 +57,8 @@ pub enum IrDeclKind {
         visibility: Visibility,
         name: String,
         target_path: Vec<String>,
+        target_origin: Option<IrImportOrigin>,
+        target_qualifier: Option<IrImportQualifier>,
     },
 
     /// Constant

--- a/src/backend/ir/emit/decls/mod.rs
+++ b/src/backend/ir/emit/decls/mod.rs
@@ -72,17 +72,13 @@ impl<'a> IrEmitter<'a> {
                 visibility,
                 name,
                 target_path,
+                target_origin,
+                target_qualifier,
             } => {
                 let vis = self.emit_visibility(visibility);
                 let name_ident = format_ident!("{}", name);
-                let target_segments = target_path
-                    .iter()
-                    .map(|segment| {
-                        let ident = format_ident!("{}", segment);
-                        quote! { #ident }
-                    })
-                    .collect::<Vec<_>>();
-                let target = join_path_tokens(&target_segments);
+                let target =
+                    self.emit_symbol_alias_target_path(target_origin.as_ref(), target_qualifier.as_ref(), target_path);
                 Ok(quote! {
                     #vis use #target as #name_ident;
                 })
@@ -232,6 +228,106 @@ impl<'a> IrEmitter<'a> {
 
     // ---- Import emission ----
 
+    /// Return whether an import path refers to the source-authored Incan stdlib namespace.
+    fn is_incan_source_stdlib_import(origin: &IrImportOrigin, qualifier: &IrImportQualifier, path: &[String]) -> bool {
+        !matches!(origin, IrImportOrigin::PubLibrary { .. })
+            && !matches!(qualifier, IrImportQualifier::None)
+            && stdlib::is_any_stdlib_path(path)
+    }
+
+    /// Convert an IR import path into Rust path segments using the same qualification rules for imports and aliases.
+    fn import_path_tokens(
+        &self,
+        origin: &IrImportOrigin,
+        qualifier: &IrImportQualifier,
+        path: &[String],
+    ) -> Vec<TokenStream> {
+        let is_pub_library_import = matches!(origin, IrImportOrigin::PubLibrary { .. });
+        let is_stdlib = Self::is_incan_source_stdlib_import(origin, qualifier, path);
+
+        if is_stdlib {
+            let mut tokens = vec![quote! { crate }];
+            let std_namespace = Self::rust_ident(stdlib::INCAN_STD_NAMESPACE);
+            tokens.push(quote! { #std_namespace });
+            for seg in path.iter().skip(1) {
+                let ident = Self::rust_ident(seg);
+                tokens.push(quote! { #ident });
+            }
+            return tokens;
+        }
+
+        if is_pub_library_import {
+            return path
+                .iter()
+                .map(|segment| {
+                    let ident = Self::rust_ident(segment);
+                    quote! { #ident }
+                })
+                .collect();
+        }
+
+        let mut tokens: Vec<TokenStream> = Vec::new();
+        match qualifier {
+            IrImportQualifier::Auto => {
+                if self.is_internal_module_path(path) {
+                    tokens.push(quote! { crate });
+                }
+            }
+            IrImportQualifier::Crate => tokens.push(quote! { crate }),
+            IrImportQualifier::Super(levels) => {
+                for _ in 0..*levels {
+                    tokens.push(quote! { super });
+                }
+            }
+            IrImportQualifier::None => {}
+        }
+        tokens.extend(path.iter().map(|segment| {
+            let ident = Self::rust_ident(segment);
+            quote! { #ident }
+        }));
+        tokens
+    }
+
+    /// Emit the Rust path used by a module-level symbol alias target.
+    ///
+    /// Imported targets use their original import path so public aliases re-export public items directly instead of
+    /// re-exporting a private local `use` binding.
+    fn emit_symbol_alias_target_path(
+        &self,
+        target_origin: Option<&IrImportOrigin>,
+        target_qualifier: Option<&IrImportQualifier>,
+        target_path: &[String],
+    ) -> TokenStream {
+        let Some(origin) = target_origin else {
+            let target_segments = target_path
+                .iter()
+                .map(|segment| {
+                    let ident = format_ident!("{}", segment);
+                    quote! { #ident }
+                })
+                .collect::<Vec<_>>();
+            return join_path_tokens(&target_segments);
+        };
+        let Some(qualifier) = target_qualifier else {
+            let target_segments = target_path
+                .iter()
+                .map(|segment| {
+                    let ident = format_ident!("{}", segment);
+                    quote! { #ident }
+                })
+                .collect::<Vec<_>>();
+            return join_path_tokens(&target_segments);
+        };
+
+        let path_tokens = self.import_path_tokens(origin, qualifier, target_path);
+        let path = join_path_tokens(&path_tokens);
+        if matches!(qualifier, IrImportQualifier::None) && !matches!(origin, IrImportOrigin::PubLibrary { .. }) {
+            quote! { :: #path }
+        } else {
+            path
+        }
+    }
+
     /// Emit a Rust import or re-export after generated-use analysis prunes private unused bindings.
     fn emit_import(
         &self,
@@ -257,64 +353,9 @@ impl<'a> IrEmitter<'a> {
         // Only Incan stdlib imports (qualifier `Auto`) are mapped. Rust crate imports like
         // `from rust::std::collections import HashMap` (qualifier `None`) are left as-is.
         let is_pub_library_import = matches!(origin, IrImportOrigin::PubLibrary { .. });
-        let is_stdlib =
-            !is_pub_library_import && !matches!(qualifier, IrImportQualifier::None) && stdlib::is_any_stdlib_path(path);
-        let is_incan_source_stdlib = is_stdlib;
+        let is_incan_source_stdlib = Self::is_incan_source_stdlib_import(origin, qualifier, path);
 
-        let path_tokens: Vec<TokenStream> = if is_incan_source_stdlib {
-            let mut tokens = vec![quote! { crate }];
-            let std_namespace = Self::rust_ident(stdlib::INCAN_STD_NAMESPACE);
-            tokens.push(quote! { #std_namespace });
-            for seg in path.iter().skip(1) {
-                let ident = Self::rust_ident(seg);
-                tokens.push(quote! { #ident });
-            }
-            tokens
-        } else if is_pub_library_import {
-            path.iter()
-                .map(|segment| {
-                    let ident = Self::rust_ident(segment);
-                    quote! { #ident }
-                })
-                .collect()
-        } else {
-            let mut tokens: Vec<TokenStream> = Vec::new();
-            let mapped_path_tokens: Vec<_> = if is_stdlib {
-                let mut mapped = vec![quote! { incan_stdlib }];
-                // Skip the `std` root, map the rest with keyword escaping.
-                for seg in path.iter().skip(1) {
-                    let ident = Self::rust_ident(seg);
-                    mapped.push(quote! { #ident });
-                }
-                mapped
-            } else {
-                path.iter()
-                    .map(|s| {
-                        let ident = Self::rust_ident(s);
-                        quote! { #ident }
-                    })
-                    .collect()
-            };
-            let apply_prefix = !is_stdlib;
-            if apply_prefix {
-                match qualifier {
-                    IrImportQualifier::Auto => {
-                        if self.is_internal_module_path(path) {
-                            tokens.push(quote! { crate });
-                        }
-                    }
-                    IrImportQualifier::Crate => tokens.push(quote! { crate }),
-                    IrImportQualifier::Super(levels) => {
-                        for _ in 0..*levels {
-                            tokens.push(quote! { super });
-                        }
-                    }
-                    IrImportQualifier::None => {}
-                }
-            }
-            tokens.extend(mapped_path_tokens);
-            tokens
-        };
+        let path_tokens = self.import_path_tokens(origin, qualifier, path);
 
         let path_ts = join_path_tokens(&path_tokens);
         // Public source imports, stdlib facades, and rust.module imports are re-exported. Private `pub::` library
@@ -434,7 +475,7 @@ impl<'a> IrEmitter<'a> {
                 })
                 .collect();
             Ok(quote! { #(#item_stmts)* })
-        } else if path.len() == 1 && !is_stdlib {
+        } else if path.len() == 1 && !is_incan_source_stdlib {
             Ok(quote! {})
         } else if export_module_import {
             Ok(quote! {

--- a/src/backend/ir/emit/statements.rs
+++ b/src/backend/ir/emit/statements.rs
@@ -95,6 +95,15 @@ fn for_body_needs_mut_iteration(pattern: &Pattern, body: &[IrStmt]) -> bool {
     body.iter().any(|s| stmt_mutates_var(s, loop_var))
 }
 
+/// Return the element target type for assignment into a list index.
+fn list_index_assignment_element_type(object_ty: &IrType) -> Option<&IrType> {
+    match object_ty {
+        IrType::Ref(inner) | IrType::RefMut(inner) => list_index_assignment_element_type(inner),
+        IrType::List(elem_ty) => Some(elem_ty.as_ref()),
+        _ => None,
+    }
+}
+
 /// Return the local `StaticBinding` name at the root of a storage-rooted expression.
 ///
 /// This is used by statement-slice analysis to detect aliases like `live` in
@@ -1132,6 +1141,18 @@ impl<'a> IrEmitter<'a> {
                     )
                     .apply(v);
                     return Ok(quote! { #o.insert(#k, #v); });
+                }
+                if let AssignTarget::Index { object, .. } = target
+                    && let Some(value_target_ty) = list_index_assignment_element_type(&object.ty)
+                {
+                    let t = self.emit_assign_target(target)?;
+                    let v = self.emit_expr_for_use(
+                        value,
+                        ValueUseSite::Assignment {
+                            target_ty: Some(value_target_ty),
+                        },
+                    )?;
+                    return Ok(quote! { #t = #v; });
                 }
                 let t = self.emit_assign_target(target)?;
                 let v = self.emit_assignment_value(value, None)?;

--- a/src/backend/ir/lower/decl/mod.rs
+++ b/src/backend/ir/lower/decl/mod.rs
@@ -16,7 +16,10 @@ mod newtypes;
 mod traits;
 
 use super::super::IrSpan;
-use super::super::decl::{IrDecl, IrDeclKind, IrInteropAdapterKind, IrInteropDirection, IrInteropEdge, Visibility};
+use super::super::decl::{
+    IrDecl, IrDeclKind, IrImportOrigin, IrImportQualifier, IrInteropAdapterKind, IrInteropDirection, IrInteropEdge,
+    Visibility,
+};
 use super::super::types::IrType;
 use super::AstLowering;
 use super::errors::LoweringError;
@@ -138,11 +141,16 @@ impl AstLowering {
                 is_rusttype: false,
                 interop_edges: Vec::new(),
             },
-            ast::Declaration::Alias(a) => IrDeclKind::SymbolAlias {
-                visibility: Self::map_visibility(a.visibility),
-                name: a.name.clone(),
-                target_path: a.target.segments.clone(),
-            },
+            ast::Declaration::Alias(a) => {
+                let (target_path, target_origin, target_qualifier) = self.alias_reexport_target(&a.target.segments);
+                IrDeclKind::SymbolAlias {
+                    visibility: Self::map_visibility(a.visibility),
+                    name: a.name.clone(),
+                    target_path,
+                    target_origin,
+                    target_qualifier,
+                }
+            }
             ast::Declaration::Partial(_) => {
                 return Err(LoweringError {
                     message: "Partial callable presets are not lowered by this syntax-only slice".to_string(),
@@ -186,6 +194,26 @@ impl AstLowering {
             }
         };
         Ok(IrDecl::new(kind))
+    }
+
+    /// Resolve the path that should be used when emitting a module-level alias declaration.
+    ///
+    /// A source alias can target a local import binding, but generated Rust public re-exports must point at the
+    /// imported item path itself. Expression lowering still keeps the source binding for ordinary calls.
+    fn alias_reexport_target(
+        &self,
+        segments: &[String],
+    ) -> (Vec<String>, Option<IrImportOrigin>, Option<IrImportQualifier>) {
+        if let [target] = segments
+            && let Some(imported) = self.imported_alias_targets.get(target)
+        {
+            return (
+                imported.path.clone(),
+                Some(imported.origin.clone()),
+                Some(imported.qualifier),
+            );
+        }
+        (segments.to_vec(), None, None)
     }
 
     fn lower_interop_edges(

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -35,7 +35,7 @@ mod types;
 use std::collections::{HashMap, HashSet};
 
 use super::TypedExpr;
-use super::decl::{FunctionParam, IrDecl, IrDeclKind};
+use super::decl::{FunctionParam, IrDecl, IrDeclKind, IrImportOrigin, IrImportQualifier};
 use super::expr::{IrCallArg, IrCallArgKind, IrExprKind, VarAccess, VarRefKind};
 use super::stmt::{IrStmt, IrStmtKind};
 use super::types::IrType;
@@ -62,6 +62,13 @@ pub(in crate::backend::ir::lower) struct TraitImplLoweringInput<'a> {
     pub impl_methods: &'a [ast::Spanned<ast::MethodDecl>],
     pub impl_properties: &'a [ast::Spanned<ast::PropertyDecl>],
     pub impl_associated_types: &'a [ast::Spanned<ast::AssociatedTypeDecl>],
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ImportedAliasTarget {
+    pub origin: IrImportOrigin,
+    pub qualifier: IrImportQualifier,
+    pub path: Vec<String>,
 }
 
 /// AST to IR lowering context.
@@ -144,6 +151,8 @@ pub struct AstLowering {
     pub(super) callable_param_scopes: Vec<HashSet<String>>,
     /// Module-level symbol aliases mapped from alias name to canonical target name.
     pub(super) symbol_aliases: HashMap<String, String>,
+    /// Imported item bindings mapped to their original import paths for public alias re-export emission.
+    pub(super) imported_alias_targets: HashMap<String, ImportedAliasTarget>,
     /// Cached stdlib metadata used to resolve rust.module-backed decorators/derives.
     pub(super) stdlib_cache: StdlibAstCache,
     /// `rusttype` underlying Rust type lookup by alias name.
@@ -235,6 +244,7 @@ impl AstLowering {
             rust_import_aliases: HashMap::new(),
             callable_param_scopes: Vec::new(),
             symbol_aliases: HashMap::new(),
+            imported_alias_targets: HashMap::new(),
             stdlib_cache: StdlibAstCache::new(),
             rusttype_underlying: HashMap::new(),
             rusttype_interop_edges: HashMap::new(),
@@ -912,6 +922,7 @@ impl AstLowering {
         let mut errors: Vec<LoweringError> = Vec::new();
         self.import_aliases = decorator_resolution::collect_import_aliases(program);
         self.rust_import_aliases = decorator_resolution::collect_rust_import_aliases(program);
+        self.imported_alias_targets = self.collect_imported_alias_targets(program);
         self.seed_imported_stdlib_trait_decls(program);
         self.alias_imported_dependency_trait_decls();
         self.symbol_aliases = program
@@ -1534,6 +1545,40 @@ impl AstLowering {
             // Return all collected errors
             Err(LoweringErrors(errors))
         }
+    }
+
+    /// Collect imported item bindings that module-level symbol aliases may need to re-export directly.
+    fn collect_imported_alias_targets(&self, program: &ast::Program) -> HashMap<String, ImportedAliasTarget> {
+        let mut targets = HashMap::new();
+        for decl in &program.declarations {
+            let ast::Declaration::Import(import) = &decl.node else {
+                continue;
+            };
+            let IrDeclKind::Import {
+                origin,
+                qualifier,
+                path,
+                items,
+                ..
+            } = self.lower_import(import)
+            else {
+                continue;
+            };
+            for item in items {
+                let binding = item.alias.unwrap_or_else(|| item.name.clone());
+                let mut item_path = path.clone();
+                item_path.push(item.name);
+                targets.insert(
+                    binding,
+                    ImportedAliasTarget {
+                        origin: origin.clone(),
+                        qualifier,
+                        path: item_path,
+                    },
+                );
+            }
+        }
+        targets
     }
 
     /// Lower a function declaration, expanding RFC 036 decorated functions into original/static/wrapper items.

--- a/src/format/formatter/expressions.rs
+++ b/src/format/formatter/expressions.rs
@@ -452,7 +452,7 @@ impl Formatter {
             match clause {
                 ComprehensionClause::For { pattern, iter } => {
                     self.writer.write(" for ");
-                    self.format_pattern(&pattern.node);
+                    self.format_for_pattern(&pattern.node);
                     self.writer.write(" in ");
                     self.format_expr(&iter.node);
                 }

--- a/src/format/formatter/statements.rs
+++ b/src/format/formatter/statements.rs
@@ -285,7 +285,8 @@ impl Formatter {
         self.writer.dedent();
     }
 
-    fn format_for_pattern(&mut self, pattern: &Pattern) {
+    /// Format a `for`-target pattern using the grammar's unparenthesized tuple-target spelling.
+    pub(super) fn format_for_pattern(&mut self, pattern: &Pattern) {
         if let Pattern::Tuple(items) = pattern {
             for (i, item) in items.iter().enumerate() {
                 if i > 0 {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -368,6 +368,20 @@ mod tests {
     }
 
     #[test]
+    fn test_format_source_list_comprehension_tuple_target_omits_parentheses() -> Result<(), FormatError> {
+        let source = r#"def labels(values: list[str]) -> list[str]:
+  return [f"{idx}:{value}" for idx, value in enumerate(values)]
+"#;
+        let expected = r#"def labels(values: list[str]) -> list[str]:
+    return [f"{idx}:{value}" for idx, value in enumerate(values)]
+"#;
+        let formatted = format_source(source)?;
+        assert_eq!(formatted, expected);
+        assert_eq!(format_source(&formatted)?, expected);
+        Ok(())
+    }
+
+    #[test]
     fn test_format_source_rfc028_operator_spellings() -> Result<(), FormatError> {
         let source = r#"def ops(a: Any, b: Any, c: Any) -> None:
   mat=a@b

--- a/src/frontend/library_exports.rs
+++ b/src/frontend/library_exports.rs
@@ -117,6 +117,7 @@ pub struct CheckedTypeAliasExport {
 pub struct CheckedAliasExport {
     pub name: String,
     pub target_path: Vec<String>,
+    pub projected_function: Option<CheckedFunctionExport>,
 }
 
 #[derive(Debug, Clone)]
@@ -324,14 +325,30 @@ pub fn collect_checked_public_exports(program: &Program, checker: &TypeChecker) 
 
 /// Build a checked public export entry for a module-level alias.
 fn checked_alias_export(alias: &AliasDecl, checker: &TypeChecker) -> Option<CheckedNamedExport> {
-    checker.lookup_symbol(alias.name.as_str())?;
+    let symbol = checker.lookup_symbol(alias.name.as_str())?;
+    let projected_function = match &symbol.kind {
+        SymbolKind::Function(info) => Some(checked_alias_function_export(&alias.name, info)),
+        _ => None,
+    };
     Some(CheckedNamedExport {
         name: alias.name.clone(),
         kind: CheckedExportKind::Alias(CheckedAliasExport {
             name: alias.name.clone(),
             target_path: alias.target.segments.clone(),
+            projected_function,
         }),
     })
+}
+
+/// Build manifest-ready callable metadata for an alias that projects a function.
+fn checked_alias_function_export(name: &str, info: &FunctionInfo) -> CheckedFunctionExport {
+    CheckedFunctionExport {
+        name: name.to_string(),
+        type_params: checked_function_type_params(info),
+        params: info.params.clone(),
+        return_type: info.return_type.clone(),
+        is_async: info.is_async,
+    }
 }
 
 /// Build checked export metadata for a public partial callable preset.
@@ -517,6 +534,20 @@ fn checked_function_export(function: &FunctionDecl, checker: &TypeChecker) -> Op
         return_type,
         is_async,
     })
+}
+
+/// Convert checked function metadata type parameters into export metadata type parameters.
+fn checked_function_type_params(info: &FunctionInfo) -> Vec<CheckedTypeParam> {
+    info.type_params
+        .iter()
+        .map(|name| CheckedTypeParam {
+            name: name.clone(),
+            bounds: info
+                .type_param_bound_details
+                .get(name)
+                .map_or_else(Vec::new, |bounds| map_type_bound_infos(bounds)),
+        })
+        .collect()
 }
 
 fn checked_type_alias_export(alias: &TypeAliasDecl, checker: &TypeChecker) -> CheckedTypeAliasExport {

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -733,6 +733,9 @@ impl TypeChecker {
                 fields: fields.iter().map(resolved_type_from_manifest_type_ref).collect(),
             }),
             ManifestExportRef::Alias(export) => {
+                if let Some(function) = &export.projected_function {
+                    return Some(SymbolKind::Function(self.function_info_from_manifest(function)));
+                }
                 let target_name = export.target_path.last()?;
                 return self.lookup_pub_library_symbol_member(library, target_name);
             }
@@ -990,13 +993,23 @@ impl TypeChecker {
                 is_used: false,
             }),
             ManifestExportRef::Alias(export) => {
-                let Some(target_name) = export.target_path.last() else {
-                    return;
-                };
-                let Some(target_export) = Self::find_manifest_export(manifest, target_name) else {
-                    return;
-                };
-                return self.define_pub_import_symbol(manifest, local_name, target_export, imported_type_aliases, span);
+                if let Some(function) = &export.projected_function {
+                    SymbolKind::Function(self.function_info_from_manifest(function))
+                } else {
+                    let Some(target_name) = export.target_path.last() else {
+                        return;
+                    };
+                    let Some(target_export) = Self::find_manifest_export(manifest, target_name) else {
+                        return;
+                    };
+                    return self.define_pub_import_symbol(
+                        manifest,
+                        local_name,
+                        target_export,
+                        imported_type_aliases,
+                        span,
+                    );
+                }
             }
         };
         self.remap_symbol_kind_with_import_aliases(&mut kind, imported_type_aliases);

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -12,10 +12,10 @@ use crate::frontend::library_manifest_index::{
 use crate::frontend::testing_markers::TestingFixtureScope;
 use crate::frontend::{lexer, parser};
 use crate::library_manifest::{
-    ClassExport, ConstExport, EnumExport, EnumValueExport, EnumValueTypeExport, EnumVariantExport, FunctionExport,
-    LibraryContractMetadata, LibraryExports, LibraryManifest, LibraryRustAbi, MethodExport, ModelExport, ParamExport,
-    ParamKindExport, PartialExport, PartialPresetExport, PartialTargetKindExport, PresetValueExport, ReceiverExport,
-    StaticExport, TraitExport, TypeBoundExport, TypeParamExport, TypeRef,
+    AliasExport, ClassExport, ConstExport, EnumExport, EnumValueExport, EnumValueTypeExport, EnumVariantExport,
+    FunctionExport, LibraryContractMetadata, LibraryExports, LibraryManifest, LibraryRustAbi, MethodExport,
+    ModelExport, ParamExport, ParamKindExport, PartialExport, PartialPresetExport, PartialTargetKindExport,
+    PresetValueExport, ReceiverExport, StaticExport, TraitExport, TypeBoundExport, TypeParamExport, TypeRef,
 };
 #[cfg(feature = "rust_inspect")]
 use crate::rust_inspect::{Inspector, InspectorConfig, write_borrowed_param_probe_crate, write_substrait_probe_crate};
@@ -1207,6 +1207,10 @@ pub mean = alias avg
     assert_eq!(manifest.exports.aliases[0].name, "mean");
     assert_eq!(manifest.exports.aliases[0].target_path, vec!["avg"]);
     assert!(
+        manifest.exports.aliases[0].projected_function.is_some(),
+        "function aliases should carry callable projection metadata for pub:: consumers"
+    );
+    assert!(
         manifest
             .exports
             .functions
@@ -1477,6 +1481,59 @@ fn library_index_with_mylib_exports() -> LibraryManifestIndex {
                     }],
                 },
             }],
+        },
+        vocab: None,
+        soft_keywords: Default::default(),
+        contract_metadata: LibraryContractMetadata::default(),
+        rust_abi: None,
+    };
+
+    LibraryManifestIndex::from_entries(HashMap::from([(
+        "mylib".to_string(),
+        LibraryManifestIndexEntry::Loaded {
+            manifest: Box::new(manifest),
+            metadata: LibraryArtifactMetadata::from_crate_root("mylib", "mylib", synthetic_artifact_root("mylib")),
+        },
+    )]))
+}
+
+fn library_index_with_callable_alias_export() -> LibraryManifestIndex {
+    let manifest = LibraryManifest {
+        name: "mylib".to_string(),
+        version: "0.1.0".to_string(),
+        incan_version: crate::version::INCAN_VERSION.to_string(),
+        manifest_format: crate::library_manifest::LIBRARY_MANIFEST_FORMAT,
+        exports: LibraryExports {
+            aliases: vec![AliasExport {
+                name: "public_target".to_string(),
+                target_path: vec!["target_impl".to_string()],
+                projected_function: Some(FunctionExport {
+                    name: "public_target".to_string(),
+                    type_params: Vec::new(),
+                    params: vec![ParamExport {
+                        name: "value".to_string(),
+                        ty: TypeRef::Named {
+                            name: "int".to_string(),
+                        },
+                        kind: ParamKindExport::Normal,
+                        has_default: false,
+                    }],
+                    return_type: TypeRef::Named {
+                        name: "int".to_string(),
+                    },
+                    is_async: false,
+                }),
+            }],
+            partials: Vec::new(),
+            models: Vec::new(),
+            classes: Vec::new(),
+            functions: Vec::new(),
+            traits: Vec::new(),
+            enums: Vec::new(),
+            type_aliases: Vec::new(),
+            newtypes: Vec::new(),
+            consts: Vec::new(),
+            statics: Vec::new(),
         },
         vocab: None,
         soft_keywords: Default::default(),
@@ -10935,6 +10992,21 @@ def build() -> Widget:
     assert!(
         result.is_ok(),
         "expected pub-imported manifest partial callable to typecheck, got: {result:?}"
+    );
+}
+
+#[test]
+fn test_pub_from_import_manifest_callable_alias_typechecks() {
+    let source = r#"
+from pub::mylib import public_target
+
+def build() -> int:
+  return public_target(1)
+"#;
+    let result = check_str_with_library_index(source, library_index_with_callable_alias_export());
+    assert!(
+        result.is_ok(),
+        "expected pub-imported callable alias to typecheck, got: {result:?}"
     );
 }
 

--- a/src/library_manifest/model.rs
+++ b/src/library_manifest/model.rs
@@ -88,6 +88,8 @@ pub struct LibraryExports {
 pub struct AliasExport {
     pub name: String,
     pub target_path: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projected_function: Option<FunctionExport>,
 }
 
 /// Exported partial callable preset metadata.
@@ -682,6 +684,7 @@ fn alias_export_from_checked(export: &CheckedAliasExport) -> AliasExport {
     AliasExport {
         name: export.name.clone(),
         target_path: export.target_path.clone(),
+        projected_function: export.projected_function.as_ref().map(function_export_from_checked),
     }
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1571,6 +1571,95 @@ pub def ping() -> str:
 }
 
 #[test]
+fn fmt_tuple_target_list_comprehension_remains_buildable() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "fmt_tuple_target_list_comp", "")?;
+    fs::write(
+        &main_path,
+        r#"def main() -> None:
+  values = ["alpha", "beta"]
+  labels: list[str] = [f"{idx}:{value}" for idx, value in enumerate(values)]
+"#,
+    )?;
+
+    let fmt_output = run_incan(
+        tmp.path(),
+        &["fmt", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(&fmt_output, "incan fmt tuple-target list comprehension");
+
+    let formatted = fs::read_to_string(&main_path)?;
+    assert!(
+        formatted.contains("for idx, value in enumerate(values)"),
+        "formatter should keep tuple comprehension targets unparenthesized, got:\n{formatted}"
+    );
+    assert!(
+        !formatted.contains("for (idx, value) in enumerate(values)"),
+        "formatter emitted parser-invalid tuple target parentheses, got:\n{formatted}"
+    );
+
+    let build_output = run_incan(
+        tmp.path(),
+        &["build", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(
+        &build_output,
+        "incan build after formatting tuple-target list comprehension",
+    );
+    Ok(())
+}
+
+#[test]
+fn build_public_alias_of_imported_item_reexports_original_path_issue617() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "public_alias_import_reexport", "")?;
+    let src_dir = main_path.parent().ok_or("main path had no parent")?;
+    fs::write(
+        src_dir.join("helper.incn"),
+        r#"pub def target(value: int) -> int:
+    """Return one incremented value."""
+    return value + 1
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from helper import target as target_builder
+
+
+pub public_target = alias target_builder
+
+
+def main() -> None:
+    """Exercise public alias re-export of an imported public function."""
+    assert public_target(1) == 2
+"#,
+    )?;
+
+    let output_dir = tmp.path().join("out");
+    let build_output = run_incan(
+        tmp.path(),
+        &[
+            "build",
+            main_path.to_str().ok_or("main path was not valid UTF-8")?,
+            output_dir.to_str().ok_or("output path was not valid UTF-8")?,
+        ],
+    )?;
+    assert_success(&build_output, "public alias of imported item build");
+
+    let generated_main = fs::read_to_string(output_dir.join("src/main.rs"))?;
+    assert!(
+        !generated_main.contains("pub use target_builder as public_target;"),
+        "public alias should not re-export the private local import binding, got:\n{generated_main}"
+    );
+    assert!(
+        generated_main.contains("pub use crate::helper::target as public_target;")
+            || generated_main.contains("pub use helper::target as public_target;"),
+        "public alias should re-export the original imported path, got:\n{generated_main}"
+    );
+    Ok(())
+}
+
+#[test]
 fn build_frozen_uses_existing_lockfile_without_network() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "cli_frozen_existing_lock_project", "")?;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1660,6 +1660,80 @@ def main() -> None:
 }
 
 #[test]
+fn build_pub_consumer_imports_public_alias_of_imported_item_issue617() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let producer_root = tmp.path().join("alias_lib");
+    let producer_src = producer_root.join("src");
+    fs::create_dir_all(&producer_src)?;
+    fs::write(
+        producer_root.join("incan.toml"),
+        r#"[project]
+name = "alias_lib"
+version = "0.1.0"
+"#,
+    )?;
+    fs::write(
+        producer_src.join("helper.incn"),
+        r#"pub def target(value: int) -> int:
+    return value + 1
+"#,
+    )?;
+    fs::write(
+        producer_src.join("functions.incn"),
+        r#"from helper import target as target_impl
+
+pub public_target = alias target_impl
+"#,
+    )?;
+    fs::write(
+        producer_src.join("lib.incn"),
+        r#"pub from functions import public_target
+"#,
+    )?;
+
+    let producer_build = run_incan(&producer_root, &["build", "--lib"])?;
+    assert_success(&producer_build, "producer build --lib for public alias issue617");
+
+    let manifest_path = producer_root.join("target").join("lib").join("alias_lib.incnlib");
+    let manifest: serde_json::Value = serde_json::from_str(&fs::read_to_string(&manifest_path)?)?;
+    assert!(
+        manifest.pointer("/exports/aliases/0/projected_function").is_some(),
+        "callable alias export should include function projection metadata, got:\n{manifest}"
+    );
+
+    let consumer_root = tmp.path().join("alias_consumer");
+    let consumer_main = write_minimal_project(
+        &consumer_root,
+        "alias_consumer",
+        r#"
+[dependencies]
+alias_lib = { path = "../alias_lib" }
+"#,
+    )?;
+    fs::write(
+        &consumer_main,
+        r#"from pub::alias_lib import public_target
+
+
+def main() -> None:
+    assert public_target(1) == 2
+"#,
+    )?;
+
+    let output_dir = tmp.path().join("consumer_out");
+    let consumer_build = run_incan(
+        &consumer_root,
+        &[
+            "build",
+            consumer_main.to_str().ok_or("consumer main path was not valid UTF-8")?,
+            output_dir.to_str().ok_or("output path was not valid UTF-8")?,
+        ],
+    )?;
+    assert_success(&consumer_build, "pub consumer build for public alias issue617");
+    Ok(())
+}
+
+#[test]
 fn build_frozen_uses_existing_lockfile_without_network() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "cli_frozen_existing_lock_project", "")?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4771,6 +4771,58 @@ def main() -> None:
     }
 
     #[test]
+    fn test_loop_item_field_index_assignment_materializes_owned_value_issue616()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let output = Command::new(incan_debug_binary())
+            .args([
+                "run",
+                "-c",
+                r#"
+@derive(Clone)
+model Assignment:
+    output_name: str
+
+def names(assignments: list[Assignment]) -> list[str]:
+    mut output_names: list[str] = []
+    for assignment in assignments:
+        existing_idx = index_of_name(output_names, assignment.output_name)
+        if existing_idx >= 0:
+            output_names[existing_idx] = assignment.output_name
+        else:
+            output_names.append(assignment.output_name)
+    return output_names
+
+def index_of_name(names: list[str], name: str) -> int:
+    for idx, current in enumerate(names):
+        if current == name:
+            return idx
+    return -1
+
+def main() -> None:
+    result = names([Assignment(output_name="amount"), Assignment(output_name="amount")])
+    println(result[0])
+"#,
+            ])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            output.status.success(),
+            "loop item field index-assignment regression failed: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = strip_ansi_escapes(&String::from_utf8_lossy(&output.stdout));
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            lines,
+            vec!["amount"],
+            "unexpected loop item field index-assignment output:\n{stdout}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_field_backed_by_value_method_args_do_not_require_user_clone_issue241()
     -> Result<(), Box<dyn std::error::Error>> {
         let output = Command::new(incan_debug_binary())


### PR DESCRIPTION
## Summary

This PR fixes the v0.3 RC2 release regressions in the release branch: formatter tuple-target comprehensions stay parseable, list-index assignments materialize borrowed field reads correctly, public aliases of imported items re-export the original public path, package-boundary `pub::` consumers can call public aliases whose source target is a private import binding, and the workspace version moves to `0.3.0-rc2`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `incan fmt` no longer inserts parser-invalid parentheses around tuple targets in list comprehensions; generated Rust no longer fails for list-index assignment from borrowed loop item fields or public aliases of imported symbols; dependency consumers can import and call public callable aliases from `.incnlib` manifests.
- **Internals**: Formatter comprehension clauses now reuse the statement `for` target formatter; list index assignment emission uses the list element type as the assignment use site; module-level symbol aliases carry imported-target origin/qualifier metadata for generated re-exports; alias manifest entries now carry callable projection metadata so `pub::` imports bind functions from metadata instead of following private producer-local target names.
- **Risks**: The alias paths now rely on both generated Rust qualification metadata and manifest projection metadata. Regressions would most likely show up around generated `use`/`pub use` paths or `pub::` manifest imports; this PR adds targeted regressions for both the producer and consumer sides and passed the local release gate plus the active InQL checkout.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` -> passed, including `2451` tests, rustdoc gate, clippy, cargo-deny, release build, assertion canary, examples matrix, and benchmark smoke builds.
- `cargo test --locked --test cli_integration fmt_tuple_target_list_comprehension_remains_buildable` -> passed.
- `cargo test --locked --test integration_tests test_loop_item_field_index_assignment_materializes_owned_value_issue616` -> passed.
- `cargo test --locked --test cli_integration build_public_alias_of_imported_item_reexports_original_path_issue617` -> passed.
- `cargo test --locked --test cli_integration build_pub_consumer_imports_public_alias_of_imported_item_issue617` -> passed.
- `cargo test --locked test_pub_from_import_manifest_callable_alias_typechecks` -> passed.
- Alias unit regressions for public/top-level alias lowering and manifest metadata -> passed.
- `cargo test --locked --test codegen_snapshot_tests test_std_graph_compiled_codegen` -> passed.
- Minimized `#617` package-boundary repro at `<scratch-path>` -> producer library build and dependency consumer build passed with `incan 0.3.0-rc2`; producer manifest includes `exports.aliases[].projected_function`.
- `make -C <inql-checkout> ci INCAN=incan` -> passed, including formatting, test-style, library build, all 88 InQL tests, and `pub consumer smoke check passed`.
- `git diff --check` -> passed.
- `incan --version` -> `incan 0.3.0-rc2`.
- `rg "0\\.3\\.0-rc1|0\\.3-rc1" -n` -> no matches.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): N/A

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #615
Closes #616
Closes #617