### PR TITLE
bugfix - preserve f-string debug and list formatting (#624, #625)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/incan_core/src/lang/trait_bounds.rs
+++ b/crates/incan_core/src/lang/trait_bounds.rs
@@ -126,6 +126,7 @@ pub mod rust {
     pub const CLONE: &str = "Clone";
 
     // Formatting
+    pub const DEBUG: &str = "std::fmt::Debug";
     pub const DISPLAY: &str = "std::fmt::Display";
 
     // Arithmetic ops

--- a/crates/incan_syntax/src/ast/exprs.rs
+++ b/crates/incan_syntax/src/ast/exprs.rs
@@ -183,9 +183,15 @@ pub struct ScopedSurfaceOwner {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum FStringFormat {
+    Display,
+    Debug,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum FStringPart {
     Literal(String),
-    Expr(Spanned<Expr>),
+    Expr { expr: Spanned<Expr>, format: FStringFormat },
 }
 
 /// Parsed integer literal with the **source substring** used for formatting.

--- a/crates/incan_syntax/src/parser/expr.rs
+++ b/crates/incan_syntax/src/parser/expr.rs
@@ -1269,17 +1269,21 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Convert lexer f-string segments into parsed AST parts while preserving interpolation spans and format markers.
     fn convert_fstring_parts(&self, parts: &[LexFStringPart]) -> Vec<FStringPart> {
         parts
             .iter()
             .map(|p| match p {
                 LexFStringPart::Literal(s) => FStringPart::Literal(s.clone()),
                 LexFStringPart::Expr { text, offset } => {
-                    // Parse simple field access chains like "user.name" or "obj.field.sub"
                     let expr_span = Span::new(*offset, offset + text.len() + 2);
-                    let mut expr = self.parse_fstring_expr(text);
+                    let (expr_text, format) = split_fstring_format(text);
+                    let mut expr = self.parse_fstring_expr(expr_text);
                     self.shift_expr_spans(&mut expr, offset + 1);
-                    FStringPart::Expr(Spanned::new(expr, expr_span))
+                    FStringPart::Expr {
+                        expr: Spanned::new(expr, expr_span),
+                        format,
+                    }
                 }
             })
             .collect()
@@ -1441,8 +1445,8 @@ impl<'a> Parser<'a> {
             }
             Expr::FString(parts) => {
                 for part in parts {
-                    if let FStringPart::Expr(value) = part {
-                        self.shift_spanned_expr(value, offset);
+                    if let FStringPart::Expr { expr, .. } = part {
+                        self.shift_spanned_expr(expr, offset);
                     }
                 }
             }
@@ -1547,7 +1551,6 @@ impl<'a> Parser<'a> {
                 next_leading = 0;
             }
         }
-
         self.expect(&TokenKind::Dedent, "Expected dedent after match body")?;
         let end = self.tokens[self.pos - 1].span.end;
         Ok(Spanned::new(
@@ -2474,4 +2477,42 @@ impl<'a> Parser<'a> {
         Ok(partial_args)
     }
 
+}
+
+/// Split a raw f-string interpolation body into expression text plus the supported top-level format marker.
+fn split_fstring_format(text: &str) -> (&str, FStringFormat) {
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut format_colon = None;
+
+    for (idx, ch) in text.char_indices() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ':' if depth == 0 => format_colon = Some(idx),
+            _ => {}
+        }
+    }
+
+    if let Some(idx) = format_colon {
+        let spec = text[idx + 1..].trim();
+        if spec == "?" {
+            return (text[..idx].trim_end(), FStringFormat::Debug);
+        }
+    }
+
+    (text, FStringFormat::Display)
 }

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -3113,14 +3113,14 @@ def main() -> int:
         };
 
         let first_expr = match &parts[1] {
-            FStringPart::Expr(expr) => expr,
+            FStringPart::Expr { expr, .. } => expr,
             _ => panic!("Expected first interpolation expression"),
         };
         assert_eq!(first_expr.span.start, first_expected_start);
         assert_eq!(first_expr.span.end, first_expected_start + "{title}".len());
 
         let second_expr = match &parts[3] {
-            FStringPart::Expr(expr) => expr,
+            FStringPart::Expr { expr, .. } => expr,
             _ => panic!("Expected second interpolation expression"),
         };
         assert_eq!(second_expr.span.start, second_expected_start);
@@ -3155,13 +3155,52 @@ def main() -> int:
         };
 
         let interpolation = match &parts[1] {
-            FStringPart::Expr(expr) => expr,
+            FStringPart::Expr { expr, .. } => expr,
             _ => panic!("Expected interpolation expression"),
         };
 
         assert_eq!(interpolation.span.start, expected_start);
         assert_eq!(interpolation.span.end, expected_start + "{x + y * z}".len());
         assert!(matches!(interpolation.node, Expr::Binary(_, _, _)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_fstring_debug_format_marker() -> Result<(), Vec<CompileError>> {
+        let source = "def render(columns: list[str]) -> str:\n  return f\"columns: {columns:?}\"\n";
+        let program = parse_str(source)?;
+
+        let function = match &program.declarations[0].node {
+            Declaration::Function(f) => f,
+            _ => panic!("Expected function"),
+        };
+
+        let return_expr = match &function.body[0].node {
+            Statement::Return(Some(expr)) => expr,
+            _ => panic!("Expected return with expression"),
+        };
+
+        let parts = match &return_expr.node {
+            Expr::FString(parts) => parts,
+            _ => panic!("Expected f-string expression"),
+        };
+
+        let expected_start = match source.find("{columns:?}") {
+            Some(start) => start,
+            None => panic!("Could not find interpolation in source"),
+        };
+        let interpolation = match &parts[1] {
+            FStringPart::Expr { expr, format } => {
+                assert!(matches!(format, FStringFormat::Debug));
+                expr
+            }
+            _ => panic!("Expected interpolation expression"),
+        };
+
+        assert_eq!(interpolation.span.start, expected_start);
+        assert_eq!(interpolation.span.end, expected_start + "{columns:?}".len());
+        assert!(matches!(interpolation.node, Expr::Ident(ref name) if name == "columns"));
 
         Ok(())
     }
@@ -3192,7 +3231,7 @@ def main() -> int:
         };
 
         let interpolation = match &parts[1] {
-            FStringPart::Expr(expr) => expr,
+            FStringPart::Expr { expr, .. } => expr,
             _ => panic!("Expected interpolation expression"),
         };
         assert_eq!(interpolation.span.start, expected_start);
@@ -3353,7 +3392,7 @@ def main() -> int:
         };
 
         let interpolation = match &parts[1] {
-            FStringPart::Expr(expr) => expr,
+            FStringPart::Expr { expr, .. } => expr,
             _ => panic!("Expected interpolation expression"),
         };
         assert_eq!(interpolation.span.start, expected_start);

--- a/src/backend/ir/emit/decls/functions.rs
+++ b/src/backend/ir/emit/decls/functions.rs
@@ -274,7 +274,7 @@ impl<'a> IrEmitter<'a> {
             }
             IrExprKind::Format { parts } => {
                 for part in parts {
-                    if let super::super::super::expr::FormatPart::Expr(expr) = part {
+                    if let super::super::super::expr::FormatPart::Expr { expr, .. } = part {
                         Self::rewrite_borrowed_param_types_in_expr(expr, borrowed);
                     }
                 }
@@ -1483,7 +1483,7 @@ impl<'a> IrEmitter<'a> {
             }
             IrExprKind::Format { parts } => {
                 for part in parts {
-                    if let super::super::super::expr::FormatPart::Expr(expr) = part {
+                    if let super::super::super::expr::FormatPart::Expr { expr, .. } = part {
                         Self::collect_expr_used_names(expr, param_names, shadowed_names, used_names);
                     }
                 }

--- a/src/backend/ir/emit/decls/mutation_scan.rs
+++ b/src/backend/ir/emit/decls/mutation_scan.rs
@@ -316,8 +316,8 @@ impl<'a> IrEmitter<'a> {
             }
             IrExprKind::Format { parts } => {
                 for part in parts {
-                    if let super::super::super::expr::FormatPart::Expr(e) = part {
-                        self.scan_expr_for_param_writes(e, param_names, mutated);
+                    if let super::super::super::expr::FormatPart::Expr { expr, .. } = part {
+                        self.scan_expr_for_param_writes(expr, param_names, mutated);
                     }
                 }
             }

--- a/src/backend/ir/emit/expressions/format.rs
+++ b/src/backend/ir/emit/expressions/format.rs
@@ -27,8 +27,8 @@ impl<'a> IrEmitter<'a> {
     /// ## Notes
     ///
     /// - Literal segments are brace-escaped via `incan_core::strings::escape_format_literal`.
-    /// - Expression segments are formatted via `format!("{}", expr)` before being passed to the semantic-core f-string
-    ///   join helper.
+    /// - Display expression segments are formatted via `format!("{}", expr)`.
+    /// - Debug expression segments are formatted via `format!("{:?}", expr)`.
     pub(in super::super) fn emit_format_expr(&self, parts: &[FormatPart]) -> Result<TokenStream, EmitError> {
         // Build literal parts (length = args + 1) and a parallel list of formatted args.
         let mut literal_parts: Vec<String> = Vec::new();
@@ -40,11 +40,15 @@ impl<'a> IrEmitter<'a> {
                 FormatPart::Literal(s) => {
                     current.push_str(&escape_format_literal(s));
                 }
-                FormatPart::Expr(e) => {
+                FormatPart::Expr { expr, style } => {
                     literal_parts.push(current.clone());
                     current.clear();
-                    let arg_expr = self.emit_expr(e)?;
-                    args.push(quote! { format!("{}", #arg_expr) });
+                    let arg_expr = self.emit_expr(expr)?;
+                    if style.emits_rust_debug(&expr.ty) {
+                        args.push(quote! { format!("{:?}", #arg_expr) });
+                    } else {
+                        args.push(quote! { format!("{}", #arg_expr) });
+                    }
                 }
             }
         }

--- a/src/backend/ir/emit/program.rs
+++ b/src/backend/ir/emit/program.rs
@@ -763,7 +763,7 @@ impl<'program> GeneratedUseAnalyzer<'program> {
             }
             IrExprKind::Format { parts } => {
                 for part in parts {
-                    if let super::super::expr::FormatPart::Expr(expr) = part {
+                    if let super::super::expr::FormatPart::Expr { expr, .. } = part {
                         self.scan_expr(expr);
                     }
                 }
@@ -1792,7 +1792,7 @@ impl<'a> IrEmitter<'a> {
             }
             IrExprKind::Format { parts } => {
                 for part in parts {
-                    if let super::super::expr::FormatPart::Expr(expr) = part {
+                    if let super::super::expr::FormatPart::Expr { expr, .. } = part {
                         Self::collect_union_types_from_expr(expr, out);
                     }
                 }

--- a/src/backend/ir/emit/statements.rs
+++ b/src/backend/ir/emit/statements.rs
@@ -773,7 +773,7 @@ fn expr_uses_binding_name(expr: &super::super::expr::IrExpr, binding_name: &str)
                     .is_some_and(|expr| expr_uses_binding_name(expr, binding_name))
         }
         IrExprKind::Format { parts } => parts.iter().any(|part| match part {
-            super::super::expr::FormatPart::Expr(expr) => expr_uses_binding_name(expr, binding_name),
+            super::super::expr::FormatPart::Expr { expr, .. } => expr_uses_binding_name(expr, binding_name),
             super::super::expr::FormatPart::Literal(_) => false,
         }),
         IrExprKind::Unit

--- a/src/backend/ir/expr.rs
+++ b/src/backend/ir/expr.rs
@@ -417,7 +417,38 @@ pub enum FormatPart {
     /// Literal text
     Literal(String),
     /// Expression to interpolate
-    Expr(IrExpr),
+    Expr { expr: IrExpr, style: FormatStyle },
+}
+
+/// Formatting style requested by one f-string interpolation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FormatStyle {
+    /// User-facing display formatting (`{value}`).
+    #[default]
+    Display,
+    /// Structured debug formatting (`{value:?}`).
+    Debug,
+}
+
+impl FormatStyle {
+    /// Return whether this interpolation should emit Rust debug formatting for the resolved backend type.
+    pub fn emits_rust_debug(self, ty: &IrType) -> bool {
+        matches!(self, Self::Debug) || matches!(self, Self::Display) && display_style_uses_structured_debug(ty)
+    }
+}
+
+/// Return whether default Incan f-string display should use structured formatting for a backend representation that
+/// does not expose Rust `Display` directly.
+pub fn display_style_uses_structured_debug(ty: &IrType) -> bool {
+    matches!(
+        ty,
+        IrType::List(_)
+            | IrType::Dict(_, _)
+            | IrType::Set(_)
+            | IrType::Tuple(_)
+            | IrType::Option(_)
+            | IrType::Result(_, _)
+    )
 }
 
 /// How a variable is accessed

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -1259,9 +1259,13 @@ impl AstLowering {
                     .iter()
                     .map(|part| match part {
                         ast::FStringPart::Literal(s) => Ok(super::super::expr::FormatPart::Literal(s.clone())),
-                        ast::FStringPart::Expr(e) => {
-                            let lowered = self.lower_expr_spanned(e)?;
-                            Ok(super::super::expr::FormatPart::Expr(lowered))
+                        ast::FStringPart::Expr { expr, format } => {
+                            let lowered = self.lower_expr_spanned(expr)?;
+                            let style = match format {
+                                ast::FStringFormat::Display => super::super::expr::FormatStyle::Display,
+                                ast::FStringFormat::Debug => super::super::expr::FormatStyle::Debug,
+                            };
+                            Ok(super::super::expr::FormatPart::Expr { expr: lowered, style })
                         }
                     })
                     .collect::<Result<Vec<_>, LoweringError>>()?;

--- a/src/backend/ir/lower/stmt.rs
+++ b/src/backend/ir/lower/stmt.rs
@@ -2188,7 +2188,7 @@ impl AstLowering {
             ast::Expr::Constructor(_, args) => self.count_call_args_ident_reads(args, counts),
             ast::Expr::FString(parts) => {
                 for part in parts {
-                    if let ast::FStringPart::Expr(expr) = part {
+                    if let ast::FStringPart::Expr { expr, .. } = part {
                         self.count_expr_ident_reads(&expr.node, counts);
                     }
                 }

--- a/src/backend/ir/trait_bound_inference.rs
+++ b/src/backend/ir/trait_bound_inference.rs
@@ -1,7 +1,7 @@
 //! RFC 023: Trait bound inference for generic functions.
 //!
 //! This module scans IR function bodies to infer which Rust trait bounds are required on each type parameter based on
-//! how the parameter is used (e.g., `==` requires `PartialEq`, f-string interpolation requires `Display`).
+//! how the parameter is used (e.g., `==` requires `PartialEq`, display f-string interpolation requires `Display`).
 //!
 //! ## Inference rules (from RFC 023)
 //!
@@ -9,7 +9,8 @@
 //! | --------------------------- | ------------------------------ |
 //! | `==`, `!=`                  | `PartialEq`                    |
 //! | `<`, `<=`, `>`, `>=`        | `PartialOrd`                   |
-//! | f-string interpolation      | `std::fmt::Display`            |
+//! | f-string `{value}`          | `std::fmt::Display`            |
+//! | f-string `{value:?}`        | `std::fmt::Debug`              |
 //! | `+`                         | `std::ops::Add<Output = T>`    |
 //! | `-`                         | `std::ops::Sub<Output = T>`    |
 //! | `*`                         | `std::ops::Mul<Output = T>`    |
@@ -1042,7 +1043,7 @@ fn collect_backend_clone_bounds_in_expr(
         }
         IrExprKind::Format { parts } => {
             for part in parts {
-                if let FormatPart::Expr(expr) = part {
+                if let FormatPart::Expr { expr, .. } = part {
                     collect_backend_clone_bounds_in_expr(expr, type_param_names, self_clone_params, clone_params);
                 }
             }
@@ -1437,12 +1438,24 @@ fn scan_expr_for_bounds(
             scan_expr_for_bounds(right, type_params, params, bounds_map);
         }
 
-        // ---- f-string interpolation: expressions used in format require Display ----
+        // ---- f-string interpolation: expressions used in format require the matching formatting trait ----
         IrExprKind::Format { parts } => {
             for part in parts {
-                if let FormatPart::Expr(inner) = part {
+                if let FormatPart::Expr { expr: inner, style } = part {
+                    let bound = if style.emits_rust_debug(&inner.ty) {
+                        tb::DEBUG
+                    } else {
+                        tb::DISPLAY
+                    };
+                    let mut formatted_type_params = HashSet::new();
                     if let Some(tp_name) = expr_type_param_name(inner, type_params, params) {
-                        add_bound(bounds_map, &tp_name, IrTraitBound::simple(tb::DISPLAY));
+                        formatted_type_params.insert(tp_name);
+                    }
+                    if style.emits_rust_debug(&inner.ty) {
+                        collect_generic_type_param_names(&inner.ty, type_params, &mut formatted_type_params);
+                    }
+                    for tp_name in formatted_type_params {
+                        add_bound(bounds_map, &tp_name, IrTraitBound::simple(bound));
                     }
                     scan_expr_for_bounds(inner, type_params, params, bounds_map);
                 }
@@ -2259,8 +2272,8 @@ fn collect_calls_in_expr(
         }
         IrExprKind::Format { parts } => {
             for part in parts {
-                if let FormatPart::Expr(e) = part {
-                    recurse_expr(e, result);
+                if let FormatPart::Expr { expr, .. } = part {
+                    recurse_expr(expr, result);
                 }
             }
         }

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -640,7 +640,7 @@ fn expr_references_name(expr: &Expr, name: &str) -> bool {
             | CallArg::KeywordUnpack(expr) => expr_references_name(&expr.node, name),
         }),
         Expr::FString(parts) => parts.iter().any(|part| {
-            if let crate::frontend::ast::FStringPart::Expr(expr) = part {
+            if let crate::frontend::ast::FStringPart::Expr { expr, .. } = part {
                 expr_references_name(&expr.node, name)
             } else {
                 false

--- a/src/format/formatter/expressions.rs
+++ b/src/format/formatter/expressions.rs
@@ -372,9 +372,12 @@ impl Formatter {
                 for part in parts {
                     match part {
                         FStringPart::Literal(s) => self.writer.write(&escape_fstring_literal(s)),
-                        FStringPart::Expr(expr) => {
+                        FStringPart::Expr { expr, format } => {
                             self.writer.write("{");
                             self.format_expr(&expr.node);
+                            if matches!(format, FStringFormat::Debug) {
+                                self.writer.write(":?");
+                            }
                             self.writer.write("}");
                         }
                     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1105,6 +1105,18 @@ async def run() -> int:
         Ok(())
     }
 
+    /// Regression (GitHub #625): f-string debug markers are semantic and must survive formatting.
+    #[test]
+    fn test_format_source_preserves_fstring_debug_marker() -> Result<(), FormatError> {
+        let source = "def main(columns: list[str]) -> str:\n    return f\"columns: {columns:?}\"\n";
+        let formatted = assert_format_round_trip_lex_parse(source)?;
+        assert!(
+            formatted.contains(r#"f"columns: {columns:?}""#),
+            "expected formatter to preserve f-string debug marker, got: {formatted}"
+        );
+        Ok(())
+    }
+
     /// Regression #235: qualified constructor patterns use `::` in the AST; the formatter must print Incan surface `.`.
     #[test]
     fn test_format_source_qualified_match_pattern_round_trip() -> Result<(), FormatError> {

--- a/src/frontend/ast_walk.rs
+++ b/src/frontend/ast_walk.rs
@@ -376,7 +376,7 @@ where
         }),
         Expr::FString(parts) => parts.iter().any(|part| match part {
             crate::frontend::ast::FStringPart::Literal(_) => false,
-            crate::frontend::ast::FStringPart::Expr(expr) => expr_has(&expr.node, pred),
+            crate::frontend::ast::FStringPart::Expr { expr, .. } => expr_has(&expr.node, pred),
         }),
         Expr::Yield(Some(expr)) => expr_has(&expr.node, pred),
         Expr::Yield(None) | Expr::Partial(_) => false,

--- a/src/frontend/typechecker/check_expr/mod.rs
+++ b/src/frontend/typechecker/check_expr/mod.rs
@@ -185,8 +185,8 @@ impl TypeChecker {
             Expr::Constructor(name, args) => self.check_constructor(name, args, expr.span),
             Expr::FString(parts) => {
                 for part in parts {
-                    if let FStringPart::Expr(e) = part {
-                        self.check_expr(e);
+                    if let FStringPart::Expr { expr, .. } = part {
+                        self.check_expr(expr);
                     }
                 }
                 ResolvedType::Str

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -1740,7 +1740,7 @@ impl TypeChecker {
             }
             Expr::FString(parts) => {
                 for part in parts {
-                    if let FStringPart::Expr(expr) = part {
+                    if let FStringPart::Expr { expr, .. } = part {
                         self.collect_static_dependencies_from_expr(&expr.node, deps, visiting_functions);
                     }
                 }
@@ -1918,7 +1918,7 @@ impl TypeChecker {
             }
             Expr::FString(parts) => {
                 for part in parts {
-                    if let FStringPart::Expr(inner) = part {
+                    if let FStringPart::Expr { expr: inner, .. } = part {
                         self.collect_static_initializer_static_writes_from_expr(
                             inner,
                             current_static,

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -1938,7 +1938,7 @@ fn local_signature_in_expr(
         }),
         Expr::Constructor(_, args) => local_signature_in_call_args(args, ast, source, offset),
         Expr::FString(parts) => parts.iter().find_map(|part| match part {
-            crate::frontend::ast::FStringPart::Expr(expr) => local_signature_in_expr(expr, ast, source, offset),
+            crate::frontend::ast::FStringPart::Expr { expr, .. } => local_signature_in_expr(expr, ast, source, offset),
             crate::frontend::ast::FStringPart::Literal(_) => None,
         }),
         Expr::Yield(Some(value)) => local_signature_in_expr(value, ast, source, offset),
@@ -3569,7 +3569,7 @@ fn scoped_symbol_in_expr<'a>(
         Expr::Constructor(_, args) => scoped_symbol_in_call_args(args, ident, symbol_span, surfaces, found),
         Expr::FString(parts) => {
             for part in parts {
-                if let crate::frontend::ast::FStringPart::Expr(expr) = part {
+                if let crate::frontend::ast::FStringPart::Expr { expr, .. } = part {
                     scoped_symbol_in_expr(expr, ident, symbol_span, surfaces, found);
                 }
             }
@@ -4086,7 +4086,7 @@ fn scoped_symbol_context_in_expr(expr: &Spanned<Expr>, offset: usize, context: &
         Expr::Constructor(_, args) => scoped_symbol_context_in_call_args(args, offset, context),
         Expr::FString(parts) => {
             for part in parts {
-                if let crate::frontend::ast::FStringPart::Expr(expr) = part {
+                if let crate::frontend::ast::FStringPart::Expr { expr, .. } = part {
                     scoped_symbol_context_in_expr(expr, offset, context);
                 }
             }

--- a/src/lsp/call_site_type_args.rs
+++ b/src/lsp/call_site_type_args.rs
@@ -251,8 +251,8 @@ fn call_site_type_in_expr(expr: &Spanned<Expr>, offset: usize) -> Option<&Spanne
         Expr::Paren(inner) => call_site_type_in_expr(inner, offset),
         Expr::Constructor(_, args) => scan_call_args(args, offset),
         Expr::FString(parts) => parts.iter().find_map(|p| {
-            if let crate::frontend::ast::FStringPart::Expr(e) = p {
-                call_site_type_in_expr(e, offset)
+            if let crate::frontend::ast::FStringPart::Expr { expr, .. } = p {
+                call_site_type_in_expr(expr, offset)
             } else {
                 None
             }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1965,6 +1965,49 @@ fn test_fstring_unknown_symbol_cli_caret_points_to_interpolation() {
 }
 
 #[test]
+fn test_fstring_list_interpolation_uses_structured_formatting() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"def debug_values[T](values: list[T]) -> str:
+  return f"{values:?}"
+
+def display_values[T](values: list[T]) -> str:
+  return f"{values}"
+
+def main() -> None:
+  columns: list[str] = ["id", "amount"]
+  println(f"debug: {columns:?}")
+  println(f"display: {columns}")
+  println(debug_values[str](["id", "amount"]))
+  println(display_values[str](["id", "amount"]))
+"#;
+    let output = Command::new(incan_debug_binary())
+        .args(["run", "-c", source])
+        .env("CARGO_NET_OFFLINE", "true")
+        .output()?;
+    assert!(
+        output.status.success(),
+        "expected list f-string interpolation to run.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("debug: [\"id\", \"amount\"]"),
+        "expected debug list output, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("display: [\"id\", \"amount\"]"),
+        "expected default list f-string output to use structured formatting, got:\n{stdout}"
+    );
+    assert!(
+        stdout.lines().filter(|line| *line == "[\"id\", \"amount\"]").count() == 2,
+        "expected both generic list helpers to render, got:\n{stdout}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn fixed_call_unpack_runs_for_positional_and_keyword_shapes() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
 def total(a: int, b: int, *rest: int, **labels: str) -> int:


### PR DESCRIPTION
## Summary

This PR fixes the v0.3 release regressions where f-string debug markers were parsed away and list interpolation leaked Rust `Vec<T>: Display` requirements into Incan code. F-string interpolation now preserves `:?` through the AST/lowering/formatter path, emits Rust debug formatting when requested, uses structured formatting for Incan container display fallbacks, infers the needed generic `Debug` bounds, and bumps the release candidate to `0.3.0-rc4`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `f"{value:?}"` now survives formatting and lowers to debug formatting. `list` f-string interpolation now works for concrete and generic list values instead of failing in generated Rust because `Vec<T>` lacks `Display`.
- **Internals**: `FStringPart::Expr` carries an explicit `FStringFormat`; IR format parts carry `FormatStyle`; codegen and trait-bound inference share the same structured-format decision for container-backed values.
- **Risks**: The default `{list}` path now renders with Rust debug-style structure for list/dict/set/tuple/Option/Result backend values. That is intentional for this release blocker, but it does lock in a visible string shape for container interpolation.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo check --workspace --all-targets` passed.
- `cargo test -p incan_syntax test_parse_fstring_debug_format_marker` passed.
- `cargo test test_format_source_preserves_fstring_debug_marker` passed.
- `cargo test --test integration_tests test_fstring_list_interpolation_uses_structured_formatting` passed.
- `git diff --check` passed.
- `make pre-commit` passed: 2460 nextest tests, LSP feature test, clippy, cargo-deny, and smoke-test-fast.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #624
Closes #625