### PR TITLE
bugfix - preserve Rust keyword call arguments (#718)

### DIFF
--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -6,7 +6,7 @@ use crate::frontend::diagnostics::errors;
 use crate::frontend::symbols::{CallableParam, ResolvedType, TypeInfo};
 use crate::frontend::typechecker::helpers::collection_type_id;
 use crate::frontend::typechecker::{RustArgCoercionInfo, RustArgCoercionKind};
-use incan_core::interop::{CoercionPolicy, RustFunctionSig, admitted_builtin_coercion};
+use incan_core::interop::{CoercionPolicy, RustFunctionSig, RustParam, admitted_builtin_coercion};
 use incan_core::lang::types::collections::CollectionTypeId;
 use incan_core::lang::types::numerics;
 
@@ -18,6 +18,12 @@ enum RustArgBoundaryMatch {
     Coercion(RustArgCoercionKind),
     /// Argument cannot satisfy the Rust parameter shape.
     NoMatch,
+}
+
+struct RustCallArgBinding<'a> {
+    arg: &'a CallArg,
+    arg_ty: &'a ResolvedType,
+    param: &'a RustParam,
 }
 
 impl TypeChecker {
@@ -378,22 +384,145 @@ impl TypeChecker {
         span: Span,
         params: &[incan_core::interop::RustParam],
         owner_path: &str,
+        force_exact: bool,
     ) {
         let params: Vec<CallableParam> = params
             .iter()
             .map(|param| {
-                CallableParam::positional(self.resolved_rust_boundary_target_from_param_display_for_owner_path(
+                let ty = self.resolved_rust_boundary_target_from_param_display_for_owner_path(
                     param.type_display.as_str(),
                     owner_path,
-                ))
+                );
+                CallableParam {
+                    name: param.name.clone(),
+                    ty,
+                    kind: ParamKind::Normal,
+                    has_default: false,
+                }
             })
             .collect();
         // Plain Rust type variables carry by-value shape, but they are not ordinary borrow-boundary snapshots.
-        if params.iter().any(|param| matches!(param.ty, ResolvedType::TypeVar(_))) {
+        if force_exact || params.iter().any(|param| matches!(param.ty, ResolvedType::TypeVar(_))) {
             self.type_info.record_call_site_callable_params_exact(span, &params);
         } else {
             self.type_info.record_call_site_callable_params(span, &params);
         }
+    }
+
+    fn bind_rust_call_args<'a>(
+        &mut self,
+        callable_display: &str,
+        params: &'a [RustParam],
+        args: &'a [CallArg],
+        arg_types: &'a [ResolvedType],
+        span: Span,
+    ) -> Vec<RustCallArgBinding<'a>> {
+        let has_keyword_args = args
+            .iter()
+            .any(|arg| matches!(arg, CallArg::Named(_, _) | CallArg::KeywordUnpack(_)));
+        let has_unpack_args = args
+            .iter()
+            .any(|arg| matches!(arg, CallArg::PositionalUnpack(_) | CallArg::KeywordUnpack(_)));
+        if !has_keyword_args || has_unpack_args {
+            if arg_types.len() != params.len() {
+                self.errors.push(errors::builtin_arity(
+                    callable_display,
+                    params.len(),
+                    arg_types.len(),
+                    span,
+                ));
+                return Vec::new();
+            }
+            return args
+                .iter()
+                .zip(arg_types.iter())
+                .zip(params.iter())
+                .map(|((arg, arg_ty), param)| RustCallArgBinding { arg, arg_ty, param })
+                .collect();
+        }
+
+        let mut params_by_name = std::collections::HashMap::new();
+        for (idx, param) in params.iter().enumerate() {
+            if let Some(name) = param.name.as_deref() {
+                params_by_name.insert(name, idx);
+            }
+        }
+
+        let mut bound_spans: Vec<Option<Span>> = vec![None; params.len()];
+        let mut named_seen: std::collections::HashMap<&str, Span> = std::collections::HashMap::new();
+        let mut positional_index = 0usize;
+        let mut unexpected_positional = 0usize;
+        let mut bindings = Vec::new();
+
+        for (arg, arg_ty) in args.iter().zip(arg_types.iter()) {
+            let arg_span = Self::call_arg_expr(arg).span;
+            match arg {
+                CallArg::Positional(_) => {
+                    if positional_index >= params.len() {
+                        unexpected_positional += 1;
+                        continue;
+                    }
+                    let param = &params[positional_index];
+                    if let Some(bound_span) = bound_spans[positional_index] {
+                        let name = param.name.as_deref().unwrap_or("<positional>");
+                        self.errors
+                            .push(errors::duplicate_call_argument(callable_display, name, bound_span));
+                    } else {
+                        bound_spans[positional_index] = Some(arg_span);
+                        bindings.push(RustCallArgBinding { arg, arg_ty, param });
+                    }
+                    positional_index += 1;
+                }
+                CallArg::Named(name, _) => {
+                    if let Some(first_span) = named_seen.insert(name.as_str(), arg_span) {
+                        self.errors
+                            .push(errors::duplicate_call_argument(callable_display, name, first_span));
+                    }
+                    let Some(param_index) = params_by_name.get(name.as_str()).copied() else {
+                        self.errors
+                            .push(errors::unknown_keyword_argument(callable_display, name, arg_span));
+                        continue;
+                    };
+                    if bound_spans[param_index].is_some() {
+                        self.errors
+                            .push(errors::duplicate_call_argument(callable_display, name, arg_span));
+                        continue;
+                    }
+                    let param = &params[param_index];
+                    bound_spans[param_index] = Some(arg_span);
+                    bindings.push(RustCallArgBinding { arg, arg_ty, param });
+                }
+                CallArg::PositionalUnpack(_) | CallArg::KeywordUnpack(_) => {}
+            }
+        }
+
+        if unexpected_positional > 0 {
+            self.errors.push(errors::builtin_arity(
+                callable_display,
+                params.len(),
+                params.len() + unexpected_positional,
+                span,
+            ));
+        }
+
+        let mut missing_unnamed_param = false;
+        for (idx, param) in params.iter().enumerate() {
+            if bound_spans[idx].is_some() {
+                continue;
+            }
+            if let Some(name) = param.name.as_deref() {
+                self.errors
+                    .push(errors::missing_required_argument(callable_display, name, span));
+            } else {
+                missing_unnamed_param = true;
+            }
+        }
+        if missing_unnamed_param {
+            self.errors
+                .push(errors::builtin_arity(callable_display, params.len(), args.len(), span));
+        }
+
+        bindings
     }
 
     /// Return whether a lookup-style Rust method should preserve the probe argument's emitted shape.
@@ -448,20 +577,21 @@ impl TypeChecker {
         } else {
             &sig.params
         };
-        self.record_rust_call_site_params(span, params, callable_display);
+        let has_keyword_args = args
+            .iter()
+            .any(|arg| matches!(arg, CallArg::Named(_, _) | CallArg::KeywordUnpack(_)));
+        self.record_rust_call_site_params(span, params, callable_display, has_keyword_args);
 
-        if arg_types.len() != params.len() {
-            self.errors.push(errors::builtin_arity(
-                callable_display,
-                params.len(),
-                arg_types.len(),
-                span,
-            ));
+        let binding_errors_before = self.errors.len();
+        let bindings = self.bind_rust_call_args(callable_display, params, args, arg_types, span);
+        if self.errors.len() != binding_errors_before {
             return self.resolved_rust_call_type_from_sig(sig, callable_display, span);
         }
 
-        for ((arg, arg_ty), param) in args.iter().zip(arg_types.iter()).zip(params.iter()) {
-            let arg_expr = Self::call_arg_expr(arg);
+        for binding in bindings {
+            let arg_expr = Self::call_arg_expr(binding.arg);
+            let arg_ty = binding.arg_ty;
+            let param = binding.param;
             let param_display = self.rust_display_for_owner_path(param.type_display.as_str(), callable_display);
             let normalized = param_display.replace(' ', "");
             let target_ty = self.resolved_rust_boundary_target_from_param_display_for_owner_path(
@@ -513,15 +643,20 @@ impl TypeChecker {
         }
         let expected_params = self.rust_params_as_callable_params(&sig.params, path);
         let arg_types = self.check_call_arg_types_for_params(args, &expected_params);
-        self.record_rust_call_site_params(span, &sig.params, path);
-        if arg_types.len() != sig.params.len() {
-            self.errors
-                .push(errors::builtin_arity(path, sig.params.len(), arg_types.len(), span));
+        let has_keyword_args = args
+            .iter()
+            .any(|arg| matches!(arg, CallArg::Named(_, _) | CallArg::KeywordUnpack(_)));
+        self.record_rust_call_site_params(span, &sig.params, path, has_keyword_args);
+        let binding_errors_before = self.errors.len();
+        let bindings = self.bind_rust_call_args(path, &sig.params, args, &arg_types, span);
+        if self.errors.len() != binding_errors_before {
             return self.resolved_rust_call_type_from_sig(sig, path, span);
         }
 
-        for ((arg, arg_ty), param) in args.iter().zip(arg_types.iter()).zip(sig.params.iter()) {
-            let arg_expr = Self::call_arg_expr(arg);
+        for binding in bindings {
+            let arg_expr = Self::call_arg_expr(binding.arg);
+            let arg_ty = binding.arg_ty;
+            let param = binding.param;
             let param_display = self.rust_display_for_owner_path(param.type_display.as_str(), path);
             let normalized = param_display.replace(' ', "");
             let target_ty =
@@ -716,6 +851,55 @@ mod validate_rust_function_call_tests {
             "expected arity error when call has fewer args than Rust params, errors={:?}",
             checker.errors
         );
+    }
+
+    #[test]
+    fn rust_function_call_binds_keyword_args_by_inspected_param_name() {
+        let mut checker = TypeChecker::new();
+        let span = Span::new(0, 60);
+        let text_span = Span::new(10, 20);
+        let count_span = Span::new(30, 31);
+        let args = [
+            CallArg::Named(
+                "text".to_string(),
+                Spanned::new(Expr::Literal(Literal::String("demo".to_string())), text_span),
+            ),
+            CallArg::Named(
+                "count".to_string(),
+                Spanned::new(Expr::Literal(Literal::Int(IntLiteral::synthetic(3))), count_span),
+            ),
+        ];
+        let sig = RustFunctionSig {
+            params: vec![
+                RustParam {
+                    name: Some("count".to_string()),
+                    type_display: "i64".to_string(),
+                },
+                RustParam {
+                    name: Some("text".to_string()),
+                    type_display: "&str".to_string(),
+                },
+            ],
+            return_type: "()".to_string(),
+            is_async: false,
+            is_unsafe: false,
+        };
+
+        let _ = checker.validate_rust_function_call("rust::crate::f", &sig, &args, span);
+
+        assert!(
+            checker.errors.is_empty(),
+            "expected keyword Rust call args to bind by parameter name, errors={:?}",
+            checker.errors
+        );
+        let recorded = checker
+            .type_info
+            .calls
+            .call_site_callable_params
+            .get(&(span.start, span.end))
+            .expect("keyword Rust calls should record exact call-site params for lowering");
+        let names: Vec<_> = recorded.iter().filter_map(|param| param.name.as_deref()).collect();
+        assert_eq!(names, vec!["count", "text"]);
     }
 
     #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -663,13 +663,13 @@ def callback(args: list[ColumnarValue]) -> Result[ColumnarValue, CallbackError]:
   return Ok(args[0].clone())
 
 def inline_arc_callback_value() -> int:
-  match create_udf("inline", Arc.from((args) => callback(args.to_vec()))):
+  match create_udf(callback=Arc.from((args) => callback(args.to_vec())), name="inline"):
     Ok(value) => return value.value()
     Err(_) => return -1
 
 pub def arc_callback_case() -> str:
   implementation: SliceCallback = Arc.from((args) => callback(args.to_vec()))
-  match create_udf("assigned", implementation):
+  match create_udf(callback=implementation, name="assigned"):
     Ok(value) => return f"arc_callback:{value.value()}:{inline_arc_callback_value()}"
     Err(_) => return "arc_callback:err"
 "#,
@@ -776,7 +776,8 @@ pub fn invoke(callback: SliceCallback) -> Result<ColumnarValue, CallbackError> {
     callback(&args)
 }
 
-pub fn create_udf(_name: &str, callback: crate::SliceCallback) -> Result<ColumnarValue, CallbackError> {
+pub fn create_udf(name: &str, callback: crate::SliceCallback) -> Result<ColumnarValue, CallbackError> {
+    let _ = name;
     let args = vec![ColumnarValue::new(11)];
     callback(&args)
 }

--- a/workspaces/docs-site/docs/language/how-to/rust_interop.md
+++ b/workspaces/docs-site/docs/language/how-to/rust_interop.md
@@ -220,6 +220,18 @@ When a library exposes Rust-backed items, run `incan build --lib` before another
 
 Consumers load that shipped ABI metadata first for Rust-backed imported symbols. `rust_inspect` remains available for producer capture, local workspace imports, and explicit fallback/debug paths, but a packaged dependency should not require consumer-side workspace inspection for signatures that were already published in its `.incnlib`.
 
+### Calling imported Rust functions
+
+Imported Rust free functions use ordinary Incan call syntax. When the compiler has inspected or shipped Rust signature metadata with parameter names, keyword arguments bind to those Rust parameters and lower to the positional Rust call shape that Cargo expects:
+
+```incan
+from rust::demo import create_widget
+
+widget = create_widget(name="primary", enabled=true)
+```
+
+If the Rust metadata does not include the named parameter, the compiler rejects the keyword argument instead of guessing a positional mapping.
+
 ### Qualified backing paths
 
 When a `rust::` import binds a Rust module (or other namespace), you can name a concrete type inside it with `::` after that binding:

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -50,6 +50,7 @@ Use this section as the map. The release note names each larger feature, says wh
 
 - **Rust trait adoption from Incan source**: Newtypes and rusttypes can adopt Rust traits with `with Trait`, method-level `for Trait`, and associated type declarations. Read [Rust interop](../language/how-to/rust_interop.md), [Rust types for Python developers](../language/how-to/rust_types_for_python_devs.md), and [`std.traits`](../language/reference/stdlib/traits.md) ([RFC 043], #200).
 - **Derived and inspected Rust metadata**: Supported `@rust.derive(...)`, associated types, inspected Rust signatures, and metadata-backed call boundaries now survive further through generated calls. Read [Derives and traits](../language/explanation/derives_and_traits.md) and [Rust-shaped confidence](../language/explanation/rust_shaped_confidence.md) ([RFC 041], #175).
+- **Rust imported calls follow Incan argument binding**: Imported Rust free functions can use keyword arguments when inspected or shipped Rust metadata provides parameter names; codegen lowers those calls to the positional Rust call shape (#718).
 - **Checked public API metadata**: Public declarations, aliases, partials, models, enum variants, decorator-backed callable context, and facade alias projections can be emitted for tools and downstream consumers. Read [Checked API metadata](../tooling/reference/checked_api_metadata.md) and [LSP protocol support](../tooling/reference/lsp_protocol_support.md) ([RFC 048], #205, #438, #694, #695).
 
 ### Standard Library


### PR DESCRIPTION
## Summary

This PR fixes imported Rust free-function calls that use Incan keyword arguments. The Rust boundary checker now preserves inspected Rust parameter names together with boundary target types, validates keyword arguments by those names, and records exact call-site metadata so lowering/codegen can emit the positional Rust call shape Cargo expects.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Imported Rust functions can be called with keyword arguments when inspected or shipped Rust metadata provides parameter names; unknown names are rejected rather than guessed.
- **Internals**: Rust call validation now binds source arguments to Rust parameters before applying Rust boundary coercions, and call-site metadata keeps parameter names plus Rust boundary target types in one handoff.
- **Risks**: The change is localized to metadata-backed Rust function and method calls. It intentionally preserves the existing positional fallback for calls without keyword arguments.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan validate_rust_function_call_tests --features lsp -- --nocapture` passed.
- `cargo test --test cli_integration run_accepts_generic_rust_param_scenarios_share_one_generated_project --features lsp -- --nocapture` passed.
- `git diff --check HEAD~1..HEAD` passed.
- `make pre-commit` passed before the docs amend, including `smoke-test-fast`; focused code checks were rerun after the final amend.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/language/how-to/rust_interop.md`, `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #718