### PR TITLE
feature - add architect codegraph advice spike (#663)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "clap",
  "flate2",
  "hex",
+ "incan_codegraph",
  "incan_core",
  "incan_semantics_core",
  "incan_semantics_stdlib",
@@ -1523,6 +1524,14 @@ dependencies = [
  "xxhash-rust",
  "xz2",
  "zstd",
+]
+
+[[package]]
+name = "incan_codegraph"
+version = "0.3.0-rc10"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/incan_vocab",
     "crates/incan_stdlib",
     "crates/incan_core",
+    "crates/incan_codegraph",
     "crates/incan_syntax",
     "crates/incan_semantics_core",
     "crates/incan_semantics_stdlib",
@@ -63,6 +64,7 @@ rust_inspect = ["dep:rust_inspect"]
 [dependencies]
 # Shared language/semantic helpers (canonical vocab)
 incan_core = { path = "crates/incan_core" }
+incan_codegraph = { path = "crates/incan_codegraph" }
 incan_vocab = { path = "crates/incan_vocab" }
 # Shared syntax frontend (lexer, parser, AST, diagnostics)
 incan_syntax = { path = "crates/incan_syntax" }

--- a/crates/incan_codegraph/Cargo.toml
+++ b/crates/incan_codegraph/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "incan_codegraph"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Stable code-index graph facts for Incan tooling"
+readme = "README.md"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+

--- a/crates/incan_codegraph/README.md
+++ b/crates/incan_codegraph/README.md
@@ -1,0 +1,15 @@
+# incan_codegraph
+
+`incan_codegraph` defines the stable, storage-agnostic code-index fact schema used by Incan tooling. It is intentionally separate from RFC 047 `std.graph`, which is a runtime graph data-structure surface for Incan programs.
+
+The compiler owns fact extraction because it has access to parsed, import-aware, and typechecked source. This crate owns only serializable graph records and helpers for JSON/JSONL output.
+
+The CLI exporter enriches source graph records with RFC 048 checked API metadata facts where available. Downstream indexers can join file/module/import topology with the typed public API contract that Incan already emits for library artifacts.
+
+Body-level facts are represented as source-backed graph nodes, starting with:
+
+- `match_dispatch` nodes for match expressions with a syntactic dispatch domain, stable pattern labels, explicit arm counts, and wildcard/default-arm context
+- `call_site` nodes for syntactic function, method, constructor, and surface-symbol calls
+- `reference` nodes for syntactic identifier, `self`, and field references
+
+These facts are intentionally deterministic and parser-backed. Name resolution and type-directed symbol binding can be layered onto the graph later without requiring agents to re-walk the AST for every architecture rule.

--- a/crates/incan_codegraph/src/lib.rs
+++ b/crates/incan_codegraph/src/lib.rs
@@ -1,0 +1,287 @@
+//! Stable code-index graph facts for Incan tooling.
+//!
+//! This crate is deliberately storage-agnostic. It does not know about CodeGraph, SurrealDB, embeddings, MCP, or the
+//! compiler pipeline. The compiler/tooling layer extracts authoritative facts and uses these types as the wire format
+//! for downstream indexers.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Current `incan_codegraph` schema version.
+pub const CODEGRAPH_SCHEMA_VERSION: &str = "incan-codegraph.v1";
+
+/// A stable, serializable code-index document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodegraphDocument {
+    /// Schema version for downstream compatibility checks.
+    pub schema_version: String,
+    /// Optional package identity for project-level exports.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<CodegraphPackage>,
+    /// Graph nodes in deterministic order.
+    pub nodes: Vec<CodegraphNode>,
+    /// Graph edges in deterministic order.
+    pub edges: Vec<CodegraphEdge>,
+}
+
+impl CodegraphDocument {
+    /// Create an empty document with the current schema version.
+    #[must_use]
+    pub fn new(package: Option<CodegraphPackage>) -> Self {
+        Self {
+            schema_version: CODEGRAPH_SCHEMA_VERSION.to_string(),
+            package,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        }
+    }
+
+    /// Append one node to the document.
+    pub fn push_node(&mut self, node: CodegraphNode) {
+        self.nodes.push(node);
+    }
+
+    /// Append one edge to the document.
+    pub fn push_edge(&mut self, edge: CodegraphEdge) {
+        self.edges.push(edge);
+    }
+
+    /// Serialize the document as stable pretty JSON.
+    pub fn to_pretty_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Serialize the document as newline-delimited records: a header, then nodes, then edges.
+    pub fn to_jsonl(&self) -> Result<String, serde_json::Error> {
+        let mut lines = Vec::with_capacity(self.nodes.len() + self.edges.len() + 1);
+        lines.push(serde_json::to_string(&CodegraphJsonlRecord::Document {
+            schema_version: self.schema_version.clone(),
+            package: self.package.clone(),
+        })?);
+        for node in &self.nodes {
+            lines.push(serde_json::to_string(&CodegraphJsonlRecord::Node(node.clone()))?);
+        }
+        for edge in &self.edges {
+            lines.push(serde_json::to_string(&CodegraphJsonlRecord::Edge(edge.clone()))?);
+        }
+        lines.push(String::new());
+        Ok(lines.join("\n"))
+    }
+}
+
+/// Project/package identity attached to a code-index export.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodegraphPackage {
+    /// Project name from `incan.toml`, when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Project version from `incan.toml`, when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Export root path, normalized by the producing command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_path: Option<String>,
+}
+
+/// One node in the code-index graph.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodegraphNode {
+    /// Stable node id unique within one export.
+    pub id: String,
+    /// Node kind.
+    pub kind: CodegraphNodeKind,
+    /// Human-readable label.
+    pub label: String,
+    /// Source file path, when the node is source-backed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_path: Option<String>,
+    /// Logical Incan module path, when known.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub module_path: Vec<String>,
+    /// Byte-span in the source file, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<CodegraphSpan>,
+    /// Additional stable facts for indexers that do not need a new schema field yet.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub facts: BTreeMap<String, String>,
+}
+
+/// Supported node categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodegraphNodeKind {
+    /// Project/package root node.
+    Package,
+    /// Source file node.
+    File,
+    /// Incan module node.
+    Module,
+    /// Source declaration node.
+    Declaration,
+    /// Checked public API member derived from RFC 048 metadata.
+    ApiMember,
+    /// Import declaration node.
+    Import,
+    /// Source match expression dispatch over a syntactic domain.
+    MatchDispatch,
+    /// Source call expression or constructor invocation.
+    CallSite,
+    /// Source identifier, receiver, or field reference.
+    Reference,
+    /// External or unresolved import target.
+    External,
+}
+
+/// One directed relationship between graph nodes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodegraphEdge {
+    /// Stable edge id unique within one export.
+    pub id: String,
+    /// Relationship kind.
+    pub kind: CodegraphEdgeKind,
+    /// Source node id.
+    pub source_id: String,
+    /// Target node id.
+    pub target_id: String,
+    /// Source span for the relationship, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<CodegraphSpan>,
+    /// Additional stable facts for downstream indexers.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub facts: BTreeMap<String, String>,
+}
+
+/// Supported relationship categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodegraphEdgeKind {
+    /// Parent contains child.
+    Contains,
+    /// Module or declaration defines a symbol.
+    Defines,
+    /// Module imports or depends on another module/symbol.
+    Imports,
+    /// Call site targets a syntactic callee.
+    Calls,
+    /// Reference site targets a syntactic symbol/reference.
+    References,
+}
+
+/// A byte-span in one source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodegraphSpan {
+    /// Start byte offset, inclusive.
+    pub start: usize,
+    /// End byte offset, exclusive.
+    pub end: usize,
+}
+
+/// Newline-delimited record shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "record", rename_all = "snake_case")]
+pub enum CodegraphJsonlRecord {
+    /// Document header.
+    Document {
+        /// Schema version for downstream compatibility checks.
+        schema_version: String,
+        /// Optional package identity for project-level exports.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        package: Option<CodegraphPackage>,
+    },
+    /// Graph node record.
+    Node(CodegraphNode),
+    /// Graph edge record.
+    Edge(CodegraphEdge),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CODEGRAPH_SCHEMA_VERSION, CodegraphDocument, CodegraphEdge, CodegraphEdgeKind, CodegraphNode,
+        CodegraphNodeKind, CodegraphPackage, CodegraphSpan,
+    };
+
+    #[test]
+    fn pretty_json_carries_schema_and_nodes() -> Result<(), Box<dyn std::error::Error>> {
+        let mut document = CodegraphDocument::new(Some(CodegraphPackage {
+            name: Some("demo".to_string()),
+            version: Some("0.1.0".to_string()),
+            root_path: None,
+        }));
+        document.push_node(CodegraphNode {
+            id: "file:src/main.incn".to_string(),
+            kind: CodegraphNodeKind::File,
+            label: "src/main.incn".to_string(),
+            file_path: Some("src/main.incn".to_string()),
+            module_path: Vec::new(),
+            span: None,
+            facts: Default::default(),
+        });
+
+        let json = document.to_pretty_json()?;
+
+        assert!(json.contains(CODEGRAPH_SCHEMA_VERSION));
+        assert!(json.contains("\"kind\": \"file\""));
+        Ok(())
+    }
+
+    #[test]
+    fn jsonl_emits_header_nodes_then_edges() -> Result<(), Box<dyn std::error::Error>> {
+        let mut document = CodegraphDocument::new(None);
+        document.push_node(CodegraphNode {
+            id: "module:main".to_string(),
+            kind: CodegraphNodeKind::Module,
+            label: "main".to_string(),
+            file_path: None,
+            module_path: vec!["main".to_string()],
+            span: None,
+            facts: Default::default(),
+        });
+        document.push_edge(CodegraphEdge {
+            id: "edge:module:main:contains:decl:main.main".to_string(),
+            kind: CodegraphEdgeKind::Contains,
+            source_id: "module:main".to_string(),
+            target_id: "decl:main.main".to_string(),
+            span: Some(CodegraphSpan { start: 0, end: 3 }),
+            facts: Default::default(),
+        });
+
+        let jsonl = document.to_jsonl()?;
+        let lines = jsonl.lines().collect::<Vec<_>>();
+
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains("\"record\":\"document\""));
+        assert!(lines[1].contains("\"record\":\"node\""));
+        assert!(lines[2].contains("\"record\":\"edge\""));
+        Ok(())
+    }
+
+    #[test]
+    fn pretty_json_supports_body_fact_kinds() -> Result<(), Box<dyn std::error::Error>> {
+        let mut document = CodegraphDocument::new(None);
+        document.push_node(CodegraphNode {
+            id: "body-fact:match:main:label:10-40".to_string(),
+            kind: CodegraphNodeKind::MatchDispatch,
+            label: "match kind".to_string(),
+            file_path: Some("main.incn".to_string()),
+            module_path: vec!["main".to_string()],
+            span: Some(CodegraphSpan { start: 10, end: 40 }),
+            facts: Default::default(),
+        });
+        document.push_edge(CodegraphEdge {
+            id: "edge:body-fact:call:target".to_string(),
+            kind: CodegraphEdgeKind::Calls,
+            source_id: "body-fact:call".to_string(),
+            target_id: "external:target".to_string(),
+            span: Some(CodegraphSpan { start: 12, end: 20 }),
+            facts: Default::default(),
+        });
+
+        let json = document.to_pretty_json()?;
+
+        assert!(json.contains("\"kind\": \"match_dispatch\""));
+        assert!(json.contains("\"kind\": \"calls\""));
+        Ok(())
+    }
+}

--- a/src/cli/commands/architect.rs
+++ b/src/cli/commands/architect.rs
@@ -1,0 +1,1084 @@
+//! Experimental architecture-advice command.
+//!
+//! The first deterministic signal is intentionally narrow: find repeated match
+//! dispatch over the same apparent domain and report the design pressure with
+//! concrete source evidence. The signal is backed by `incan_codegraph` body
+//! facts so future architecture rules can share the same graph substrate.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::path::{Path, PathBuf};
+
+use clap::ValueEnum;
+use incan_codegraph::{CodegraphDocument, CodegraphEdgeKind, CodegraphNode, CodegraphNodeKind};
+use incan_core::lang::stdlib;
+use serde_json::json;
+
+use crate::cli::{CliError, CliResult, ExitCode};
+
+use super::tools::collect_codegraph_document_suppressing_diagnostics;
+
+/// Output format for `incan architect`.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArchitectFormat {
+    /// Human-readable advisory report.
+    Text,
+    /// Machine-readable report for tools and agents.
+    Json,
+}
+
+/// Run an experimental architecture scan over an Incan source file or project.
+pub fn architect_project(path: &Path, format: ArchitectFormat) -> CliResult<ExitCode> {
+    let scan_path = resolve_architect_scan_path(path)?;
+    let document = collect_codegraph_document_suppressing_diagnostics(&scan_path, true)?;
+    let report = ArchitectureReport::from_codegraph(&document);
+
+    match format {
+        ArchitectFormat::Text => print_text_report(&report),
+        ArchitectFormat::Json => print_json_report(&report)?,
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Resolve a source file or directory used as the scan input.
+fn resolve_architect_scan_path(path: &Path) -> CliResult<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()
+            .map_err(|error| CliError::failure(format!("failed to determine current directory: {error}")))?
+            .join(path)
+    };
+
+    if absolute.is_file() {
+        return Ok(absolute);
+    }
+    if absolute.is_dir() {
+        return Ok(absolute);
+    }
+
+    Err(CliError::failure(format!(
+        "architect scan requires an Incan source file or directory: {}",
+        absolute.display()
+    )))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ArchitectureReport {
+    findings: Vec<ArchitectureFinding>,
+}
+
+impl ArchitectureReport {
+    fn from_codegraph(document: &CodegraphDocument) -> Self {
+        let mut sites = document
+            .nodes
+            .iter()
+            .filter(|node| node.kind == CodegraphNodeKind::MatchDispatch)
+            .filter(|node| !is_stdlib_node(node))
+            .filter_map(match_dispatch_site_from_node)
+            .collect::<Vec<_>>();
+        deduplicate_match_dispatch_sites(&mut sites);
+
+        let mut findings = fail_fast_call_findings(document);
+        findings.extend(repeated_dispatch_findings(&sites));
+        deduplicate_findings(&mut findings);
+        sort_findings(&mut findings);
+
+        Self { findings }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ArchitectureFinding {
+    code: &'static str,
+    priority: &'static str,
+    title: String,
+    pressure: String,
+    suggestions: Vec<String>,
+    risks: Vec<String>,
+    shared_patterns: Vec<String>,
+    shared_pattern_count: usize,
+    largest_pattern_count: usize,
+    default_arm_site_count: usize,
+    evidence: Vec<MatchEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MatchDispatchSite {
+    domain_key: String,
+    domain_label: String,
+    patterns: BTreeSet<PatternLabel>,
+    explicit_pattern_count: usize,
+    has_default_arm: bool,
+    evidence: MatchEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MatchEvidence {
+    file_path: String,
+    owner: String,
+    line: usize,
+    column: usize,
+    summary: String,
+    arm_labels: Vec<String>,
+    explicit_arm_count: Option<usize>,
+    source_arm_count: Option<usize>,
+    has_default_arm: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PatternLabel {
+    family: PatternFamily,
+    label: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum PatternFamily {
+    Constructor,
+    StringLiteral,
+    Literal,
+}
+
+type EvidenceDedupeKey = (
+    String,
+    String,
+    usize,
+    usize,
+    String,
+    Vec<String>,
+    Option<usize>,
+    Option<usize>,
+    Option<bool>,
+);
+
+type FindingDedupeKey = (&'static str, &'static str, String, Vec<String>, Vec<EvidenceDedupeKey>);
+
+type MatchDispatchSiteDedupeKey = (String, String, Vec<PatternLabel>, usize, bool, EvidenceDedupeKey);
+
+fn is_stdlib_node(node: &CodegraphNode) -> bool {
+    node.module_path
+        .first()
+        .is_some_and(|segment| segment == stdlib::INCAN_STD_NAMESPACE)
+}
+
+fn match_dispatch_site_from_node(node: &CodegraphNode) -> Option<MatchDispatchSite> {
+    let domain_key = node.facts.get("domain_key")?.clone();
+    let domain_label = node.facts.get("domain_label")?.clone();
+    let owner = node
+        .facts
+        .get("owner")
+        .cloned()
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let pattern_labels = parse_json_string_list(node.facts.get("pattern_labels")?)?;
+    let pattern_families = node
+        .facts
+        .get("pattern_families")
+        .and_then(|value| parse_json_string_list(value))
+        .unwrap_or_default();
+
+    if pattern_labels.len() < 2 {
+        return None;
+    }
+
+    let patterns = pattern_labels
+        .iter()
+        .enumerate()
+        .map(|(idx, label)| PatternLabel {
+            family: pattern_families
+                .get(idx)
+                .and_then(|family| pattern_family_from_fact(family))
+                .unwrap_or_else(|| infer_pattern_family(label)),
+            label: label.clone(),
+        })
+        .collect::<BTreeSet<_>>();
+    let arm_labels = patterns.iter().map(|pattern| pattern.label.clone()).collect::<Vec<_>>();
+
+    Some(MatchDispatchSite {
+        domain_key,
+        domain_label: domain_label.clone(),
+        explicit_pattern_count: node
+            .facts
+            .get("explicit_pattern_count")
+            .and_then(|count| count.parse().ok())
+            .unwrap_or(patterns.len()),
+        has_default_arm: node.facts.get("has_default_arm").is_some_and(|value| value == "true"),
+        patterns,
+        evidence: MatchEvidence {
+            file_path: node.file_path.clone().unwrap_or_else(|| "<unknown>".to_string()),
+            owner,
+            line: node.facts.get("line").and_then(|line| line.parse().ok()).unwrap_or(1),
+            column: node
+                .facts
+                .get("column")
+                .and_then(|column| column.parse().ok())
+                .unwrap_or(1),
+            summary: format!("match over `{domain_label}`"),
+            arm_labels,
+            explicit_arm_count: Some(
+                node.facts
+                    .get("explicit_pattern_count")
+                    .and_then(|count| count.parse().ok())
+                    .unwrap_or(pattern_labels.len()),
+            ),
+            source_arm_count: Some(
+                node.facts
+                    .get("arm_count")
+                    .and_then(|count| count.parse().ok())
+                    .unwrap_or(pattern_labels.len()),
+            ),
+            has_default_arm: Some(node.facts.get("has_default_arm").is_some_and(|value| value == "true")),
+        },
+    })
+}
+
+fn parse_json_string_list(value: &str) -> Option<Vec<String>> {
+    serde_json::from_str(value).ok()
+}
+
+fn pattern_family_from_fact(value: &str) -> Option<PatternFamily> {
+    match value {
+        "constructor" => Some(PatternFamily::Constructor),
+        "string_literal" => Some(PatternFamily::StringLiteral),
+        "literal" => Some(PatternFamily::Literal),
+        _ => None,
+    }
+}
+
+fn infer_pattern_family(label: &str) -> PatternFamily {
+    if label.starts_with('"') {
+        PatternFamily::StringLiteral
+    } else if label.ends_with("(...)") {
+        PatternFamily::Constructor
+    } else {
+        PatternFamily::Literal
+    }
+}
+
+fn fail_fast_call_findings(document: &CodegraphDocument) -> Vec<ArchitectureFinding> {
+    let declarations = document
+        .nodes
+        .iter()
+        .filter(|node| node.kind == CodegraphNodeKind::Declaration)
+        .map(|node| (node.id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    let declaration_by_body_fact = document
+        .edges
+        .iter()
+        .filter(|edge| edge.kind == CodegraphEdgeKind::Contains)
+        .filter(|edge| declarations.contains_key(edge.source_id.as_str()))
+        .map(|edge| (edge.target_id.as_str(), edge.source_id.as_str()))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut findings = Vec::new();
+    for call in document
+        .nodes
+        .iter()
+        .filter(|node| node.kind == CodegraphNodeKind::CallSite)
+    {
+        let Some(call_kind) = fail_fast_call_kind(call) else {
+            continue;
+        };
+        let Some(declaration_id) = declaration_by_body_fact.get(call.id.as_str()) else {
+            continue;
+        };
+        let Some(declaration) = declarations.get(declaration_id) else {
+            continue;
+        };
+        findings.push(fail_fast_call_finding(call, declaration, call_kind));
+    }
+    findings
+}
+
+fn fail_fast_call_kind(call: &CodegraphNode) -> Option<&'static str> {
+    let callee_key = call.facts.get("callee_key")?.as_str();
+    let callee_label = call.facts.get("callee_label").map_or("", String::as_str);
+    match (callee_key, callee_label) {
+        ("method:unwrap", _) | (_, ".unwrap()") => Some("unwrap"),
+        ("method:expect", _) | (_, ".expect()") => Some("expect"),
+        ("call:ident:panic", _) | (_, "panic(...)") => Some("panic"),
+        ("call:ident:todo", _) | (_, "todo(...)") => Some("todo"),
+        ("call:ident:unreachable", _) | (_, "unreachable(...)") => Some("unreachable"),
+        _ => None,
+    }
+}
+
+fn fail_fast_call_finding(call: &CodegraphNode, declaration: &CodegraphNode, call_kind: &str) -> ArchitectureFinding {
+    let is_public_boundary = declaration_is_public(declaration);
+    let priority = if is_public_boundary { "P1" } else { "P2" };
+    let boundary_phrase = if is_public_boundary {
+        "a public API boundary"
+    } else {
+        "an internal boundary"
+    };
+    let owner = call
+        .facts
+        .get("owner")
+        .cloned()
+        .unwrap_or_else(|| declaration.label.clone());
+    let callee_label = call
+        .facts
+        .get("callee_label")
+        .cloned()
+        .unwrap_or_else(|| call.label.clone());
+    let pressure = format!(
+        "`{}` calls fail-fast `{callee_label}` inside {boundary_phrase}; recoverable errors can become process-level failures.",
+        declaration.label
+    );
+    let title = if is_public_boundary {
+        format!("Public API boundary calls fail-fast `{call_kind}`")
+    } else {
+        format!("Internal boundary calls fail-fast `{call_kind}`")
+    };
+
+    ArchitectureFinding {
+        code: "arch.fail_fast_boundary_call",
+        priority,
+        title,
+        pressure,
+        suggestions: vec![
+            "Return a typed Result/Error value across the boundary instead of failing inside it.".to_string(),
+            "Move fail-fast handling to the executable edge if this is intentionally unrecoverable.".to_string(),
+        ],
+        risks: vec![
+            "Do not replace fail-fast calls blindly when an invariant violation really should abort.".to_string(),
+            "Check whether the caller can usefully recover before widening the error surface.".to_string(),
+        ],
+        shared_patterns: Vec::new(),
+        shared_pattern_count: 0,
+        largest_pattern_count: 0,
+        default_arm_site_count: 0,
+        evidence: vec![body_fact_evidence(call, owner, format!("callee: {callee_label}"))],
+    }
+}
+
+fn declaration_is_public(declaration: &CodegraphNode) -> bool {
+    declaration
+        .facts
+        .get("visibility")
+        .is_some_and(|visibility| visibility == "public")
+        || declaration.facts.contains_key("checked_api_anchor_id")
+}
+
+fn body_fact_evidence(node: &CodegraphNode, owner: String, summary: String) -> MatchEvidence {
+    MatchEvidence {
+        file_path: node.file_path.clone().unwrap_or_else(|| "<unknown>".to_string()),
+        owner,
+        line: node.facts.get("line").and_then(|line| line.parse().ok()).unwrap_or(1),
+        column: node
+            .facts
+            .get("column")
+            .and_then(|column| column.parse().ok())
+            .unwrap_or(1),
+        summary,
+        arm_labels: Vec::new(),
+        explicit_arm_count: None,
+        source_arm_count: None,
+        has_default_arm: None,
+    }
+}
+
+fn deduplicate_findings(findings: &mut Vec<ArchitectureFinding>) {
+    let mut seen = BTreeSet::new();
+    findings.retain(|finding| seen.insert(finding_dedupe_key(finding)));
+}
+
+fn finding_dedupe_key(finding: &ArchitectureFinding) -> FindingDedupeKey {
+    let mut evidence = finding.evidence.iter().map(evidence_dedupe_key).collect::<Vec<_>>();
+    evidence.sort();
+    (
+        finding.code,
+        finding.priority,
+        finding.title.clone(),
+        finding.shared_patterns.clone(),
+        evidence,
+    )
+}
+
+fn deduplicate_match_dispatch_sites(sites: &mut Vec<MatchDispatchSite>) {
+    let mut seen = BTreeSet::new();
+    sites.retain(|site| seen.insert(match_dispatch_site_dedupe_key(site)));
+}
+
+fn match_dispatch_site_dedupe_key(site: &MatchDispatchSite) -> MatchDispatchSiteDedupeKey {
+    (
+        site.domain_key.clone(),
+        site.domain_label.clone(),
+        site.patterns.iter().cloned().collect(),
+        site.explicit_pattern_count,
+        site.has_default_arm,
+        evidence_dedupe_key(&site.evidence),
+    )
+}
+
+fn evidence_dedupe_key(evidence: &MatchEvidence) -> EvidenceDedupeKey {
+    (
+        evidence.file_path.clone(),
+        evidence.owner.clone(),
+        evidence.line,
+        evidence.column,
+        evidence.summary.clone(),
+        evidence.arm_labels.clone(),
+        evidence.explicit_arm_count,
+        evidence.source_arm_count,
+        evidence.has_default_arm,
+    )
+}
+
+fn repeated_dispatch_findings(sites: &[MatchDispatchSite]) -> Vec<ArchitectureFinding> {
+    let mut groups: BTreeMap<&str, Vec<&MatchDispatchSite>> = BTreeMap::new();
+    for site in sites {
+        groups.entry(&site.domain_key).or_default().push(site);
+    }
+
+    let mut findings = Vec::new();
+    for grouped_sites in groups.into_values() {
+        if grouped_sites.len() < 2 {
+            continue;
+        }
+        let shared_patterns = shared_patterns(&grouped_sites);
+        if shared_patterns.len() < 2 {
+            continue;
+        }
+        if is_mechanical_wrapper_pattern_set(&shared_patterns) {
+            continue;
+        }
+        if is_low_signal_default_overlap(&shared_patterns, &grouped_sites) {
+            continue;
+        }
+        let Some(first) = grouped_sites.first() else {
+            continue;
+        };
+        findings.push(repeated_dispatch_finding(
+            first.domain_label.clone(),
+            shared_patterns,
+            grouped_sites,
+        ));
+    }
+    findings
+}
+
+fn repeated_dispatch_finding(
+    domain_label: String,
+    shared_patterns: Vec<PatternLabel>,
+    sites: Vec<&MatchDispatchSite>,
+) -> ArchitectureFinding {
+    let pattern_labels = shared_patterns
+        .iter()
+        .map(|pattern| pattern.label.clone())
+        .collect::<Vec<_>>();
+    let largest_pattern_count = largest_pattern_count(&sites);
+    let default_arm_site_count = sites.iter().filter(|site| site.has_default_arm).count();
+    let pattern_family = dominant_pattern_family(&shared_patterns);
+    let priority = repeated_dispatch_priority(pattern_family, sites.len(), shared_patterns.len());
+    let suggestions = suggestions_for(pattern_family, sites.len());
+    let risks = vec![
+        "Do not introduce a registry if the matched domain is intentionally closed and exhaustiveness matters."
+            .to_string(),
+        "Do not introduce a visitor/table abstraction if the repeated matches are clearer as local domain logic."
+            .to_string(),
+    ];
+    let pressure = format!(
+        "{} match expressions dispatch over `{}` and share {}/{} explicit arms: {}",
+        sites.len(),
+        domain_label,
+        pattern_labels.len(),
+        largest_pattern_count,
+        pattern_labels.join(", ")
+    );
+
+    ArchitectureFinding {
+        code: "arch.repeated_match_dispatch",
+        priority,
+        title: format!("Repeated match dispatch over `{domain_label}`"),
+        pressure,
+        suggestions,
+        risks,
+        shared_patterns: pattern_labels,
+        shared_pattern_count: shared_patterns.len(),
+        largest_pattern_count,
+        default_arm_site_count,
+        evidence: sites.into_iter().map(|site| site.evidence.clone()).collect(),
+    }
+}
+
+fn repeated_dispatch_priority(
+    pattern_family: PatternFamily,
+    site_count: usize,
+    shared_pattern_count: usize,
+) -> &'static str {
+    if pattern_family == PatternFamily::StringLiteral && site_count >= 3 && shared_pattern_count >= 3 {
+        "P2"
+    } else {
+        "P3"
+    }
+}
+
+fn largest_pattern_count(sites: &[&MatchDispatchSite]) -> usize {
+    sites.iter().map(|site| site.explicit_pattern_count).max().unwrap_or(0)
+}
+
+fn is_low_signal_default_overlap(shared_patterns: &[PatternLabel], sites: &[&MatchDispatchSite]) -> bool {
+    let largest_pattern_count = largest_pattern_count(sites);
+    if largest_pattern_count == 0 {
+        return false;
+    }
+    let shared_count = shared_patterns.len();
+    let overlap_is_tiny = shared_count * 10 <= largest_pattern_count * 3;
+    let default_subset_site = sites
+        .iter()
+        .any(|site| site.has_default_arm && site.explicit_pattern_count <= shared_count);
+
+    overlap_is_tiny && default_subset_site
+}
+
+fn shared_patterns(sites: &[&MatchDispatchSite]) -> Vec<PatternLabel> {
+    let Some((first, rest)) = sites.split_first() else {
+        return Vec::new();
+    };
+    let mut shared = first.patterns.clone();
+    for site in rest {
+        shared = shared.intersection(&site.patterns).cloned().collect();
+    }
+    shared.into_iter().collect()
+}
+
+fn is_mechanical_wrapper_pattern_set(patterns: &[PatternLabel]) -> bool {
+    let labels = patterns
+        .iter()
+        .map(|pattern| pattern.label.as_str())
+        .collect::<Vec<_>>();
+    matches!(
+        labels.as_slice(),
+        ["Err(...)", "Ok(...)"] | ["None", "Some(...)"] | ["Some(...)", "None"]
+    )
+}
+
+fn dominant_pattern_family(patterns: &[PatternLabel]) -> PatternFamily {
+    let mut counts: BTreeMap<PatternFamily, usize> = BTreeMap::new();
+    for pattern in patterns {
+        *counts.entry(pattern.family).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .max_by_key(|(_, count)| *count)
+        .map(|(family, _)| family)
+        .unwrap_or(PatternFamily::Literal)
+}
+
+fn suggestions_for(pattern_family: PatternFamily, site_count: usize) -> Vec<String> {
+    let mut suggestions = Vec::new();
+    match pattern_family {
+        PatternFamily::StringLiteral => {
+            suggestions.push(
+                "Consider replacing the string-literal domain with an enum or value enum if the set is closed."
+                    .to_string(),
+            );
+            suggestions.push(
+                "If libraries should add cases, consider a registry keyed by the parsed enum/value object instead of raw strings."
+                    .to_string(),
+            );
+        }
+        PatternFamily::Constructor => {
+            suggestions.push(
+                "Decide whether this is intentionally exhaustive local logic or a growing operation boundary."
+                    .to_string(),
+            );
+            suggestions.push(
+                "If it is a growing operation boundary, prefer a visitor/table/registry adapter outside the domain type when the operation belongs to another subsystem."
+                    .to_string(),
+            );
+            suggestions.push(
+                "Keep local exhaustive matches when they are clearer than an abstraction and the case set changes rarely."
+                    .to_string(),
+            );
+        }
+        PatternFamily::Literal => {
+            suggestions.push(
+                "Consider naming the literal domain with an enum/newtype before adding more branch sites.".to_string(),
+            );
+        }
+    }
+    if site_count >= 3 {
+        suggestions.push(
+            "Because this appears in three or more places, check whether adding one case requires shotgun edits."
+                .to_string(),
+        );
+    }
+    suggestions
+}
+
+fn sort_findings(findings: &mut [ArchitectureFinding]) {
+    findings.sort_by(|left, right| {
+        priority_rank(left.priority)
+            .cmp(&priority_rank(right.priority))
+            .then_with(|| left.code.cmp(right.code))
+            .then_with(|| left.title.cmp(&right.title))
+    });
+}
+
+fn priority_rank(priority: &str) -> usize {
+    match priority {
+        "P1" => 0,
+        "P2" => 1,
+        "P3" => 2,
+        _ => 3,
+    }
+}
+
+fn print_text_report(report: &ArchitectureReport) {
+    if report.findings.is_empty() {
+        println!("Architecture Findings");
+        println!();
+        println!("No deterministic architecture findings.");
+        return;
+    }
+
+    println!("Architecture Findings");
+    for finding in &report.findings {
+        println!();
+        println!("[{}] {}", finding.priority, finding.title);
+        println!("Pressure: {}", finding.pressure);
+        if finding.default_arm_site_count > 0 {
+            println!(
+                "Default context: {} of {} sites include a wildcard/default arm.",
+                finding.default_arm_site_count,
+                finding.evidence.len()
+            );
+        }
+        println!("Suggestions:");
+        for suggestion in &finding.suggestions {
+            println!("  - {suggestion}");
+        }
+        println!("Risks:");
+        for risk in &finding.risks {
+            println!("  - {risk}");
+        }
+        println!("Evidence:");
+        for evidence in &finding.evidence {
+            print!(
+                "  - {}:{}:{} in {}",
+                evidence.file_path, evidence.line, evidence.column, evidence.owner
+            );
+            if !evidence.summary.is_empty() {
+                print!(" ({})", evidence.summary);
+            }
+            if let (Some(explicit_arm_count), Some(source_arm_count), Some(has_default_arm)) = (
+                evidence.explicit_arm_count,
+                evidence.source_arm_count,
+                evidence.has_default_arm,
+            ) {
+                print!(
+                    " (explicit arms: {explicit_arm_count}/{source_arm_count}; fallback: {}; arms: {})",
+                    if has_default_arm { "yes" } else { "no" },
+                    evidence.arm_labels.join(", ")
+                );
+            }
+            println!();
+        }
+    }
+}
+
+fn print_json_report(report: &ArchitectureReport) -> CliResult<()> {
+    let findings = report
+        .findings
+        .iter()
+        .map(|finding| {
+            json!({
+                "code": finding.code,
+                "priority": finding.priority,
+                "title": finding.title,
+                "pressure": finding.pressure,
+                "suggestions": finding.suggestions,
+                "risks": finding.risks,
+                "shared_patterns": finding.shared_patterns,
+                "shared_pattern_count": finding.shared_pattern_count,
+                "largest_pattern_count": finding.largest_pattern_count,
+                "default_arm_site_count": finding.default_arm_site_count,
+                "evidence": finding.evidence.iter().map(|evidence| {
+                    json!({
+                        "file_path": evidence.file_path,
+                        "owner": evidence.owner,
+                        "line": evidence.line,
+                        "column": evidence.column,
+                        "summary": evidence.summary,
+                        "arm_labels": evidence.arm_labels,
+                        "explicit_arm_count": evidence.explicit_arm_count,
+                        "source_arm_count": evidence.source_arm_count,
+                        "has_default_arm": evidence.has_default_arm,
+                    })
+                }).collect::<Vec<_>>(),
+            })
+        })
+        .collect::<Vec<_>>();
+    let output = serde_json::to_string_pretty(&json!({ "findings": findings }))
+        .map_err(|error| CliError::failure(format!("failed to serialize architecture report: {error}")))?;
+    println!("{output}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+
+    use incan_codegraph::{CodegraphEdge, CodegraphEdgeKind, CodegraphNode, CodegraphSpan};
+
+    use super::*;
+
+    fn report_for_source(source: &str) -> Result<ArchitectureReport, Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let path = tmp.path().join("architect_severity.incn");
+        fs::write(&path, source)?;
+        let document = collect_codegraph_document_suppressing_diagnostics(&path, true)?;
+        Ok(ArchitectureReport::from_codegraph(&document))
+    }
+
+    fn report_for_directory(entries: &[(&str, &str)]) -> Result<ArchitectureReport, Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        for (path, source) in entries {
+            let file_path = tmp.path().join(path);
+            if let Some(parent) = file_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(file_path, source)?;
+        }
+        let document =
+            collect_codegraph_document_suppressing_diagnostics(&resolve_architect_scan_path(tmp.path())?, true)?;
+        Ok(ArchitectureReport::from_codegraph(&document))
+    }
+
+    fn contains_edge(source_id: &str, target_id: &str) -> CodegraphEdge {
+        let mut facts = BTreeMap::new();
+        facts.insert("relation".to_string(), "test_contains".to_string());
+        CodegraphEdge {
+            id: format!("edge:{source_id}:{target_id}"),
+            kind: CodegraphEdgeKind::Contains,
+            source_id: source_id.to_string(),
+            target_id: target_id.to_string(),
+            span: None,
+            facts,
+        }
+    }
+
+    fn declaration_node(id: &str, label: &str, visibility: &str) -> CodegraphNode {
+        let mut facts = BTreeMap::new();
+        facts.insert("declaration_kind".to_string(), "function".to_string());
+        facts.insert("visibility".to_string(), visibility.to_string());
+        CodegraphNode {
+            id: id.to_string(),
+            kind: CodegraphNodeKind::Declaration,
+            label: label.to_string(),
+            file_path: Some("src/api.incn".to_string()),
+            module_path: vec!["src".to_string(), "api".to_string()],
+            span: Some(CodegraphSpan { start: 0, end: 10 }),
+            facts,
+        }
+    }
+
+    fn call_site_node(id: &str, line: usize) -> CodegraphNode {
+        let mut facts = BTreeMap::new();
+        facts.insert("owner".to_string(), "public_boundary".to_string());
+        facts.insert("line".to_string(), line.to_string());
+        facts.insert("column".to_string(), "12".to_string());
+        facts.insert("callee_key".to_string(), "method:unwrap".to_string());
+        facts.insert("callee_label".to_string(), ".unwrap()".to_string());
+        CodegraphNode {
+            id: id.to_string(),
+            kind: CodegraphNodeKind::CallSite,
+            label: ".unwrap()".to_string(),
+            file_path: Some("src/api.incn".to_string()),
+            module_path: vec!["src".to_string(), "api".to_string()],
+            span: Some(CodegraphSpan { start: 10, end: 18 }),
+            facts,
+        }
+    }
+
+    fn match_dispatch_node(
+        id: &str,
+        owner: &str,
+        domain_key: &str,
+        domain_label: &str,
+        patterns: &[&str],
+        families: &[&str],
+        has_default_arm: bool,
+    ) -> CodegraphNode {
+        let mut facts = BTreeMap::new();
+        facts.insert("owner".to_string(), owner.to_string());
+        facts.insert("line".to_string(), "3".to_string());
+        facts.insert("column".to_string(), "5".to_string());
+        facts.insert("domain_key".to_string(), domain_key.to_string());
+        facts.insert("domain_label".to_string(), domain_label.to_string());
+        facts.insert("explicit_pattern_count".to_string(), patterns.len().to_string());
+        facts.insert(
+            "arm_count".to_string(),
+            (patterns.len() + usize::from(has_default_arm)).to_string(),
+        );
+        facts.insert("has_default_arm".to_string(), has_default_arm.to_string());
+        facts.insert("pattern_labels".to_string(), json!(patterns).to_string());
+        facts.insert("pattern_families".to_string(), json!(families).to_string());
+
+        CodegraphNode {
+            id: id.to_string(),
+            kind: CodegraphNodeKind::MatchDispatch,
+            label: format!("match {domain_label}"),
+            file_path: Some("demo.incn".to_string()),
+            module_path: vec!["demo".to_string()],
+            span: Some(CodegraphSpan { start: 0, end: 10 }),
+            facts,
+        }
+    }
+
+    #[test]
+    fn repeated_string_match_dispatch_reports_finding() {
+        let mut document = CodegraphDocument::new(None);
+        document.push_node(match_dispatch_node(
+            "body-fact:match:label",
+            "label",
+            "ident:kind",
+            "kind",
+            &["\"create\"", "\"update\""],
+            &["string_literal", "string_literal"],
+            true,
+        ));
+        document.push_node(match_dispatch_node(
+            "body-fact:match:severity",
+            "severity",
+            "ident:kind",
+            "kind",
+            &["\"create\"", "\"update\""],
+            &["string_literal", "string_literal"],
+            true,
+        ));
+
+        let report = ArchitectureReport::from_codegraph(&document);
+
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].code, "arch.repeated_match_dispatch");
+        assert_eq!(
+            report.findings[0].shared_patterns,
+            vec!["\"create\"".to_string(), "\"update\"".to_string()]
+        );
+    }
+
+    #[test]
+    fn single_match_does_not_report_finding() {
+        let mut document = CodegraphDocument::new(None);
+        document.push_node(match_dispatch_node(
+            "body-fact:match:label",
+            "label",
+            "ident:kind",
+            "kind",
+            &["\"create\"", "\"update\""],
+            &["string_literal", "string_literal"],
+            true,
+        ));
+
+        let report = ArchitectureReport::from_codegraph(&document);
+
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn tiny_overlap_with_default_fallback_is_suppressed() {
+        let mut document = CodegraphDocument::new(None);
+        document.push_node(match_dispatch_node(
+            "body-fact:match:catalog",
+            "core_scenario",
+            "ident:key",
+            "key",
+            &[
+                "CoreScenarioKey.ReferenceRelSharedSubplan(...)",
+                "CoreScenarioKey.SetRelOperations(...)",
+                "CoreScenarioKey.AggregateGroupingSets(...)",
+                "CoreScenarioKey.CrossRelCartesian(...)",
+                "CoreScenarioKey.FetchRelLimitOffset(...)",
+                "CoreScenarioKey.FilterRows(...)",
+                "CoreScenarioKey.JoinRelVariants(...)",
+                "CoreScenarioKey.ProjectComputedColumns(...)",
+                "CoreScenarioKey.ReadLocalFiles(...)",
+                "CoreScenarioKey.ReadNamedTable(...)",
+                "CoreScenarioKey.ReadVirtualTable(...)",
+                "CoreScenarioKey.SortRelOrdering(...)",
+            ],
+            &[
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+                "constructor",
+            ],
+            false,
+        ));
+        document.push_node(match_dispatch_node(
+            "body-fact:match:invariants",
+            "scenario_matches_key_invariants",
+            "ident:key",
+            "key",
+            &[
+                "CoreScenarioKey.ReferenceRelSharedSubplan(...)",
+                "CoreScenarioKey.SetRelOperations(...)",
+            ],
+            &["constructor", "constructor"],
+            true,
+        ));
+
+        let report = ArchitectureReport::from_codegraph(&document);
+
+        assert!(
+            report.findings.is_empty(),
+            "expected low-overlap default-heavy repeated dispatch to be treated as noise"
+        );
+    }
+
+    #[test]
+    fn constructor_dispatch_suggestion_frames_closed_domain_as_decision() {
+        let mut document = CodegraphDocument::new(None);
+        document.push_node(match_dispatch_node(
+            "body-fact:match:register",
+            "register_backend",
+            "ident:source_kind",
+            ".source_kind",
+            &["SourceKind.Arrow(...)", "SourceKind.Csv(...)"],
+            &["constructor", "constructor"],
+            false,
+        ));
+        document.push_node(match_dispatch_node(
+            "body-fact:match:schema",
+            "infer_schema",
+            "ident:source_kind",
+            ".source_kind",
+            &["SourceKind.Arrow(...)", "SourceKind.Csv(...)"],
+            &["constructor", "constructor"],
+            false,
+        ));
+
+        let report = ArchitectureReport::from_codegraph(&document);
+
+        assert_eq!(report.findings.len(), 1);
+        let suggestions = report.findings[0].suggestions.join("\n");
+        assert!(
+            suggestions.contains("intentionally exhaustive local logic or a growing operation boundary"),
+            "expected constructor-domain suggestion to frame the choice as a decision: {suggestions}"
+        );
+        assert!(
+            !suggestions.contains("moving repeated operations onto the enum"),
+            "constructor-domain suggestion should not imply subsystem behavior belongs on the enum: {suggestions}"
+        );
+    }
+
+    #[test]
+    fn directory_scan_includes_unimported_project_sources() -> Result<(), Box<dyn std::error::Error>> {
+        let report = report_for_directory(&[
+            (
+                "src/main.incn",
+                r#"
+pub def main_value() -> int:
+    return 1
+"#,
+            ),
+            (
+                "src/adapter.incn",
+                r#"
+pub def public_boundary(raw: Result[int, str]) -> int:
+    return raw.unwrap()
+"#,
+            ),
+        ])?;
+
+        assert!(
+            report.findings.iter().any(|finding| {
+                finding.code == "arch.fail_fast_boundary_call"
+                    && finding.priority == "P1"
+                    && finding
+                        .evidence
+                        .iter()
+                        .any(|evidence| evidence.file_path == "src/adapter.incn")
+            }),
+            "expected directory architect scan to include unimported source files: {report:#?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_body_facts_do_not_duplicate_findings() {
+        let mut document = CodegraphDocument::new(None);
+        document.push_node(declaration_node(
+            "decl:api::public_boundary",
+            "public_boundary",
+            "public",
+        ));
+        document.push_node(call_site_node("body-fact:call:first", 7));
+        document.push_node(call_site_node("body-fact:call:duplicate", 7));
+        document.push_edge(contains_edge("decl:api::public_boundary", "body-fact:call:first"));
+        document.push_edge(contains_edge("decl:api::public_boundary", "body-fact:call:duplicate"));
+
+        let report = ArchitectureReport::from_codegraph(&document);
+        let fail_fast_findings = report
+            .findings
+            .iter()
+            .filter(|finding| finding.code == "arch.fail_fast_boundary_call")
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            fail_fast_findings.len(),
+            1,
+            "expected identical fail-fast evidence to be reported once: {report:#?}"
+        );
+    }
+
+    #[test]
+    fn deliberately_bad_source_flags_p1_and_p2_findings() -> Result<(), Box<dyn std::error::Error>> {
+        let report = report_for_source(
+            r#"
+pub def public_boundary(raw: Result[int, str]) -> int:
+    return raw.unwrap()
+
+def label(kind: str) -> str:
+    match kind:
+        "create" => "Create"
+        "update" => "Update"
+        "delete" => "Delete"
+        _ => "Other"
+
+def severity(kind: str) -> int:
+    match kind:
+        "create" => 1
+        "update" => 2
+        "delete" => 3
+        _ => 0
+
+def route(kind: str) -> str:
+    match kind:
+        "create" => "/new"
+        "update" => "/edit"
+        "delete" => "/remove"
+        _ => "/"
+"#,
+        )?;
+
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == "arch.fail_fast_boundary_call" && finding.priority == "P1"),
+            "expected public fail-fast boundary call to be flagged as P1: {report:#?}"
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == "arch.repeated_match_dispatch"
+                    && finding.priority == "P2"
+                    && finding.shared_patterns.len() == 3),
+            "expected repeated raw string dispatch across three sites to be flagged as P2: {report:#?}"
+        );
+        Ok(())
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -15,6 +15,7 @@
 //! - `stdlib_loader` — RFC 023: Stdlib module loading for compilation
 //! - `tools` — Local toolchain inspection and metadata helpers
 
+pub mod architect;
 pub mod build;
 pub mod common;
 pub mod debug;
@@ -27,6 +28,7 @@ pub mod tools;
 pub(crate) mod vocab_extraction;
 
 // Re-export public API so callers can use `commands::build_file()` etc.
+pub use architect::{ArchitectFormat, architect_project};
 pub use build::{build_file, build_library, run_file};
 pub use common::{collect_modules, read_source};
 pub use debug::{check_file, emit_rust, lex_file, parse_file};
@@ -35,8 +37,8 @@ pub use init::init_project;
 pub use lifecycle::{env_list, env_run, env_show, version_project};
 pub use lock::lock_project;
 pub use tools::{
-    ToolsDoctorFormat, ToolsMetadataFormat, ToolsModelMetadataFormat, tools_doctor, tools_metadata_api,
-    tools_metadata_model,
+    ToolsCodegraphFormat, ToolsDoctorFormat, ToolsMetadataFormat, ToolsModelMetadataFormat, tools_codegraph_export,
+    tools_doctor, tools_metadata_api, tools_metadata_model,
 };
 
 // Crate-internal API (used by test_runner and other CLI modules)

--- a/src/cli/commands/tools.rs
+++ b/src/cli/commands/tools.rs
@@ -1,19 +1,30 @@
 //! Local toolchain inspection commands.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use clap::ValueEnum;
+use incan_codegraph::{
+    CodegraphDocument, CodegraphEdge, CodegraphEdgeKind, CodegraphNode, CodegraphNodeKind, CodegraphPackage,
+    CodegraphSpan,
+};
 use serde_json::json;
 
 use crate::cli::prelude::ParsedModule;
 use crate::cli::{CliError, CliResult, ExitCode};
 use crate::frontend::api_metadata::{
-    ApiDeclaration, ApiFunction, ApiPartial, CHECKED_API_METADATA_SCHEMA_VERSION, CheckedApiMetadataPackage,
-    CheckedApiPackageIdentity, collect_checked_api_metadata, validate_checked_api_docstrings,
+    ApiDeclaration, ApiFunction, ApiMethod, ApiPartial, CHECKED_API_METADATA_SCHEMA_VERSION, CheckedApiMetadata,
+    CheckedApiMetadataPackage, CheckedApiPackageIdentity, SourceAnchor, collect_checked_api_metadata,
+    validate_checked_api_docstrings,
+};
+use crate::frontend::ast::{
+    AliasDecl, AssertKind, CallArg, ClassDecl, ComprehensionClause, Condition, ConstDecl, Declaration, DecoratorArg,
+    DecoratorArgValue, DictEntry, EnumDecl, Expr, FStringPart, FunctionDecl, ImportDecl, ImportItem, ImportKind,
+    ImportPath, Literal, MatchBody, ModelDecl, NewtypeDecl, PartialDecl, Pattern, RaceForBody, Span, Spanned,
+    Statement, StaticDecl, TestModuleDecl, TraitDecl, TypeAliasDecl, Visibility,
 };
 use crate::frontend::contract_metadata::{
     CanonicalModelBundle, read_model_bundles_from_json, read_project_model_bundles,
@@ -21,7 +32,7 @@ use crate::frontend::contract_metadata::{
 use crate::frontend::diagnostics;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::typechecker;
-use crate::library_manifest::{LibraryManifest, ParamExport, ParamKindExport, TypeRef};
+use crate::library_manifest::{FieldExport, LibraryManifest, ParamExport, ParamKindExport, ReceiverExport, TypeRef};
 use crate::manifest::ProjectManifest;
 
 use super::common::{collect_modules, imported_module_deps_for_with_index, module_key_index, resolve_project_root};
@@ -33,6 +44,15 @@ pub enum ToolsDoctorFormat {
     Text,
     /// Machine-readable JSON report for editor integrations and issue templates.
     Json,
+}
+
+/// Output format for `incan tools codegraph export`.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolsCodegraphFormat {
+    /// Stable pretty JSON document.
+    Json,
+    /// Newline-delimited graph records.
+    Jsonl,
 }
 
 /// Output format for `incan tools metadata api`.
@@ -59,6 +79,26 @@ pub fn tools_doctor(format: ToolsDoctorFormat) -> CliResult<ExitCode> {
     match format {
         ToolsDoctorFormat::Text => report.print_text(),
         ToolsDoctorFormat::Json => report.print_json()?,
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Emit compiler-backed codegraph facts for a source file or project directory.
+pub fn tools_codegraph_export(path: &Path, format: ToolsCodegraphFormat, allow_errors: bool) -> CliResult<ExitCode> {
+    let document = collect_codegraph_document(path, allow_errors)?;
+    match format {
+        ToolsCodegraphFormat::Json => {
+            let output = document
+                .to_pretty_json()
+                .map_err(|error| CliError::failure(format!("failed to serialize codegraph document: {error}")))?;
+            println!("{output}");
+        }
+        ToolsCodegraphFormat::Jsonl => {
+            let output = document
+                .to_jsonl()
+                .map_err(|error| CliError::failure(format!("failed to serialize codegraph records: {error}")))?;
+            print!("{output}");
+        }
     }
     Ok(ExitCode::SUCCESS)
 }
@@ -363,6 +403,1955 @@ fn absolute_path(path: &Path) -> CliResult<PathBuf> {
     }
 }
 
+/// Type-check a codegraph input path and collect deterministic source graph facts.
+pub(crate) fn collect_codegraph_document(path: &Path, allow_errors: bool) -> CliResult<CodegraphDocument> {
+    collect_codegraph_document_with_diagnostics(path, allow_errors, true)
+}
+
+/// Collect codegraph facts without printing type-check diagnostics when unchecked source is allowed.
+pub(crate) fn collect_codegraph_document_suppressing_diagnostics(
+    path: &Path,
+    allow_errors: bool,
+) -> CliResult<CodegraphDocument> {
+    collect_codegraph_document_with_diagnostics(path, allow_errors, false)
+}
+
+/// Type-check a codegraph input path and collect deterministic source graph facts.
+fn collect_codegraph_document_with_diagnostics(
+    path: &Path,
+    allow_errors: bool,
+    emit_diagnostics: bool,
+) -> CliResult<CodegraphDocument> {
+    let input = collect_codegraph_input(path)?;
+    let manifest =
+        ProjectManifest::discover(&input.project_root).map_err(|error| CliError::failure(error.to_string()))?;
+    let declared = manifest.as_ref().map(ProjectManifest::declared_rust_crate_names);
+    let library_manifest_index = manifest
+        .as_ref()
+        .map(LibraryManifestIndex::from_project_manifest)
+        .unwrap_or_default();
+    let module_idx_by_key = module_key_index(&input.modules);
+    let mut all_errors = String::new();
+    let mut metadata_modules = Vec::new();
+
+    for (idx, module) in input.modules.iter().enumerate() {
+        let deps_for_module = imported_module_deps_for_with_index(&input.modules, idx, &module_idx_by_key);
+        let mut checker = typechecker::TypeChecker::new();
+        if let Some(names) = declared.clone() {
+            checker.set_declared_crate_names(names);
+        }
+        checker.set_library_manifest_index(library_manifest_index.clone());
+
+        match checker.check_with_imports(&module.ast, &deps_for_module) {
+            Ok(()) => {
+                if emit_diagnostics {
+                    for warn in checker.warnings() {
+                        eprint!(
+                            "{}",
+                            diagnostics::format_error(
+                                module.file_path.to_string_lossy().as_ref(),
+                                &module.source,
+                                warn
+                            )
+                        );
+                    }
+                }
+                metadata_modules.push(collect_checked_api_metadata(
+                    &module.ast,
+                    &checker,
+                    codegraph_module_path(module, input.entry_path.as_deref()),
+                ));
+            }
+            Err(errs) => {
+                for err in &errs {
+                    all_errors.push_str(&diagnostics::format_error(
+                        module.file_path.to_string_lossy().as_ref(),
+                        &module.source,
+                        err,
+                    ));
+                }
+            }
+        }
+    }
+
+    if !all_errors.is_empty() && !allow_errors {
+        return Err(CliError::failure(all_errors.trim_end()));
+    }
+    if !all_errors.is_empty() && emit_diagnostics {
+        eprintln!("warning: codegraph export continuing with unchecked source graph after type-check errors");
+        eprint!("{all_errors}");
+    }
+
+    Ok(build_codegraph_document(
+        &input.modules,
+        manifest.as_ref(),
+        &input.project_root,
+        input.entry_path.as_deref(),
+        &metadata_modules,
+    ))
+}
+
+/// Collected codegraph input modules plus the path context used to render stable facts.
+struct CodegraphInput {
+    modules: Vec<ParsedModule>,
+    project_root: PathBuf,
+    entry_path: Option<PathBuf>,
+}
+
+/// Collect codegraph modules from a file, project directory, or arbitrary source directory.
+fn collect_codegraph_input(path: &Path) -> CliResult<CodegraphInput> {
+    let absolute = absolute_path(path)?;
+    if absolute.is_file() {
+        let modules = collect_modules(&absolute.to_string_lossy())?;
+        let project_root = resolve_project_root(&absolute);
+        return Ok(CodegraphInput {
+            modules,
+            project_root,
+            entry_path: Some(absolute),
+        });
+    }
+
+    if absolute.is_dir() {
+        let project_root = fs::canonicalize(&absolute).unwrap_or(absolute);
+        let entry_paths = collect_codegraph_directory_entries(&project_root)?;
+        let modules = collect_codegraph_directory_modules(&project_root, &entry_paths)?;
+        return Ok(CodegraphInput {
+            modules,
+            project_root,
+            entry_path: None,
+        });
+    }
+
+    Err(CliError::failure(format!(
+        "codegraph export path does not exist: {}",
+        absolute.display()
+    )))
+}
+
+/// Return every `.incn` source file under a directory in deterministic order.
+fn collect_codegraph_directory_entries(root: &Path) -> CliResult<Vec<PathBuf>> {
+    let mut entries = Vec::new();
+    collect_codegraph_directory_entries_into(root, &mut entries)?;
+    entries.sort();
+    if entries.is_empty() {
+        return Err(CliError::failure(format!(
+            "codegraph export found no `.incn` files under directory: {}",
+            root.display()
+        )));
+    }
+    Ok(entries)
+}
+
+/// Recursively collect `.incn` source files under a directory.
+fn collect_codegraph_directory_entries_into(dir: &Path, entries: &mut Vec<PathBuf>) -> CliResult<()> {
+    for entry in fs::read_dir(dir).map_err(|error| {
+        CliError::failure(format!(
+            "failed to read codegraph export directory {}: {error}",
+            dir.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            CliError::failure(format!(
+                "failed to read codegraph export directory entry under {}: {error}",
+                dir.display()
+            ))
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|error| {
+            CliError::failure(format!(
+                "failed to inspect codegraph export path {}: {error}",
+                path.display()
+            ))
+        })?;
+        if file_type.is_dir() {
+            collect_codegraph_directory_entries_into(&path, entries)?;
+        } else if file_type.is_file() && path.extension().is_some_and(|extension| extension == "incn") {
+            entries.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Collect and deduplicate modules reached by every directory entry source.
+fn collect_codegraph_directory_modules(root: &Path, entry_paths: &[PathBuf]) -> CliResult<Vec<ParsedModule>> {
+    let mut modules_by_path: BTreeMap<PathBuf, ParsedModule> = BTreeMap::new();
+    for entry_path in entry_paths {
+        let collected = collect_modules(&entry_path.to_string_lossy())?;
+        for mut module in collected {
+            module.file_path = fs::canonicalize(&module.file_path).unwrap_or(module.file_path);
+            if module.file_path.starts_with(root) {
+                module.path_segments = codegraph_module_segments_for_path(&module.file_path, root)?;
+                module.name = module.path_segments.join("_");
+            }
+            modules_by_path.entry(module.file_path.clone()).or_insert(module);
+        }
+    }
+    Ok(modules_by_path.into_values().collect())
+}
+
+/// Derive a module path from a source file's path relative to a globbed codegraph root.
+fn codegraph_module_segments_for_path(path: &Path, root: &Path) -> CliResult<Vec<String>> {
+    let relative = path.strip_prefix(root).map_err(|error| {
+        CliError::failure(format!(
+            "failed to derive codegraph module path for {} relative to {}: {error}",
+            path.display(),
+            root.display()
+        ))
+    })?;
+    let mut segments = Vec::new();
+    for component in relative.components() {
+        let value = component.as_os_str().to_string_lossy();
+        if value.ends_with(".incn") {
+            segments.push(value.trim_end_matches(".incn").to_string());
+        } else {
+            segments.push(value.to_string());
+        }
+    }
+    Ok(segments)
+}
+
+/// Build a codegraph document from parsed and checked modules.
+fn build_codegraph_document(
+    modules: &[ParsedModule],
+    manifest: Option<&ProjectManifest>,
+    project_root: &Path,
+    entry_path: Option<&Path>,
+    metadata_modules: &[CheckedApiMetadata],
+) -> CodegraphDocument {
+    let package = Some(CodegraphPackage {
+        name: manifest
+            .and_then(|manifest| manifest.project.as_ref())
+            .and_then(|project| project.name.clone()),
+        version: manifest
+            .and_then(|manifest| manifest.project.as_ref())
+            .and_then(|project| project.version.clone()),
+        root_path: Some(".".to_string()),
+    });
+    let mut document = CodegraphDocument::new(package);
+    let package_id = "package:root".to_string();
+    document.push_node(CodegraphNode {
+        id: package_id.clone(),
+        kind: CodegraphNodeKind::Package,
+        label: manifest
+            .and_then(|manifest| manifest.project.as_ref())
+            .and_then(|project| project.name.clone())
+            .unwrap_or_else(|| "package".to_string()),
+        file_path: None,
+        module_path: Vec::new(),
+        span: None,
+        facts: BTreeMap::new(),
+    });
+
+    for module in modules {
+        push_module_codegraph(
+            &mut document,
+            module,
+            project_root,
+            entry_path,
+            &package_id,
+            metadata_modules,
+        );
+    }
+    document
+}
+
+/// Add file, module, declaration, and import facts for one parsed module.
+fn push_module_codegraph(
+    document: &mut CodegraphDocument,
+    module: &ParsedModule,
+    project_root: &Path,
+    entry_path: Option<&Path>,
+    package_id: &str,
+    metadata_modules: &[CheckedApiMetadata],
+) {
+    let rel_path = codegraph_path(&module.file_path, project_root);
+    let file_id = format!("file:{rel_path}");
+    document.push_node(CodegraphNode {
+        id: file_id.clone(),
+        kind: CodegraphNodeKind::File,
+        label: rel_path.clone(),
+        file_path: Some(rel_path.clone()),
+        module_path: Vec::new(),
+        span: None,
+        facts: BTreeMap::new(),
+    });
+    document.push_edge(codegraph_edge(
+        package_id,
+        &file_id,
+        CodegraphEdgeKind::Contains,
+        None,
+        "package_contains_file",
+    ));
+
+    let module_path = codegraph_module_path(module, entry_path);
+    let metadata = metadata_modules
+        .iter()
+        .find(|metadata| metadata.module_path == module_path);
+    let module_id = format!("module:{}", module_path.join("::"));
+    document.push_node(CodegraphNode {
+        id: module_id.clone(),
+        kind: CodegraphNodeKind::Module,
+        label: module_path.join("::"),
+        file_path: Some(rel_path.clone()),
+        module_path: module_path.clone(),
+        span: Some(CodegraphSpan {
+            start: 0,
+            end: module.source.len(),
+        }),
+        facts: BTreeMap::new(),
+    });
+    document.push_edge(codegraph_edge(
+        &file_id,
+        &module_id,
+        CodegraphEdgeKind::Contains,
+        None,
+        "file_contains_module",
+    ));
+
+    for declaration in &module.ast.declarations {
+        match &declaration.node {
+            Declaration::Import(import) => {
+                push_import_codegraph(document, import, declaration.span, &module_id, &module_path, &rel_path);
+            }
+            Declaration::Docstring(_) => {}
+            other => {
+                if let Some((kind, name, visibility)) = declaration_codegraph_info(other) {
+                    let decl_id = format!("decl:{}::{name}:{}", module_path.join("::"), declaration.span.start);
+                    let mut facts = BTreeMap::new();
+                    facts.insert("declaration_kind".to_string(), kind.to_string());
+                    facts.insert("visibility".to_string(), visibility.to_string());
+                    let checked_declaration =
+                        metadata.and_then(|metadata| find_api_metadata_declaration(metadata, &name, declaration.span));
+                    if let Some(api_declaration) = checked_declaration {
+                        facts.extend(api_declaration_facts(api_declaration));
+                    }
+                    document.push_node(CodegraphNode {
+                        id: decl_id.clone(),
+                        kind: CodegraphNodeKind::Declaration,
+                        label: name,
+                        file_path: Some(rel_path.clone()),
+                        module_path: module_path.clone(),
+                        span: Some(CodegraphSpan {
+                            start: declaration.span.start,
+                            end: declaration.span.end,
+                        }),
+                        facts,
+                    });
+                    document.push_edge(codegraph_edge(
+                        &module_id,
+                        &decl_id,
+                        CodegraphEdgeKind::Contains,
+                        Some(CodegraphSpan {
+                            start: declaration.span.start,
+                            end: declaration.span.end,
+                        }),
+                        "module_contains_declaration",
+                    ));
+                    document.push_edge(codegraph_edge(
+                        &module_id,
+                        &decl_id,
+                        CodegraphEdgeKind::Defines,
+                        Some(CodegraphSpan {
+                            start: declaration.span.start,
+                            end: declaration.span.end,
+                        }),
+                        "module_defines_declaration",
+                    ));
+                    if let Some(api_declaration) = checked_declaration {
+                        push_api_member_codegraph(document, api_declaration, &decl_id, &rel_path, &module_path);
+                    }
+                    push_declaration_body_facts(
+                        document,
+                        declaration,
+                        &decl_id,
+                        &rel_path,
+                        &module_path,
+                        &module.source,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Context needed to turn parsed body syntax into source-backed graph facts.
+#[derive(Clone)]
+struct BodyFactContext<'a> {
+    parent_id: &'a str,
+    rel_path: &'a str,
+    module_path: &'a [String],
+    source: &'a str,
+    owner: String,
+}
+
+impl<'a> BodyFactContext<'a> {
+    fn with_owner(&self, owner: impl Into<String>) -> Self {
+        Self {
+            parent_id: self.parent_id,
+            rel_path: self.rel_path,
+            module_path: self.module_path,
+            source: self.source,
+            owner: owner.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PatternLabel {
+    family: PatternFamily,
+    label: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum PatternFamily {
+    Constructor,
+    StringLiteral,
+    Literal,
+}
+
+impl PatternFamily {
+    fn as_fact(self) -> &'static str {
+        match self {
+            Self::Constructor => "constructor",
+            Self::StringLiteral => "string_literal",
+            Self::Literal => "literal",
+        }
+    }
+}
+
+/// Add deterministic body-level graph facts contained by one declaration.
+fn push_declaration_body_facts(
+    document: &mut CodegraphDocument,
+    declaration: &Spanned<Declaration>,
+    declaration_id: &str,
+    rel_path: &str,
+    module_path: &[String],
+    source: &str,
+) {
+    collect_declaration_body_facts(
+        document,
+        declaration,
+        BodyFactContext {
+            parent_id: declaration_id,
+            rel_path,
+            module_path,
+            source,
+            owner: "<module>".to_string(),
+        },
+    );
+}
+
+fn collect_declaration_body_facts(
+    document: &mut CodegraphDocument,
+    declaration: &Spanned<Declaration>,
+    context: BodyFactContext<'_>,
+) {
+    match &declaration.node {
+        Declaration::Import(_)
+        | Declaration::Alias(_)
+        | Declaration::Partial(_)
+        | Declaration::TypeAlias(_)
+        | Declaration::Docstring(_) => {}
+        Declaration::Const(const_decl) => {
+            collect_expr_body_facts(document, &const_decl.value, context.with_owner(&const_decl.name));
+        }
+        Declaration::Static(static_decl) => {
+            collect_expr_body_facts(document, &static_decl.value, context.with_owner(&static_decl.name));
+        }
+        Declaration::Function(function) => {
+            let context = context.with_owner(&function.name);
+            collect_decorator_body_facts(document, &function.decorators, context.clone());
+            collect_param_body_facts(document, &function.params, context.clone());
+            collect_body_facts(document, &function.body, context);
+        }
+        Declaration::Model(model) => {
+            collect_type_body_facts(
+                document,
+                &model.name,
+                &model.decorators,
+                &model.fields,
+                &model.properties,
+                &model.methods,
+                context,
+            );
+        }
+        Declaration::Class(class) => {
+            collect_type_body_facts(
+                document,
+                &class.name,
+                &class.decorators,
+                &class.fields,
+                &class.properties,
+                &class.methods,
+                context,
+            );
+        }
+        Declaration::Trait(trait_decl) => {
+            collect_decorator_body_facts(document, &trait_decl.decorators, context.with_owner(&trait_decl.name));
+            for property in &trait_decl.properties {
+                let owner = format!("{}.{}", trait_decl.name, property.node.name);
+                if let Some(body) = &property.node.body {
+                    collect_body_facts(document, body, context.with_owner(owner));
+                }
+            }
+            for method in &trait_decl.methods {
+                collect_method_body_facts(document, &trait_decl.name, method, context.clone());
+            }
+        }
+        Declaration::Newtype(newtype_decl) => {
+            collect_decorator_body_facts(
+                document,
+                &newtype_decl.decorators,
+                context.with_owner(&newtype_decl.name),
+            );
+            for rebinding in &newtype_decl.rebindings {
+                let owner = format!("{}.{}", newtype_decl.name, rebinding.node.name);
+                collect_expr_body_facts(document, &rebinding.node.target, context.with_owner(owner));
+            }
+            for interop_edge in &newtype_decl.interop_edges {
+                let owner = format!("{}.interop", newtype_decl.name);
+                collect_expr_body_facts(document, &interop_edge.node.adapter, context.with_owner(owner));
+            }
+            for method in &newtype_decl.methods {
+                collect_method_body_facts(document, &newtype_decl.name, method, context.clone());
+            }
+        }
+        Declaration::Enum(enum_decl) => {
+            collect_decorator_body_facts(document, &enum_decl.decorators, context.with_owner(&enum_decl.name));
+            for method in &enum_decl.methods {
+                collect_method_body_facts(document, &enum_decl.name, method, context.clone());
+            }
+        }
+        Declaration::TestModule(test_module) => {
+            let context = context.with_owner(format!("module {}", test_module.name));
+            for nested in &test_module.body {
+                collect_declaration_body_facts(document, nested, context.clone());
+            }
+        }
+    }
+}
+
+fn collect_type_body_facts(
+    document: &mut CodegraphDocument,
+    type_name: &str,
+    decorators: &[Spanned<crate::frontend::ast::Decorator>],
+    fields: &[Spanned<crate::frontend::ast::FieldDecl>],
+    properties: &[Spanned<crate::frontend::ast::PropertyDecl>],
+    methods: &[Spanned<crate::frontend::ast::MethodDecl>],
+    context: BodyFactContext<'_>,
+) {
+    collect_decorator_body_facts(document, decorators, context.with_owner(type_name));
+    for field in fields {
+        if let Some(default) = &field.node.default {
+            let owner = format!("{type_name}.{}", field.node.name);
+            collect_expr_body_facts(document, default, context.with_owner(owner));
+        }
+    }
+    for property in properties {
+        let owner = format!("{type_name}.{}", property.node.name);
+        if let Some(body) = &property.node.body {
+            collect_body_facts(document, body, context.with_owner(owner));
+        }
+    }
+    for method in methods {
+        collect_method_body_facts(document, type_name, method, context.clone());
+    }
+}
+
+fn collect_method_body_facts(
+    document: &mut CodegraphDocument,
+    type_name: &str,
+    method: &Spanned<crate::frontend::ast::MethodDecl>,
+    context: BodyFactContext<'_>,
+) {
+    let context = context.with_owner(format!("{type_name}.{}", method.node.name));
+    collect_decorator_body_facts(document, &method.node.decorators, context.clone());
+    collect_param_body_facts(document, &method.node.params, context.clone());
+    if let Some(body) = &method.node.body {
+        collect_body_facts(document, body, context);
+    }
+}
+
+fn collect_decorator_body_facts(
+    document: &mut CodegraphDocument,
+    decorators: &[Spanned<crate::frontend::ast::Decorator>],
+    context: BodyFactContext<'_>,
+) {
+    for decorator in decorators {
+        for arg in &decorator.node.args {
+            match arg {
+                DecoratorArg::Positional(value) => collect_expr_body_facts(document, value, context.clone()),
+                DecoratorArg::Named(_, DecoratorArgValue::Expr(value)) => {
+                    collect_expr_body_facts(document, value, context.clone());
+                }
+                DecoratorArg::Named(_, DecoratorArgValue::Type(_)) => {}
+            }
+        }
+    }
+}
+
+fn collect_param_body_facts(
+    document: &mut CodegraphDocument,
+    params: &[Spanned<crate::frontend::ast::Param>],
+    context: BodyFactContext<'_>,
+) {
+    for param in params {
+        if let Some(default) = &param.node.default {
+            collect_expr_body_facts(document, default, context.clone());
+        }
+    }
+}
+
+fn collect_body_facts(document: &mut CodegraphDocument, body: &[Spanned<Statement>], context: BodyFactContext<'_>) {
+    for statement in body {
+        collect_statement_body_facts(document, statement, context.clone());
+    }
+}
+
+fn collect_statement_body_facts(
+    document: &mut CodegraphDocument,
+    statement: &Spanned<Statement>,
+    context: BodyFactContext<'_>,
+) {
+    match &statement.node {
+        Statement::Assignment(stmt) => collect_expr_body_facts(document, &stmt.value, context),
+        Statement::FieldAssignment(stmt) => {
+            collect_expr_body_facts(document, &stmt.object, context.clone());
+            collect_expr_body_facts(document, &stmt.value, context);
+        }
+        Statement::IndexAssignment(stmt) => {
+            collect_expr_body_facts(document, &stmt.object, context.clone());
+            collect_expr_body_facts(document, &stmt.index, context.clone());
+            collect_expr_body_facts(document, &stmt.value, context);
+        }
+        Statement::Return(Some(expr)) | Statement::Expr(expr) | Statement::Break(Some(expr)) => {
+            collect_expr_body_facts(document, expr, context);
+        }
+        Statement::CompoundAssignment(stmt) => collect_expr_body_facts(document, &stmt.value, context),
+        Statement::TupleUnpack(stmt) => collect_expr_body_facts(document, &stmt.value, context),
+        Statement::TupleAssign(stmt) => {
+            for target in &stmt.targets {
+                collect_expr_body_facts(document, target, context.clone());
+            }
+            collect_expr_body_facts(document, &stmt.value, context);
+        }
+        Statement::ChainedAssignment(stmt) => collect_expr_body_facts(document, &stmt.value, context),
+        Statement::Assert(assert_stmt) => collect_assert_body_facts(document, assert_stmt, context),
+        Statement::Surface(surface_stmt) => match &surface_stmt.payload {
+            crate::frontend::ast::SurfaceStmtPayload::KeywordArgs(args) => {
+                for arg in args {
+                    collect_expr_body_facts(document, arg, context.clone());
+                }
+            }
+        },
+        Statement::VocabBlock(block) => {
+            collect_decorator_body_facts(document, &block.decorators, context.clone());
+            for arg in &block.header_args {
+                collect_expr_body_facts(document, arg, context.clone());
+            }
+            collect_body_facts(document, &block.body, context);
+        }
+        Statement::If(stmt) => {
+            collect_condition_body_facts(document, &stmt.condition, context.clone());
+            collect_body_facts(document, &stmt.then_body, context.clone());
+            for (condition, body) in &stmt.elif_branches {
+                collect_expr_body_facts(document, condition, context.clone());
+                collect_body_facts(document, body, context.clone());
+            }
+            if let Some(else_body) = &stmt.else_body {
+                collect_body_facts(document, else_body, context);
+            }
+        }
+        Statement::Loop(stmt) => collect_body_facts(document, &stmt.body, context),
+        Statement::While(stmt) => {
+            collect_condition_body_facts(document, &stmt.condition, context.clone());
+            collect_body_facts(document, &stmt.body, context);
+        }
+        Statement::For(stmt) => {
+            collect_expr_body_facts(document, &stmt.iter, context.clone());
+            collect_body_facts(document, &stmt.body, context);
+        }
+        Statement::Return(None) | Statement::Break(None) | Statement::Pass | Statement::Continue => {}
+    }
+}
+
+fn collect_assert_body_facts(
+    document: &mut CodegraphDocument,
+    assert_stmt: &crate::frontend::ast::AssertStmt,
+    context: BodyFactContext<'_>,
+) {
+    match &assert_stmt.kind {
+        AssertKind::Condition(condition) => collect_expr_body_facts(document, condition, context.clone()),
+        AssertKind::IsPattern { value, .. } => collect_expr_body_facts(document, value, context.clone()),
+        AssertKind::Raises { call, .. } => collect_expr_body_facts(document, call, context.clone()),
+    }
+    if let Some(message) = &assert_stmt.message {
+        collect_expr_body_facts(document, message, context);
+    }
+}
+
+fn collect_condition_body_facts(document: &mut CodegraphDocument, condition: &Condition, context: BodyFactContext<'_>) {
+    match condition {
+        Condition::Expr(expr) | Condition::Let { value: expr, .. } => collect_expr_body_facts(document, expr, context),
+    }
+}
+
+fn collect_expr_body_facts(document: &mut CodegraphDocument, expr: &Spanned<Expr>, context: BodyFactContext<'_>) {
+    match &expr.node {
+        Expr::Ident(_) | Expr::SelfExpr => push_reference_fact(document, expr.span, &expr.node, context),
+        Expr::Literal(_) => {}
+        Expr::Binary(left, _, right) | Expr::Index(left, right) => {
+            collect_expr_body_facts(document, left, context.clone());
+            collect_expr_body_facts(document, right, context);
+        }
+        Expr::Unary(_, operand) | Expr::Try(operand) | Expr::Paren(operand) => {
+            collect_expr_body_facts(document, operand, context);
+        }
+        Expr::Field(operand, _) => {
+            collect_expr_body_facts(document, operand, context.clone());
+            push_reference_fact(document, expr.span, &expr.node, context);
+        }
+        Expr::Call(callee, _type_args, args) => {
+            push_call_fact(document, expr.span, &expr.node, context.clone());
+            collect_expr_body_facts(document, callee, context.clone());
+            collect_call_arg_body_facts(document, args, context);
+        }
+        Expr::MethodCall(base, _, _type_args, args) => {
+            push_call_fact(document, expr.span, &expr.node, context.clone());
+            collect_expr_body_facts(document, base, context.clone());
+            collect_call_arg_body_facts(document, args, context);
+        }
+        Expr::Constructor(_, args) => {
+            push_call_fact(document, expr.span, &expr.node, context.clone());
+            collect_call_arg_body_facts(document, args, context);
+        }
+        Expr::Partial(partial) => {
+            collect_expr_body_facts(document, &partial.target, context.clone());
+            for arg in &partial.args {
+                collect_expr_body_facts(document, &arg.value, context.clone());
+            }
+        }
+        Expr::Slice(base, slice) => {
+            collect_expr_body_facts(document, base, context.clone());
+            if let Some(start) = &slice.start {
+                collect_expr_body_facts(document, start, context.clone());
+            }
+            if let Some(end) = &slice.end {
+                collect_expr_body_facts(document, end, context.clone());
+            }
+            if let Some(step) = &slice.step {
+                collect_expr_body_facts(document, step, context);
+            }
+        }
+        Expr::Match(scrutinee, arms) => {
+            push_match_dispatch_fact(document, expr.span, scrutinee, arms, context.clone());
+            collect_expr_body_facts(document, scrutinee, context.clone());
+            for arm in arms {
+                if let Some(guard) = &arm.node.guard {
+                    collect_expr_body_facts(document, guard, context.clone());
+                }
+                match &arm.node.body {
+                    MatchBody::Expr(value) => collect_expr_body_facts(document, value, context.clone()),
+                    MatchBody::Block(body) => collect_body_facts(document, body, context.clone()),
+                }
+            }
+        }
+        Expr::If(if_expr) => {
+            collect_expr_body_facts(document, &if_expr.condition, context.clone());
+            collect_body_facts(document, &if_expr.then_body, context.clone());
+            if let Some(else_body) = &if_expr.else_body {
+                collect_body_facts(document, else_body, context);
+            }
+        }
+        Expr::Loop(loop_expr) => collect_body_facts(document, &loop_expr.body, context),
+        Expr::ListComp(comp) => {
+            collect_expr_body_facts(document, &comp.expr, context.clone());
+            collect_expr_body_facts(document, &comp.iter, context.clone());
+            if let Some(filter) = &comp.filter {
+                collect_expr_body_facts(document, filter, context.clone());
+            }
+            collect_comprehension_clause_body_facts(document, &comp.clauses, context);
+        }
+        Expr::DictComp(comp) => {
+            collect_expr_body_facts(document, &comp.key, context.clone());
+            collect_expr_body_facts(document, &comp.value, context.clone());
+            collect_expr_body_facts(document, &comp.iter, context.clone());
+            if let Some(filter) = &comp.filter {
+                collect_expr_body_facts(document, filter, context.clone());
+            }
+            collect_comprehension_clause_body_facts(document, &comp.clauses, context);
+        }
+        Expr::Generator(generator) => {
+            collect_expr_body_facts(document, &generator.expr, context.clone());
+            collect_comprehension_clause_body_facts(document, &generator.clauses, context);
+        }
+        Expr::Closure(params, body) => {
+            collect_param_body_facts(document, params, context.clone());
+            collect_expr_body_facts(document, body, context);
+        }
+        Expr::Tuple(items) | Expr::Set(items) => {
+            for item in items {
+                collect_expr_body_facts(document, item, context.clone());
+            }
+        }
+        Expr::List(entries) => {
+            for entry in entries {
+                match entry {
+                    crate::frontend::ast::ListEntry::Element(value)
+                    | crate::frontend::ast::ListEntry::Spread(value) => {
+                        collect_expr_body_facts(document, value, context.clone());
+                    }
+                }
+            }
+        }
+        Expr::Dict(entries) => {
+            for entry in entries {
+                match entry {
+                    DictEntry::Pair(key, value) => {
+                        collect_expr_body_facts(document, key, context.clone());
+                        collect_expr_body_facts(document, value, context.clone());
+                    }
+                    DictEntry::Spread(value) => collect_expr_body_facts(document, value, context.clone()),
+                }
+            }
+        }
+        Expr::FString(parts) => {
+            for part in parts {
+                if let FStringPart::Expr { expr, .. } = part {
+                    collect_expr_body_facts(document, expr, context.clone());
+                }
+            }
+        }
+        Expr::Yield(Some(value)) => collect_expr_body_facts(document, value, context),
+        Expr::Yield(None) => {}
+        Expr::Range { start, end, .. } => {
+            collect_expr_body_facts(document, start, context.clone());
+            collect_expr_body_facts(document, end, context);
+        }
+        Expr::Surface(surface_expr) => match &surface_expr.payload {
+            crate::frontend::ast::SurfaceExprPayload::PrefixUnary(value) => {
+                collect_expr_body_facts(document, value, context);
+            }
+            crate::frontend::ast::SurfaceExprPayload::RaceFor(race) => {
+                for arm in &race.arms {
+                    collect_expr_body_facts(document, &arm.awaitable, context.clone());
+                    match &arm.body {
+                        RaceForBody::Expr(value) => collect_expr_body_facts(document, value, context.clone()),
+                        RaceForBody::Block(body) => collect_body_facts(document, body, context.clone()),
+                    }
+                }
+            }
+            crate::frontend::ast::SurfaceExprPayload::LeadingDotPath { .. } => {}
+            crate::frontend::ast::SurfaceExprPayload::ScopedGlyph { left, right, .. } => {
+                collect_expr_body_facts(document, left, context.clone());
+                collect_expr_body_facts(document, right, context);
+            }
+            crate::frontend::ast::SurfaceExprPayload::ScopedSymbolCall { args, .. } => {
+                push_call_fact(document, expr.span, &expr.node, context.clone());
+                collect_call_arg_body_facts(document, args, context);
+            }
+        },
+    }
+}
+
+fn collect_comprehension_clause_body_facts(
+    document: &mut CodegraphDocument,
+    clauses: &[ComprehensionClause],
+    context: BodyFactContext<'_>,
+) {
+    for clause in clauses {
+        match clause {
+            ComprehensionClause::For { iter, .. } | ComprehensionClause::If(iter) => {
+                collect_expr_body_facts(document, iter, context.clone());
+            }
+        }
+    }
+}
+
+fn collect_call_arg_body_facts(document: &mut CodegraphDocument, args: &[CallArg], context: BodyFactContext<'_>) {
+    for arg in args {
+        match arg {
+            CallArg::Positional(value)
+            | CallArg::Named(_, value)
+            | CallArg::PositionalUnpack(value)
+            | CallArg::KeywordUnpack(value) => collect_expr_body_facts(document, value, context.clone()),
+        }
+    }
+}
+
+fn push_match_dispatch_fact(
+    document: &mut CodegraphDocument,
+    span: Span,
+    scrutinee: &Spanned<Expr>,
+    arms: &[Spanned<crate::frontend::ast::MatchArm>],
+    context: BodyFactContext<'_>,
+) {
+    let patterns = collect_match_patterns(arms);
+    if patterns.len() < 2 {
+        return;
+    }
+    let Some((domain_key, domain_label)) = domain_key_and_label(&scrutinee.node, &context.owner) else {
+        return;
+    };
+    let pattern_labels = patterns.iter().map(|pattern| pattern.label.clone()).collect::<Vec<_>>();
+    let pattern_families = patterns
+        .iter()
+        .map(|pattern| pattern.family.as_fact().to_string())
+        .collect::<Vec<_>>();
+    let mut facts = BTreeMap::new();
+    facts.insert("domain_key".to_string(), domain_key);
+    facts.insert("domain_label".to_string(), domain_label.clone());
+    facts.insert("arm_count".to_string(), arms.len().to_string());
+    facts.insert("explicit_pattern_count".to_string(), patterns.len().to_string());
+    facts.insert("has_default_arm".to_string(), match_has_default_arm(arms).to_string());
+    facts.insert("pattern_labels".to_string(), json_string_list(&pattern_labels));
+    facts.insert("pattern_families".to_string(), json_string_list(&pattern_families));
+
+    push_body_fact_node(
+        document,
+        BodyFactNodeInput {
+            context,
+            span,
+            kind: CodegraphNodeKind::MatchDispatch,
+            fact_kind: "match_dispatch",
+            label: format!("match {domain_label}"),
+            facts,
+            contains_relation: "declaration_contains_match_dispatch",
+        },
+    );
+}
+
+fn push_call_fact(document: &mut CodegraphDocument, span: Span, expr: &Expr, context: BodyFactContext<'_>) {
+    let Some((callee_key, callee_label)) = call_site_key_and_label(expr, &context.owner) else {
+        return;
+    };
+    let mut facts = BTreeMap::new();
+    facts.insert("callee_key".to_string(), callee_key.clone());
+    facts.insert("callee_label".to_string(), callee_label.clone());
+    let node_id = push_body_fact_node(
+        document,
+        BodyFactNodeInput {
+            context,
+            span,
+            kind: CodegraphNodeKind::CallSite,
+            fact_kind: "call_site",
+            label: format!("call {callee_label}"),
+            facts,
+            contains_relation: "declaration_contains_call_site",
+        },
+    );
+    push_body_external_target(
+        document,
+        BodyExternalTargetInput {
+            source_id: &node_id,
+            span,
+            edge_kind: CodegraphEdgeKind::Calls,
+            relation: "call_site_targets_callee",
+            target_kind: "call_target",
+            target_key: &callee_key,
+            target_label: &callee_label,
+        },
+    );
+}
+
+fn push_reference_fact(document: &mut CodegraphDocument, span: Span, expr: &Expr, context: BodyFactContext<'_>) {
+    let Some((reference_key, reference_label, reference_kind)) = reference_key_and_label(expr, &context.owner) else {
+        return;
+    };
+    let mut facts = BTreeMap::new();
+    facts.insert("reference_key".to_string(), reference_key.clone());
+    facts.insert("reference_label".to_string(), reference_label.clone());
+    facts.insert("reference_kind".to_string(), reference_kind.to_string());
+    let node_id = push_body_fact_node(
+        document,
+        BodyFactNodeInput {
+            context,
+            span,
+            kind: CodegraphNodeKind::Reference,
+            fact_kind: "reference",
+            label: reference_label.clone(),
+            facts,
+            contains_relation: "declaration_contains_reference",
+        },
+    );
+    push_body_external_target(
+        document,
+        BodyExternalTargetInput {
+            source_id: &node_id,
+            span,
+            edge_kind: CodegraphEdgeKind::References,
+            relation: "reference_targets_symbol",
+            target_kind: "reference_target",
+            target_key: &reference_key,
+            target_label: &reference_label,
+        },
+    );
+}
+
+struct BodyFactNodeInput<'a> {
+    context: BodyFactContext<'a>,
+    span: Span,
+    kind: CodegraphNodeKind,
+    fact_kind: &'static str,
+    label: String,
+    facts: BTreeMap<String, String>,
+    contains_relation: &'static str,
+}
+
+fn push_body_fact_node(document: &mut CodegraphDocument, input: BodyFactNodeInput<'_>) -> String {
+    let mut facts = input.facts;
+    let (line, column) = line_column(input.context.source, input.span);
+    facts.insert("body_fact_kind".to_string(), input.fact_kind.to_string());
+    facts.insert("owner".to_string(), input.context.owner.clone());
+    facts.insert("line".to_string(), line.to_string());
+    facts.insert("column".to_string(), column.to_string());
+
+    let node_id = format!(
+        "body-fact:{}:{}:{}:{}-{}",
+        input.fact_kind,
+        stable_id_piece(&input.context.module_path.join("::")),
+        stable_id_piece(&input.context.owner),
+        input.span.start,
+        input.span.end
+    );
+    let span = Some(CodegraphSpan {
+        start: input.span.start,
+        end: input.span.end,
+    });
+    document.push_node(CodegraphNode {
+        id: node_id.clone(),
+        kind: input.kind,
+        label: input.label,
+        file_path: Some(input.context.rel_path.to_string()),
+        module_path: input.context.module_path.to_vec(),
+        span,
+        facts,
+    });
+    document.push_edge(codegraph_edge(
+        input.context.parent_id,
+        &node_id,
+        CodegraphEdgeKind::Contains,
+        span,
+        input.contains_relation,
+    ));
+    node_id
+}
+
+struct BodyExternalTargetInput<'a> {
+    source_id: &'a str,
+    span: Span,
+    edge_kind: CodegraphEdgeKind,
+    relation: &'a str,
+    target_kind: &'a str,
+    target_key: &'a str,
+    target_label: &'a str,
+}
+
+fn push_body_external_target(document: &mut CodegraphDocument, input: BodyExternalTargetInput<'_>) {
+    let target_id = format!("external:{}:{}", input.target_kind, stable_id_piece(input.target_key));
+    if !codegraph_document_has_node(document, &target_id) {
+        let mut facts = BTreeMap::new();
+        facts.insert("target_kind".to_string(), input.target_kind.to_string());
+        facts.insert("target_key".to_string(), input.target_key.to_string());
+        document.push_node(CodegraphNode {
+            id: target_id.clone(),
+            kind: CodegraphNodeKind::External,
+            label: input.target_label.to_string(),
+            file_path: None,
+            module_path: Vec::new(),
+            span: None,
+            facts,
+        });
+    }
+    document.push_edge(codegraph_edge(
+        input.source_id,
+        &target_id,
+        input.edge_kind,
+        Some(CodegraphSpan {
+            start: input.span.start,
+            end: input.span.end,
+        }),
+        input.relation,
+    ));
+}
+
+fn collect_match_patterns(arms: &[Spanned<crate::frontend::ast::MatchArm>]) -> BTreeSet<PatternLabel> {
+    let mut labels = BTreeSet::new();
+    for arm in arms {
+        collect_pattern_labels(&arm.node.pattern.node, &mut labels);
+    }
+    labels
+}
+
+fn collect_pattern_labels(pattern: &Pattern, labels: &mut BTreeSet<PatternLabel>) {
+    match pattern {
+        Pattern::Wildcard | Pattern::Binding(_) => {}
+        Pattern::Literal(literal) => {
+            let (family, label) = literal_label(literal);
+            labels.insert(PatternLabel { family, label });
+        }
+        Pattern::Constructor(name, _args) => {
+            labels.insert(PatternLabel {
+                family: PatternFamily::Constructor,
+                label: format!("{}(...)", incan_source_path_label(name)),
+            });
+        }
+        Pattern::Tuple(items) | Pattern::Or(items) => {
+            for item in items {
+                collect_pattern_labels(&item.node, labels);
+            }
+        }
+        Pattern::Group(inner) => collect_pattern_labels(&inner.node, labels),
+    }
+}
+
+fn match_has_default_arm(arms: &[Spanned<crate::frontend::ast::MatchArm>]) -> bool {
+    arms.iter().any(|arm| pattern_is_default(&arm.node.pattern.node))
+}
+
+fn pattern_is_default(pattern: &Pattern) -> bool {
+    match pattern {
+        Pattern::Wildcard | Pattern::Binding(_) => true,
+        Pattern::Group(inner) => pattern_is_default(&inner.node),
+        Pattern::Or(items) => items.iter().any(|item| pattern_is_default(&item.node)),
+        Pattern::Literal(_) | Pattern::Constructor(_, _) | Pattern::Tuple(_) => false,
+    }
+}
+
+fn literal_label(literal: &Literal) -> (PatternFamily, String) {
+    match literal {
+        Literal::String(value) => (PatternFamily::StringLiteral, format!("\"{}\"", compact(value))),
+        Literal::Int(value) => (PatternFamily::Literal, value.repr.clone()),
+        Literal::Float(value) => (PatternFamily::Literal, value.repr.clone()),
+        Literal::Decimal(value) => (PatternFamily::Literal, value.repr.clone()),
+        Literal::Bool(value) => (PatternFamily::Literal, value.to_string()),
+        Literal::None => (PatternFamily::Literal, "None".to_string()),
+        Literal::Bytes(value) => (PatternFamily::Literal, format!("bytes[{}]", value.len())),
+    }
+}
+
+fn call_site_key_and_label(expr: &Expr, owner: &str) -> Option<(String, String)> {
+    match expr {
+        Expr::Call(callee, _, _) => {
+            let (callee_key, callee_label) = domain_key_and_label(&callee.node, owner)?;
+            Some((format!("call:{callee_key}"), format!("{callee_label}(...)")))
+        }
+        Expr::MethodCall(base, method, _, _) => {
+            let key = match &base.node {
+                Expr::SelfExpr => owner_type(owner)
+                    .map(|type_name| format!("method:self:{type_name}:{method}"))
+                    .unwrap_or_else(|| format!("method:self:{method}")),
+                _ => format!("method:{method}"),
+            };
+            let label = match &base.node {
+                Expr::SelfExpr => format!("self.{method}()"),
+                _ => format!(".{method}()"),
+            };
+            Some((key, label))
+        }
+        Expr::Constructor(name, _) => Some((
+            format!("constructor:{name}"),
+            format!("{}(...)", incan_source_path_label(name)),
+        )),
+        Expr::Surface(surface_expr) => match &surface_expr.payload {
+            crate::frontend::ast::SurfaceExprPayload::ScopedSymbolCall { symbol, .. } => {
+                Some((format!("surface_symbol:{symbol}"), format!("{symbol}(...)")))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn incan_source_path_label(name: &str) -> String {
+    name.replace("::", ".")
+}
+
+fn reference_key_and_label(expr: &Expr, owner: &str) -> Option<(String, String, &'static str)> {
+    match expr {
+        Expr::Ident(name) => Some((format!("ident:{name}"), name.clone(), "identifier")),
+        Expr::SelfExpr => {
+            let key = owner_type(owner)
+                .map(|type_name| format!("self:{type_name}"))
+                .unwrap_or_else(|| "self".to_string());
+            let label = owner_type(owner)
+                .map(|type_name| format!("self ({type_name})"))
+                .unwrap_or_else(|| "self".to_string());
+            Some((key, label, "self"))
+        }
+        Expr::Field(base, field) => {
+            let key = match &base.node {
+                Expr::SelfExpr => owner_type(owner)
+                    .map(|type_name| format!("field:self:{type_name}:{field}"))
+                    .unwrap_or_else(|| format!("field:self:{field}")),
+                _ => format!("field:{field}"),
+            };
+            let label = match &base.node {
+                Expr::SelfExpr => format!("self.{field}"),
+                _ => format!(".{field}"),
+            };
+            Some((key, label, "field"))
+        }
+        _ => None,
+    }
+}
+
+fn domain_key_and_label(expr: &Expr, owner: &str) -> Option<(String, String)> {
+    match expr {
+        Expr::SelfExpr => {
+            let key = owner_type(owner)
+                .map(|type_name| format!("self:{type_name}"))
+                .unwrap_or_else(|| "self".to_string());
+            let label = owner_type(owner)
+                .map(|type_name| format!("self ({type_name})"))
+                .unwrap_or_else(|| "self".to_string());
+            Some((key, label))
+        }
+        Expr::Ident(name) => Some((format!("ident:{name}"), name.clone())),
+        Expr::Field(base, field) => {
+            let key = match &base.node {
+                Expr::SelfExpr => owner_type(owner)
+                    .map(|type_name| format!("field:self:{type_name}:{field}"))
+                    .unwrap_or_else(|| format!("field:self:{field}")),
+                _ => format!("field:{field}"),
+            };
+            let label = match &base.node {
+                Expr::SelfExpr => format!("self.{field}"),
+                _ => format!(".{field}"),
+            };
+            Some((key, label))
+        }
+        Expr::MethodCall(_, method, _, _) => Some((format!("method:{method}"), format!(".{method}()"))),
+        Expr::Call(callee, _, _) => {
+            let (callee_key, callee_label) = domain_key_and_label(&callee.node, owner)?;
+            Some((format!("call:{callee_key}"), format!("{callee_label}(...)")))
+        }
+        _ => None,
+    }
+}
+
+fn owner_type(owner: &str) -> Option<&str> {
+    let (type_name, method_name) = owner.split_once('.')?;
+    if type_name.is_empty() || method_name.is_empty() {
+        None
+    } else {
+        Some(type_name)
+    }
+}
+
+fn json_string_list(values: &[String]) -> String {
+    serde_json::to_string(values).unwrap_or_else(|_| "[]".to_string())
+}
+
+fn line_column(source: &str, span: Span) -> (usize, usize) {
+    let offset = span.start.min(source.len());
+    let mut line = 1usize;
+    let mut column = 1usize;
+    for ch in source[..offset].chars() {
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    (line, column)
+}
+
+fn compact(value: &str) -> String {
+    const LIMIT: usize = 48;
+    if value.chars().count() <= LIMIT {
+        return value.to_string();
+    }
+    let mut compacted = value.chars().take(LIMIT - 3).collect::<String>();
+    compacted.push_str("...");
+    compacted
+}
+
+/// Find a checked API declaration by exported name and exact source anchor.
+fn find_api_metadata_declaration<'a>(
+    metadata: &'a CheckedApiMetadata,
+    name: &str,
+    span: crate::frontend::ast::Span,
+) -> Option<&'a ApiDeclaration> {
+    metadata.declarations.iter().find(|declaration| {
+        let anchor = api_declaration_anchor(declaration);
+        api_declaration_name(declaration) == name && anchor.span.start == span.start && anchor.span.end == span.end
+    })
+}
+
+/// Add RFC 048 API metadata facts to a source declaration node.
+fn api_declaration_facts(declaration: &ApiDeclaration) -> BTreeMap<String, String> {
+    let mut facts = BTreeMap::new();
+    let anchor = api_declaration_anchor(declaration);
+    facts.insert("checked_api_anchor_id".to_string(), anchor.id.clone());
+    facts.insert(
+        "checked_api_schema_version".to_string(),
+        CHECKED_API_METADATA_SCHEMA_VERSION.to_string(),
+    );
+    facts.insert(
+        "checked_api_kind".to_string(),
+        api_declaration_kind(declaration).to_string(),
+    );
+    facts.insert(
+        "checked_api_signature".to_string(),
+        api_declaration_signature(declaration),
+    );
+    if let Some(summary) = api_declaration_doc_summary(declaration) {
+        facts.insert("checked_api_doc_summary".to_string(), summary);
+    }
+    facts
+}
+
+/// Add checked API child nodes that are useful for package exploration but are not top-level declarations.
+fn push_api_member_codegraph(
+    document: &mut CodegraphDocument,
+    declaration: &ApiDeclaration,
+    declaration_id: &str,
+    rel_path: &str,
+    module_path: &[String],
+) {
+    match declaration {
+        ApiDeclaration::Model(model) => {
+            for field in &model.fields {
+                push_api_field_member(document, declaration_id, &model.anchor, rel_path, module_path, field);
+            }
+            for method in &model.methods {
+                push_api_method_member(document, declaration_id, &model.anchor, rel_path, module_path, method);
+            }
+        }
+        ApiDeclaration::Class(class) => {
+            for field in &class.fields {
+                push_api_field_member(document, declaration_id, &class.anchor, rel_path, module_path, field);
+            }
+            for method in &class.methods {
+                push_api_method_member(document, declaration_id, &class.anchor, rel_path, module_path, method);
+            }
+        }
+        ApiDeclaration::Trait(trait_decl) => {
+            for field in &trait_decl.requires {
+                push_api_field_member(
+                    document,
+                    declaration_id,
+                    &trait_decl.anchor,
+                    rel_path,
+                    module_path,
+                    field,
+                );
+            }
+            for method in &trait_decl.methods {
+                push_api_method_member(
+                    document,
+                    declaration_id,
+                    &trait_decl.anchor,
+                    rel_path,
+                    module_path,
+                    method,
+                );
+            }
+        }
+        ApiDeclaration::Enum(enum_decl) => {
+            for variant in &enum_decl.variants {
+                let mut facts = BTreeMap::new();
+                facts.insert("member_kind".to_string(), "enum_variant".to_string());
+                facts.insert("checked_api_parent_anchor_id".to_string(), enum_decl.anchor.id.clone());
+                if !variant.fields.is_empty() {
+                    facts.insert(
+                        "checked_api_signature".to_string(),
+                        format!(
+                            "{}({})",
+                            variant.name,
+                            variant
+                                .fields
+                                .iter()
+                                .map(format_api_type_ref)
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                    );
+                }
+                push_api_member_node(
+                    document,
+                    ApiMemberNodeInput {
+                        declaration_id,
+                        parent_anchor: &enum_decl.anchor,
+                        rel_path,
+                        module_path,
+                        member_kind: "enum_variant",
+                        label: &variant.name,
+                        span: None,
+                        facts,
+                    },
+                );
+            }
+            for alias in &enum_decl.variant_aliases {
+                let mut facts = BTreeMap::new();
+                facts.insert("member_kind".to_string(), "enum_variant_alias".to_string());
+                facts.insert("checked_api_parent_anchor_id".to_string(), enum_decl.anchor.id.clone());
+                facts.insert("target".to_string(), alias.target.clone());
+                push_api_member_node(
+                    document,
+                    ApiMemberNodeInput {
+                        declaration_id,
+                        parent_anchor: &enum_decl.anchor,
+                        rel_path,
+                        module_path,
+                        member_kind: "enum_variant_alias",
+                        label: &alias.name,
+                        span: None,
+                        facts,
+                    },
+                );
+            }
+        }
+        ApiDeclaration::Newtype(newtype) => {
+            for method in &newtype.methods {
+                push_api_method_member(document, declaration_id, &newtype.anchor, rel_path, module_path, method);
+            }
+        }
+        ApiDeclaration::Function(_)
+        | ApiDeclaration::TypeAlias(_)
+        | ApiDeclaration::Const(_)
+        | ApiDeclaration::Static(_)
+        | ApiDeclaration::Alias(_)
+        | ApiDeclaration::Partial(_) => {}
+    }
+}
+
+/// Add a field-like API member node.
+fn push_api_field_member(
+    document: &mut CodegraphDocument,
+    declaration_id: &str,
+    parent_anchor: &SourceAnchor,
+    rel_path: &str,
+    module_path: &[String],
+    field: &FieldExport,
+) {
+    let mut facts = BTreeMap::new();
+    facts.insert("member_kind".to_string(), "field".to_string());
+    facts.insert("checked_api_parent_anchor_id".to_string(), parent_anchor.id.clone());
+    facts.insert("checked_api_type".to_string(), format_api_type_ref(&field.ty));
+    facts.insert("has_default".to_string(), field.has_default.to_string());
+    if let Some(alias) = &field.alias {
+        facts.insert("alias".to_string(), alias.clone());
+    }
+    if let Some(description) = &field.description {
+        facts.insert("description".to_string(), description.clone());
+    }
+    push_api_member_node(
+        document,
+        ApiMemberNodeInput {
+            declaration_id,
+            parent_anchor,
+            rel_path,
+            module_path,
+            member_kind: "field",
+            label: &field.name,
+            span: None,
+            facts,
+        },
+    );
+}
+
+/// Add a method API member node.
+fn push_api_method_member(
+    document: &mut CodegraphDocument,
+    declaration_id: &str,
+    parent_anchor: &SourceAnchor,
+    rel_path: &str,
+    module_path: &[String],
+    method: &ApiMethod,
+) {
+    let mut facts = BTreeMap::new();
+    facts.insert("member_kind".to_string(), "method".to_string());
+    facts.insert("checked_api_anchor_id".to_string(), method.anchor.id.clone());
+    facts.insert("checked_api_parent_anchor_id".to_string(), parent_anchor.id.clone());
+    facts.insert("checked_api_signature".to_string(), api_method_signature(method));
+    if let Some(summary) = compact_api_doc_summary(
+        method
+            .docstring_sections
+            .as_ref()
+            .and_then(|docstring| docstring.summary.as_deref()),
+    ) {
+        facts.insert("checked_api_doc_summary".to_string(), summary);
+    }
+    push_api_member_node(
+        document,
+        ApiMemberNodeInput {
+            declaration_id,
+            parent_anchor,
+            rel_path,
+            module_path,
+            member_kind: "method",
+            label: &method.name,
+            span: Some(CodegraphSpan {
+                start: method.anchor.span.start,
+                end: method.anchor.span.end,
+            }),
+            facts,
+        },
+    );
+}
+
+/// Inputs for adding one checked API member graph node.
+struct ApiMemberNodeInput<'a> {
+    declaration_id: &'a str,
+    parent_anchor: &'a SourceAnchor,
+    rel_path: &'a str,
+    module_path: &'a [String],
+    member_kind: &'a str,
+    label: &'a str,
+    span: Option<CodegraphSpan>,
+    facts: BTreeMap<String, String>,
+}
+
+/// Add one checked API member node and containment edge.
+fn push_api_member_node(document: &mut CodegraphDocument, input: ApiMemberNodeInput<'_>) {
+    let member_id = format!(
+        "api-member:{}:{}:{}",
+        stable_id_piece(&input.parent_anchor.id),
+        input.member_kind,
+        stable_id_piece(input.label)
+    );
+    document.push_node(CodegraphNode {
+        id: member_id.clone(),
+        kind: CodegraphNodeKind::ApiMember,
+        label: input.label.to_string(),
+        file_path: Some(input.rel_path.to_string()),
+        module_path: input.module_path.to_vec(),
+        span: input.span,
+        facts: input.facts,
+    });
+    document.push_edge(codegraph_edge(
+        input.declaration_id,
+        &member_id,
+        CodegraphEdgeKind::Contains,
+        input.span,
+        "declaration_contains_api_member",
+    ));
+}
+
+/// Return the source anchor attached to a checked API declaration.
+fn api_declaration_anchor(declaration: &ApiDeclaration) -> &SourceAnchor {
+    match declaration {
+        ApiDeclaration::Function(function) => &function.anchor,
+        ApiDeclaration::Model(model) => &model.anchor,
+        ApiDeclaration::Class(class) => &class.anchor,
+        ApiDeclaration::Trait(trait_decl) => &trait_decl.anchor,
+        ApiDeclaration::Enum(enum_decl) => &enum_decl.anchor,
+        ApiDeclaration::Newtype(newtype) => &newtype.anchor,
+        ApiDeclaration::TypeAlias(alias) => &alias.anchor,
+        ApiDeclaration::Const(konst) => &konst.anchor,
+        ApiDeclaration::Static(static_decl) => &static_decl.anchor,
+        ApiDeclaration::Alias(alias) => &alias.anchor,
+        ApiDeclaration::Partial(partial) => &partial.anchor,
+    }
+}
+
+/// Return the exported source name attached to a checked API declaration.
+fn api_declaration_name(declaration: &ApiDeclaration) -> &str {
+    match declaration {
+        ApiDeclaration::Function(function) => &function.name,
+        ApiDeclaration::Model(model) => &model.name,
+        ApiDeclaration::Class(class) => &class.name,
+        ApiDeclaration::Trait(trait_decl) => &trait_decl.name,
+        ApiDeclaration::Enum(enum_decl) => &enum_decl.name,
+        ApiDeclaration::Newtype(newtype) => &newtype.name,
+        ApiDeclaration::TypeAlias(alias) => &alias.name,
+        ApiDeclaration::Const(konst) => &konst.name,
+        ApiDeclaration::Static(static_decl) => &static_decl.name,
+        ApiDeclaration::Alias(alias) => &alias.name,
+        ApiDeclaration::Partial(partial) => &partial.name,
+    }
+}
+
+/// Return the RFC 048 declaration kind label used by graph facts.
+fn api_declaration_kind(declaration: &ApiDeclaration) -> &'static str {
+    match declaration {
+        ApiDeclaration::Function(_) => "function",
+        ApiDeclaration::Model(_) => "model",
+        ApiDeclaration::Class(_) => "class",
+        ApiDeclaration::Trait(_) => "trait",
+        ApiDeclaration::Enum(_) => "enum",
+        ApiDeclaration::Newtype(newtype) if newtype.is_rusttype => "rusttype",
+        ApiDeclaration::Newtype(_) => "newtype",
+        ApiDeclaration::TypeAlias(_) => "type_alias",
+        ApiDeclaration::Const(_) => "const",
+        ApiDeclaration::Static(_) => "static",
+        ApiDeclaration::Alias(_) => "alias",
+        ApiDeclaration::Partial(_) => "partial",
+    }
+}
+
+/// Return a compact source-like signature for checked API graph facts.
+fn api_declaration_signature(declaration: &ApiDeclaration) -> String {
+    match declaration {
+        ApiDeclaration::Function(function) => {
+            let prefix = if function.is_async { "pub async def" } else { "pub def" };
+            format!(
+                "{prefix} {}({}) -> {}",
+                function.name,
+                format_api_params(&function.params),
+                format_api_type_ref(&function.return_type)
+            )
+        }
+        ApiDeclaration::Model(model) => format!("pub model {}", model.name),
+        ApiDeclaration::Class(class) => format!("pub class {}", class.name),
+        ApiDeclaration::Trait(trait_decl) => format!("pub trait {}", trait_decl.name),
+        ApiDeclaration::Enum(enum_decl) => format!("pub enum {}", enum_decl.name),
+        ApiDeclaration::Newtype(newtype) => {
+            let keyword = if newtype.is_rusttype { "rusttype" } else { "newtype" };
+            format!(
+                "pub {keyword} {} = {}",
+                newtype.name,
+                format_api_type_ref(&newtype.underlying)
+            )
+        }
+        ApiDeclaration::TypeAlias(alias) => {
+            format!(
+                "pub type {} = {}",
+                alias.name,
+                format_api_type_ref(&alias.type_alias.target)
+            )
+        }
+        ApiDeclaration::Const(konst) => format!("pub const {}: {}", konst.name, format_api_type_ref(&konst.ty)),
+        ApiDeclaration::Static(static_decl) => {
+            format!(
+                "pub static {}: {}",
+                static_decl.name,
+                format_api_type_ref(&static_decl.ty)
+            )
+        }
+        ApiDeclaration::Alias(alias) => format!("pub {} = alias {}", alias.name, alias.target_path.join("::")),
+        ApiDeclaration::Partial(partial) => {
+            let prefix = if partial.is_async {
+                "pub async partial"
+            } else {
+                "pub partial"
+            };
+            format!(
+                "{prefix} {}({}) -> {}",
+                partial.name,
+                format_api_params(&partial.params),
+                format_api_type_ref(&partial.return_type)
+            )
+        }
+    }
+}
+
+/// Return a compact source-like signature for a checked API method.
+fn api_method_signature(method: &ApiMethod) -> String {
+    let prefix = if method.is_async { "async def" } else { "def" };
+    let mut params = Vec::new();
+    if let Some(receiver) = &method.receiver {
+        params.push(match receiver {
+            ReceiverExport::Immutable => "self".to_string(),
+            ReceiverExport::Mutable => "mut self".to_string(),
+        });
+    }
+    params.extend(method.params.iter().map(format_api_param));
+    format!(
+        "{prefix} {}({}) -> {}",
+        method.name,
+        params.join(", "),
+        format_api_type_ref(&method.return_type)
+    )
+}
+
+/// Return the parsed docstring summary attached to a checked API declaration.
+fn api_declaration_doc_summary(declaration: &ApiDeclaration) -> Option<String> {
+    let summary = match declaration {
+        ApiDeclaration::Function(function) => function
+            .docstring_sections
+            .as_ref()
+            .and_then(|docstring| docstring.summary.as_deref()),
+        ApiDeclaration::Model(model) => model
+            .docstring_sections
+            .as_ref()
+            .and_then(|docstring| docstring.summary.as_deref()),
+        ApiDeclaration::Class(class) => class
+            .docstring_sections
+            .as_ref()
+            .and_then(|docstring| docstring.summary.as_deref()),
+        ApiDeclaration::Trait(trait_decl) => trait_decl
+            .docstring_sections
+            .as_ref()
+            .and_then(|docstring| docstring.summary.as_deref()),
+        ApiDeclaration::Enum(enum_decl) => enum_decl
+            .docstring_sections
+            .as_ref()
+            .and_then(|docstring| docstring.summary.as_deref()),
+        ApiDeclaration::Newtype(newtype) => newtype
+            .docstring_sections
+            .as_ref()
+            .and_then(|docstring| docstring.summary.as_deref()),
+        ApiDeclaration::TypeAlias(_)
+        | ApiDeclaration::Const(_)
+        | ApiDeclaration::Static(_)
+        | ApiDeclaration::Alias(_)
+        | ApiDeclaration::Partial(_) => None,
+    };
+    compact_api_doc_summary(summary)
+}
+
+/// Keep graph doc facts small enough for indexing and previews.
+fn compact_api_doc_summary(summary: Option<&str>) -> Option<String> {
+    let trimmed = summary?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let paragraph = trimmed.split("\n\n").next().unwrap_or(trimmed);
+    let mut compact = paragraph.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() > 240 {
+        compact = compact.chars().take(237).collect::<String>();
+        compact.push_str("...");
+    }
+    Some(compact)
+}
+
+/// Add an import declaration and its textual target as graph facts.
+fn push_import_codegraph(
+    document: &mut CodegraphDocument,
+    import: &ImportDecl,
+    span: crate::frontend::ast::Span,
+    module_id: &str,
+    module_path: &[String],
+    rel_path: &str,
+) {
+    let import_label = import_label(import);
+    let import_id = format!("import:{}:{}:{}", module_path.join("::"), span.start, span.end);
+    let mut facts = BTreeMap::new();
+    facts.insert(
+        "visibility".to_string(),
+        visibility_label(import.visibility).to_string(),
+    );
+    facts.insert("target".to_string(), import_label.clone());
+    document.push_node(CodegraphNode {
+        id: import_id.clone(),
+        kind: CodegraphNodeKind::Import,
+        label: import_label.clone(),
+        file_path: Some(rel_path.to_string()),
+        module_path: module_path.to_vec(),
+        span: Some(CodegraphSpan {
+            start: span.start,
+            end: span.end,
+        }),
+        facts,
+    });
+    document.push_edge(codegraph_edge(
+        module_id,
+        &import_id,
+        CodegraphEdgeKind::Contains,
+        Some(CodegraphSpan {
+            start: span.start,
+            end: span.end,
+        }),
+        "module_contains_import",
+    ));
+
+    let external_id = format!("external:{}", stable_id_piece(&import_label));
+    if !codegraph_document_has_node(document, &external_id) {
+        document.push_node(CodegraphNode {
+            id: external_id.clone(),
+            kind: CodegraphNodeKind::External,
+            label: import_label,
+            file_path: None,
+            module_path: Vec::new(),
+            span: None,
+            facts: BTreeMap::new(),
+        });
+    }
+    document.push_edge(codegraph_edge(
+        &import_id,
+        &external_id,
+        CodegraphEdgeKind::Imports,
+        Some(CodegraphSpan {
+            start: span.start,
+            end: span.end,
+        }),
+        "import_targets_external",
+    ));
+}
+
+/// Return the codegraph kind, name, and visibility for declarations with stable source identity.
+fn declaration_codegraph_info(declaration: &Declaration) -> Option<(&'static str, String, &'static str)> {
+    match declaration {
+        Declaration::Const(ConstDecl { visibility, name, .. }) => {
+            Some(("const", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Static(StaticDecl { visibility, name, .. }) => {
+            Some(("static", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Model(ModelDecl { visibility, name, .. }) => {
+            Some(("model", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Class(ClassDecl { visibility, name, .. }) => {
+            Some(("class", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Trait(TraitDecl { visibility, name, .. }) => {
+            Some(("trait", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Alias(AliasDecl { visibility, name, .. }) => {
+            Some(("alias", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Partial(PartialDecl { visibility, name, .. }) => {
+            Some(("partial", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::TypeAlias(TypeAliasDecl { visibility, name, .. }) => {
+            Some(("type_alias", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Newtype(NewtypeDecl {
+            visibility,
+            name,
+            is_rusttype,
+            ..
+        }) => {
+            let kind = if *is_rusttype { "rusttype" } else { "newtype" };
+            Some((kind, name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Enum(EnumDecl { visibility, name, .. }) => {
+            Some(("enum", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::Function(FunctionDecl { visibility, name, .. }) => {
+            Some(("function", name.clone(), visibility_label(*visibility)))
+        }
+        Declaration::TestModule(TestModuleDecl { name, .. }) => Some(("test_module", name.clone(), "private")),
+        Declaration::Import(_) | Declaration::Docstring(_) => None,
+    }
+}
+
+/// Format one import declaration as a stable target label.
+fn import_label(import: &ImportDecl) -> String {
+    match &import.kind {
+        ImportKind::Module(path) => {
+            let mut label = format_import_path(path);
+            if let Some(alias) = &import.alias {
+                label.push_str(" as ");
+                label.push_str(alias);
+            }
+            label
+        }
+        ImportKind::From { module, items } => {
+            format!(
+                "from {} import {}",
+                format_import_path(module),
+                format_import_items(items)
+            )
+        }
+        ImportKind::PubLibrary { library } => format!("pub::{library}"),
+        ImportKind::PubFrom { library, items } => {
+            format!("from pub::{library} import {}", format_import_items(items))
+        }
+        ImportKind::Python(module) => format!("python:{module}"),
+        ImportKind::RustCrate {
+            crate_name,
+            path,
+            version,
+            features,
+        } => format_rust_import(crate_name, path, version.as_deref(), features),
+        ImportKind::RustFrom {
+            crate_name,
+            path,
+            version,
+            features,
+            items,
+        } => format!(
+            "from {} import {}",
+            format_rust_import(crate_name, path, version.as_deref(), features),
+            format_import_items(items)
+        ),
+    }
+}
+
+/// Format one source import path.
+fn format_import_path(path: &ImportPath) -> String {
+    path.to_rust_path()
+}
+
+/// Format one imported item list.
+fn format_import_items(items: &[ImportItem]) -> String {
+    items
+        .iter()
+        .map(|item| {
+            if let Some(alias) = &item.alias {
+                format!("{} as {}", item.name, alias)
+            } else {
+                item.name.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Format one Rust-origin import path with optional dependency metadata.
+fn format_rust_import(crate_name: &str, path: &[String], version: Option<&str>, features: &[String]) -> String {
+    let mut parts = vec!["rust".to_string(), crate_name.to_string()];
+    parts.extend(path.iter().cloned());
+    let mut label = parts.join("::");
+    if let Some(version) = version {
+        label.push_str(&format!("@{version}"));
+    }
+    if !features.is_empty() {
+        label.push_str("[features=");
+        label.push_str(&features.join(","));
+        label.push(']');
+    }
+    label
+}
+
+/// Return a stable visibility label.
+fn visibility_label(visibility: Visibility) -> &'static str {
+    match visibility {
+        Visibility::Private => "private",
+        Visibility::Public => "public",
+    }
+}
+
+/// Build one edge with a deterministic id.
+fn codegraph_edge(
+    source_id: &str,
+    target_id: &str,
+    kind: CodegraphEdgeKind,
+    span: Option<CodegraphSpan>,
+    relation: &str,
+) -> CodegraphEdge {
+    let mut facts = BTreeMap::new();
+    facts.insert("relation".to_string(), relation.to_string());
+    CodegraphEdge {
+        id: format!(
+            "edge:{}:{relation}:{}",
+            stable_id_piece(source_id),
+            stable_id_piece(target_id)
+        ),
+        kind,
+        source_id: source_id.to_string(),
+        target_id: target_id.to_string(),
+        span,
+        facts,
+    }
+}
+
+/// Render a path relative to the project root when possible so exported facts are shareable.
+fn codegraph_path(path: &Path, project_root: &Path) -> String {
+    path.strip_prefix(project_root).unwrap_or(path).display().to_string()
+}
+
+/// Sanitize a string for use inside stable ids.
+fn stable_id_piece(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '.' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
+/// Return whether a document already contains a node id.
+fn codegraph_document_has_node(document: &CodegraphDocument, id: &str) -> bool {
+    document.nodes.iter().any(|node| node.id == id)
+}
+
 /// Type-check a metadata entry path and collect checked API metadata for all local modules.
 fn collect_api_metadata_package(path: &Path) -> CliResult<CheckedApiMetadataPackage> {
     let entry_path = resolve_metadata_entry_path(path)?;
@@ -473,6 +2462,17 @@ fn metadata_module_path(module: &ParsedModule, entry_path: &Path) -> Vec<String>
     module.path_segments.clone()
 }
 
+/// Return the logical module path used in codegraph facts for one parsed module.
+fn codegraph_module_path(module: &ParsedModule, entry_path: Option<&Path>) -> Vec<String> {
+    if let Some(entry_path) = entry_path
+        && module.file_path == entry_path
+        && let Some(stem) = entry_path.file_stem().and_then(|stem| stem.to_str())
+    {
+        return vec![stem.to_string()];
+    }
+    module.path_segments.clone()
+}
+
 /// Resolve a file or project directory to the source file used as the metadata entry point.
 fn resolve_metadata_entry_path(path: &Path) -> CliResult<PathBuf> {
     let absolute = if path.is_absolute() {
@@ -496,13 +2496,13 @@ fn resolve_metadata_entry_path(path: &Path) -> CliResult<PathBuf> {
             return Ok(main);
         }
         return Err(CliError::failure(format!(
-            "metadata API extraction requires an Incan source file, or a project directory with `src/lib.incn` or `src/main.incn`: {}",
+            "tool export requires an Incan source file, or a project directory with `src/lib.incn` or `src/main.incn`: {}",
             absolute.display()
         )));
     }
 
     Err(CliError::failure(format!(
-        "metadata API extraction path does not exist: {}",
+        "tool export path does not exist: {}",
         absolute.display()
     )))
 }
@@ -1242,6 +3242,7 @@ fn display_option_path(path: &Option<PathBuf>) -> String {
 mod tests {
     use super::*;
     use crate::frontend::api_metadata::ApiDeclaration;
+    use incan_codegraph::{CODEGRAPH_SCHEMA_VERSION, CodegraphEdgeKind, CodegraphNodeKind};
 
     #[test]
     fn collect_api_metadata_package_extracts_project_lib() -> Result<(), Box<dyn std::error::Error>> {
@@ -1292,6 +3293,230 @@ pub quick_label = partial label(prefix=LABEL)
             markdown.contains("pub quick_label = partial label(prefix: str = ..., suffix: str = ...) -> str")
                 && markdown.contains("- Presets: `prefix`"),
             "expected generated API Markdown to render partial signatures and provenance, got:\n{markdown}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn collect_codegraph_document_exports_modules_declarations_and_imports() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src)?;
+        fs::write(
+            tmp.path().join("incan.toml"),
+            r#"
+[project]
+name = "codegraph_demo"
+version = "0.1.0"
+"#,
+        )?;
+        fs::write(
+            src.join("helper.incn"),
+            r#"
+pub def helper() -> int:
+    return 1
+"#,
+        )?;
+        fs::write(
+            src.join("lib.incn"),
+            r#"
+from helper import helper
+
+pub model User:
+    id: int
+
+pub def load() -> int:
+    return helper()
+
+pub def label(kind: str) -> str:
+    match kind:
+        "create" => "Create"
+        "update" => "Update"
+        _ => "Other"
+"#,
+        )?;
+
+        let document = collect_codegraph_document(tmp.path(), false)?;
+
+        assert_eq!(document.schema_version, CODEGRAPH_SCHEMA_VERSION);
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::Declaration
+                    && node.label == "User"
+                    && node.facts.get("declaration_kind").is_some_and(|kind| kind == "model")
+                    && node
+                        .facts
+                        .get("checked_api_anchor_id")
+                        .is_some_and(|anchor| anchor == "src::lib::User")),
+            "expected model declaration node to carry checked API metadata facts: {document:?}"
+        );
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::ApiMember
+                    && node.label == "id"
+                    && node.facts.get("member_kind").is_some_and(|kind| kind == "field")
+                    && node.facts.get("checked_api_type").is_some_and(|ty| ty == "int")),
+            "expected model field API member node in codegraph export: {document:?}"
+        );
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::Declaration
+                    && node.label == "load"
+                    && node
+                        .facts
+                        .get("checked_api_signature")
+                        .is_some_and(|signature| signature == "pub def load() -> int")),
+            "expected function declaration node to carry checked API signature: {document:?}"
+        );
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::Import && node.label == "from helper import helper"),
+            "expected import node in codegraph export: {document:?}"
+        );
+        assert!(
+            document
+                .edges
+                .iter()
+                .any(|edge| edge.kind == CodegraphEdgeKind::Imports),
+            "expected import edge in codegraph export: {document:?}"
+        );
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::CallSite
+                    && node
+                        .facts
+                        .get("callee_key")
+                        .is_some_and(|callee| callee == "call:ident:helper")),
+            "expected function call site node in codegraph export: {document:?}"
+        );
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::Reference
+                    && node
+                        .facts
+                        .get("reference_key")
+                        .is_some_and(|reference| reference == "ident:helper")),
+            "expected identifier reference node in codegraph export: {document:?}"
+        );
+        assert!(
+            document.nodes.iter().any(|node| {
+                node.kind == CodegraphNodeKind::MatchDispatch
+                    && node
+                        .facts
+                        .get("domain_key")
+                        .is_some_and(|domain| domain == "ident:kind")
+                    && node
+                        .facts
+                        .get("explicit_pattern_count")
+                        .is_some_and(|count| count == "2")
+                    && node.facts.get("arm_count").is_some_and(|count| count == "3")
+                    && node
+                        .facts
+                        .get("has_default_arm")
+                        .is_some_and(|has_default| has_default == "true")
+                    && node.facts.get("pattern_labels").is_some_and(|patterns| {
+                        patterns.contains("\\\"create\\\"") && patterns.contains("\\\"update\\\"")
+                    })
+            }),
+            "expected match dispatch node in codegraph export: {document:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn collect_codegraph_document_globs_directory_sources() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let nested = tmp.path().join("nested");
+        fs::create_dir_all(&nested)?;
+        fs::write(
+            tmp.path().join("alpha.incn"),
+            r#"
+pub def alpha() -> int:
+    return 1
+"#,
+        )?;
+        fs::write(
+            nested.join("beta.incn"),
+            r#"
+pub model Beta:
+    id: int
+"#,
+        )?;
+
+        let document = collect_codegraph_document(tmp.path(), false)?;
+
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::File && node.file_path.as_deref() == Some("alpha.incn")),
+            "expected directory export to include top-level .incn file: {document:?}"
+        );
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::File
+                    && node.file_path.as_deref() == Some("nested/beta.incn")),
+            "expected directory export to include nested .incn file: {document:?}"
+        );
+        assert!(
+            document.nodes.iter().any(|node| node.kind == CodegraphNodeKind::Module
+                && node.module_path == vec!["nested".to_string(), "beta".to_string()]),
+            "expected nested directory source to get path-derived module facts: {document:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn collect_codegraph_document_allow_errors_exports_unchecked_source_graph() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let tmp = tempfile::tempdir()?;
+        fs::write(
+            tmp.path().join("broken.incn"),
+            r#"
+pub def broken() -> int:
+    return "wrong"
+"#,
+        )?;
+
+        assert!(
+            collect_codegraph_document(tmp.path(), false).is_err(),
+            "expected checked codegraph export to fail on type errors"
+        );
+
+        let document = collect_codegraph_document(tmp.path(), true)?;
+
+        assert!(
+            document
+                .nodes
+                .iter()
+                .any(|node| node.kind == CodegraphNodeKind::Declaration
+                    && node.label == "broken"
+                    && node
+                        .facts
+                        .get("declaration_kind")
+                        .is_some_and(|kind| kind == "function")),
+            "expected unchecked source graph to keep declaration facts: {document:?}"
+        );
+        assert!(
+            !document
+                .nodes
+                .iter()
+                .any(|node| node.facts.contains_key("checked_api_signature")),
+            "expected unchecked export to omit checked API facts for failing modules: {document:?}"
         );
         Ok(())
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,9 +44,10 @@ use std::process;
 
 use crate::manifest::ProjectManifest;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use commands::architect::ArchitectFormat;
 use commands::common::{CargoPolicy, CargoPolicyCliFlags};
 use commands::lifecycle::{EnvOutputFormat, VersionBumpArg};
-use commands::tools::{ToolsDoctorFormat, ToolsMetadataFormat, ToolsModelMetadataFormat};
+use commands::tools::{ToolsCodegraphFormat, ToolsDoctorFormat, ToolsMetadataFormat, ToolsModelMetadataFormat};
 
 // ============================================================================
 // CLI Error handling
@@ -301,6 +302,16 @@ pub enum Command {
         command: ToolsCommand,
     },
 
+    /// Experimental architecture-advice scan
+    Architect {
+        /// Incan source file or project directory to inspect
+        #[arg(value_name = "PATH", default_value = ".")]
+        path: PathBuf,
+        /// Output format
+        #[arg(long = "format", value_enum, default_value = "text")]
+        format: ArchitectFormat,
+    },
+
     /// Run tests (pytest-style)
     Test {
         /// Path to test file or directory
@@ -520,6 +531,27 @@ pub enum ToolsCommand {
     Metadata {
         #[command(subcommand)]
         command: ToolsMetadataCommand,
+    },
+    /// Export compiler-backed codegraph facts for downstream code indexers
+    Codegraph {
+        #[command(subcommand)]
+        command: ToolsCodegraphCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ToolsCodegraphCommand {
+    /// Export Incan code-index facts as JSON or JSONL
+    Export {
+        /// Incan source file or project directory to inspect
+        #[arg(value_name = "PATH", default_value = ".")]
+        path: PathBuf,
+        /// Output format
+        #[arg(long = "format", value_enum, default_value = "jsonl")]
+        format: ToolsCodegraphFormat,
+        /// Continue after type-check errors and emit the unchecked source graph
+        #[arg(long = "allow-errors")]
+        allow_errors: bool,
     },
 }
 
@@ -791,6 +823,13 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
         },
         Some(Command::Tools { command }) => match command {
             ToolsCommand::Doctor { format } => commands::tools_doctor(format),
+            ToolsCommand::Codegraph { command } => match command {
+                ToolsCodegraphCommand::Export {
+                    path,
+                    format,
+                    allow_errors,
+                } => commands::tools_codegraph_export(&path, format, allow_errors),
+            },
             ToolsCommand::Metadata { command } => match command {
                 ToolsMetadataCommand::Api { path, format } => commands::tools_metadata_api(&path, format),
                 ToolsMetadataCommand::Model { path, model, format } => {
@@ -798,6 +837,7 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
                 }
             },
         },
+        Some(Command::Architect { path, format }) => commands::architect_project(&path, format),
         Some(Command::New {
             name,
             dir,
@@ -1403,6 +1443,67 @@ mod tests {
         };
         assert_eq!(path, std::path::PathBuf::from("src/lib.incn"));
         assert_eq!(format, ToolsMetadataFormat::Markdown);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_tools_codegraph_export_jsonl() -> Result<(), clap::Error> {
+        let cli = parse_cli([
+            "incan",
+            "tools",
+            "codegraph",
+            "export",
+            "src/lib.incn",
+            "--format",
+            "jsonl",
+        ])?;
+        let Some(Command::Tools {
+            command:
+                ToolsCommand::Codegraph {
+                    command:
+                        ToolsCodegraphCommand::Export {
+                            path,
+                            format,
+                            allow_errors,
+                        },
+                },
+        }) = cli.command
+        else {
+            return Err(expected_command("tools codegraph export"));
+        };
+        assert_eq!(path, std::path::PathBuf::from("src/lib.incn"));
+        assert_eq!(format, ToolsCodegraphFormat::Jsonl);
+        assert!(!allow_errors);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_tools_codegraph_export_allow_errors() -> Result<(), clap::Error> {
+        let cli = parse_cli([
+            "incan",
+            "tools",
+            "codegraph",
+            "export",
+            "src/lib.incn",
+            "--allow-errors",
+        ])?;
+        let Some(Command::Tools {
+            command:
+                ToolsCommand::Codegraph {
+                    command:
+                        ToolsCodegraphCommand::Export {
+                            path,
+                            format,
+                            allow_errors,
+                        },
+                },
+        }) = cli.command
+        else {
+            return Err(expected_command("tools codegraph export"));
+        };
+        assert_eq!(path, std::path::PathBuf::from("src/lib.incn"));
+        assert_eq!(format, ToolsCodegraphFormat::Jsonl);
+        assert!(allow_errors);
         Ok(())
     }
 

--- a/workspaces/codegraph/README.md
+++ b/workspaces/codegraph/README.md
@@ -1,0 +1,31 @@
+# Incan CodeGraph Bridge
+
+This workspace is the handoff point for integrating Incan's compiler-backed code-index facts with external CodeGraph-style tools.
+
+Incan exports authoritative facts with:
+
+```bash
+incan tools codegraph export path/to/source-or-directory --format jsonl
+```
+
+For work-in-progress repositories that do not currently type-check, use:
+
+```bash
+incan tools codegraph export path/to/source-or-directory --format jsonl --allow-errors
+```
+
+The exporter is intentionally Incan-first:
+
+- Incan parses and type-checks source before exporting facts by default.
+- `--allow-errors` still emits the source graph after type-check errors, but omits checked API facts for failing modules.
+- Directory inputs recursively export every `.incn` file under that root.
+- Public declaration nodes link to RFC 048 checked API metadata through stable `checked_api_*` facts.
+- Checked API members such as fields, methods, and enum variants are exported as graph children for package exploration.
+- Body facts such as `match_dispatch`, `call_site`, and `reference` nodes are exported from parsed source bodies.
+- `match_dispatch` facts include explicit pattern counts and wildcard/default-arm context for overlap-ratio filtering.
+- `incan architect` consumes `match_dispatch` and `call_site` graph facts for deterministic architecture signals.
+- `incan_codegraph` owns only the stable wire schema.
+- External indexers should ingest the exported JSON/JSONL instead of reparsing `.incn` as syntax-only text.
+- CodeGraph storage, embeddings, MCP tools, and tree-sitter support remain outside the compiler.
+
+This is separate from RFC 047 `std.graph`, which is the runtime graph data-structure surface available to Incan programs.

--- a/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
+++ b/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
@@ -1,0 +1,373 @@
+# RFC 105: `incan architect` rule engine for design, safety, idiom, and smell findings
+
+- **Status:** Draft
+- **Created:** 2026-05-24
+- **Author(s):** Danny Meijer (@dannymeijer)
+- **Related:**
+    - RFC 006 (generators)
+    - RFC 048 (contract-backed models emit and tooling)
+    - RFC 070 (Result combinators)
+    - RFC 088 (iterator adapter surface)
+    - RFC 096 (declaration metadata blocks)
+- **Issue:** https://github.com/dannys-code-corner/incan/issues/663
+- **RFC PR:** —
+- **Written against:** v0.3
+- **Shipped in:** —
+
+## Summary
+
+This RFC proposes `incan architect` as a deterministic code-advice command for Incan projects. The command reports evidence-backed findings across architecture, safety, idiom usage, and maintainability smells by running maintainable rules over compiler-backed codegraph facts. The central goal is not to create a broad subjective linter, but to create a durable rule authoring surface where new advice can be added cheaply, tested precisely, calibrated against real projects, and consumed by humans, agents, editors, and CI without relying on model inference for core detection.
+
+## Core model
+
+1. **Compiler-backed facts first:** `incan architect` consumes source facts produced by Incan's parser, module/import resolver, typechecker, metadata pipeline, and codegraph exporter rather than independently scraping text.
+2. **Rules interpret facts:** Each rule consumes typed fact views and emits findings with stable codes, priorities, categories, confidence, evidence, suggestions, and risks.
+3. **Findings are advisory:** Architect findings are not compiler errors. They describe design pressure or code-shape opportunities with enough evidence for a human or agent to decide whether to act.
+4. **Categories are explicit:** Architecture findings, safety findings, idiom findings, and code-smell findings remain separate in rule codes and profiles even when they share one command.
+5. **Conservative detection is preferred:** The command should under-report ambiguous style opportunities rather than produce noisy, low-trust advice.
+6. **Rule authoring is a product surface:** The feature is only maintainable if adding a rule means using stable typed facts and reusable queries, not hand-parsing raw graph nodes or reimplementing AST walks.
+
+## Motivation
+
+Incan already has syntax checks, semantic checks, formatter behavior, tests, and generated-Rust validation. Those tools answer whether a program parses, typechecks, formats, and runs. They do not answer whether a project is accumulating design pressure: repeated dispatch over the same domain, public boundaries that can panic on recoverable input, old-shaped control flow that should now use language features, or small helper functions that add indirection without carrying domain meaning.
+
+The first experiments with an architecture-advice command showed that deterministic rules can surface useful pressure when they report concrete source evidence and stay cautious about severity. Repeated match dispatch can reveal a growing operation boundary. Fail-fast calls inside public APIs can reveal recoverability problems. Body-shape facts can also support smaller maintainability smells such as compound-assignment candidates, single-use trivial helpers, append-only list builders that could become comprehensions, or `Result` matches that could use RFC 070 combinators.
+
+Without a formal rule engine, each new check risks becoming a one-off command-private AST walk with custom parsing, inconsistent output, and ad hoc severity. That path does not scale. The value is in a shared substrate: one project-wide codegraph, one typed query layer, one finding model, one de-duplication path, and many small rules that are easy to review and calibrate.
+
+This feature also matters for agent workflows. Agents can already make broad refactoring suggestions, but those suggestions are often expensive to verify and easy to overfit. `incan architect` should provide deterministic evidence that an agent can use as grounding: exact files, lines, matched domains, shared patterns, call sites, usage counts, and counterexample risks. A model may later summarize or prioritize findings, but the core detection should remain inspectable and reproducible.
+
+## Goals
+
+- Define `incan architect` as the umbrella command for deterministic design, safety, idiom, and maintainability-smell advice.
+- Provide a stable finding model with rule code, category, priority, confidence, evidence, pressure, suggestions, risks, and machine-readable output.
+- Provide project-wide directory scanning over `.incn` source trees with deterministic module de-duplication and finding de-duplication.
+- Establish rule categories and profiles so users can run architecture-only, safety-only, idiom-only, smell-only, or all-rule scans.
+- Establish a maintainable rule authoring surface based on typed facts and reusable queries over codegraph data.
+- Extend codegraph body facts as needed for rule families such as match dispatch, call sites, references, assignment/update shapes, helper usage, loop-builder shapes, and result-match shapes.
+- Include code smells in scope when they can be detected conservatively with clear evidence and useful counterexamples.
+- Keep detection deterministic for the first version; no language model is required for core finding generation.
+- Support text output for humans and stable JSON output for tools, agents, editors, and CI.
+- Make suppression and baselining part of the product model so mature codebases can adopt the command incrementally.
+
+## Non-Goals
+
+- This RFC does not make architect findings compiler errors.
+- This RFC does not replace formatter rules, typechecker diagnostics, Clippy-style generated-Rust checks, or project tests.
+- This RFC does not require a small language model or remote AI service for rule detection.
+- This RFC does not attempt to infer developer intent from names alone.
+- This RFC does not require every possible code smell to ship in the first version.
+- This RFC does not define automatic rewrites or apply fixes.
+- This RFC does not define a public plugin ABI for third-party binary rule packages.
+- This RFC does not require every codegraph fact to be part of a permanently stable external schema in the first release; only the JSON findings format and documented command behavior need v0.5 stability.
+
+## Guide-level explanation
+
+Users run `incan architect` on a file or project directory.
+
+```bash
+incan architect .
+incan architect src/lib.incn --format json
+incan architect . --profile architecture
+incan architect . --profile smells
+```
+
+The command prints findings grouped by priority and grounded in source evidence.
+
+```text
+[P3] Repeated match dispatch over `source_kind`
+Pressure: 2 match expressions dispatch over `source_kind` and share 3/3 explicit arms: SourceKind.Arrow(...), SourceKind.Csv(...), SourceKind.Parquet(...)
+Suggestions:
+  - Decide whether this is intentionally exhaustive local logic or a growing operation boundary.
+  - If it is a growing operation boundary, prefer an adapter or registry outside the domain type when the operation belongs to another subsystem.
+Risks:
+  - Keep local exhaustive matches when they are clearer than an abstraction and the case set changes rarely.
+Evidence:
+  - src/backend.incn:160:5 in register_one (explicit arms: 3/3; fallback: no)
+  - src/schema.incn:322:5 in schema_columns_for_source (explicit arms: 3/3; fallback: no)
+```
+
+The architecture value is not merely that two matches are textually similar. The useful signal is that separate subsystems are making parallel decisions over the same closed domain. For example, an ingestion package might register execution backends in one module and infer schemas in another module, with both operations matching every `SourceKind` variant.
+
+```incan
+def register_backend(kind: SourceKind, registry: BackendRegistry) -> None:
+    match kind:
+        SourceKind.Csv(_) => registry.add("csv", csv_backend())
+        SourceKind.Json(_) => registry.add("json", json_backend())
+        SourceKind.Parquet(_) => registry.add("parquet", parquet_backend())
+
+
+def infer_columns(source: Source) -> Result[list[Column], SchemaError]:
+    match source.kind:
+        SourceKind.Csv(_) => return infer_csv_columns(source)
+        SourceKind.Json(_) => return infer_json_columns(source)
+        SourceKind.Parquet(_) => return infer_parquet_columns(source)
+```
+
+The recommendation should not be "put backend registration and schema inference methods on `SourceKind`." That would move subsystem responsibilities onto the enum. The more architectural advice is to ask whether this is a growing operation boundary. If every new source format requires coordinated edits to backend registration, schema inference, validation, documentation, and test fixtures, the code may want a format-handler registry or adapter table where each format owns its related operations.
+
+```text
+[P3] Repeated match dispatch over `source.kind`
+Pressure: backend registration and schema inference both dispatch over all source formats.
+Suggestion: Consider a format-handler registry if adding one format requires shotgun edits across subsystems.
+Risk: Keep exhaustive local matches if the format set is closed, the operations are genuinely local, and cross-format registration would obscure control flow.
+```
+
+Architect findings use categories. Architecture findings describe design pressure. Safety findings describe failure or recoverability risk. Idiom findings describe opportunities to use Incan features more directly. Smell findings describe local maintainability pressure.
+
+```text
+safety.fail_fast_boundary_call
+idiom.result_combinator_candidate
+smell.single_use_trivial_helper
+arch.repeated_match_dispatch
+```
+
+Small smells are allowed when they are precise and humble. A trivial helper rule can identify a private helper that is used once and only returns a pure expression.
+
+```incan
+def add(left: int, right: int) -> int:
+    return left + right
+```
+
+The finding should not say that the helper is definitely wrong. It should say that the helper may be unnecessary unless its name carries useful domain meaning.
+
+```text
+[P3] Private helper only wraps one expression
+Pressure: `add` is private, used once, and only returns `left + right`.
+Suggestion: Inline the expression if the helper does not name a useful domain concept.
+Risk: Keep the helper if it documents intent, preserves API shape, acts as a callback, or is expected to grow.
+```
+
+A comprehension candidate should likewise report a specific body shape, not a broad preference.
+
+```incan
+def positive_scores(scores: list[int]) -> list[int]:
+    out = []
+    for score in scores:
+        if score > 0:
+            out.append(score)
+    return out
+```
+
+The corresponding advice is useful only because the shape is append-only, the accumulator is returned, and no other mutation or side effect participates in the loop.
+
+```text
+[P3] Append-only list builder can be a comprehension
+Pressure: `positive_scores` builds and returns a list with one append-only loop.
+Suggestion: Use `[score for score in scores if score > 0]` if the eager list is the intended result.
+Risk: Keep the loop if additional statements, logging, early exits, or mutation are part of the real workflow.
+```
+
+For RFC 070 `Result` combinators, architect can identify obvious match shapes and suggest the equivalent method only when the transformation is mechanically recognizable.
+
+```incan
+match parsed:
+    Ok(value) => Ok(clean(value))
+    Err(err) => Err(err)
+```
+
+The finding can suggest `parsed.map(clean)` because one branch transforms the `Ok` payload and the `Err` branch passes through unchanged.
+
+## Reference-level explanation
+
+### Command behavior
+
+`incan architect [PATH] [OPTIONS]` must accept a source file or directory. When `PATH` is omitted, the command should scan the current directory.
+
+When `PATH` is a file, the command must scan the file and the modules needed to resolve its imports according to ordinary Incan module rules.
+
+When `PATH` is a directory, the command must scan `.incn` files under that directory recursively. The scan must be deterministic. The scan must de-duplicate modules by source path so a file imported by multiple roots contributes facts once.
+
+The command must provide `--format text` and `--format json`. Text output is for humans. JSON output is the integration surface for agents, editors, CI, dashboards, and future baselining tools.
+
+The command should provide `--profile` with at least `architecture`, `safety`, `idioms`, `smells`, and `all`. The default profile is unresolved by this draft.
+
+### Finding model
+
+Every finding must have a stable rule code. Rule codes must be namespaced by category.
+
+```text
+arch.repeated_match_dispatch
+safety.fail_fast_boundary_call
+idiom.result_combinator_candidate
+smell.single_use_trivial_helper
+```
+
+Every finding must include a category, priority, confidence, title, pressure, evidence, suggestions, and risks.
+
+Priority must describe expected action pressure, not proof certainty.
+
+```text
+P1: likely correctness, reliability, or public-boundary risk that should be reviewed before release
+P2: meaningful design or maintainability pressure that should be tracked or scheduled
+P3: watchlist, idiom, or local smell that may be worth cleanup when nearby work touches the code
+Info: low-pressure educational or style-level advice
+```
+
+Confidence must describe how mechanically strong the rule match is.
+
+```text
+High: the rule found a narrow, mechanically recognizable shape
+Medium: the rule found a useful pattern with plausible counterexamples
+Low: the rule is exploratory and should normally be hidden outside explicit profiles
+```
+
+Evidence must identify source file, line, column, owner declaration when available, and rule-specific context. Rule-specific context may include matched arms, overlap counts, fallback/default-arm presence, callee labels, usage counts, body-shape summaries, or suggested replacement text.
+
+Suggestions must be phrased as advice, not certainty. Risks must name the common counterexamples that would make the suggestion wrong.
+
+Findings must be de-duplicated before output. Identical findings produced through multiple import roots must appear once.
+
+### Rule categories
+
+Architecture rules describe design pressure across declarations, modules, domains, or boundaries. Repeated match dispatch, growing literal domains, and operation-boundary pressure belong here.
+
+Safety rules describe recoverability, fail-fast behavior, partial handling, unchecked assumptions, or public-boundary hazards. A public function that can panic on caller-provided data belongs here.
+
+Idiom rules describe opportunities to use Incan language or stdlib features more directly. Result combinator candidates, iterator adapter candidates, generator/comprehension candidates, and compound assignment candidates belong here.
+
+Smell rules describe local maintainability pressure. Single-use trivial helpers, repeated literals, unnecessary wrappers, long branch-heavy functions, and append-only builders belong here when detected conservatively.
+
+Rules must not be categorized as architecture findings merely because they are emitted by `incan architect`.
+
+### Rule authoring contract
+
+Rules must declare metadata: code, category, default priority, default confidence, profile membership, required fact kinds, and a short explanation.
+
+Rules must consume typed fact views rather than raw serialized facts. A rule that needs match dispatch sites, call sites, assignment shapes, helper usage counts, or loop-builder shapes should ask for those views directly.
+
+Rules should be small and independently testable. Each rule should have positive and negative fixtures. Negative fixtures are required for common counterexamples named in the rule's risk text.
+
+Rules must not require typechecked metadata when a syntactic fact is sufficient. Rules may use type facts when precision depends on type information, such as recognizing `Result[T, E]` match shapes.
+
+Rules should prefer narrow body-shape facts over broad textual heuristics. For example, a comprehension candidate should be based on an append-only list-builder shape, not the mere presence of a `for` loop and `append`.
+
+Rules must not emit findings for generated stdlib internals or known external code unless the user explicitly scans those sources.
+
+### Codegraph fact requirements
+
+The codegraph exporter must provide enough source facts for rules to avoid command-private AST walks. The first useful fact families are declarations, imports, public API metadata, match dispatches, call sites, references, assignment/update shapes, function body summaries, usage counts, loop-builder shapes, and result-match shapes.
+
+Match dispatch facts must include the matched domain, explicit pattern labels, explicit pattern count, source arm count, and wildcard/default-arm context.
+
+Call-site facts must include callee key, callee label, receiver shape when available, source location, and owner declaration.
+
+Reference facts must support usage counting for private declarations and helper functions.
+
+Assignment/update facts must make compound-assignment candidates expressible without string matching.
+
+Function body summary facts should identify simple shapes such as single-return expression, pure expression wrapper, append-only list builder, and short result-match transform. These summaries must be conservative.
+
+Result-match facts should identify branch-preserving transformations only when the matched expression is known to be a `Result[T, E]` or the syntactic shape is unambiguous enough for an idiom finding with appropriate confidence.
+
+### Suppression and baselining
+
+The command should support local suppression of a specific rule at a specific source location. Suppression syntax is unresolved by this draft.
+
+The command should support project baselines so existing findings can be recorded and new findings can fail CI or be highlighted separately. Baseline storage is unresolved by this draft.
+
+Suppressions and baselines must preserve rule code and evidence identity. A future change that moves or changes the evidence should not silently suppress an unrelated finding.
+
+## Design details
+
+### Profiles
+
+Profiles let users choose the kind of advice they want. `architecture` should include cross-cutting design pressure. `safety` should include fail-fast and recoverability risk. `idioms` should include feature-usage opportunities. `smells` should include local maintainability findings. `all` should include every non-experimental rule.
+
+Rules may belong to more than one profile only when that does not blur the category. For example, a public fail-fast boundary call is a safety finding even if it also has architecture implications.
+
+Exploratory rules may exist behind an explicit experimental profile, but they must not be enabled by default.
+
+### Severity calibration
+
+Severity should be calibrated against evidence strength, public surface impact, and likely cost of ignoring the finding. Public API failures are generally higher priority than private helper smells. Repeated design pressure across files is generally higher priority than a local expression-level cleanup. Idiom suggestions are generally P3 or Info unless the shape creates repeated complexity or risk.
+
+Rules should downrank or suppress known low-action cases. For example, fail-fast calls around trusted constants may be lower priority than fail-fast calls around caller-provided input. Exhaustive matches over a closed domain may be preferable to abstraction when the matched operation is local and the domain changes rarely.
+
+### Examples of initial rules
+
+`arch.repeated_match_dispatch` reports repeated match expressions that dispatch over the same domain and share multiple explicit arms. The rule should report overlap counts and wildcard/default context.
+
+`safety.fail_fast_boundary_call` reports `unwrap`, `expect`, `panic`, `todo`, and `unreachable` inside public or internal boundaries. Public API boundaries should generally be P1. Internal boundaries should generally be P2 unless evidence shows trusted constants or invariant setup.
+
+`idiom.result_combinator_candidate` reports obvious RFC 070 match shapes that can be expressed with `map`, `map_err`, `and_then`, `or_else`, `inspect`, or `inspect_err`.
+
+`idiom.compound_assignment_candidate` reports assignments such as `i = i + 1` when the target and left operand are the same simple storage place and `i += 1` is equivalent.
+
+`idiom.comprehension_candidate` reports append-only list builders that can be represented as eager list comprehensions.
+
+`smell.single_use_trivial_helper` reports private, undocumented, undecorated helpers that are used once and only return a simple pure expression. The rule must mention that domain vocabulary can justify keeping the helper.
+
+`smell.repeated_literal_domain` reports repeated raw string or scalar literal domains used as branch keys or dispatch keys across multiple sites.
+
+## Alternatives considered
+
+### Keep architect as architecture-only
+
+This would preserve a narrow name, but it would force closely related idiom and smell findings into a separate command even though they need the same project-wide codegraph, evidence model, de-duplication, profiles, suppressions, and JSON output. The better boundary is category namespace, not separate infrastructure.
+
+### Build a general linter instead
+
+A general linter would fit small syntax-level advice, but it would understate the project-wide design-pressure use case. The command should remain broader than a linter while still identifying local smells as one category.
+
+### Use a language model for rule detection
+
+Model-based detection may be useful later for summarization, clustering, or explaining findings in pull requests. It is not the right foundation for v0.5 rule detection because findings need to be reproducible, testable, source-grounded, and suitable for CI.
+
+### Let every rule walk the AST directly
+
+This is the fastest way to add a first rule and the worst way to maintain many rules. It duplicates traversal logic, fragments fact extraction, and makes rule behavior harder to share with agents, editors, and other code-intelligence tools.
+
+### Make findings auto-fixable from the start
+
+Some findings will eventually support safe rewrites, such as compound assignment candidates. Making fixes part of the first version would expand the scope into formatter, semantic preservation, and edit application. The first version should focus on reliable findings and stable output.
+
+## Drawbacks
+
+This feature adds a new advisory surface that can become noisy if rule quality is poor. The command must earn trust by being conservative, showing evidence, and naming counterexamples.
+
+The codegraph fact model will grow. If facts are added without a typed query layer, rules will become stringly and brittle. If facts are over-designed too early, implementation will slow down before the rule set proves itself.
+
+Some code smells are subjective. A helper that looks unnecessary may carry important domain meaning. A loop that could be a comprehension may be clearer as a loop when side effects are about to be added. The finding model must make room for this uncertainty through confidence and risk text.
+
+Project-wide scanning may be slower than entry-point scanning. The implementation should keep scans deterministic and should leave room for caching, but v0.5 should prioritize correctness and evidence over premature optimization.
+
+## Implementation architecture
+
+This section is non-normative.
+
+The recommended internal shape is a layered pipeline: source collection, compiler-backed codegraph extraction, typed fact views, query indexes, independent rule modules, finding normalization, de-duplication, profile filtering, and text/JSON rendering.
+
+The codegraph layer should remain the producer of source facts. The architect layer should not own parsing or typechecking behavior. Architect rules should operate over typed views such as match dispatch sites, call sites, references, assignment/update candidates, usage counts, loop-builder shapes, and result-match shapes.
+
+The rule engine should provide a small metadata contract for rule authors. A rule should declare its code, category, default priority, confidence, profiles, required facts, and explanation. A rule should receive a query context and emit findings.
+
+The report layer should be shared by all rules. Sorting, de-duplication, JSON serialization, text formatting, suppression matching, and baseline matching should not be implemented per rule.
+
+The first version should ship with a small calibrated rule set rather than a large catalogue. New rules should be added only when they have clear positive fixtures, negative fixtures, and calibration evidence from real source.
+
+## Layers affected
+
+- **Parser / AST**: No new user syntax is required, but source traversal must expose enough body shapes for codegraph facts.
+- **Typechecker / Symbol resolution**: Rules may need checked public API metadata, resolved imports, type facts for `Result` shapes, and symbol usage information.
+- **IR Lowering**: No required impact.
+- **Emission**: No required impact.
+- **Stdlib / Runtime (`incan_stdlib`)**: No required runtime impact, though stdlib feature surfaces such as Result combinators and iterator adapters inform idiom rules.
+- **Formatter**: No required impact unless future auto-fix support is added.
+- **LSP / Tooling**: The JSON findings format should be usable by editors, agents, CI, and future diagnostics-style surfaces.
+- **CLI / Project tooling**: `incan architect` needs project-wide scanning, profiles, stable text/JSON output, suppression support, and baseline support.
+- **Documentation**: The CLI reference must document command behavior, profiles, categories, priorities, confidence, suppressions, and examples.
+
+## Unresolved questions
+
+- What is the default profile for `incan architect .`: architecture-only, architecture plus safety, or all stable rules?
+- What suppression syntax should Incan use for architect findings, and should it share vocabulary with compiler diagnostic suppressions?
+- Should baselines live in `incan.toml`, a separate lock-like file, or a generated artifact under project tooling state?
+- Which finding fields are stable enough to commit as v0.5 JSON output, and which should remain experimental?
+- Should code-smell findings use the namespace `smell.*` or `maintainability.*`?
+- Should project-wide directory scanning include tests by default, and should findings from tests use a separate priority calibration?
+- How should architect distinguish trusted-constant fail-fast calls from caller-input fail-fast calls in a deterministic, maintainable way?
+- Should third-party rule packages be considered after v0.5, or should v0.5 explicitly restrict rule authoring to the Incan repository?
+
+<!-- Rename this section to "Design Decisions" once all questions have been resolved.
+     An RFC cannot move from Draft to Planned until no unresolved questions remain. -->

--- a/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
+++ b/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
@@ -10,7 +10,7 @@
     - RFC 088 (iterator adapter surface)
     - RFC 096 (declaration metadata blocks)
 - **Issue:** https://github.com/dannys-code-corner/incan/issues/663
-- **RFC PR:** —
+- **RFC PR:** https://github.com/dannys-code-corner/incan/pull/664
 - **Written against:** v0.3
 - **Shipped in:** —
 

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -25,6 +25,7 @@ Commands:
 - `version` - Update the project version in `incan.toml`
 - `env` - List, inspect, or run configured project environments
 - `lock` - Generate or update `incan.lock`
+- `architect` - Report deterministic architecture-advice findings
 - `tools` - Inspect local toolchain, editor integration state, and checked metadata
 
 ## Global options
@@ -408,6 +409,35 @@ The generated `incan.lock` contains an embedded `Cargo.lock` payload and a finge
 
 See: [Managing dependencies](../how-to/dependencies.md) for practical guidance.
 
+### `incan architect`
+
+Usage:
+
+```text
+incan architect [PATH] [OPTIONS]
+```
+
+Scans an Incan source file or source tree for deterministic architecture-advice findings. Directory inputs scan `.incn` files recursively and de-duplicate imported modules by source path, so unreferenced source files are still included in project-wide reports.
+
+Options:
+
+- `--format text`: Output a human-readable report (default).
+- `--format json`: Output machine-readable findings for agents and editor tooling.
+
+The first implemented signals are deterministic graph checks:
+
+- `arch.fail_fast_boundary_call`: reports fail-fast calls such as `unwrap`, `expect`, `panic`, `todo`, or `unreachable` inside source boundaries. Public API boundaries are `P1`; internal boundaries are `P2`.
+- `arch.repeated_match_dispatch`: reports repeated match expressions that dispatch over the same syntactic domain and share multiple arms. It reports shared-arm overlap against the largest explicit pattern set and suppresses tiny-overlap matches when a narrower site mostly relies on a wildcard/default fallback. Repeated raw string dispatch across three or more sites is `P2`; lower-pressure repeated dispatch remains `P3`.
+
+The command consumes body facts from the compiler-backed codegraph exporter rather than walking command-private AST state. Project-wide scans de-duplicate identical findings by rule and evidence location before printing.
+
+Examples:
+
+```bash
+incan architect src/lib.incn
+incan architect . --format json
+```
+
 ### `incan tools doctor`
 
 Usage:
@@ -441,6 +471,49 @@ Examples:
 ```bash
 incan tools doctor
 incan tools doctor --format json
+```
+
+### `incan tools codegraph export`
+
+Usage:
+
+```text
+incan tools codegraph export [PATH] [OPTIONS]
+```
+
+Exports compiler-backed code-index facts for an Incan source file or directory. By default, the command parses and type-checks the target before producing output, so downstream indexers receive facts from Incan's own module/import/typechecking pipeline rather than a syntax-only scrape.
+
+If `PATH` is omitted, the current directory is inspected. If `PATH` is a directory, every `.incn` file under that directory is exported in deterministic path order.
+
+Options:
+
+- `--format jsonl`: Output newline-delimited codegraph records (default).
+- `--format json`: Output one pretty JSON document.
+- `--allow-errors`: Continue after type-check errors and emit the unchecked source graph. Checked API member facts are omitted for modules that failed type-checking.
+
+The export includes:
+
+- project/package identity from `incan.toml`, when available
+- file and module nodes
+- declaration nodes for top-level functions, models, classes, traits, enums, newtypes, type aliases, consts, statics, aliases, partials, and inline test modules
+- RFC 048 checked API metadata facts on public declaration nodes, including metadata anchor ids and source-like signatures
+- `api_member` nodes for checked public API members such as model fields, class fields, trait requirements, methods, enum variants, and enum variant aliases
+- import nodes and import-target edges
+- body fact nodes for match dispatches, call sites, and references
+- match-dispatch facts for explicit pattern counts, source arm counts, and wildcard/default-arm context
+- containment and definition edges
+- call-site and reference-target edges for syntactic targets
+- source byte spans for source-backed facts
+
+This command is a code-intelligence export for tools and agents. It extends the RFC 048 metadata surface with graph topology: checked API metadata remains the source of truth for public API contracts, while codegraph records make packages easier to navigate by file, module, import, declaration, and member relationships. It is separate from `std.graph` and RFC 047, which define runtime graph data structures for Incan programs. It does not embed CodeGraph storage, embeddings, MCP behavior, or tree-sitter parsing into the compiler.
+
+Examples:
+
+```bash
+incan tools codegraph export
+incan tools codegraph export src/lib.incn --format json
+incan tools codegraph export crates/incan_stdlib/stdlib --format jsonl
+incan tools codegraph export src --format jsonl --allow-errors
 ```
 
 ### `incan tools metadata api`


### PR DESCRIPTION
## Summary

This PR adds the `incan architect` spike and the supporting compiler-backed codegraph substrate. It introduces an `incan_codegraph` crate, body-level codegraph facts for match dispatches, call sites, and references, an experimental `incan architect` command with deterministic architecture/safety findings, CLI reference docs, and RFC 105 for growing the spike into a maintainable v0.5 rule engine covering architecture, safety, idioms, and code smells.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan tools codegraph export` can export project/file/module/declaration/import/API-member facts plus body-level match/call/reference facts. `incan architect` can scan a file or directory and emit text or JSON findings for repeated match dispatch and fail-fast boundary calls.
- **Internals**: Adds the `incan_codegraph` wire-format crate, extends the tools command with project-wide codegraph collection, and keeps architect rules backed by codegraph facts rather than command-private AST walking. Directory scans de-duplicate modules by source path and report-level findings by rule/evidence.
- **Risks**: This is intentionally a spike. The rule set is small and conservative, and the codegraph body-fact schema may need refinement before v0.5 stabilization. Recursive directory scans also broaden the scanned surface compared with entry-point-only analysis.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed after rebasing onto `origin/release/v0.3`.
- The pre-commit gate included formatting, rustdoc coverage, 2466 nextest tests, clippy, cargo-deny, smoke examples, and benchmark build checks.
- Focused architect/codegraph tests are included for project-wide scans, repeated dispatch, fail-fast findings, and duplicate finding suppression.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/tooling/reference/cli_reference.md`, `workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md`, `crates/incan_codegraph/README.md`, `workspaces/codegraph/README.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #663