### PR TITLE
bugfix - fix union variants, static mutation, and pub aliases (#620, #621, #622)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -174,10 +174,30 @@ impl<'a> IrEmitter<'a> {
         target_ty: &IrType,
         union_qualifier: Option<&[String]>,
     ) -> Result<Option<TokenStream>, EmitError> {
-        if arg.ty.is_union() {
+        self.emit_union_payload_arg_for_site(
+            arg,
+            target_ty,
+            union_qualifier,
+            ValueUseSite::IncanCallArg {
+                target_ty: None,
+                callee_param: None,
+                in_return: false,
+            },
+        )
+    }
+
+    /// Emit a concrete payload argument for a `Union[...]` target while preserving the caller's ownership site.
+    pub(super) fn emit_union_payload_arg_for_site(
+        &self,
+        arg: &TypedExpr,
+        target_ty: &IrType,
+        union_qualifier: Option<&[String]>,
+        site: ValueUseSite<'_>,
+    ) -> Result<Option<TokenStream>, EmitError> {
+        let Some(value_ty) = self.union_payload_candidate_type(arg, target_ty) else {
             return Ok(None);
-        }
-        let Some(variant_index) = target_ty.union_variant_index_for_member(&arg.ty) else {
+        };
+        let Some(variant_index) = target_ty.union_variant_index_for_member(&value_ty) else {
             return Ok(None);
         };
         let Some(members) = target_ty.union_members() else {
@@ -188,15 +208,33 @@ impl<'a> IrEmitter<'a> {
         };
         let variant_ident = quote::format_ident!("{}", IrType::union_variant_name(variant_index));
         let union_path = self.emit_union_type_path_with_qualifier(target_ty, union_qualifier);
-        let emitted = self.emit_expr_for_use(
-            arg,
-            ValueUseSite::IncanCallArg {
-                target_ty: Some(member_ty),
-                callee_param: None,
-                in_return: false,
-            },
-        )?;
+        let emitted = self.emit_expr_for_use(arg, Self::retarget_value_use_site(site, Some(member_ty)))?;
         Ok(Some(quote! { #union_path :: #variant_ident(#emitted) }))
+    }
+
+    /// Return the concrete union-member payload type for an argument that may already be typed as the target union.
+    fn union_payload_candidate_type(&self, arg: &TypedExpr, target_ty: &IrType) -> Option<IrType> {
+        if !arg.ty.is_union() {
+            return Some(arg.ty.clone());
+        }
+
+        let candidate_name = match &arg.kind {
+            IrExprKind::Struct { name, .. } => Some(name.as_str()),
+            IrExprKind::Call { func, .. } => match &func.kind {
+                IrExprKind::Var {
+                    name,
+                    ref_kind: VarRefKind::TypeName,
+                    ..
+                } => Some(name.as_str()),
+                _ => None,
+            },
+            _ => None,
+        }?;
+        target_ty
+            .union_members()?
+            .iter()
+            .find(|member| member.nominal_type_name() == Some(candidate_name))
+            .cloned()
     }
 
     /// Emit a type-seeded literal argument for `None`/`Ok`/`Err` when possible.

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -621,9 +621,13 @@ impl<'a> IrEmitter<'a> {
                 });
             }
 
-            let rewritten_receiver = Self::rewrite_storage_root_expr(receiver, "__incan_static_value");
-            let inner = self.emit_known_method_call(&rewritten_receiver, kind, &rewritten_args)?;
             let use_mut = super::method_kind_uses_mutable_receiver(kind);
+            let rewritten_receiver = if use_mut {
+                Self::rewrite_storage_root_expr_for_mut(receiver, "__incan_static_value")
+            } else {
+                Self::rewrite_storage_root_expr(receiver, "__incan_static_value")
+            };
+            let inner = self.emit_known_method_call(&rewritten_receiver, kind, &rewritten_args)?;
             let wrapped = if use_mut {
                 self.emit_storage_with_mut(receiver, inner)
             } else {
@@ -721,7 +725,12 @@ impl<'a> IrEmitter<'a> {
     ) -> Result<TokenStream, EmitError> {
         if Self::expr_is_storage_rooted(receiver) {
             let (arg_bindings, rewritten_args) = self.materialize_storage_rooted_args(args)?;
-            let rewritten_receiver = Self::rewrite_storage_root_expr(receiver, "__incan_static_value");
+            let use_mut = !matches!(arg_policy, MethodCallArgPolicy::PreserveShape);
+            let rewritten_receiver = if use_mut {
+                Self::rewrite_storage_root_expr_for_mut(receiver, "__incan_static_value")
+            } else {
+                Self::rewrite_storage_root_expr(receiver, "__incan_static_value")
+            };
             let inner = self.emit_method_call_expr_with_result_use(
                 &rewritten_receiver,
                 method,
@@ -732,10 +741,10 @@ impl<'a> IrEmitter<'a> {
                 arg_policy,
                 result_use_site,
             )?;
-            let wrapped = if matches!(arg_policy, MethodCallArgPolicy::PreserveShape) {
-                self.emit_storage_with_ref(receiver, inner)
-            } else {
+            let wrapped = if use_mut {
                 self.emit_storage_with_mut(receiver, inner)
+            } else {
+                self.emit_storage_with_ref(receiver, inner)
             }?;
             return Ok(quote! {
                 #(#arg_bindings)*

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -350,11 +350,16 @@ impl<'a> IrEmitter<'a> {
     /// expression is emitted. Non-aggregate expressions are emitted normally, then the planned conversion is applied to
     /// the resulting token stream.
     pub(super) fn emit_expr_for_use(&self, expr: &TypedExpr, site: ValueUseSite<'_>) -> Result<TokenStream, EmitError> {
-        if matches!(site, ValueUseSite::CollectionElement { .. })
-            && let Some(target_ty) = Self::use_site_target_ty(site)
-            && let Some(wrapped) = self.emit_inference_seeded_literal_arg(expr, target_ty)?
-        {
-            return Ok(wrapped);
+        let resolved_target_ty = Self::use_site_target_ty(site).map(|ty| self.resolve_type_aliases_for_emit(ty));
+        if let Some(target_ty) = resolved_target_ty.as_ref() {
+            if let Some(wrapped) = self.emit_union_payload_arg_for_site(expr, target_ty, None, site)? {
+                return Ok(wrapped);
+            }
+            if matches!(site, ValueUseSite::CollectionElement { .. })
+                && let Some(wrapped) = self.emit_inference_seeded_literal_arg(expr, target_ty)?
+            {
+                return Ok(wrapped);
+            }
         }
 
         match &expr.kind {
@@ -374,7 +379,7 @@ impl<'a> IrEmitter<'a> {
                 return self.emit_expr_for_use(inner, site);
             }
             IrExprKind::List(items) => {
-                let site_item_ty = match Self::use_site_target_ty(site) {
+                let site_item_ty = match resolved_target_ty.as_ref() {
                     Some(IrType::List(elem)) => Some(elem.as_ref()),
                     _ => None,
                 };
@@ -386,7 +391,7 @@ impl<'a> IrEmitter<'a> {
                 return self.emit_list_literal_entries(items, item_target_ty);
             }
             IrExprKind::Dict(pairs) => {
-                let (site_key_ty, site_value_ty) = match Self::use_site_target_ty(site) {
+                let (site_key_ty, site_value_ty) = match resolved_target_ty.as_ref() {
                     Some(IrType::Dict(key, value)) => (Some(key.as_ref()), Some(value.as_ref())),
                     _ => (None, None),
                 };
@@ -402,7 +407,7 @@ impl<'a> IrEmitter<'a> {
                 if items.is_empty() {
                     return Ok(quote! { std::collections::HashSet::new() });
                 }
-                let site_item_ty = match Self::use_site_target_ty(site) {
+                let site_item_ty = match resolved_target_ty.as_ref() {
                     Some(IrType::Set(elem)) => Some(elem.as_ref()),
                     _ => None,
                 };
@@ -425,7 +430,7 @@ impl<'a> IrEmitter<'a> {
                 return Ok(quote! { [#(#item_tokens),*].into_iter().collect::<std::collections::HashSet<_>>() });
             }
             IrExprKind::Tuple(items) => {
-                let site_tuple_items = match Self::use_site_target_ty(site) {
+                let site_tuple_items = match resolved_target_ty.as_ref() {
                     Some(IrType::Tuple(items)) => Some(items.as_slice()),
                     _ => None,
                 };
@@ -483,13 +488,18 @@ impl<'a> IrEmitter<'a> {
                 callable_signature,
                 canonical_path,
             } => {
+                let target_site = if let Some(target_ty) = resolved_target_ty.as_ref() {
+                    Self::retarget_value_use_site(site, Some(target_ty))
+                } else {
+                    site
+                };
                 return self.emit_call_expr_for_use(
                     func,
                     type_args,
                     args,
                     callable_signature.as_ref(),
                     canonical_path.as_deref(),
-                    site,
+                    target_site,
                 );
             }
             _ => {}
@@ -555,15 +565,31 @@ impl<'a> IrEmitter<'a> {
         Self::expr_storage_root(expr).is_some()
     }
 
+    /// Rewrite a static/storage binding root to the local borrowed value used inside `with_ref`.
     pub(super) fn rewrite_storage_root_expr(expr: &TypedExpr, local_name: &str) -> TypedExpr {
+        Self::rewrite_storage_root_expr_inner(expr, local_name, false)
+    }
+
+    /// Rewrite a static/storage binding root to the local mutable borrow used inside `with_mut`.
+    pub(super) fn rewrite_storage_root_expr_for_mut(expr: &TypedExpr, local_name: &str) -> TypedExpr {
+        Self::rewrite_storage_root_expr_inner(expr, local_name, true)
+    }
+
+    /// Rewrite the root of a storage-backed path while preserving the original field/index chain.
+    fn rewrite_storage_root_expr_inner(expr: &TypedExpr, local_name: &str, mutable_root: bool) -> TypedExpr {
         let replacement = || {
+            let ty = if mutable_root {
+                IrType::RefMut(Box::new(expr.ty.clone()))
+            } else {
+                expr.ty.clone()
+            };
             TypedExpr::new(
                 IrExprKind::Var {
                     name: local_name.to_string(),
                     access: super::super::expr::VarAccess::Read,
                     ref_kind: VarRefKind::Value,
                 },
-                expr.ty.clone(),
+                ty,
             )
         };
 
@@ -575,14 +601,14 @@ impl<'a> IrEmitter<'a> {
             } => replacement(),
             IrExprKind::Field { object, field } => TypedExpr::new(
                 IrExprKind::Field {
-                    object: Box::new(Self::rewrite_storage_root_expr(object, local_name)),
+                    object: Box::new(Self::rewrite_storage_root_expr_inner(object, local_name, mutable_root)),
                     field: field.clone(),
                 },
                 expr.ty.clone(),
             ),
             IrExprKind::Index { object, index } => TypedExpr::new(
                 IrExprKind::Index {
-                    object: Box::new(Self::rewrite_storage_root_expr(object, local_name)),
+                    object: Box::new(Self::rewrite_storage_root_expr_inner(object, local_name, mutable_root)),
                     index: index.clone(),
                 },
                 expr.ty.clone(),

--- a/src/backend/ir/emit/mod.rs
+++ b/src/backend/ir/emit/mod.rs
@@ -220,6 +220,8 @@ pub struct IrEmitter<'a> {
     struct_field_defaults: std::collections::HashMap<(String, String), super::IrExpr>,
     /// Constructor metadata variants for source-defined structs that share a simple name across modules.
     struct_constructor_metadata: HashMap<String, Vec<StructConstructorMetadata>>,
+    /// Transparent local type aliases keyed by alias name.
+    type_aliases: HashMap<String, IrType>,
     /// Incan `rusttype` aliases that should use compiler-owned call conversion rules at the surface boundary.
     rusttype_alias_names: HashSet<String>,
     /// Method signature lookup for Incan-owned nominal receivers, including imported modules.
@@ -326,6 +328,7 @@ impl<'a> IrEmitter<'a> {
             struct_field_descriptions: std::collections::HashMap::new(),
             struct_field_defaults: std::collections::HashMap::new(),
             struct_constructor_metadata: HashMap::new(),
+            type_aliases: HashMap::new(),
             rusttype_alias_names: HashSet::new(),
             method_signatures: HashMap::new(),
             method_signature_type_params: HashMap::new(),
@@ -349,6 +352,67 @@ impl<'a> IrEmitter<'a> {
             result_observer_callable_types: RefCell::new(HashSet::new()),
             emitted_result_observer_callable_helpers: RefCell::new(HashSet::new()),
             borrowed_function_adapters: RefCell::new(HashSet::new()),
+        }
+    }
+
+    /// Resolve transparent type aliases before emission decisions that need structural type information.
+    pub(in crate::backend::ir::emit) fn resolve_type_aliases_for_emit(&self, ty: &IrType) -> IrType {
+        let mut visiting = HashSet::new();
+        self.resolve_type_aliases_for_emit_inner(ty, &mut visiting)
+    }
+
+    /// Resolve nested transparent aliases while preserving cycles as their original alias names.
+    fn resolve_type_aliases_for_emit_inner(&self, ty: &IrType, visiting: &mut HashSet<String>) -> IrType {
+        match ty {
+            IrType::Struct(name) | IrType::NamedGeneric(name, _) if self.type_aliases.contains_key(name) => {
+                if !visiting.insert(name.clone()) {
+                    return ty.clone();
+                }
+                let Some(target) = self.type_aliases.get(name) else {
+                    visiting.remove(name);
+                    return ty.clone();
+                };
+                let resolved = self.resolve_type_aliases_for_emit_inner(target, visiting);
+                visiting.remove(name);
+                resolved
+            }
+            IrType::List(inner) => IrType::List(Box::new(self.resolve_type_aliases_for_emit_inner(inner, visiting))),
+            IrType::Dict(key, value) => IrType::Dict(
+                Box::new(self.resolve_type_aliases_for_emit_inner(key, visiting)),
+                Box::new(self.resolve_type_aliases_for_emit_inner(value, visiting)),
+            ),
+            IrType::Set(inner) => IrType::Set(Box::new(self.resolve_type_aliases_for_emit_inner(inner, visiting))),
+            IrType::Tuple(items) => IrType::Tuple(
+                items
+                    .iter()
+                    .map(|item| self.resolve_type_aliases_for_emit_inner(item, visiting))
+                    .collect(),
+            ),
+            IrType::Option(inner) => {
+                IrType::Option(Box::new(self.resolve_type_aliases_for_emit_inner(inner, visiting)))
+            }
+            IrType::Result(ok, err) => IrType::Result(
+                Box::new(self.resolve_type_aliases_for_emit_inner(ok, visiting)),
+                Box::new(self.resolve_type_aliases_for_emit_inner(err, visiting)),
+            ),
+            IrType::NamedGeneric(name, args) => IrType::NamedGeneric(
+                name.clone(),
+                args.iter()
+                    .map(|arg| self.resolve_type_aliases_for_emit_inner(arg, visiting))
+                    .collect(),
+            ),
+            IrType::Function { params, ret } => IrType::Function {
+                params: params
+                    .iter()
+                    .map(|param| self.resolve_type_aliases_for_emit_inner(param, visiting))
+                    .collect(),
+                ret: Box::new(self.resolve_type_aliases_for_emit_inner(ret, visiting)),
+            },
+            IrType::Ref(inner) => IrType::Ref(Box::new(self.resolve_type_aliases_for_emit_inner(inner, visiting))),
+            IrType::RefMut(inner) => {
+                IrType::RefMut(Box::new(self.resolve_type_aliases_for_emit_inner(inner, visiting)))
+            }
+            _ => ty.clone(),
         }
     }
 
@@ -676,13 +740,20 @@ impl<'a> IrEmitter<'a> {
                 }
                 IrDeclKind::TypeAlias {
                     name,
-                    is_rusttype: true,
+                    type_params,
+                    ty,
+                    is_rusttype,
                     ..
                 } => {
                     if skip_ambiguous && self.ambiguous_type_names.contains(name) {
                         continue;
                     }
-                    self.rusttype_alias_names.insert(name.clone());
+                    if type_params.is_empty() && !is_rusttype {
+                        self.type_aliases.insert(name.clone(), ty.clone());
+                    }
+                    if *is_rusttype {
+                        self.rusttype_alias_names.insert(name.clone());
+                    }
                 }
                 IrDeclKind::Impl(i) => {
                     for method in &i.methods {

--- a/src/backend/ir/emit/program.rs
+++ b/src/backend/ir/emit/program.rs
@@ -2165,6 +2165,18 @@ impl<'a> IrEmitter<'a> {
             }
             if let IrDeclKind::TypeAlias {
                 name,
+                type_params,
+                ty,
+                is_rusttype,
+                ..
+            } = &decl.kind
+                && type_params.is_empty()
+                && !is_rusttype
+            {
+                self.type_aliases.insert(name.clone(), ty.clone());
+            }
+            if let IrDeclKind::TypeAlias {
+                name,
                 is_rusttype: true,
                 ..
             } = &decl.kind

--- a/src/backend/ir/emit/statements.rs
+++ b/src/backend/ir/emit/statements.rs
@@ -990,11 +990,11 @@ impl<'a> IrEmitter<'a> {
         let rhs_ident = format_ident!("{}", rhs_name);
         let rewritten_target = match target {
             AssignTarget::Field { object, field } => AssignTarget::Field {
-                object: Box::new(Self::rewrite_storage_root_expr(object, local_name)),
+                object: Box::new(Self::rewrite_storage_root_expr_for_mut(object, local_name)),
                 field: field.clone(),
             },
             AssignTarget::Index { object, index } => AssignTarget::Index {
-                object: Box::new(Self::rewrite_storage_root_expr(object, local_name)),
+                object: Box::new(Self::rewrite_storage_root_expr_for_mut(object, local_name)),
                 index: index.clone(),
             },
             _ => {

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -11,7 +11,7 @@ use crate::frontend::testing_markers::{
     TestingFixtureMarkerArgs, TestingMarkerSemantics, load_testing_marker_semantics,
     resolve_testing_fixture_marker_args,
 };
-use crate::frontend::typechecker::helpers::{dict_ty, list_ty};
+use crate::frontend::typechecker::helpers::{collection_type_id, dict_ty, list_ty};
 
 use super::{DecoratedFunctionBindingInfo, DecoratedMethodBindingInfo, TestingFixtureInfo, TypeChecker, YieldContext};
 use incan_core::interop::{RustItemKind, RustItemMetadata, RustTraitAssoc};
@@ -20,6 +20,7 @@ use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::magic_methods;
 use incan_core::lang::stdlib;
 use incan_core::lang::traits::{self as builtin_traits, TraitId};
+use incan_core::lang::types::collections::CollectionTypeId;
 use incan_semantics_core::SurfaceModifierTypeCheck;
 use std::collections::{HashMap, HashSet};
 
@@ -2439,6 +2440,7 @@ impl TypeChecker {
         // Define fields in scope
         for field in &model.fields {
             let ty = self.resolve_type_checked(&field.node.ty);
+            self.validate_direct_recursive_model_field(&model.name, &ty, field.span);
             self.symbols.define(Symbol {
                 name: field.node.name.clone(),
                 kind: SymbolKind::Field(FieldInfo {
@@ -2483,6 +2485,129 @@ impl TypeChecker {
         }
 
         self.symbols.exit_scope();
+    }
+
+    /// Reject model fields whose resolved type contains the model itself without an indirection boundary.
+    fn validate_direct_recursive_model_field(&mut self, model_name: &str, field_ty: &ResolvedType, span: Span) {
+        let mut visiting = HashSet::new();
+        if self.type_contains_direct_recursive_model(field_ty, model_name, &mut visiting) {
+            self.errors.push(CompileError::type_error(
+                format!(
+                    "Model '{model_name}' has a direct recursive field type '{field_ty}'. Use an indirection such as List[...] for recursive payloads."
+                ),
+                span,
+            ));
+        }
+    }
+
+    /// Return whether a type contains the target model through only inline Rust-layout positions.
+    fn type_contains_direct_recursive_model(
+        &self,
+        ty: &ResolvedType,
+        model_name: &str,
+        visiting: &mut HashSet<String>,
+    ) -> bool {
+        match ty {
+            ResolvedType::Named(name) => {
+                self.nominal_type_contains_direct_recursive_model(name, &[], model_name, visiting)
+            }
+            ResolvedType::Generic(name, args) if name == UNION_TYPE_NAME => args
+                .iter()
+                .any(|arg| self.type_contains_direct_recursive_model(arg, model_name, visiting)),
+            ResolvedType::Generic(name, args) => match collection_type_id(name.as_str()) {
+                Some(
+                    CollectionTypeId::List
+                    | CollectionTypeId::Dict
+                    | CollectionTypeId::Set
+                    | CollectionTypeId::FrozenList
+                    | CollectionTypeId::FrozenDict
+                    | CollectionTypeId::FrozenSet
+                    | CollectionTypeId::Generator,
+                ) => false,
+                Some(CollectionTypeId::Tuple | CollectionTypeId::Option | CollectionTypeId::Result) => args
+                    .iter()
+                    .any(|arg| self.type_contains_direct_recursive_model(arg, model_name, visiting)),
+                None => self.nominal_type_contains_direct_recursive_model(name, args, model_name, visiting),
+            },
+            ResolvedType::Tuple(items) => items
+                .iter()
+                .any(|item| self.type_contains_direct_recursive_model(item, model_name, visiting)),
+            ResolvedType::Ref(_)
+            | ResolvedType::RefMut(_)
+            | ResolvedType::FrozenList(_)
+            | ResolvedType::FrozenDict(_, _)
+            | ResolvedType::FrozenSet(_)
+            | ResolvedType::Function(_, _) => false,
+            ResolvedType::Int
+            | ResolvedType::Float
+            | ResolvedType::Numeric(_)
+            | ResolvedType::Bool
+            | ResolvedType::Str
+            | ResolvedType::Bytes
+            | ResolvedType::FrozenStr
+            | ResolvedType::FrozenBytes
+            | ResolvedType::Unit
+            | ResolvedType::TypeVar(_)
+            | ResolvedType::SelfType
+            | ResolvedType::RustPath(_)
+            | ResolvedType::CallSiteInfer
+            | ResolvedType::Unknown => false,
+        }
+    }
+
+    /// Follow known nominal field types to find direct recursive model layouts.
+    fn nominal_type_contains_direct_recursive_model(
+        &self,
+        type_name: &str,
+        type_args: &[ResolvedType],
+        model_name: &str,
+        visiting: &mut HashSet<String>,
+    ) -> bool {
+        if type_name == model_name {
+            return true;
+        }
+
+        let visit_key = if type_args.is_empty() {
+            type_name.to_string()
+        } else {
+            format!(
+                "{}[{}]",
+                type_name,
+                type_args.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+            )
+        };
+        if !visiting.insert(visit_key.clone()) {
+            return false;
+        }
+
+        let result = match self.lookup_semantic_type_info(type_name) {
+            Some(TypeInfo::Model(info)) => {
+                let subst = type_param_subst_map(&info.type_params, type_args);
+                info.fields.values().any(|field| {
+                    let field_ty = substitute_resolved_type(&field.ty, &subst);
+                    let field_ty = self.expand_type_aliases(field_ty);
+                    self.type_contains_direct_recursive_model(&field_ty, model_name, visiting)
+                })
+            }
+            Some(TypeInfo::Class(info)) => {
+                let subst = type_param_subst_map(&info.type_params, type_args);
+                info.fields.values().any(|field| {
+                    let field_ty = substitute_resolved_type(&field.ty, &subst);
+                    let field_ty = self.expand_type_aliases(field_ty);
+                    self.type_contains_direct_recursive_model(&field_ty, model_name, visiting)
+                })
+            }
+            Some(TypeInfo::Newtype(info)) => {
+                let subst = type_param_subst_map(&info.type_params, type_args);
+                let underlying = substitute_resolved_type(&info.underlying, &subst);
+                let underlying = self.expand_type_aliases(underlying);
+                self.type_contains_direct_recursive_model(&underlying, model_name, visiting)
+            }
+            Some(TypeInfo::Enum(_) | TypeInfo::Builtin | TypeInfo::TypeAlias) | None => false,
+        };
+
+        visiting.remove(&visit_key);
+        result
     }
 
     fn check_validate_derive_model(&mut self, model: &ModelDecl) {

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -3065,6 +3065,12 @@ impl TypeChecker {
             }
         }
 
+        if let Some(ret) =
+            self.resolve_union_clone_trait_method_call(&base_ty, method, type_args, args, &arg_types, span)
+        {
+            return ret;
+        }
+
         if let ResolvedType::Generic(type_name, _type_args) = &base_ty
             && let Some(type_info) = self.lookup_semantic_type_info(type_name).cloned()
         {
@@ -3309,6 +3315,37 @@ impl TypeChecker {
                 .push(errors::missing_method(&base_ty.to_string(), method, span));
         }
         ResolvedType::Unknown
+    }
+
+    /// Resolve methods supplied by Clone for anonymous union wrappers.
+    fn resolve_union_clone_trait_method_call(
+        &mut self,
+        receiver_ty: &ResolvedType,
+        method: &str,
+        type_args: &[Spanned<Type>],
+        args: &[CallArg],
+        arg_types: &[ResolvedType],
+        span: Span,
+    ) -> Option<ResolvedType> {
+        if !receiver_ty.is_union() {
+            return None;
+        }
+
+        let adoption = TypeBoundInfo {
+            name: core_traits::as_str(TraitId::Clone).to_string(),
+            source_name: None,
+            type_args: Vec::new(),
+            module_path: None,
+        };
+        let method_info = self.trait_method_info_resolved_for_adoption(&adoption, method, span)?;
+        if !self.is_clone_type(receiver_ty) {
+            self.errors.push(CompileError::type_error(
+                format!("Union type '{receiver_ty}' cannot use '{method}(...)' because not all variants are cloneable"),
+                span,
+            ));
+            return Some(ResolvedType::Unknown);
+        }
+        Some(self.check_generic_method_call(method, method_info, type_args, args, arg_types, span, receiver_ty))
     }
 
     /// Return known method result types for Rust imports when rust-inspect metadata is not specific enough.

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -16,7 +16,7 @@ use crate::frontend::typechecker::type_info::RustTraitImportInfo;
 use crate::library_manifest::{
     AliasExport, ClassExport, ConstExport, EnumExport, EnumValueExport, EnumValueTypeExport, FieldExport,
     FunctionExport, LibraryManifest, MethodExport, ModelExport, NewtypeExport, ParamExport, ParamKindExport,
-    PartialExport, ReceiverExport, StaticExport, TraitExport, TypeBoundExport, TypeParamExport,
+    PartialExport, ReceiverExport, StaticExport, TraitExport, TypeAliasExport, TypeBoundExport, TypeParamExport,
     resolved_type_from_manifest_type_ref,
 };
 use incan_core::interop::{RustItemKind, RustTraitAssoc, is_rust_capability_bound};
@@ -36,7 +36,7 @@ enum ManifestExportRef<'a> {
         enum_name: &'a str,
         fields: &'a [crate::library_manifest::TypeRef],
     },
-    TypeAlias,
+    TypeAlias(&'a TypeAliasExport),
     Newtype(&'a NewtypeExport),
     Const(&'a ConstExport),
     Static(&'a StaticExport),
@@ -713,7 +713,7 @@ impl TypeChecker {
             ManifestExportRef::Partial(export) => SymbolKind::Function(self.partial_info_from_manifest(export)),
             ManifestExportRef::Trait(export) => SymbolKind::Trait(self.trait_info_from_manifest(export)),
             ManifestExportRef::Enum(export) => SymbolKind::Type(TypeInfo::Enum(self.enum_info_from_manifest(export))),
-            ManifestExportRef::TypeAlias => SymbolKind::Type(TypeInfo::TypeAlias),
+            ManifestExportRef::TypeAlias(_) => SymbolKind::Type(TypeInfo::TypeAlias),
             ManifestExportRef::Newtype(export) => {
                 SymbolKind::Type(TypeInfo::Newtype(self.newtype_info_from_manifest(export)))
             }
@@ -907,8 +907,8 @@ impl TypeChecker {
                 });
             }
         }
-        if manifest.exports.type_aliases.iter().any(|item| item.name == name) {
-            return Some(ManifestExportRef::TypeAlias);
+        if let Some(item) = manifest.exports.type_aliases.iter().find(|item| item.name == name) {
+            return Some(ManifestExportRef::TypeAlias(item));
         }
         if let Some(item) = manifest.exports.newtypes.iter().find(|item| item.name == name) {
             return Some(ManifestExportRef::Newtype(item));
@@ -922,6 +922,7 @@ impl TypeChecker {
         None
     }
 
+    /// Return whether a manifest export introduces a type-like name into the importing module.
     fn manifest_export_is_type(export: &ManifestExportRef<'_>) -> bool {
         matches!(
             export,
@@ -929,7 +930,7 @@ impl TypeChecker {
                 | ManifestExportRef::Class(_)
                 | ManifestExportRef::Trait(_)
                 | ManifestExportRef::Enum(_)
-                | ManifestExportRef::TypeAlias
+                | ManifestExportRef::TypeAlias(_)
                 | ManifestExportRef::Newtype(_)
         )
     }
@@ -977,7 +978,18 @@ impl TypeChecker {
                 enum_name: enum_name.to_string(),
                 fields: fields.iter().map(resolved_type_from_manifest_type_ref).collect(),
             }),
-            ManifestExportRef::TypeAlias => SymbolKind::Type(TypeInfo::TypeAlias),
+            ManifestExportRef::TypeAlias(export) => {
+                let mut target = resolved_type_from_manifest_type_ref(&export.target);
+                Self::remap_resolved_type_with_import_aliases(&mut target, imported_type_aliases);
+                self.type_aliases.insert(
+                    local_name.clone(),
+                    crate::frontend::typechecker::TypeAliasTarget {
+                        type_params: export.type_params.iter().map(|param| param.name.clone()).collect(),
+                        target,
+                    },
+                );
+                SymbolKind::Type(TypeInfo::TypeAlias)
+            }
             ManifestExportRef::Newtype(export) => {
                 SymbolKind::Type(TypeInfo::Newtype(self.newtype_info_from_manifest(export)))
             }

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -3815,6 +3815,12 @@ impl TypeChecker {
             }
         };
 
+        let expanded_actual = self.expand_type_aliases(actual.clone());
+        let expanded_expected = self.expand_type_aliases(expected.clone());
+        if &expanded_actual != actual || &expanded_expected != expected {
+            return self.types_compatible(&expanded_actual, &expanded_expected);
+        }
+
         if actual == expected {
             return true;
         }

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -15,7 +15,8 @@ use crate::library_manifest::{
     AliasExport, ClassExport, ConstExport, EnumExport, EnumValueExport, EnumValueTypeExport, EnumVariantExport,
     FunctionExport, LibraryContractMetadata, LibraryExports, LibraryManifest, LibraryRustAbi, MethodExport,
     ModelExport, ParamExport, ParamKindExport, PartialExport, PartialPresetExport, PartialTargetKindExport,
-    PresetValueExport, ReceiverExport, StaticExport, TraitExport, TypeBoundExport, TypeParamExport, TypeRef,
+    PresetValueExport, ReceiverExport, StaticExport, TraitExport, TypeAliasExport, TypeBoundExport, TypeParamExport,
+    TypeRef,
 };
 #[cfg(feature = "rust_inspect")]
 use crate::rust_inspect::{Inspector, InspectorConfig, write_borrowed_param_probe_crate, write_substrait_probe_crate};
@@ -1464,7 +1465,13 @@ fn library_index_with_mylib_exports() -> LibraryManifestIndex {
                 }],
                 derives: Vec::new(),
             }],
-            type_aliases: Vec::new(),
+            type_aliases: vec![TypeAliasExport {
+                name: "WidgetAlias".to_string(),
+                type_params: Vec::new(),
+                target: TypeRef::Named {
+                    name: "Widget".to_string(),
+                },
+            }],
             newtypes: Vec::new(),
             consts: vec![ConstExport {
                 name: "DEFAULT_NAME".to_string(),
@@ -2883,6 +2890,49 @@ def normalize(value: int | str) -> str:
             .iter()
             .any(|error| error.message.contains("non-exhaustive") || error.message.contains("str")),
         "expected non-exhaustive union match diagnostic, got: {:?}",
+        errors.iter().map(|error| &error.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_union_clone_method_typechecks_when_members_are_cloneable() {
+    let source = r#"
+@derive(Clone)
+model Leaf:
+  value: int
+
+@derive(Clone)
+model Pair:
+  args: List[Expr]
+
+type Expr = Union[Leaf, Pair]
+
+def clone_expr(expr: Expr) -> Expr:
+  return expr.clone()
+"#;
+    assert!(check_str(source).is_ok());
+}
+
+#[test]
+fn test_union_model_variants_reject_direct_recursive_payload_without_indirection() {
+    let source = r#"
+@derive(Clone)
+model Leaf:
+  value: int
+
+@derive(Clone)
+model Pair:
+  left: Expr
+  right: Expr
+
+type Expr = Union[Leaf, Pair]
+"#;
+    let errors = check_str_err(source, "direct recursive union model payload should be rejected");
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("direct recursive") && error.message.contains("Pair")),
+        "expected direct recursive model diagnostic, got: {:?}",
         errors.iter().map(|error| &error.message).collect::<Vec<_>>()
     );
 }
@@ -10972,6 +11022,24 @@ def build() -> Widget:
 "#;
     let result = check_str_with_library_index(source, library_index_with_mylib_exports());
     assert!(result.is_ok(), "expected pub import to typecheck, got: {result:?}");
+}
+
+#[test]
+fn test_pub_from_import_type_alias_is_transparent() {
+    let source = r#"
+from pub::mylib import WidgetAlias, make_widget
+
+def keep(widget: WidgetAlias) -> WidgetAlias:
+  return widget
+
+def build() -> WidgetAlias:
+  return keep(make_widget("ok"))
+"#;
+    let result = check_str_with_library_index(source, library_index_with_mylib_exports());
+    assert!(
+        result.is_ok(),
+        "expected pub-imported type alias to behave transparently, got: {result:?}"
+    );
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2297,6 +2297,36 @@ def main() -> None:
 }
 
 #[test]
+fn test_static_list_index_assignment_and_remove_compile_and_run() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+static entries: list[int] = []
+
+def main() -> None:
+  entries.append(1)
+  entries[0] = 2
+  println(entries[0])
+  entries.remove(0)
+  entries.append(3)
+  println(entries[0])
+"#;
+    let output = Command::new(incan_debug_binary())
+        .args(["run", "-c", source])
+        .env("CARGO_NET_OFFLINE", "true")
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "expected static list index mutation program to run.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+    assert_eq!(lines, ["2", "3"], "unexpected static list mutation output");
+    Ok(())
+}
+
+#[test]
 fn test_list_concatenation_plus_operator_runs() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
 def main() -> None:
@@ -4372,6 +4402,111 @@ def main() -> None:
                 "from-path"
             ],
             "unexpected union output:\n{stdout}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_union_model_variants_compile_and_run() -> Result<(), Box<dyn std::error::Error>> {
+        let output = Command::new(incan_debug_binary())
+            .args([
+                "run",
+                "-c",
+                r#"
+@derive(Clone)
+model Leaf:
+    value: int
+
+@derive(Clone)
+model Pair:
+    args: list[Expr]
+
+type Expr = Union[Leaf, Pair]
+
+def pair() -> Expr:
+    return Pair(args=[Leaf(value=1), Leaf(value=2)])
+
+def clone_expr(expr: Expr) -> Expr:
+    return expr.clone()
+
+def sum_expr(expr: Expr) -> int:
+    match expr:
+        Leaf(leaf) =>
+            return leaf.value
+        Pair(pair) =>
+            return sum_expr(pair.args[0])
+
+def main() -> None:
+    println(sum_expr(clone_expr(pair())))
+"#,
+            ])
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            output.status.success(),
+            "union model variant run-path regression failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = strip_ansi_escapes(&String::from_utf8_lossy(&output.stdout));
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(lines, vec!["1"], "unexpected union model variant output:\n{stdout}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_imported_union_alias_list_field_compiles_issue622() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project_root = tmp.path().join("union_list_cross_module_alias_repro");
+        fs::create_dir_all(project_root.join("src"))?;
+        fs::write(
+            project_root.join("incan.toml"),
+            "[project]\nname = \"union_list_cross_module_alias_repro\"\nversion = \"0.1.0\"\n",
+        )?;
+        fs::write(
+            project_root.join("src/exprs.incn"),
+            r#"
+@derive(Clone)
+pub model Leaf:
+    pub value: int
+
+@derive(Clone)
+pub model Pair:
+    pub args: list[Expr]
+
+pub type Expr = Union[Leaf, Pair]
+
+pub def pair() -> Expr:
+    return Pair(args=[Leaf(value=1), Leaf(value=2)])
+"#,
+        )?;
+        fs::write(
+            project_root.join("src/lib.incn"),
+            r#"
+from exprs import Expr, Leaf, Pair, pair
+
+def sum_expr(expr: Expr) -> int:
+    match expr:
+        Leaf(leaf) => return leaf.value
+        Pair(pair_expr) => return sum_expr(pair_expr.args[0])
+
+pub def main_value() -> int:
+    return sum_expr(pair())
+"#,
+        )?;
+
+        let output = Command::new(incan_debug_binary())
+            .args(["build", "--lib"])
+            .current_dir(&project_root)
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            output.status.success(),
+            "expected imported union alias list-field project to build for #622.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

This PR fixes the remaining v0.3 release regressions around union model variants, static storage mutation, and pub-imported type aliases, then bumps the release candidate version to `0.3.0-rc3`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Cloneable union wrappers can use `clone()`, model constructors can flow into union return/collection sites, static list index assignment and mutating methods compile, and pub-imported type aliases stay transparent across package boundaries.
- **Internals**: The typechecker now expands aliases for compatibility checks, imports manifest type aliases into the consumer alias table, rejects direct recursive inline model payloads, and resolves union `Clone` via trait metadata. The emitter resolves transparent aliases for structural decisions and rewrites static storage roots through the correct mutable binding path.
- **Risks**: The highest-risk area is alias expansion feeding compatibility and codegen decisions. The new tests cover the reported regressions, direct recursive union payload rejection, and the release smoke path.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make -C <incan-checkout> fmt` passed
- `cargo test test_static_list_index_assignment_and_remove_compile_and_run --manifest-path <incan-checkout>/Cargo.toml` passed after commit
- `git diff --check HEAD^..HEAD` passed after commit
- `make -C <incan-checkout> pre-commit` passed before commit: 2457 tests passed, clippy passed, cargo-deny passed, smoke-test-fast passed, benchmark smoke passed

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #620
Closes #621
Closes #622