### PR TITLE
bugfix - raw-ident keyword public aliases (#669)

### DIFF
--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -1187,6 +1187,38 @@ def main() -> int:
     }
 
     #[test]
+    fn top_level_keyword_named_callable_alias_uses_raw_identifier_reexport() {
+        let code = generate(
+            r#"
+pub def modulo_value(value: int) -> int:
+  return value
+
+pub mod = alias modulo_value
+
+def main() -> int:
+  return mod(10)
+"#,
+        );
+        assert!(code.contains("pub fn modulo_value(value: i64) -> i64"), "{code}");
+        assert!(code.contains("pub use modulo_value as r#mod;"), "{code}");
+        assert!(code.contains("return modulo_value(10);"), "{code}");
+    }
+
+    #[test]
+    fn top_level_alias_to_keyword_named_callable_uses_raw_identifier_target_path() {
+        let code = generate(
+            r#"
+pub def mod(value: int) -> int:
+  return value
+
+pub modulo = alias mod
+"#,
+        );
+        assert!(code.contains("pub fn r#mod(value: i64) -> i64"), "{code}");
+        assert!(code.contains("pub use r#mod as modulo;"), "{code}");
+    }
+
+    #[test]
     fn top_level_qualified_alias_preserves_target_path() {
         let code = generate(
             r#"

--- a/src/backend/ir/emit/decls/mod.rs
+++ b/src/backend/ir/emit/decls/mod.rs
@@ -21,7 +21,7 @@ mod mutation_scan;
 mod structures;
 
 use proc_macro2::{Literal, TokenStream};
-use quote::{format_ident, quote};
+use quote::quote;
 
 use incan_core::lang::stdlib;
 
@@ -61,7 +61,7 @@ impl<'a> IrEmitter<'a> {
                 interop_edges: _,
             } => {
                 let vis = self.emit_visibility(visibility);
-                let name_ident = format_ident!("{}", name);
+                let name_ident = Self::rust_ident(name);
                 let ty_tokens = self.emit_type(ty);
                 let generics = self.emit_type_params(type_params);
                 Ok(quote! {
@@ -76,7 +76,7 @@ impl<'a> IrEmitter<'a> {
                 target_qualifier,
             } => {
                 let vis = self.emit_visibility(visibility);
-                let name_ident = format_ident!("{}", name);
+                let name_ident = Self::rust_ident(name);
                 let target =
                     self.emit_symbol_alias_target_path(target_origin.as_ref(), target_qualifier.as_ref(), target_path);
                 Ok(quote! {
@@ -145,7 +145,7 @@ impl<'a> IrEmitter<'a> {
         self.validate_const_emittable(name, ty, value)?;
 
         let vis = self.emit_visibility(visibility);
-        let name_ident = format_ident!("{}", name);
+        let name_ident = Self::rust_ident(name);
         let ty_tokens = self.emit_type(ty);
         let value_tokens = self.emit_const_value_for_type(ty, value)?;
 
@@ -352,7 +352,7 @@ impl<'a> IrEmitter<'a> {
             let target_segments = target_path
                 .iter()
                 .map(|segment| {
-                    let ident = format_ident!("{}", segment);
+                    let ident = Self::rust_ident(segment);
                     quote! { #ident }
                 })
                 .collect::<Vec<_>>();
@@ -362,7 +362,7 @@ impl<'a> IrEmitter<'a> {
             let target_segments = target_path
                 .iter()
                 .map(|segment| {
-                    let ident = format_ident!("{}", segment);
+                    let ident = Self::rust_ident(segment);
                     quote! { #ident }
                 })
                 .collect::<Vec<_>>();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4408,6 +4408,39 @@ pub def main_value() -> int:
     }
 
     #[test]
+    fn test_keyword_named_public_alias_compiles_issue669() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project_root = tmp.path().join("keyword_named_public_alias_repro");
+        fs::create_dir_all(&project_root)?;
+        fs::write(
+            project_root.join("test_keyword_alias_probe.incn"),
+            r#"
+pub def modulo_value(value: int) -> int:
+    return value
+
+pub mod = alias modulo_value
+
+
+def test_keyword_alias_probe__can_call_alias() -> None:
+    assert mod(7) == 7, "keyword alias should call the implementation"
+"#,
+        )?;
+
+        let output = incan_command()
+            .args(["test", "test_keyword_alias_probe.incn"])
+            .current_dir(&project_root)
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            output.status.success(),
+            "expected keyword-named public alias test project to pass for #669.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_issue562_type_alias_dict_and_union_surfaces_compile_and_run() -> Result<(), Box<dyn std::error::Error>> {
         let output = incan_command()
             .args([


### PR DESCRIPTION
## Summary
- Emit public alias/type/const names through the existing Rust identifier helper so keyword names become raw identifiers.
- Apply the same raw-ident handling to local alias target paths.
- Add codegen and integration coverage for keyword-named public callable aliases.

Fixes #669.

## Testing
- `cargo fmt --check`
- `cargo test -p incan top_level_keyword_named_callable_alias_uses_raw_identifier_reexport --lib`
- `cargo test -p incan top_level_alias_to_keyword_named_callable_uses_raw_identifier_target_path --lib`
- `cargo test -p incan --test integration_tests test_keyword_named_public_alias_compiles_issue669`
- `make pre-commit`