### PR TITLE
bugfix - materialize static receiver method args (#671)

### DIFF
--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -7,9 +7,10 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use super::super::super::FunctionSignature;
+use super::super::super::decl::FunctionParam;
 use super::super::super::expr::{
-    CollectionMethodKind, InternalMethodKind, IrCallArg, IrExprKind, IrMethodDispatch, MethodCallArgPolicy, MethodKind,
-    TypedExpr, VarAccess, VarRefKind,
+    CollectionMethodKind, InternalMethodKind, IrCallArg, IrCallArgKind, IrExprKind, IrMethodDispatch,
+    MethodCallArgPolicy, MethodKind, TypedExpr, VarAccess, VarRefKind,
 };
 use super::super::super::ownership::{
     ArgumentPassingPlan, RegularMethodArgumentContext, ValueUseSite, regular_method_argument_use_site,
@@ -560,24 +561,38 @@ impl<'a> IrEmitter<'a> {
     /// Materialize method-call arguments before entering a static storage lock.
     ///
     /// This prevents lock reentry when argument expressions also read/write static-backed values.
-    fn materialize_storage_rooted_args(
+    fn materialize_storage_rooted_args<'site>(
         &self,
         args: &[IrCallArg],
+        callable_signature: Option<&'site FunctionSignature>,
+        base_use_site: ValueUseSite<'site>,
     ) -> Result<(Vec<TokenStream>, Vec<IrCallArg>), EmitError> {
         let mut bindings = Vec::with_capacity(args.len());
         let mut rewritten = Vec::with_capacity(args.len());
         for (idx, arg) in args.iter().enumerate() {
             let name = format!("__incan_static_arg_{idx}");
             let ident = format_ident!("{}", name);
-            let emitted = self.emit_expr(&arg.expr)?;
-            bindings.push(quote! { let #ident = #emitted; });
+            let param = Self::signature_param_for_original_call_arg(args, idx, callable_signature);
+            let materialize_site = Self::storage_arg_materialization_use_site(base_use_site, param);
+            let emitted = self.emit_expr_for_use(&arg.expr, materialize_site)?;
+            let mutable =
+                param.is_some_and(|param| matches!(param.mutability, super::super::super::types::Mutability::Mutable));
+            let binding = if mutable {
+                quote! { let mut #ident = #emitted; }
+            } else {
+                quote! { let #ident = #emitted; }
+            };
+            bindings.push(binding);
+            let rewritten_ty = param
+                .map(|param| param.ty.clone())
+                .unwrap_or_else(|| arg.expr.ty.clone());
             let rewritten_expr = TypedExpr::new(
                 IrExprKind::Var {
                     name,
-                    access: VarAccess::Read,
+                    access: VarAccess::Move,
                     ref_kind: VarRefKind::Value,
                 },
-                arg.expr.ty.clone(),
+                rewritten_ty,
             )
             .with_ownership(arg.expr.ownership)
             .with_span(arg.expr.span);
@@ -588,6 +603,48 @@ impl<'a> IrEmitter<'a> {
             });
         }
         Ok((bindings, rewritten))
+    }
+
+    /// Return the callable parameter matched by one original call argument before storage-lock materialization.
+    fn signature_param_for_original_call_arg<'sig>(
+        args: &[IrCallArg],
+        idx: usize,
+        callable_signature: Option<&'sig FunctionSignature>,
+    ) -> Option<&'sig FunctionParam> {
+        let signature = callable_signature?;
+        let arg = args.get(idx)?;
+        if matches!(arg.kind, IrCallArgKind::PositionalUnpack | IrCallArgKind::KeywordUnpack) {
+            return None;
+        }
+        if let Some(name) = arg.name.as_deref() {
+            return signature.params.iter().find(|param| param.name == name);
+        }
+        let positional_idx = args
+            .iter()
+            .take(idx)
+            .filter(|arg| arg.name.is_none() && matches!(arg.kind, IrCallArgKind::Positional))
+            .count();
+        signature.params.get(positional_idx)
+    }
+
+    /// Pick the use-site plan used when evaluating one storage-rooted method argument before taking the storage lock.
+    fn storage_arg_materialization_use_site<'site>(
+        base_use_site: ValueUseSite<'site>,
+        param: Option<&'site FunctionParam>,
+    ) -> ValueUseSite<'site> {
+        match (base_use_site, param) {
+            (ValueUseSite::IncanCallArg { in_return, .. }, Some(param)) => ValueUseSite::IncanCallArg {
+                target_ty: Some(&param.ty),
+                callee_param: Some(param),
+                in_return,
+            },
+            (ValueUseSite::ExternalCallArg { .. }, Some(param)) | (ValueUseSite::MethodArg, Some(param)) => {
+                ValueUseSite::ExternalCallArg {
+                    target_ty: Some(&param.ty),
+                }
+            }
+            (site, _) => site,
+        }
     }
 
     /// Strip reference wrappers from a receiver type before builtin-family or ownership-sensitive dispatch.
@@ -682,7 +739,8 @@ impl<'a> IrEmitter<'a> {
         args: &[IrCallArg],
     ) -> Result<TokenStream, EmitError> {
         if Self::expr_is_storage_rooted(receiver) {
-            let (arg_bindings, rewritten_args) = self.materialize_storage_rooted_args(args)?;
+            let (arg_bindings, rewritten_args) =
+                self.materialize_storage_rooted_args(args, None, ValueUseSite::MethodArg)?;
             if matches!(kind, MethodKind::Collection(CollectionMethodKind::Get)) {
                 let rewritten_receiver = Self::rewrite_storage_root_expr(receiver, "__incan_static_value");
                 let arg_exprs: Vec<TypedExpr> = rewritten_args.iter().map(|a| a.expr.clone()).collect();
@@ -819,13 +877,38 @@ impl<'a> IrEmitter<'a> {
         result_use_site: Option<ValueUseSite<'_>>,
     ) -> Result<TokenStream, EmitError> {
         if Self::expr_is_storage_rooted(receiver) {
-            let (arg_bindings, rewritten_args) = self.materialize_storage_rooted_args(args)?;
             let use_mut = !matches!(arg_policy, MethodCallArgPolicy::PreserveShape);
             let rewritten_receiver = if use_mut {
                 Self::rewrite_storage_root_expr_for_mut(receiver, "__incan_static_value")
             } else {
                 Self::rewrite_storage_root_expr(receiver, "__incan_static_value")
             };
+            let in_return = *self.in_return_context.borrow();
+            let receiver_ref_kind = match &rewritten_receiver.kind {
+                IrExprKind::Var { ref_kind, .. } => Some(*ref_kind),
+                _ => None,
+            };
+            let has_incan_method_signature = self
+                .method_signature_for_receiver(&rewritten_receiver.ty, method)
+                .is_some();
+            let preserve_lookup_arg_shape = matches!(arg_policy, MethodCallArgPolicy::PreserveShape)
+                || rust_collection_family_for_ir_type(&rewritten_receiver.ty)
+                    .is_some_and(|family| family.preserves_lookup_arg_shape(method));
+            let rusttype_alias_receiver = self.is_rusttype_alias_receiver(&rewritten_receiver.ty);
+            let base_use_site = regular_method_argument_use_site(
+                RegularMethodArgumentContext {
+                    arg_policy,
+                    receiver_ref_kind,
+                    has_incan_method_signature,
+                    is_incan_owned_nominal_receiver: self.is_incan_owned_nominal_receiver(&rewritten_receiver.ty),
+                    is_rusttype_alias_receiver: rusttype_alias_receiver,
+                    preserves_lookup_arg_shape: preserve_lookup_arg_shape,
+                    in_return,
+                },
+                None,
+            );
+            let (arg_bindings, rewritten_args) =
+                self.materialize_storage_rooted_args(args, callable_signature, base_use_site)?;
             let inner = self.emit_method_call_expr_with_result_use(
                 &rewritten_receiver,
                 method,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8749,8 +8749,75 @@ def main() -> None:
         );
         assert!(
             generated.contains(".with_mut(|__incan_static_value|")
-                && generated.contains("__incan_static_value.add(__incan_static_arg_0.to_string())"),
+                && (generated.contains("let __incan_static_arg_0 = \"instance\".to_string();")
+                    || generated.contains("let __incan_static_arg_0 = \"instance\".into();"))
+                && generated.contains("__incan_static_value.add(__incan_static_arg_0)"),
             "static registry receiver should lower through static storage access:\n{}",
+            generated,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn build_lib_imported_static_decorator_receiver_materializes_string_arg_issue671()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let dir = write_test_project(
+            "incan.toml",
+            r#"[project]
+name = "imported_static_decorator_receiver"
+version = "0.1.0"
+"#,
+        );
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir)?;
+        std::fs::write(
+            src_dir.join("probe_registry.incn"),
+            r#"
+@derive(Clone)
+pub class ProbeRegistry:
+    @staticmethod
+    def new() -> Self:
+        return ProbeRegistry()
+
+    def add[F](mut self, name: str, value: int) -> (F) -> F:
+        return (func) => func
+
+
+pub static PROBE_REGISTRY: ProbeRegistry = ProbeRegistry.new()
+"#,
+        )?;
+        std::fs::write(
+            src_dir.join("probe_decorated.incn"),
+            r#"
+from probe_registry import PROBE_REGISTRY
+
+@PROBE_REGISTRY.add("decorated", 1)
+pub def decorated(value: int) -> int:
+    return value
+"#,
+        )?;
+        std::fs::write(src_dir.join("lib.incn"), "pub from probe_decorated import decorated\n")?;
+
+        let output = incan_command()
+            .args(["build", "--lib"])
+            .current_dir(&*dir)
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "expected imported static decorator receiver project to build for #671.\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr,
+        );
+
+        let generated = std::fs::read_to_string(dir.join("target/lib/src/probe_decorated.rs"))?;
+        assert!(
+            (generated.contains("let __incan_static_arg_0 = \"decorated\".into();")
+                || generated.contains("let __incan_static_arg_0 = \"decorated\".to_string();"))
+                && !generated.contains("__incan_static_arg_0.clone()"),
+            "imported static decorator string argument should materialize as owned String:\n{}",
             generated,
         );
         Ok(())


### PR DESCRIPTION
## Summary

Fixes #671 by making storage-rooted method calls materialize their hoisted arguments through the same ownership/coercion plan used for normal method-call arguments. Imported static decorator receivers now pre-materialize string arguments as owned values before entering `StaticCell::with_mut`, instead of binding `&str` and later cloning it into the generated call.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: split-module decorator registries can import a shared static registry and pass string literal metadata without generating invalid Rust.
- **Internals**: static/storage-rooted method calls now select a value-use site from callable metadata, materialize arguments before the lock using `emit_expr_for_use`, and rewrite the hoisted temp type/access to match the materialized value.
- **Risks**: this changes generated Rust shape for storage-rooted method-call arguments; focused coverage checks the existing local static decorator path and the imported static decorator package build.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo fmt --check`
- `cargo test -p incan --test integration_tests build_lib_imported_static_decorator_receiver_materializes_string_arg_issue671`
- `cargo test -p incan --test integration_tests e2e_method_call_decorator_factories_use_checked_receiver_lowering`
- `git diff --check`
- `make pre-commit` passed during the final fix loop before trimming an unrelated speculative metadata lookup change; after that trim, the final focused checks above were rerun.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
