### PR TITLE
bugfix - materialize imported decorator const str arguments (#638)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc8"
+version = "0.3.0-rc9"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/lower/decl/functions.rs
+++ b/src/backend/ir/lower/decl/functions.rs
@@ -175,6 +175,15 @@ impl AstLowering {
         format!("__incan_decorated_{name}")
     }
 
+    /// Return the span used for synthetic decorator callee nodes.
+    ///
+    /// The full decorator factory call keeps the source decorator span for typechecker handoff. Nested synthetic
+    /// callees must not reuse that span because expression metadata is span-keyed and the factory result type would
+    /// otherwise overwrite the callee's callable signature during lowering.
+    pub(in crate::backend::ir::lower) fn decorator_synthetic_callee_span() -> ast::Span {
+        ast::Span::default()
+    }
+
     /// Build an expression that resolves a decorator's path through ordinary expression lowering.
     pub(in crate::backend::ir::lower) fn decorator_path_expr(
         decorator: &ast::Decorator,
@@ -220,14 +229,15 @@ impl AstLowering {
                         is_absolute: decorator.node.path.is_absolute,
                         segments: path[..path.len() - 1].to_vec(),
                     };
-                    let base = Self::decorator_path_expr_from_import_path(&base_path, decorator.span);
+                    let base =
+                        Self::decorator_path_expr_from_import_path(&base_path, Self::decorator_synthetic_callee_span());
                     let method = path.last().cloned().unwrap_or_default();
                     Spanned::new(
                         Expr::MethodCall(Box::new(base), method, Vec::new(), args),
                         decorator.span,
                     )
                 } else {
-                    let callee = Self::decorator_path_expr(&decorator.node, decorator.span);
+                    let callee = Self::decorator_path_expr(&decorator.node, Self::decorator_synthetic_callee_span());
                     Spanned::new(Expr::Call(Box::new(callee), Vec::new(), args), decorator.span)
                 }
             } else {

--- a/src/backend/ir/lower/decl/methods.rs
+++ b/src/backend/ir/lower/decl/methods.rs
@@ -73,14 +73,15 @@ impl AstLowering {
                         is_absolute: decorator.node.path.is_absolute,
                         segments: path[..path.len() - 1].to_vec(),
                     };
-                    let base = Self::decorator_path_expr_from_import_path(&base_path, decorator.span);
+                    let base =
+                        Self::decorator_path_expr_from_import_path(&base_path, Self::decorator_synthetic_callee_span());
                     let method_name = path.last().cloned().unwrap_or_default();
                     Spanned::new(
                         ast::Expr::MethodCall(Box::new(base), method_name, Vec::new(), args),
                         decorator.span,
                     )
                 } else {
-                    let callee = Self::decorator_path_expr(&decorator.node, decorator.span);
+                    let callee = Self::decorator_path_expr(&decorator.node, Self::decorator_synthetic_callee_span());
                     Spanned::new(ast::Expr::Call(Box::new(callee), Vec::new(), args), decorator.span)
                 }
             } else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -9108,6 +9108,72 @@ def test_imported_const_str_call_arguments_materialize() -> None:
     }
 
     #[test]
+    fn e2e_imported_decorator_factory_const_str_argument_materializes() {
+        let dir = write_test_project(
+            "incan.toml",
+            r#"[project]
+name = "imported_decorator_const_str_materialization"
+version = "0.1.0"
+"#,
+        );
+        let src_dir = dir.join("src");
+        let tests_dir = dir.join("tests");
+
+        if let Err(err) = std::fs::create_dir_all(&src_dir) {
+            panic!("failed to create src dir: {}", err);
+        }
+        if let Err(err) = std::fs::create_dir_all(&tests_dir) {
+            panic!("failed to create tests dir: {}", err);
+        }
+        if let Err(err) = std::fs::write(
+            src_dir.join("registry.incn"),
+            r#"
+pub const TOKEN: str = "probe.value"
+
+def keep_int(func: (int) -> int) -> (int) -> int:
+    return func
+
+pub def registered(_name: str) -> Callable[(int) -> int, (int) -> int]:
+    return keep_int
+"#,
+        ) {
+            panic!("failed to write registry source: {}", err);
+        }
+        if let Err(err) = std::fs::write(
+            tests_dir.join("test_imported_decorator_const_str.incn"),
+            r#"
+from std.testing import assert_eq
+from registry import TOKEN, registered
+
+@registered(TOKEN)
+def increment(value: int) -> int:
+    return value + 1
+
+def test_imported_decorator_factory_const_str_argument_materializes() -> None:
+    assert_eq(increment(1), 2)
+"#,
+        ) {
+            panic!("failed to write imported decorator const string test: {}", err);
+        }
+
+        let output = run_incan_test(&dir);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "expected imported decorator factory const str materialization test to succeed.\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr,
+        );
+        assert!(
+            !stderr.contains("expected `String`, found `&str`"),
+            "decorator factory const str argument should materialize as an owned string.\nstderr:\n{}",
+            stderr,
+        );
+    }
+
+    #[test]
     fn e2e_empty_list_arguments_in_tests_preserve_string_element_type() -> Result<(), Box<dyn std::error::Error>> {
         let dir = write_test_project(
             "incan.toml",


### PR DESCRIPTION
## Summary

This PR fixes the remaining #638 decorator case where both the decorator factory and `const str` argument are imported. Decorator factory lowering now gives nested synthetic callees their own neutral span so span-keyed expression metadata for the full factory call cannot overwrite the callee signature needed by argument materialization.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Imported decorator factories now accept imported `const str` arguments in `incan test`, matching the intended InQL/RFC 014 authoring shape.
- **Internals**: The full synthetic decorator factory call keeps the source decorator span for typechecker handoff, while its nested synthetic callee uses a neutral span to avoid span-keyed metadata collision.
- **Risks**: Decorator lowering spans are touched for function and method decorators. Existing decorator codegen coverage plus the new imported factory regression test cover the affected path.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test e2e_imported_decorator_factory_const_str_argument_materializes --test integration_tests -- --nocapture`
- `cargo test e2e_imported_const_str_materializes_at_test_call_sites --test integration_tests -- --nocapture`
- `cargo test user_defined --test codegen_snapshot_tests`
- `make pre-commit`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): N/A

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #638