### PR TITLE
feature - materialize decorator metadata projections (#694, #695)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc16"
+version = "0.3.0-rc17"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -13,7 +13,7 @@ use crate::cli::{CliError, CliResult, ExitCode};
 use crate::dependency_resolver::{resolve_dependencies, resolve_reachable_dependencies};
 use crate::frontend::api_metadata::{
     CHECKED_API_METADATA_SCHEMA_VERSION, CheckedApiMetadataPackage, CheckedApiPackageIdentity,
-    collect_checked_api_metadata, validate_checked_api_docstrings,
+    collect_checked_api_metadata, materialize_api_alias_projections, validate_checked_api_docstrings,
 };
 use crate::frontend::ast::{Declaration, Decorator, ImportKind, Span, Spanned};
 use crate::frontend::contract_metadata::{ContractMetadataPackage, read_project_model_bundles};
@@ -834,6 +834,8 @@ pub fn build_library(
     if !all_errors.is_empty() {
         return Err(CliError::failure(all_errors.trim_end()));
     }
+
+    materialize_api_alias_projections(&mut api_metadata_modules);
 
     for diagnostic in validate_checked_api_docstrings(&api_metadata_modules) {
         if let Some(module) = modules

--- a/src/cli/commands/tools.rs
+++ b/src/cli/commands/tools.rs
@@ -13,7 +13,8 @@ use crate::cli::prelude::ParsedModule;
 use crate::cli::{CliError, CliResult, ExitCode};
 use crate::frontend::api_metadata::{
     ApiDeclaration, ApiFunction, ApiPartial, CHECKED_API_METADATA_SCHEMA_VERSION, CheckedApiMetadataPackage,
-    CheckedApiPackageIdentity, collect_checked_api_metadata, validate_checked_api_docstrings,
+    CheckedApiPackageIdentity, collect_checked_api_metadata, materialize_api_alias_projections,
+    validate_checked_api_docstrings,
 };
 use crate::frontend::contract_metadata::{
     CanonicalModelBundle, read_model_bundles_from_json, read_project_model_bundles,
@@ -416,6 +417,8 @@ fn collect_api_metadata_package(path: &Path) -> CliResult<CheckedApiMetadataPack
     if !all_errors.is_empty() {
         return Err(CliError::failure(all_errors.trim_end()));
     }
+
+    materialize_api_alias_projections(&mut metadata_modules);
 
     for diagnostic in validate_checked_api_docstrings(&metadata_modules) {
         if let Some((module, _)) = modules
@@ -1292,6 +1295,96 @@ pub quick_label = partial label(prefix=LABEL)
             markdown.contains("pub quick_label = partial label(prefix: str = ..., suffix: str = ...) -> str")
                 && markdown.contains("- Presets: `prefix`"),
             "expected generated API Markdown to render partial signatures and provenance, got:\n{markdown}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn collect_api_metadata_package_materializes_facade_decorator_projection_issue695()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let src = tmp.path().join("src");
+        let operators = src.join("functions").join("operators");
+        fs::create_dir_all(&operators)?;
+        fs::write(
+            tmp.path().join("incan.toml"),
+            r#"
+[project]
+name = "metadata_registry"
+version = "0.1.0"
+"#,
+        )?;
+        fs::write(
+            src.join("registry.incn"),
+            r#"
+pub def registered[F](spec: str) -> ((F) -> F):
+    return (func) => func
+"#,
+        )?;
+        fs::write(
+            operators.join("eq.incn"),
+            r#"
+from registry import registered
+
+pub model ColumnExpr:
+    pub name: str
+
+@registered("equal")
+pub def eq(left: ColumnExpr, right: ColumnExpr) -> ColumnExpr:
+    return left
+"#,
+        )?;
+        fs::write(
+            operators.join("mod.incn"),
+            "pub from functions.operators.eq import eq\n",
+        )?;
+        fs::write(src.join("lib.incn"), "pub from functions.operators.mod import eq\n")?;
+
+        let package = collect_api_metadata_package(tmp.path())?;
+        let lib_alias = package
+            .modules
+            .iter()
+            .find(|module| module.module_path == vec!["lib".to_string()])
+            .and_then(|module| {
+                module.declarations.iter().find_map(|decl| match decl {
+                    ApiDeclaration::Alias(alias) if alias.name == "eq" => Some(alias),
+                    _ => None,
+                })
+            })
+            .ok_or("expected lib facade alias")?;
+        let projection = lib_alias
+            .projected_function
+            .as_ref()
+            .ok_or("expected projected function metadata on facade alias")?;
+
+        assert_eq!(projection.callable.name, "eq");
+        assert_eq!(
+            projection.source_path,
+            vec![
+                "functions".to_string(),
+                "operators".to_string(),
+                "eq".to_string(),
+                "eq".to_string(),
+            ]
+        );
+        assert_eq!(
+            projection
+                .callable
+                .params
+                .iter()
+                .map(|param| param.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["left", "right"]
+        );
+        assert!(
+            projection.decorators.iter().any(|decorator| {
+                decorator.path == vec!["registry".to_string(), "registered".to_string()]
+                    && decorator
+                        .decorated_callable
+                        .as_ref()
+                        .is_some_and(|callable| callable.name == "eq")
+            }),
+            "expected projected decorator metadata with decorated callable context, got {projection:?}"
         );
         Ok(())
     }

--- a/src/frontend/api_metadata.rs
+++ b/src/frontend/api_metadata.rs
@@ -9,9 +9,9 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use serde::{Deserialize, Serialize};
 
 use crate::frontend::ast::{
-    ClassDecl, Declaration, Decorator, DecoratorArg, DecoratorArgValue, EnumDecl, Expr, FieldDecl, FunctionDecl,
-    ImportDecl, ImportItem, ImportKind, MethodDecl, ModelDecl, NewtypeDecl, Program, Span, Spanned, Statement,
-    TraitDecl, TypeAliasDecl, Visibility,
+    CallArg, ClassDecl, Declaration, Decorator, DecoratorArg, DecoratorArgValue, DictEntry, EnumDecl, Expr, FieldDecl,
+    FunctionDecl, ImportDecl, ImportItem, ImportKind, ListEntry, MethodDecl, ModelDecl, NewtypeDecl, Program, Span,
+    Spanned, Statement, TraitDecl, TypeAliasDecl, Visibility,
 };
 use crate::frontend::decorator_resolution;
 use crate::frontend::diagnostics::CompileError;
@@ -21,6 +21,7 @@ use crate::frontend::library_exports::{
     CheckedPartialTargetKind, CheckedPresetValue, CheckedTraitExport, CheckedTypeAliasExport, CheckedTypeBound,
     CheckedTypeParam, collect_checked_public_exports,
 };
+use crate::frontend::module::canonicalize_source_module_segments;
 use crate::frontend::typechecker::{ConstValue, TypeChecker};
 use crate::library_manifest::{
     EnumValueExport, EnumValueTypeExport, FieldExport, ParamExport, ParamKindExport, PartialPresetExport,
@@ -208,6 +209,8 @@ pub struct ApiAlias {
     pub name: String,
     pub anchor: SourceAnchor,
     pub target_path: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projected_function: Option<ApiProjectedFunction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -244,7 +247,30 @@ pub struct DecoratorMetadata {
     pub path: Vec<String>,
     pub source_name: String,
     pub anchor: SourceSpan,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub type_args: Vec<TypeRef>,
     pub args: Vec<DecoratorArgMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decorated_callable: Option<ApiCallableMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApiProjectedFunction {
+    pub source_path: Vec<String>,
+    pub callable: ApiCallableMetadata,
+    pub decorators: Vec<DecoratorMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApiCallableMetadata {
+    pub name: String,
+    pub anchor: SourceAnchor,
+    pub type_params: Vec<TypeParamExport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receiver: Option<ReceiverExport>,
+    pub params: Vec<ParamExport>,
+    pub return_type: TypeRef,
+    pub is_async: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -264,12 +290,41 @@ pub enum DecoratorValue {
         name: String,
         value: Option<SafeMetadataValue>,
     },
+    SymbolRef {
+        path: Vec<String>,
+    },
+    List {
+        items: Vec<DecoratorValue>,
+    },
+    Dict {
+        entries: Vec<DecoratorDictEntry>,
+    },
+    Call {
+        callee: Vec<String>,
+        type_args: Vec<TypeRef>,
+        args: Vec<DecoratorCallArgMetadata>,
+    },
     Type {
         ty: TypeRef,
     },
     Unsupported {
         reason: String,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DecoratorDictEntry {
+    pub key: DecoratorValue,
+    pub value: DecoratorValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DecoratorCallArgMetadata {
+    Positional { value: DecoratorValue },
+    Named { name: String, value: DecoratorValue },
+    PositionalUnpack { value: DecoratorValue },
+    KeywordUnpack { value: DecoratorValue },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -443,6 +498,7 @@ pub fn collect_checked_api_metadata(
                     name: alias.name.clone(),
                     anchor: anchor(&module_path, &alias.name, decl.span),
                     target_path: alias.target.segments.clone(),
+                    projected_function: None,
                 }));
             }
             Declaration::Partial(partial) if public(partial.visibility) => {
@@ -466,6 +522,106 @@ pub fn collect_checked_api_metadata(
         module_path,
         declarations,
     }
+}
+
+/// Attach checked function projections to public aliases that target decorated or ordinary public functions.
+///
+/// Metadata package consumers should not need to force producer module initialization just to discover declaration-side
+/// decorator facts. This projection pass resolves aliases across the already checked API package and carries the target
+/// function's decorators and checked callable shape onto facade aliases.
+pub fn materialize_api_alias_projections(modules: &mut [CheckedApiMetadata]) {
+    let mut projections = HashMap::new();
+    let mut aliases = Vec::new();
+
+    for module in modules.iter() {
+        for declaration in &module.declarations {
+            match declaration {
+                ApiDeclaration::Function(function) => {
+                    projections.insert(
+                        declaration_path(&module.module_path, &function.name),
+                        ApiProjectedFunction {
+                            source_path: declaration_path(&module.module_path, &function.name),
+                            callable: callable_from_function(function),
+                            decorators: function.decorators.clone(),
+                        },
+                    );
+                }
+                ApiDeclaration::Alias(alias) => aliases.push(ApiAliasProjectionRequest {
+                    path: declaration_path(&module.module_path, &alias.name),
+                    target_path: normalized_api_target_path(&alias.target_path),
+                    name: alias.name.clone(),
+                    anchor: alias.anchor.clone(),
+                }),
+                _ => {}
+            }
+        }
+    }
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for alias in &aliases {
+            if projections.contains_key(&alias.path) {
+                continue;
+            }
+            if let Some(target) = projections.get(&alias.target_path) {
+                projections.insert(alias.path.clone(), projected_function_for_alias(alias, target));
+                changed = true;
+            }
+        }
+    }
+
+    for module in modules {
+        for declaration in &mut module.declarations {
+            if let ApiDeclaration::Alias(alias) = declaration {
+                let alias_path = declaration_path(&module.module_path, &alias.name);
+                alias.projected_function = projections.get(&alias_path).cloned();
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ApiAliasProjectionRequest {
+    path: Vec<String>,
+    target_path: Vec<String>,
+    name: String,
+    anchor: SourceAnchor,
+}
+
+fn declaration_path(module_path: &[String], name: &str) -> Vec<String> {
+    let mut path = module_path.to_vec();
+    path.push(name.to_string());
+    path
+}
+
+fn normalized_api_target_path(path: &[String]) -> Vec<String> {
+    if path.first().is_some_and(|segment| segment == "crate") {
+        return path[1..].to_vec();
+    }
+    path.to_vec()
+}
+
+fn callable_from_function(function: &ApiFunction) -> ApiCallableMetadata {
+    ApiCallableMetadata {
+        name: function.name.clone(),
+        anchor: function.anchor.clone(),
+        type_params: function.type_params.clone(),
+        receiver: None,
+        params: function.params.clone(),
+        return_type: function.return_type.clone(),
+        is_async: function.is_async,
+    }
+}
+
+fn projected_function_for_alias(
+    alias: &ApiAliasProjectionRequest,
+    target: &ApiProjectedFunction,
+) -> ApiProjectedFunction {
+    let mut projected = target.clone();
+    projected.callable.name = alias.name.clone();
+    projected.callable.anchor = alias.anchor.clone();
+    projected
 }
 
 fn checked_kind<'a>(exports: &'a HashMap<String, CheckedNamedExport>, name: &str) -> Option<&'a CheckedExportKind> {
@@ -553,13 +709,32 @@ fn api_function(
     module_path: &[String],
 ) -> ApiFunction {
     let docstring = function_docstring(&function.body);
+    let callable = api_callable_for_function(function, span, export, checker, module_path);
     ApiFunction {
-        name: export.name.clone(),
-        anchor: anchor(module_path, &export.name, span),
+        name: callable.name.clone(),
+        anchor: callable.anchor.clone(),
         docstring_sections: parse_docstring(docstring.as_deref()),
         docstring,
-        decorators: decorators_metadata(&function.decorators, checker),
+        decorators: decorators_metadata(&function.decorators, checker, Some(&callable)),
+        type_params: callable.type_params,
+        params: callable.params,
+        return_type: callable.return_type,
+        is_async: callable.is_async,
+    }
+}
+
+fn api_callable_for_function(
+    function: &FunctionDecl,
+    span: Span,
+    export: &CheckedFunctionExport,
+    checker: &TypeChecker,
+    module_path: &[String],
+) -> ApiCallableMetadata {
+    ApiCallableMetadata {
+        name: export.name.clone(),
+        anchor: anchor(module_path, &export.name, span),
         type_params: type_params(&export.type_params),
+        receiver: None,
         params: source_function_params(function, checker),
         return_type: source_function_return_type(function, checker),
         is_async: function.is_async(),
@@ -611,7 +786,7 @@ fn api_model(
         anchor: anchor(module_path, &export.name, span),
         docstring_sections: parse_docstring(docstring.as_deref()),
         docstring,
-        decorators: decorators_metadata(&model.decorators, checker),
+        decorators: decorators_metadata(&model.decorators, checker, None),
         type_params: type_params(&export.type_params),
         traits: export.traits.clone(),
         derives: export.derives.clone(),
@@ -633,7 +808,7 @@ fn api_class(
         anchor: anchor(module_path, &export.name, span),
         docstring_sections: parse_docstring(docstring.as_deref()),
         docstring,
-        decorators: decorators_metadata(&class.decorators, checker),
+        decorators: decorators_metadata(&class.decorators, checker, None),
         type_params: type_params(&export.type_params),
         extends: export.extends.clone(),
         traits: export.traits.clone(),
@@ -657,7 +832,7 @@ fn api_trait(
         anchor: anchor(module_path, &export.name, span),
         docstring_sections: parse_docstring(docstring.as_deref()),
         docstring,
-        decorators: decorators_metadata(&trait_decl.decorators, checker),
+        decorators: decorators_metadata(&trait_decl.decorators, checker, None),
         type_params: type_params(&export.type_params),
         supertraits: export.supertraits.iter().map(type_bound).collect(),
         requires: export
@@ -689,7 +864,7 @@ fn api_enum(
         anchor: anchor(module_path, &export.name, span),
         docstring_sections: parse_docstring(docstring.as_deref()),
         docstring,
-        decorators: decorators_metadata(&enum_decl.decorators, checker),
+        decorators: decorators_metadata(&enum_decl.decorators, checker, None),
         type_params: type_params(&export.type_params),
         value_type: export.value_type.map(|value_type| match value_type {
             crate::frontend::symbols::ValueEnumBacking::Str => EnumValueTypeExport::Str,
@@ -732,7 +907,7 @@ fn api_newtype(
         anchor: anchor(module_path, &export.name, span),
         docstring_sections: parse_docstring(docstring.as_deref()),
         docstring,
-        decorators: decorators_metadata(&newtype.decorators, checker),
+        decorators: decorators_metadata(&newtype.decorators, checker, None),
         type_params: type_params(&export.type_params),
         is_rusttype: export.is_rusttype,
         underlying: type_ref_from_resolved(&export.underlying),
@@ -775,7 +950,8 @@ fn api_const(
 fn api_aliases(import: &ImportDecl, span: Span, module_path: &[String]) -> Vec<ApiAlias> {
     match &import.kind {
         ImportKind::From { module, items } => {
-            let base_path = decorator_resolution::path_segments_with_prefix(module);
+            let base_path =
+                canonicalize_source_module_segments(&decorator_resolution::path_segments_with_prefix(module));
             aliases_from_items(items, base_path, span, module_path)
         }
         ImportKind::RustFrom {
@@ -812,6 +988,7 @@ fn aliases_from_items(
                 anchor: anchor(module_path, &name, span),
                 name,
                 target_path,
+                projected_function: None,
             }
         })
         .collect()
@@ -841,12 +1018,9 @@ fn methods(
             continue;
         };
         let docstring = method.node.body.as_ref().and_then(|body| function_docstring(body));
-        out.push(ApiMethod {
+        let callable = ApiCallableMetadata {
             name: checked.name.clone(),
             anchor: anchor(module_path, &format!("{owner}.{}", checked.name), method.span),
-            docstring_sections: parse_docstring(docstring.as_deref()),
-            docstring,
-            decorators: decorators_metadata(&method.node.decorators, checker),
             type_params: type_params(&checked.type_params),
             receiver: checked.receiver.map(|receiver| match receiver {
                 crate::frontend::ast::Receiver::Immutable => ReceiverExport::Immutable,
@@ -855,6 +1029,18 @@ fn methods(
             params: params(&checked.params),
             return_type: type_ref_from_resolved(&checked.return_type),
             is_async: checked.is_async,
+        };
+        out.push(ApiMethod {
+            name: callable.name.clone(),
+            anchor: callable.anchor.clone(),
+            docstring_sections: parse_docstring(docstring.as_deref()),
+            docstring,
+            decorators: decorators_metadata(&method.node.decorators, checker, Some(&callable)),
+            type_params: callable.type_params,
+            receiver: callable.receiver,
+            params: callable.params,
+            return_type: callable.return_type,
+            is_async: callable.is_async,
             has_body: checked.has_body,
         });
     }
@@ -1001,7 +1187,11 @@ fn fields_in_source_order(ast_fields: &[Spanned<FieldDecl>], checked_fields: &[C
     out
 }
 
-fn decorators_metadata(decorators: &[Spanned<Decorator>], checker: &TypeChecker) -> Vec<DecoratorMetadata> {
+fn decorators_metadata(
+    decorators: &[Spanned<Decorator>],
+    checker: &TypeChecker,
+    decorated_callable: Option<&ApiCallableMetadata>,
+) -> Vec<DecoratorMetadata> {
     decorators
         .iter()
         .map(|decorator| {
@@ -1010,12 +1200,24 @@ fn decorators_metadata(decorators: &[Spanned<Decorator>], checker: &TypeChecker)
                 path: resolved,
                 source_name: decorator.node.path.segments.join("."),
                 anchor: source_span(decorator.span),
+                type_args: decorator
+                    .node
+                    .type_args
+                    .iter()
+                    .map(|type_arg| {
+                        type_ref_from_resolved(&crate::frontend::symbols::resolve_type(
+                            &type_arg.node,
+                            &checker.symbols,
+                        ))
+                    })
+                    .collect(),
                 args: decorator
                     .node
                     .args
                     .iter()
                     .map(|arg| decorator_arg_metadata(arg, checker))
                     .collect(),
+                decorated_callable: decorated_callable.cloned(),
             }
         })
         .collect()
@@ -1048,9 +1250,131 @@ fn decorator_expr_value(expr: &Spanned<Expr>, checker: &TypeChecker) -> Decorato
             name: name.clone(),
             value: checker.type_info().const_value(name).map(safe_value_from_const),
         },
+        Expr::Field(base, field) => {
+            let mut path = decorator_expr_path(&base.node);
+            if path.is_empty() {
+                DecoratorValue::Unsupported {
+                    reason: "decorator field expression is not a symbolic path".to_string(),
+                }
+            } else {
+                path.push(field.clone());
+                DecoratorValue::SymbolRef { path }
+            }
+        }
+        Expr::List(entries) => DecoratorValue::List {
+            items: entries
+                .iter()
+                .map(|entry| match entry {
+                    ListEntry::Element(value) => decorator_expr_value(value, checker),
+                    ListEntry::Spread(value) => DecoratorValue::Unsupported {
+                        reason: format!(
+                            "decorator list spread `{}` is not declaration-safe metadata",
+                            decorator_expr_label(&value.node)
+                        ),
+                    },
+                })
+                .collect(),
+        },
+        Expr::Dict(entries) => {
+            let mut metadata_entries = Vec::new();
+            for entry in entries {
+                match entry {
+                    DictEntry::Pair(key, value) => metadata_entries.push(DecoratorDictEntry {
+                        key: decorator_expr_value(key, checker),
+                        value: decorator_expr_value(value, checker),
+                    }),
+                    DictEntry::Spread(value) => metadata_entries.push(DecoratorDictEntry {
+                        key: DecoratorValue::Unsupported {
+                            reason: "decorator dict spread has no declaration-safe key".to_string(),
+                        },
+                        value: decorator_expr_value(value, checker),
+                    }),
+                }
+            }
+            DecoratorValue::Dict {
+                entries: metadata_entries,
+            }
+        }
+        Expr::Call(callee, type_args, args) => {
+            let path = decorator_expr_path(&callee.node);
+            if path.is_empty() {
+                return DecoratorValue::Unsupported {
+                    reason: "decorator call callee is not a symbolic path".to_string(),
+                };
+            }
+            DecoratorValue::Call {
+                callee: path,
+                type_args: type_args
+                    .iter()
+                    .map(|type_arg| {
+                        type_ref_from_resolved(&crate::frontend::symbols::resolve_type(
+                            &type_arg.node,
+                            &checker.symbols,
+                        ))
+                    })
+                    .collect(),
+                args: args
+                    .iter()
+                    .map(|arg| decorator_call_arg_metadata(arg, checker))
+                    .collect(),
+            }
+        }
+        Expr::Constructor(name, args) => DecoratorValue::Call {
+            callee: vec![name.clone()],
+            type_args: Vec::new(),
+            args: args
+                .iter()
+                .map(|arg| decorator_call_arg_metadata(arg, checker))
+                .collect(),
+        },
         _ => DecoratorValue::Unsupported {
             reason: "decorator argument is not a literal, const reference, or type".to_string(),
         },
+    }
+}
+
+fn decorator_call_arg_metadata(arg: &CallArg, checker: &TypeChecker) -> DecoratorCallArgMetadata {
+    match arg {
+        CallArg::Positional(value) => DecoratorCallArgMetadata::Positional {
+            value: decorator_expr_value(value, checker),
+        },
+        CallArg::Named(name, value) => DecoratorCallArgMetadata::Named {
+            name: name.clone(),
+            value: decorator_expr_value(value, checker),
+        },
+        CallArg::PositionalUnpack(value) => DecoratorCallArgMetadata::PositionalUnpack {
+            value: decorator_expr_value(value, checker),
+        },
+        CallArg::KeywordUnpack(value) => DecoratorCallArgMetadata::KeywordUnpack {
+            value: decorator_expr_value(value, checker),
+        },
+    }
+}
+
+fn decorator_expr_path(expr: &Expr) -> Vec<String> {
+    match expr {
+        Expr::Ident(name) => vec![name.clone()],
+        Expr::Field(base, field) => {
+            let mut path = decorator_expr_path(&base.node);
+            if path.is_empty() {
+                return Vec::new();
+            }
+            path.push(field.clone());
+            path
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn decorator_expr_label(expr: &Expr) -> &'static str {
+    match expr {
+        Expr::Ident(_) => "identifier",
+        Expr::Literal(_) => "literal",
+        Expr::Call(_, _, _) | Expr::Constructor(_, _) => "call",
+        Expr::List(_) => "list",
+        Expr::Dict(_) => "dict",
+        Expr::Field(_, _) => "field",
+        _ => "expression",
     }
 }
 
@@ -1983,6 +2307,183 @@ pub def col(name: str) -> ColumnExpr:
             diagnostics.is_empty(),
             "expected generic decorator factory source signature to satisfy docstring validation, got {diagnostics:?}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn checked_api_metadata_projects_decorated_callable_context_issue694() -> Result<(), String> {
+        let source = r#"
+const EQUAL_FUNCTION_ANCHOR = "substrait.equal"
+
+model ColumnExpr:
+    name: str
+
+model FunctionLifecycle:
+    since: str
+    changed: List[str]
+    deprecated: Option[str]
+
+def extension_mapping(name: str, anchor: str) -> str:
+    return name
+
+def deterministic_spec(kind: str, lifecycle: FunctionLifecycle, mapping: str) -> str:
+    return kind
+
+def registered[F](spec: str) -> ((F) -> F):
+    return (func) => func
+
+@registered(deterministic_spec("scalar", FunctionLifecycle(since="v0.3", changed=[], deprecated=None), extension_mapping("equal", EQUAL_FUNCTION_ANCHOR)))
+pub def eq(left: ColumnExpr, right: ColumnExpr) -> ColumnExpr:
+    return left
+"#;
+        let metadata = metadata_for(source).map_err(|errs| format!("{errs:?}"))?;
+        let function = metadata
+            .declarations
+            .iter()
+            .find_map(|decl| match decl {
+                ApiDeclaration::Function(function) if function.name == "eq" => Some(function),
+                _ => None,
+            })
+            .ok_or_else(|| "expected decorated function metadata".to_string())?;
+        let decorator = function
+            .decorators
+            .first()
+            .ok_or_else(|| "expected decorator metadata".to_string())?;
+        let callable = decorator
+            .decorated_callable
+            .as_ref()
+            .ok_or_else(|| "expected decorated callable context".to_string())?;
+
+        assert_eq!(callable.name, "eq");
+        assert_eq!(
+            callable
+                .params
+                .iter()
+                .map(|param| (param.name.as_str(), &param.ty))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "left",
+                    &TypeRef::Named {
+                        name: "ColumnExpr".to_string(),
+                    },
+                ),
+                (
+                    "right",
+                    &TypeRef::Named {
+                        name: "ColumnExpr".to_string(),
+                    },
+                ),
+            ]
+        );
+        assert_eq!(
+            callable.return_type,
+            TypeRef::Named {
+                name: "ColumnExpr".to_string(),
+            }
+        );
+
+        let [
+            DecoratorArgMetadata::Positional {
+                value: DecoratorValue::Call { callee, args, .. },
+            },
+        ] = decorator.args.as_slice()
+        else {
+            return Err(format!(
+                "expected structured decorator call metadata, got {decorator:?}"
+            ));
+        };
+        assert_eq!(callee, &vec!["deterministic_spec".to_string()]);
+        let lifecycle_args = args
+            .iter()
+            .find_map(|arg| match arg {
+                DecoratorCallArgMetadata::Positional {
+                    value: DecoratorValue::Call { callee, args, .. },
+                } if callee == &vec!["FunctionLifecycle".to_string()] => Some(args),
+                _ => None,
+            })
+            .ok_or_else(|| format!("expected nested lifecycle constructor call metadata, got {args:?}"))?;
+        assert!(
+            lifecycle_args.iter().any(|arg| matches!(
+                arg,
+                DecoratorCallArgMetadata::Named {
+                    name,
+                    value: DecoratorValue::List { items },
+                } if name == "changed" && items.is_empty()
+            )),
+            "expected lifecycle `changed=[]` metadata, got {lifecycle_args:?}"
+        );
+        assert!(
+            lifecycle_args.iter().any(|arg| matches!(
+                arg,
+                DecoratorCallArgMetadata::Named {
+                    name,
+                    value: DecoratorValue::Literal {
+                        value: SafeMetadataValue::None,
+                    },
+                } if name == "deprecated"
+            )),
+            "expected lifecycle `deprecated=None` metadata, got {lifecycle_args:?}"
+        );
+        assert!(
+            args.iter().any(|arg| matches!(
+                arg,
+                DecoratorCallArgMetadata::Positional {
+                    value: DecoratorValue::Call { callee, args, .. },
+                } if callee == &vec!["extension_mapping".to_string()]
+                    && args.iter().any(|arg| matches!(
+                        arg,
+                        DecoratorCallArgMetadata::Positional {
+                            value: DecoratorValue::ConstRef {
+                                name,
+                                value: Some(SafeMetadataValue::String(value)),
+                            },
+                        } if name == "EQUAL_FUNCTION_ANCHOR" && value == "substrait.equal"
+                    ))
+            )),
+            "expected nested extension mapping call metadata with checked const ref, got {args:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn checked_api_metadata_rejects_non_symbolic_decorator_field_metadata() -> Result<(), String> {
+        let source = r#"
+model Holder:
+    value: str
+
+def holder() -> Holder:
+    return Holder(value="equal")
+
+def registered[F](name: str) -> ((F) -> F):
+    return (func) => func
+
+@registered(holder().value)
+pub def eq(left: int, right: int) -> int:
+    return left
+"#;
+        let metadata = metadata_for(source).map_err(|errs| format!("{errs:?}"))?;
+        let function = metadata
+            .declarations
+            .iter()
+            .find_map(|decl| match decl {
+                ApiDeclaration::Function(function) if function.name == "eq" => Some(function),
+                _ => None,
+            })
+            .ok_or_else(|| "expected decorated function metadata".to_string())?;
+        let [
+            DecoratorArgMetadata::Positional {
+                value: DecoratorValue::Unsupported { reason },
+            },
+        ] = function.decorators[0].args.as_slice()
+        else {
+            return Err(format!(
+                "expected non-symbolic field decorator argument to stay unsupported, got {:?}",
+                function.decorators[0].args
+            ));
+        };
+
+        assert_eq!(reason, "decorator field expression is not a symbolic path");
         Ok(())
     }
 

--- a/src/frontend/library_exports.rs
+++ b/src/frontend/library_exports.rs
@@ -6,9 +6,12 @@
 use std::collections::HashMap;
 
 use crate::frontend::ast::{
-    AliasDecl, ClassDecl, Declaration, DictEntry, EnumDecl, Expr, FunctionDecl, ListEntry, Literal, ModelDecl,
-    NewtypeDecl, PartialDecl, Program, Spanned, TraitBound, TraitDecl, TypeAliasDecl, TypeParam, Visibility,
+    AliasDecl, ClassDecl, Declaration, DictEntry, EnumDecl, Expr, FunctionDecl, ImportDecl, ImportItem, ImportKind,
+    ListEntry, Literal, ModelDecl, NewtypeDecl, PartialDecl, Program, Spanned, TraitBound, TraitDecl, TypeAliasDecl,
+    TypeParam, Visibility,
 };
+use crate::frontend::decorator_resolution;
+use crate::frontend::module::canonicalize_source_module_segments;
 use crate::frontend::symbols::{
     CallableParam, ClassInfo, FieldInfo, FunctionInfo, MethodInfo, ModelInfo, NewtypeInfo, ResolvedType, SymbolKind,
     TraitInfo, TypeBoundInfo, TypeInfo, ValueEnumBacking, ValueEnumValue, VariableInfo, resolve_type,
@@ -307,6 +310,9 @@ pub fn collect_checked_public_exports(program: &Program, checker: &TypeChecker) 
                     exports.push(export);
                 }
             }
+            Declaration::Import(import) if matches!(import.visibility, Visibility::Public) => {
+                exports.extend(checked_import_exports(import, checker));
+            }
             Declaration::Partial(partial) if matches!(partial.visibility, Visibility::Public) => {
                 if let Some(export) = checked_partial_export(partial, checker) {
                     exports.push(CheckedNamedExport {
@@ -326,10 +332,7 @@ pub fn collect_checked_public_exports(program: &Program, checker: &TypeChecker) 
 /// Build a checked public export entry for a module-level alias.
 fn checked_alias_export(alias: &AliasDecl, checker: &TypeChecker) -> Option<CheckedNamedExport> {
     let symbol = checker.lookup_symbol(alias.name.as_str())?;
-    let projected_function = match &symbol.kind {
-        SymbolKind::Function(info) => Some(checked_alias_function_export(&alias.name, info)),
-        _ => None,
-    };
+    let projected_function = checked_projected_function_export(&alias.name, &symbol.kind);
     Some(CheckedNamedExport {
         name: alias.name.clone(),
         kind: CheckedExportKind::Alias(CheckedAliasExport {
@@ -340,6 +343,57 @@ fn checked_alias_export(alias: &AliasDecl, checker: &TypeChecker) -> Option<Chec
     })
 }
 
+fn checked_import_exports(import: &ImportDecl, checker: &TypeChecker) -> Vec<CheckedNamedExport> {
+    match &import.kind {
+        ImportKind::From { module, items } => {
+            let base_path =
+                canonicalize_source_module_segments(&decorator_resolution::path_segments_with_prefix(module));
+            checked_import_item_exports(items, base_path, checker)
+        }
+        ImportKind::RustFrom {
+            crate_name,
+            path,
+            items,
+            ..
+        } => {
+            let mut base_path = vec!["rust".to_string(), crate_name.clone()];
+            base_path.extend(path.iter().cloned());
+            checked_import_item_exports(items, base_path, checker)
+        }
+        ImportKind::PubFrom { library, items } => {
+            let base_path = vec!["pub".to_string(), library.clone()];
+            checked_import_item_exports(items, base_path, checker)
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn checked_import_item_exports(
+    items: &[ImportItem],
+    base_path: Vec<String>,
+    checker: &TypeChecker,
+) -> Vec<CheckedNamedExport> {
+    items
+        .iter()
+        .map(|item| {
+            let exported_name = item.alias.as_ref().unwrap_or(&item.name).clone();
+            let mut target_path = base_path.clone();
+            target_path.push(item.name.clone());
+            let projected_function = checker
+                .lookup_symbol(exported_name.as_str())
+                .and_then(|symbol| checked_projected_function_export(&exported_name, &symbol.kind));
+            CheckedNamedExport {
+                name: exported_name.clone(),
+                kind: CheckedExportKind::Alias(CheckedAliasExport {
+                    name: exported_name,
+                    target_path,
+                    projected_function,
+                }),
+            }
+        })
+        .collect()
+}
+
 /// Build manifest-ready callable metadata for an alias that projects a function.
 fn checked_alias_function_export(name: &str, info: &FunctionInfo) -> CheckedFunctionExport {
     CheckedFunctionExport {
@@ -348,6 +402,23 @@ fn checked_alias_function_export(name: &str, info: &FunctionInfo) -> CheckedFunc
         params: info.params.clone(),
         return_type: info.return_type.clone(),
         is_async: info.is_async,
+    }
+}
+
+fn checked_projected_function_export(name: &str, kind: &SymbolKind) -> Option<CheckedFunctionExport> {
+    match kind {
+        SymbolKind::Function(info) => Some(checked_alias_function_export(name, info)),
+        SymbolKind::Variable(VariableInfo {
+            ty: ResolvedType::Function(params, return_type),
+            ..
+        }) => Some(CheckedFunctionExport {
+            name: name.to_string(),
+            type_params: Vec::new(),
+            params: params.clone(),
+            return_type: return_type.as_ref().clone(),
+            is_async: false,
+        }),
+        _ => None,
     }
 }
 
@@ -499,6 +570,9 @@ fn checked_preset_path(expr: &Expr) -> Vec<String> {
         Expr::Ident(name) => vec![name.clone()],
         Expr::Field(base, field) => {
             let mut path = checked_preset_path(&base.node);
+            if path.is_empty() {
+                return Vec::new();
+            }
             path.push(field.clone());
             path
         }
@@ -896,4 +970,28 @@ fn method_signature_sort_key(method: &CheckedMethod) -> String {
 fn sorted_vec(mut values: Vec<String>) -> Vec<String> {
     values.sort();
     values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frontend::ast::{Span, Spanned};
+
+    fn spanned(expr: Expr) -> Spanned<Expr> {
+        Spanned::new(expr, Span::default())
+    }
+
+    #[test]
+    fn checked_preset_value_rejects_non_symbolic_field_paths() {
+        let value = Expr::Field(
+            Box::new(spanned(Expr::Call(
+                Box::new(spanned(Expr::Ident("defaults".to_string()))),
+                Vec::new(),
+                Vec::new(),
+            ))),
+            "method".to_string(),
+        );
+
+        assert_eq!(checked_preset_value(&value), CheckedPresetValue::Unsupported);
+    }
 }

--- a/src/library_manifest/tests.rs
+++ b/src/library_manifest/tests.rs
@@ -241,6 +241,67 @@ fn manifest_validation_rejects_unsupported_rust_abi_schema_version() {
 }
 
 #[test]
+fn manifest_validation_rejects_unsupported_api_metadata_package_schema_version() {
+    let raw = format!(
+        r#"{{
+  "name": "mylib",
+  "version": "0.1.0",
+  "incan_version": "{}",
+  "manifest_format": {},
+  "exports": {{}},
+  "soft_keywords": {{}},
+  "contract_metadata": {{
+    "api": {{
+      "schema_version": {},
+      "package": null,
+      "modules": []
+    }}
+  }}
+}}"#,
+        crate::version::INCAN_VERSION,
+        LIBRARY_MANIFEST_FORMAT,
+        crate::frontend::api_metadata::CHECKED_API_METADATA_SCHEMA_VERSION + 1
+    );
+
+    let err = LibraryManifest::from_json_str(&raw);
+    assert!(err.is_err(), "expected unsupported API metadata schema to fail");
+}
+
+#[test]
+fn manifest_validation_rejects_unsupported_api_metadata_module_schema_version() {
+    let raw = format!(
+        r#"{{
+  "name": "mylib",
+  "version": "0.1.0",
+  "incan_version": "{}",
+  "manifest_format": {},
+  "exports": {{}},
+  "soft_keywords": {{}},
+  "contract_metadata": {{
+    "api": {{
+      "schema_version": {},
+      "package": null,
+      "modules": [
+        {{
+          "schema_version": {},
+          "module_path": ["lib"],
+          "declarations": []
+        }}
+      ]
+    }}
+  }}
+}}"#,
+        crate::version::INCAN_VERSION,
+        LIBRARY_MANIFEST_FORMAT,
+        crate::frontend::api_metadata::CHECKED_API_METADATA_SCHEMA_VERSION,
+        crate::frontend::api_metadata::CHECKED_API_METADATA_SCHEMA_VERSION + 1
+    );
+
+    let err = LibraryManifest::from_json_str(&raw);
+    assert!(err.is_err(), "expected unsupported API metadata module schema to fail");
+}
+
+#[test]
 fn manifest_io_round_trip_preserves_rest_parameter_metadata() -> Result<(), Box<dyn std::error::Error>> {
     let mut manifest = LibraryManifest::new("mylib", "0.1.0");
     manifest.exports.functions.push(FunctionExport {

--- a/src/library_manifest/validation.rs
+++ b/src/library_manifest/validation.rs
@@ -15,6 +15,7 @@ use super::{
     EnumExport, EnumValueExport, EnumValueTypeExport, LIBRARY_MANIFEST_FORMAT, LibraryManifestError, ParamExport,
     ParamKindExport, PartialExport, RUST_ABI_SCHEMA_VERSION, VocabProviderManifest,
 };
+use crate::frontend::api_metadata::CHECKED_API_METADATA_SCHEMA_VERSION;
 use crate::frontend::contract_metadata::CONTRACT_METADATA_SCHEMA_VERSION;
 
 /// Validate one raw manifest payload before it is written or decoded into the semantic model.
@@ -69,6 +70,23 @@ fn validate_contract_metadata(raw: &RawLibraryManifest) -> Result<(), LibraryMan
     metadata
         .validate()
         .map_err(|error| LibraryManifestError::Invalid(error.to_string()))?;
+
+    if let Some(api) = &raw.contract_metadata.api {
+        if api.schema_version != CHECKED_API_METADATA_SCHEMA_VERSION {
+            return Err(LibraryManifestError::Invalid(format!(
+                "contract_metadata.api.schema_version {} is unsupported (expected {})",
+                api.schema_version, CHECKED_API_METADATA_SCHEMA_VERSION
+            )));
+        }
+        for module in &api.modules {
+            if module.schema_version != CHECKED_API_METADATA_SCHEMA_VERSION {
+                return Err(LibraryManifestError::Invalid(format!(
+                    "contract_metadata.api.modules schema_version {} is unsupported (expected {})",
+                    module.schema_version, CHECKED_API_METADATA_SCHEMA_VERSION
+                )));
+            }
+        }
+    }
     Ok(())
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1681,6 +1681,101 @@ def main() -> None:
 }
 
 #[test]
+fn build_lib_materializes_facade_decorator_metadata_projection_issue695() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let producer_root = tmp.path().join("metadata_registry");
+    let src = producer_root.join("src");
+    let operators = src.join("functions").join("operators");
+    fs::create_dir_all(&operators)?;
+    fs::write(
+        producer_root.join("incan.toml"),
+        r#"[project]
+name = "metadata_registry"
+version = "0.1.0"
+"#,
+    )?;
+    fs::write(
+        src.join("registry.incn"),
+        r#"pub def registered[F](spec: str) -> ((F) -> F):
+    return (func) => func
+"#,
+    )?;
+    fs::write(
+        operators.join("eq.incn"),
+        r#"from registry import registered
+
+pub model ColumnExpr:
+    pub name: str
+
+@registered("equal")
+pub def eq(left: ColumnExpr, right: ColumnExpr) -> ColumnExpr:
+    return left
+"#,
+    )?;
+    fs::write(
+        operators.join("mod.incn"),
+        "pub from functions.operators.eq import eq\n",
+    )?;
+    fs::write(src.join("lib.incn"), "pub from functions.operators.mod import eq\n")?;
+
+    let producer_build = run_incan(&producer_root, &["build", "--lib"])?;
+    assert_success(
+        &producer_build,
+        "producer build --lib for decorator metadata projection issue695",
+    );
+
+    let manifest_path = producer_root
+        .join("target")
+        .join("lib")
+        .join("metadata_registry.incnlib");
+    let manifest: serde_json::Value = serde_json::from_str(&fs::read_to_string(&manifest_path)?)?;
+    assert!(
+        manifest.pointer("/exports/aliases/0/projected_function").is_some(),
+        "reexport-only facade should materialize callable alias projection in manifest exports, got:\n{manifest}"
+    );
+    let api_modules = manifest
+        .pointer("/contract_metadata/api/modules")
+        .and_then(|value| value.as_array())
+        .ok_or("expected checked API modules in manifest")?;
+    let lib_alias = api_modules
+        .iter()
+        .flat_map(|module| {
+            module
+                .pointer("/declarations")
+                .and_then(|value| value.as_array())
+                .into_iter()
+                .flatten()
+        })
+        .find(|decl| {
+            decl.pointer("/kind").and_then(|value| value.as_str()) == Some("alias")
+                && decl.pointer("/name").and_then(|value| value.as_str()) == Some("eq")
+                && decl.pointer("/projected_function").is_some()
+        })
+        .ok_or("expected projected eq alias declaration in checked API metadata")?;
+    assert_eq!(
+        lib_alias
+            .pointer("/projected_function/callable/name")
+            .and_then(|value| value.as_str()),
+        Some("eq")
+    );
+    assert_eq!(
+        lib_alias
+            .pointer("/projected_function/source_path")
+            .and_then(|value| value.as_array())
+            .map(|values| values.iter().filter_map(|value| value.as_str()).collect::<Vec<_>>()),
+        Some(vec!["functions", "operators", "eq", "eq"])
+    );
+    assert!(
+        lib_alias
+            .pointer("/projected_function/decorators/0/decorated_callable/name")
+            .and_then(|value| value.as_str())
+            == Some("eq"),
+        "projected decorator metadata should carry decorated callable identity/signature, got:\n{lib_alias}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_accepts_public_alias_of_imported_item_issue631() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "public_alias_test_reexport", "")?;

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -49,7 +49,7 @@ Use this section as the map. The release note names each larger feature, says wh
 
 - **Rust trait adoption from Incan source**: Newtypes and rusttypes can adopt Rust traits with `with Trait`, method-level `for Trait`, and associated type declarations. Read [Rust interop](../language/how-to/rust_interop.md), [Rust types for Python developers](../language/how-to/rust_types_for_python_devs.md), and [`std.traits`](../language/reference/stdlib/traits.md) ([RFC 043], #200).
 - **Derived and inspected Rust metadata**: Supported `@rust.derive(...)`, associated types, inspected Rust signatures, and metadata-backed call boundaries now survive further through generated calls. Read [Derives and traits](../language/explanation/derives_and_traits.md) and [Rust-shaped confidence](../language/explanation/rust_shaped_confidence.md) ([RFC 041], #175).
-- **Checked public API metadata**: Public declarations, aliases, partials, models, enum variants, and selected decorator metadata can be emitted for tools and downstream consumers. Read [Checked API metadata](../tooling/reference/checked_api_metadata.md) and [LSP protocol support](../tooling/reference/lsp_protocol_support.md) ([RFC 048], #205, #438).
+- **Checked public API metadata**: Public declarations, aliases, partials, models, enum variants, decorator-backed callable context, and facade alias projections can be emitted for tools and downstream consumers. Read [Checked API metadata](../tooling/reference/checked_api_metadata.md) and [LSP protocol support](../tooling/reference/lsp_protocol_support.md) ([RFC 048], #205, #438, #694, #695).
 
 ### Standard Library
 
@@ -106,7 +106,7 @@ This section is grouped by outcome rather than by every minimized repro. Issue n
 - **Cross-module codegen is more predictable**: Imported defaults qualify correctly, same-shaped union wrappers are shared, wide union narrowing lowers fully, keyword-named modules escape consistently, and public submodule reexports work under `src/` (#395, #457, #461, #458, #122, #287).
 - **Web registration keeps private internals private**: Private route handlers and models are retained for web registration without making them user-visible public API (#117).
 - **Package exports match ordinary builds**: Public aliases, package-boundary alias consumption, lowercase exported statics, imported static decorator strings, and keyword-named public symbols follow the same rules across build modes (#617, #631, #633, #658, #659).
-- **Decorator metadata crosses package boundaries**: Source signatures, imported/decorator `const str` arguments, generic decorator factories, and method-call decorator factories are represented in checked metadata more reliably (#636, #638, #640, #669).
+- **Decorator metadata crosses package boundaries**: Source signatures, imported/decorator `const str` arguments, generic decorator factories, method-call decorator factories, and reexport-only facade projections are represented in checked metadata more reliably (#636, #638, #640, #669, #694, #695).
 - **Script and test manifests are scoped**: Generated Cargo manifests include only reachable dependencies instead of blindly inheriting package-level heavy dependencies (#665).
 
 ### Formatter And Test Runner

--- a/workspaces/docs-site/docs/tooling/reference/checked_api_metadata.md
+++ b/workspaces/docs-site/docs/tooling/reference/checked_api_metadata.md
@@ -163,12 +163,16 @@ The metadata is derived from parsed and typechecked semantics. Public declaratio
 - public partial callable presets with target provenance, preset metadata, projected callable parameters, return type, and async status
 - raw docstring text when the declaration or method has a docstring
 - parsed docstring sections in `docstring_sections`, including summary, parameters, returns, fields, aliases, and decorators
-- decorator metadata with resolved decorator paths
+- decorator metadata with resolved decorator paths, safe argument projections, and decorated callable context when the decorator is attached to a callable declaration
 - safe const values for public consts and safe decorator arguments
 
 Types use the same structural `TypeRef` encoding as library manifest exports. For example, a non-generic type is encoded as `{"Named": {"name": "str"}}`, while a generic application is encoded as `{"Applied": {"name": "List", "args": [...]}}`.
 
-When decorator processing exposes a public function as a callable-valued binding, metadata follows that checked binding. In that case, function metadata reports the callable binding's parameters and return type rather than the original source signature. Existing decorator metadata remains attached separately through `decorators`, so consumers that inspect marker decorators, safe decorator arguments, or docstring `Decorators:` sections can keep using that lane without inferring binding types from it.
+Function metadata keeps the source declaration's public callable surface. For a decorated callable, each decorator entry also carries `decorated_callable`, which contains the decorated declaration's checked public identity, source anchor, type parameters, parameter names and types, return type, receiver when applicable, and async marker. Registry and catalog tooling should read that field instead of asking authors to repeat the decorated function name or signature in decorator arguments.
+
+Decorator arguments are represented structurally when the compiler can do so without executing user code. Literals, checked const references, symbolic references, lists, dicts, constructors, and ordinary calls can appear as metadata values. Unsupported expressions remain explicit `unsupported` entries.
+
+Public import aliases can include `projected_function` when the alias target resolves to a public function or callable-valued decorated binding. The projection includes the source declaration path, the callable signature under the alias name, and the source decorators. This lets reexport-only facades expose declaration metadata without no-op loader functions or runtime module initialization hooks.
 
 Public partial declarations use `kind: "partial"`. A partial declaration remains distinct from a hand-written function or alias:
 
@@ -198,7 +202,7 @@ Metadata only carries values that the compiler can expose without executing user
 | `bytes`  | Bytes literal or frozen bytes const   |
 | `none`   | Literal `None`                        |
 
-Decorator arguments that are not literals, type arguments, or const references are reported as `unsupported` metadata values instead of being evaluated.
+Decorator arguments that are not declaration-safe literals, const references, symbolic references, lists, dicts, constructors, or ordinary call trees are reported as `unsupported` metadata values instead of being evaluated.
 
 ## Docstrings
 
@@ -242,4 +246,4 @@ The metadata JSON describes public declarations from checked Incan source and ma
 
 Checked API metadata extraction does not inspect built `.incnlib` artifacts. Artifact inspection remains a separate tooling surface from source/project metadata extraction.
 
-The extractor exposes only checked compiler facts and safe literal/const values. Unsupported decorator expressions are reported as `unsupported` metadata rather than evaluated, and consumers should not treat docstrings or decorator payloads as trusted executable input.
+The extractor exposes only checked compiler facts and declaration-safe metadata values. Unsupported decorator expressions are reported as `unsupported` metadata rather than evaluated, and consumers should not treat docstrings or decorator payloads as trusted executable input.


### PR DESCRIPTION
## Summary

This PR adds checked decorator metadata projections for registry/catalog use cases. Decorator metadata now carries the decorated callable identity and checked source signature, public import aliases can materialize projected function metadata through reexport-only facades, and embedded checked API metadata in `.incnlib` manifests is schema-validated before consumers trust it.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Checked API metadata can now describe decorator-backed callable identity/signature without authors repeating the function name or signature in decorator arguments. Reexport-only facades can expose projected decorator metadata without no-op runtime loader hooks.
- **Internals**: Added `decorated_callable` and richer declaration-safe decorator argument values to API metadata, added alias `projected_function` materialization across checked API modules, made public import aliases participate in checked library exports, and validated checked API metadata schema inside library manifests.
- **Risks**: This extends serialized metadata shape additively. Consumers that assume exhaustive decorator value variants may need to handle the new value kinds.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo fmt --check` passed.
- `git diff --check origin/release/v0.3...HEAD` passed.
- `cargo check --features cli` passed after the final commit.
- Targeted #694/#695 and alias-regression tests passed during the Ralph loop.
- `make pre-commit` passed after the final code changes: 2485 tests, clippy, cargo-deny, smoke examples, and benchmark build smoke.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/tooling/reference/checked_api_metadata.md`, `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #694
Closes #695