### PR TITLE
bugfix - rebase multi-file test batch spans (#692)

### DIFF
--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -454,6 +454,24 @@ fn partition_collision_free_file_groups(
         .collect()
 }
 
+fn rebase_token_spans(tokens: &mut [lexer::Token], source_offset: usize) {
+    if source_offset == 0 {
+        return;
+    }
+
+    for token in tokens {
+        token.span.start = token.span.start.saturating_add(source_offset);
+        token.span.end = token.span.end.saturating_add(source_offset);
+        if let lexer::TokenKind::FString(parts) = &mut token.kind {
+            for part in parts {
+                if let lexer::FStringPart::Expr { offset, .. } = part {
+                    *offset = offset.saturating_add(source_offset);
+                }
+            }
+        }
+    }
+}
+
 /// Parse each source file in a generated test batch independently, then merge declarations for the shared harness.
 ///
 /// The parser's `module tests:` cardinality rule is intentionally per source file. A worker batch may contain several
@@ -466,12 +484,14 @@ fn parse_test_batch_sources(
     let mut declarations = Vec::new();
     let mut warnings = Vec::new();
     let mut rust_module_path = None;
+    let mut source_offset = 0usize;
     let source_path = batch_sources
         .first()
         .map(|(path, _)| path.to_string_lossy().to_string());
 
     for (path, source) in batch_sources {
-        let tokens = lexer::lex(source).map_err(|e| format!("Lexer error in {}: {:?}", path.display(), e))?;
+        let mut tokens = lexer::lex(source).map_err(|e| format!("Lexer error in {}: {:?}", path.display(), e))?;
+        rebase_token_spans(&mut tokens, source_offset);
         let parsed = parser::parse_with_context_and_surfaces(
             &tokens,
             Some(path.to_string_lossy().as_ref()),
@@ -490,6 +510,7 @@ fn parse_test_batch_sources(
         }
         warnings.extend(parsed.warnings);
         declarations.extend(parsed.declarations);
+        source_offset = source_offset.saturating_add(source.len()).saturating_add(1);
     }
 
     Ok(Program {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7455,6 +7455,57 @@ def test_b() -> None:
     }
 
     #[test]
+    fn e2e_cross_file_batch_rebases_spans_for_type_info_issue692() -> Result<(), Box<dyn std::error::Error>> {
+        fn source_with_call_offset(header: &str, call_prefix: &str, call_and_tail: &str, offset: usize) -> String {
+            let fixed_len = header.len() + call_prefix.len();
+            assert!(
+                offset >= fixed_len + 6,
+                "test fixture offset leaves no room for padding"
+            );
+            let padding = format!("    #{}\n", "x".repeat(offset - fixed_len - 6));
+            format!("{header}{padding}{call_prefix}{call_and_tail}")
+        }
+
+        let target_offset = 320;
+        let dir = write_test_project(
+            "test_constructor_marker.incn",
+            &source_with_call_offset(
+                "model Box:\n    value: int\n\ndef test_type_constructor() -> None:\n",
+                "    item = ",
+                "Box(value=1)\n    assert item.value == 1\n",
+                target_offset,
+            ),
+        );
+        std::fs::write(
+            dir.join("test_zero_arg_call.incn"),
+            source_with_call_offset(
+                "def tap() -> str:\n    return \"ok\"\n\ndef test_zero_arg_call_in_list() -> None:\n",
+                "    values = [",
+                "tap()]\n    assert values[0] == \"ok\"\n",
+                target_offset,
+            ),
+        )?;
+
+        let output = run_incan_test(&dir);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "expected same-span constructor and zero-argument calls from different files not to share type-info facts.\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr,
+        );
+        assert!(
+            stdout.contains("test_constructor_marker.incn::test_type_constructor")
+                && stdout.contains("test_zero_arg_call.incn::test_zero_arg_call_in_list"),
+            "expected both files to run in one directory test batch.\nstdout:\n{}",
+            stdout,
+        );
+        Ok(())
+    }
+
+    #[test]
     fn e2e_imported_default_expression_expands_with_required_scope_issue395() -> Result<(), Box<dyn std::error::Error>>
     {
         let dir = write_test_project(


### PR DESCRIPTION
## Summary

This PR fixes a multi-file `incan test` batching bug where independently parsed files could reuse the same raw byte spans, causing span-keyed semantic facts from one file to affect another file. Combined conventional test batches now rebase token-derived spans into one synthetic source coordinate space before parsing, so a zero-argument function call in one test file cannot be mistaken for a constructor because another file has a type at the same raw offset.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `incan test` directory runs with multiple conventional test files now preserve zero-argument calls inside merged batches instead of occasionally emitting Rust struct literals such as `helper {}`.
- **Internals**: `parse_test_batch_sources` rebases token spans for each source before parse, including nested f-string expression offsets, so downstream span-keyed `TypeCheckInfo` maps remain file-isolated inside the merged harness.
- **Risks**: This touches the conventional test-runner parse path. The main compatibility risk is any code that accidentally depended on per-file raw spans inside merged batches; focused and full gates passed against the rebased coordinate model.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo check --features cli`
- `cargo build --features cli`
- `cargo test --test integration_tests e2e_cross_file_batch_rebases_spans_for_type_info_issue692 --features cli -- --nocapture`
- `cargo test --test integration_tests e2e_cross_file_batch --features cli`
- `cargo test --test integration_tests e2e_conventional_test_batches_split_import_declaration_collisions_issue676 --features cli`
- `cargo test --test integration_tests e2e_directory_run_preserves_per_file_inline_test_modules_issue676 --features cli`
- `cargo test --test integration_tests e2e_inline_and_imported_surfaces_share_one_project --features cli`
- copied InQL RFC 015 draft: `incan test target/batch_probe_pair` passed, 24 tests
- `git diff --check`
- `make pre-commit`
- post-commit focused regression rerun: `cargo test --test integration_tests e2e_cross_file_batch_rebases_spans_for_type_info_issue692 --features cli -- --nocapture`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): …

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #692