### PR TITLE
bugfix - preserve Rust bridge identity across reexports (#705)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc20"
+version = "0.3.0-rc21"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/rust_inspect/src/cache.rs
+++ b/crates/rust_inspect/src/cache.rs
@@ -341,6 +341,43 @@ fn canonical_path_candidates(canonical_path: &str) -> Vec<String> {
     }
 }
 
+/// Return whether two Rust paths may name the same item after cache-supported spelling aliases.
+fn cache_path_aliases_match(left: &str, right: &str) -> bool {
+    let right_candidates = canonical_path_candidates(right);
+    canonical_path_candidates(left).iter().any(|left_candidate| {
+        right_candidates
+            .iter()
+            .any(|right_candidate| left_candidate == right_candidate)
+    })
+}
+
+/// Re-key a cached item for a query path while preserving the extracted Rust metadata.
+fn insert_aliased_item(
+    inner: &mut CacheInner,
+    root: &Path,
+    canonical_path: &str,
+    hit: &Arc<RustItemMetadata>,
+) -> Arc<RustItemMetadata> {
+    let mut aliased = (*hit.as_ref()).clone();
+    aliased.canonical_path = canonical_path.to_owned();
+    let arc = Arc::new(aliased);
+    let key_item = (root.to_path_buf(), canonical_path.to_owned());
+    inner.failed_items.remove(&key_item);
+    inner.items.insert(key_item, Arc::clone(&arc));
+    arc
+}
+
+/// Look up cached public aliases whose recorded definition path matches the requested path.
+fn cached_definition_alias(inner: &CacheInner, root: &Path, canonical_path: &str) -> Option<Arc<RustItemMetadata>> {
+    inner.items.iter().find_map(|((item_root, _), cached)| {
+        if item_root != root {
+            return None;
+        }
+        let definition = cached.definition_path.as_deref()?;
+        cache_path_aliases_match(definition, canonical_path).then(|| Arc::clone(cached))
+    })
+}
+
 /// Attempt extraction through primary workspace, out-dirs workspace, then resolved dependency workspace.
 fn extract_in_workspace_set(
     inner: &mut CacheInner,
@@ -584,7 +621,7 @@ impl RustMetadataCache {
     /// Return metadata for `canonical_path`, loading/extracting on cache miss.
     ///
     /// Lookup order is:
-    /// 1. in-memory exact/alias hits
+    /// 1. in-memory exact, definition-path, and spelling-alias hits
     /// 2. workspace extraction using canonical-path candidates
     /// 3. dependency-workspace extraction fallback
     /// 4. persisted disk-cache update for future sessions
@@ -620,6 +657,29 @@ impl RustMetadataCache {
             trace.set_outcome("hit.memory.exact");
             return Ok(Arc::clone(hit));
         }
+        if let Some(hit) = cached_definition_alias(&inner, &root, canonical_path) {
+            let arc = insert_aliased_item(&mut inner, &root, canonical_path, &hit);
+            let persist_started = Instant::now();
+            if let Err(err) = persist_item_to_disk_cache(&inner, &root, arc.as_ref())
+                && timing_enabled
+            {
+                eprintln!(
+                    "[rust-inspect-timing] root={} query={} stage=disk_cache.persist.definition_alias_hit status=error err={err}",
+                    root.display(),
+                    canonical_path
+                );
+            }
+            log_timing_stage(
+                timing_enabled,
+                &root,
+                canonical_path,
+                "disk_cache.persist.definition_alias_hit",
+                persist_started.elapsed(),
+                "",
+            );
+            trace.set_outcome("hit.memory.definition_alias");
+            return Ok(arc);
+        }
         if let Some(miss) = inner.failed_items.get(&key_item) {
             trace.set_outcome("hit.memory.negative");
             return Err(miss.to_error());
@@ -629,11 +689,8 @@ impl RustMetadataCache {
         let mut meta = None;
         for candidate in canonical_path_candidates(canonical_path) {
             let candidate_key = (root.clone(), candidate.clone());
-            if let Some(hit) = inner.items.get(&candidate_key) {
-                let mut aliased = (*hit.as_ref()).clone();
-                aliased.canonical_path = canonical_path.to_owned();
-                let arc = Arc::new(aliased);
-                inner.items.insert(key_item.clone(), Arc::clone(&arc));
+            if let Some(hit) = inner.items.get(&candidate_key).cloned() {
+                let arc = insert_aliased_item(&mut inner, &root, canonical_path, &hit);
                 let persist_started = Instant::now();
                 if let Err(err) = persist_item_to_disk_cache(&inner, &root, arc.as_ref())
                     && timing_enabled
@@ -761,13 +818,33 @@ impl RustMetadataCache {
             }));
         }
 
+        if let Some(hit) = cached_definition_alias(&inner, &root, canonical_path) {
+            let arc = insert_aliased_item(&mut inner, &root, canonical_path, &hit);
+            if let Err(err) = persist_item_to_disk_cache(&inner, &root, arc.as_ref()) {
+                tracing::warn!(
+                    root = %root.display(),
+                    query = %canonical_path,
+                    error = %err,
+                    "failed to persist rust-inspect disk cache after definition alias hit"
+                );
+                if rust_inspect_timing_enabled() {
+                    eprintln!(
+                        "[rust-inspect-timing] root={} query={} stage=disk_cache.persist.cached_definition_alias status=error err={err}",
+                        root.display(),
+                        canonical_path
+                    );
+                }
+            }
+            return Ok(Some(CacheLookupHit {
+                metadata: arc,
+                alias_used: true,
+            }));
+        }
+
         for candidate in canonical_path_candidates(canonical_path) {
             let candidate_key = (root.clone(), candidate.clone());
-            if let Some(hit) = inner.items.get(&candidate_key) {
-                let mut aliased = (*hit.as_ref()).clone();
-                aliased.canonical_path = canonical_path.to_owned();
-                let arc = Arc::new(aliased);
-                inner.items.insert(key_item.clone(), Arc::clone(&arc));
+            if let Some(hit) = inner.items.get(&candidate_key).cloned() {
+                let arc = insert_aliased_item(&mut inner, &root, canonical_path, &hit);
                 if let Err(err) = persist_item_to_disk_cache(&inner, &root, arc.as_ref()) {
                     tracing::warn!(
                         root = %root.display(),

--- a/crates/rust_inspect/src/cache_tests.rs
+++ b/crates/rust_inspect/src/cache_tests.rs
@@ -17,6 +17,21 @@ fn dummy_type_metadata(path: &str) -> RustItemMetadata {
     }
 }
 
+/// Build minimal public Rust type metadata that records its defining module path.
+fn dummy_reexported_type_metadata(path: &str, definition_path: &str) -> RustItemMetadata {
+    RustItemMetadata {
+        canonical_path: path.to_string(),
+        definition_path: Some(definition_path.to_string()),
+        visibility: RustVisibility::Public,
+        kind: RustItemKind::Type(RustTypeInfo {
+            methods: Vec::new(),
+            implemented_traits: Vec::new(),
+            fields: Vec::new(),
+            variants: Vec::new(),
+        }),
+    }
+}
+
 #[test]
 fn lockfile_registry_fallback_resolves_hyphenated_package_for_underscored_crate_name()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -162,6 +177,36 @@ fn raw_identifier_alias_hits_existing_cached_item() -> Result<(), Box<dyn std::e
 
     let hit = cache.get_or_extract(tmp.path(), "incan_stdlib::r#async::sync::RawSemaphore", &|_| ())?;
     assert_eq!(hit.canonical_path, "incan_stdlib::r#async::sync::RawSemaphore");
+    Ok(())
+}
+
+#[test]
+/// Definition paths should reuse cached public re-export metadata instead of forcing another extraction.
+fn definition_path_alias_hits_existing_cached_reexport() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+
+    let cache = RustMetadataCache::new();
+    cache.insert_test_item(
+        tmp.path(),
+        dummy_reexported_type_metadata("bridge::ScalarUDF", "bridge::udf::ScalarUDF"),
+    )?;
+
+    let hit = cache
+        .get_cached(tmp.path(), "bridge::udf::ScalarUDF")?
+        .ok_or_else(|| std::io::Error::other("expected definition-path cache alias hit"))?;
+    assert_eq!(hit.metadata.canonical_path, "bridge::udf::ScalarUDF");
+    assert_eq!(
+        hit.metadata.definition_path.as_deref(),
+        Some("bridge::udf::ScalarUDF")
+    );
+    assert!(hit.alias_used);
+
+    let extracted = cache.get_or_extract(tmp.path(), "bridge::udf::ScalarUDF", &|_| ())?;
+    assert_eq!(extracted.canonical_path, "bridge::udf::ScalarUDF");
     Ok(())
 }
 

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -28,24 +28,45 @@ impl TypeChecker {
     /// signature is known lets the next method call validate against its real signature instead of falling back to
     /// permissive unknown-method lowering.
     fn prewarm_rust_return_type_metadata(&self, ty: &ResolvedType) {
+        self.prewarm_rust_type_identity_metadata(ty);
+    }
+
+    /// Eagerly cache Rust identity metadata for nominal paths nested inside Rust display types.
+    ///
+    /// rust-inspect can report public signatures such as `Arc<crate::Type>` while another API returns the same type
+    /// through its defining module, for example `Arc<crate::private::Type>`. The outer generic wrapper is not the
+    /// semantic identity; the nested Rust path is. Prewarming those nested paths lets compatibility use cache-only
+    /// definition metadata instead of treating the two displays as unrelated nominal types.
+    fn prewarm_rust_type_identity_metadata(&self, ty: &ResolvedType) {
         match ty {
             ResolvedType::RustPath(path) => {
-                let _ = self.rust_item_metadata_for_path_blocking(path);
+                let (base, args) = self.rust_path_base_and_args(path);
+                if base.contains("::") {
+                    let _ = self.rust_item_metadata_for_path_blocking(base.as_str());
+                }
+                for arg in args {
+                    self.prewarm_rust_type_identity_metadata(&arg);
+                }
             }
-            ResolvedType::Ref(inner) | ResolvedType::RefMut(inner) => self.prewarm_rust_return_type_metadata(inner),
+            ResolvedType::Ref(inner) | ResolvedType::RefMut(inner) => self.prewarm_rust_type_identity_metadata(inner),
             ResolvedType::Generic(_, args) | ResolvedType::Tuple(args) => {
                 for arg in args {
-                    self.prewarm_rust_return_type_metadata(arg);
+                    self.prewarm_rust_type_identity_metadata(arg);
                 }
             }
             ResolvedType::FrozenList(inner) | ResolvedType::FrozenSet(inner) => {
-                self.prewarm_rust_return_type_metadata(inner);
+                self.prewarm_rust_type_identity_metadata(inner);
             }
             ResolvedType::FrozenDict(key, value) => {
-                self.prewarm_rust_return_type_metadata(key);
-                self.prewarm_rust_return_type_metadata(value);
+                self.prewarm_rust_type_identity_metadata(key);
+                self.prewarm_rust_type_identity_metadata(value);
             }
-            ResolvedType::Function(_, ret) => self.prewarm_rust_return_type_metadata(ret),
+            ResolvedType::Function(params, ret) => {
+                for param in params {
+                    self.prewarm_rust_type_identity_metadata(&param.ty);
+                }
+                self.prewarm_rust_type_identity_metadata(ret);
+            }
             _ => {}
         }
     }
@@ -414,6 +435,8 @@ impl TypeChecker {
             let arg_expr = Self::call_arg_expr(arg);
             let normalized = param.type_display.replace(' ', "");
             let target_ty = self.resolved_rust_boundary_target_from_param_display(param.type_display.as_str());
+            self.prewarm_rust_type_identity_metadata(arg_ty);
+            self.prewarm_rust_type_identity_metadata(&target_ty);
             if preserves_lookup_arg_shape && self.rust_lookup_probe_boundary_match(arg_ty, &target_ty) {
                 continue;
             }
@@ -467,6 +490,8 @@ impl TypeChecker {
             let arg_expr = Self::call_arg_expr(arg);
             let normalized = param.type_display.replace(' ', "");
             let target_ty = self.resolved_rust_boundary_target_from_param_display(param.type_display.as_str());
+            self.prewarm_rust_type_identity_metadata(arg_ty);
+            self.prewarm_rust_type_identity_metadata(&target_ty);
             match self.rust_arg_boundary_match(arg_ty, param.type_display.as_str()) {
                 RustArgBoundaryMatch::Exact => {}
                 RustArgBoundaryMatch::Coercion(kind) => {
@@ -504,6 +529,23 @@ mod validate_rust_function_call_tests {
     use incan_core::lang::types::numerics::NumericTypeId;
     use std::collections::HashMap;
 
+    #[cfg(feature = "rust_inspect")]
+    fn scalar_udf_metadata(path: &str, definition_path: &str) -> incan_core::interop::RustItemMetadata {
+        use incan_core::interop::{RustItemKind, RustTypeInfo, RustVisibility};
+
+        incan_core::interop::RustItemMetadata {
+            canonical_path: path.to_string(),
+            definition_path: Some(definition_path.to_string()),
+            visibility: RustVisibility::Public,
+            kind: RustItemKind::Type(RustTypeInfo {
+                methods: Vec::new(),
+                implemented_traits: Vec::new(),
+                fields: Vec::new(),
+                variants: Vec::new(),
+            }),
+        }
+    }
+
     #[test]
     fn zero_parameter_rust_sig_rejects_extra_arguments() {
         let mut checker = TypeChecker::new();
@@ -528,6 +570,61 @@ mod validate_rust_function_call_tests {
             "expected builtin_arity for 0-param Rust call with 1 arg, errors={:?}",
             checker.errors
         );
+    }
+
+    #[cfg(feature = "rust_inspect")]
+    #[test]
+    fn rust_function_call_matches_reexported_identity_inside_generic_wrapper() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut checker = TypeChecker::new();
+        let tmp = tempfile::tempdir()?;
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"incan_test_rust_generic_identity\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )?;
+        let manifest_dir = tmp.path().to_path_buf();
+        checker.set_rust_inspect_manifest_dir(manifest_dir.clone());
+        checker.rust_inspect_cache.insert_test_item(
+            &manifest_dir,
+            scalar_udf_metadata("bridge::ScalarUDF", "bridge::udf::ScalarUDF"),
+        )?;
+        checker.rust_inspect_cache.insert_test_item(
+            &manifest_dir,
+            scalar_udf_metadata("bridge::udf::ScalarUDF", "bridge::udf::ScalarUDF"),
+        )?;
+
+        let span = Span::new(10, 20);
+        checker.symbols.define(Symbol {
+            name: "udf".to_string(),
+            kind: SymbolKind::Variable(VariableInfo {
+                ty: ResolvedType::RustPath("rust::Arc<bridge::udf::ScalarUDF>".to_string()),
+                is_mutable: false,
+                is_used: false,
+            }),
+            span,
+            scope: 0,
+        });
+
+        let arg_expr = Spanned::new(Expr::Ident("udf".to_string()), span);
+        let args = [CallArg::Positional(arg_expr)];
+        let sig = RustFunctionSig {
+            params: vec![RustParam {
+                name: Some("udf".to_string()),
+                type_display: "Arc<bridge::ScalarUDF>".to_string(),
+            }],
+            return_type: "()".to_string(),
+            is_async: false,
+            is_unsafe: false,
+        };
+
+        let _ = checker.validate_rust_function_call("rust::bridge::consume_udf", &sig, &args, span);
+
+        assert!(
+            checker.errors.is_empty(),
+            "expected Rust re-export identity to match inside generic wrapper, errors={:?}",
+            checker.errors
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -543,9 +543,9 @@ impl TypeChecker {
         (Self::normalize_rust_namespace_path(trimmed).to_string(), Vec::new())
     }
 
-    fn attached_rust_definition_for_path(&self, canonical_path: &str) -> Option<String> {
+    fn rust_definition_for_path(&self, canonical_path: &str) -> Option<String> {
         let canonical_path = Self::normalize_rust_namespace_path(canonical_path);
-        self.symbols.all_symbols().iter().find_map(|sym| {
+        if let Some(definition) = self.symbols.all_symbols().iter().find_map(|sym| {
             let SymbolKind::RustItem(info) = &sym.kind else {
                 return None;
             };
@@ -553,19 +553,24 @@ impl TypeChecker {
                 return None;
             }
             info.metadata.as_ref().and_then(|meta| meta.definition_path.clone())
-        })
+        }) {
+            return Some(definition);
+        }
+        self.rust_item_metadata_for_path(canonical_path)
+            .and_then(|metadata| metadata.definition_path)
     }
 
     /// Extract the cheap Rust identity already known to the checker for compatibility checks.
     ///
     /// This must stay metadata-light. `types_compatible(...)` calls it frequently, so it may only use symbol-local
-    /// metadata already attached during import collection. Fresh rust-inspect extraction from this path would leak a
-    /// heavy workspace/indexing concern into ordinary semantic checks.
+    /// metadata already attached during import collection plus cache-only Rust ABI/rust-inspect reads. Fresh
+    /// rust-inspect extraction from this path would leak a heavy workspace/indexing concern into ordinary semantic
+    /// checks.
     fn rust_identity_for_type(&self, ty: &ResolvedType) -> Option<(String, Option<String>, Vec<ResolvedType>)> {
         match ty {
             ResolvedType::RustPath(path) => {
                 let (base, args) = self.rust_path_base_and_args(path);
-                let definition = self.attached_rust_definition_for_path(base.as_str());
+                let definition = self.rust_definition_for_path(base.as_str());
                 Some((base, definition, args))
             }
             ResolvedType::Named(name) => {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -632,6 +632,7 @@ decode_helper = { path = "rust/decode_helper" }
 decode_trait_helper = { path = "rust/decode_trait_helper" }
 prost = { path = "rust/prost" }
 prost-types = { path = "rust/prost-types" }
+reexport_identity = { path = "rust/reexport_identity" }
 "#,
     )?;
     fs::write(
@@ -639,6 +640,7 @@ prost-types = { path = "rust/prost-types" }
         r#"from borrowed_generic import borrowed_generic_case
 from by_value_decode import by_value_decode_case
 from cross_crate_decode import cross_crate_decode_case
+from reexport_identity import reexport_identity_case
 from trait_by_value_decode import trait_by_value_decode_case
 
 def main() -> None:
@@ -646,6 +648,7 @@ def main() -> None:
   println(by_value_decode_case())
   println(trait_by_value_decode_case())
   println(cross_crate_decode_case())
+  println(reexport_identity_case())
 "#,
     )?;
     fs::write(
@@ -694,6 +697,18 @@ pub def cross_crate_decode_case() -> str:
   match FileDescriptorSet.decode(encoded.as_slice()):
     Ok(_) => return "cross_crate:ok"
     Err(_) => return "cross_crate:err"
+"#,
+    )?;
+    fs::write(
+        tmp.path().join("src").join("reexport_identity.incn"),
+        r#"from rust::reexport_identity import Expr as RustExpr, ScalarFunction as RustScalarFunction, registry
+
+pub def reexport_identity_case() -> str:
+  state = registry()
+  udf = state.udf()
+  args: list[RustExpr] = []
+  _ = RustExpr.ScalarFunction(RustScalarFunction.new_udf(udf, args))
+  return "reexport_identity:ok"
 "#,
     )?;
 
@@ -840,6 +855,58 @@ impl prost::Message for FileDescriptorSet {
 }
 "#,
     )?;
+    let reexport_identity_src = tmp.path().join("rust").join("reexport_identity").join("src");
+    fs::create_dir_all(&reexport_identity_src)?;
+    fs::write(
+        reexport_identity_src
+            .parent()
+            .ok_or("reexport_identity src has no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "reexport_identity"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        reexport_identity_src.join("lib.rs"),
+        r#"use std::sync::Arc;
+
+pub mod udf {
+    pub struct ScalarUDF;
+}
+
+pub use udf::ScalarUDF;
+
+pub struct FunctionRegistry;
+
+pub fn registry() -> FunctionRegistry {
+    FunctionRegistry
+}
+
+impl FunctionRegistry {
+    pub fn udf(&self) -> Arc<udf::ScalarUDF> {
+        Arc::new(udf::ScalarUDF)
+    }
+}
+
+pub struct Expr;
+pub struct ScalarFunction;
+
+impl ScalarFunction {
+    pub fn new_udf(_udf: Arc<ScalarUDF>, _args: Vec<Expr>) -> Self {
+        Self
+    }
+}
+
+impl Expr {
+    #[allow(non_snake_case)]
+    pub fn ScalarFunction(_function: ScalarFunction) -> Self {
+        Self
+    }
+}
+"#,
+    )?;
 
     let output = run_incan(
         tmp.path(),
@@ -850,7 +917,7 @@ impl prost::Message for FileDescriptorSet {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert_eq!(
         stdout.trim(),
-        "borrowed:1\nby_value:ok\ntrait_by_value:ok\ncross_crate:ok",
+        "borrowed:1\nby_value:ok\ntrait_by_value:ok\ncross_crate:ok\nreexport_identity:ok",
         "expected batched generic Rust param output, got:\n{stdout}"
     );
     Ok(())

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -94,7 +94,7 @@ This section is grouped by outcome rather than by every minimized repro. Issue n
 ### Rust Interop And Generated Rust
 
 - **Borrowing decisions are metadata-backed**: Borrowed `str`/bytes calls, method fallback borrowing, and retained generated imports now follow the same decisions across typechecking, lowering, and emission.
-- **Rust bridge identity is preserved**: Inspected methods with unknown generic or lifetime placeholders and re-exported Rust argument displays keep stable bridge identity (#645, #630).
+- **Rust bridge identity is preserved**: Inspected methods with unknown generic or lifetime placeholders and re-exported Rust argument displays keep stable bridge identity, including nested generic wrappers such as `Arc<T>` (#645, #630, #705).
 - **Collection adaptation is less manual**: Owned Incan values can flow to shared borrowed generic Rust parameters, and `list[T]` can adapt to `Vec<U>` where metadata proves the boundary (#506, #128).
 - **Protobuf-style APIs need fewer workarounds**: Prost-style inherent and trait-provided `decode<T: Buf>(buf: T)` calls lower correctly (#609, #612).
 - **Generated Rust pruning is safer**: Enum-pattern imports and metadata-derived extension-trait imports survive pruning, while unused generated Rust is pruned without broad `allow` attributes (#459, #447, #214).


### PR DESCRIPTION
## Summary

This PR fixes Rust bridge type identity when a Rust API exposes the same nominal type through both a public re-export and its defining module path, including nested generic wrappers such as `Arc<T>`. The typechecker now prewarms Rust identity metadata for nested Rust path arguments before boundary matching, and `rust_inspect` can reuse cached public re-export metadata when a later lookup asks for the recorded `definition_path`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Rust bridge calls no longer reject equivalent re-exported and defining-module Rust types inside generic wrappers, avoiding DataFusion-style `ScalarUDF` false mismatches.
- **Internals**: Rust-boundary validation recursively prewarms nested Rust path metadata, type compatibility uses cache-backed definition identity, and `rust_inspect` resolves definition-path aliases from cached metadata without forcing a second extraction.
- **Risks**: This broadens Rust nominal compatibility only when rust-inspect metadata records a shared definition identity; the fallback exact-path behavior remains unchanged when metadata is unavailable.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p rust_inspect definition_path_alias_hits_existing_cached_reexport`
- `cargo test rust_function_call_matches_reexported_identity_inside_generic_wrapper --features rust_inspect`
- `cargo test --test cli_integration run_accepts_generic_rust_param_scenarios_share_one_generated_project`
- `git diff --check`
- `make pre-commit` passed after commit, including 2,498 nextest tests and `smoke-test-fast`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #705