### PR TITLE
bugfix - preserve vocab item modifiers and raw Rust keyword fields (#724, #725)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc30"
+version = "0.3.0-rc33"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -405,7 +405,10 @@ pub fn split_top_level_rust_args(text: &str) -> Vec<&str> {
 /// A public field surfaced on a Rust struct/union-like type.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RustFieldInfo {
-    /// Field name as it appears in Rust.
+    /// Source-facing Rust field name accepted by Incan, with raw identifier prefixes removed.
+    ///
+    /// A Rust field declared as `r#type` is surfaced as `type`; an ordinary Rust field declared as `type_` remains
+    /// `type_`. Codegen rawifies keyword names when emitting Rust.
     pub name: String,
     /// Pretty-printed type for diagnostics and debug output.
     pub type_display: String,

--- a/crates/incan_syntax/src/ast/stmts.rs
+++ b/crates/incan_syntax/src/ast/stmts.rs
@@ -28,6 +28,8 @@ pub enum Statement {
     For(ForStmt),
     /// Expression statement
     Expr(Spanned<Expr>),
+    /// DSL-owned expression-list item with declared trailing keyword metadata.
+    VocabExpressionItem(VocabExpressionItemStmt),
     /// `assert expr`, `assert expr, msg`, `assert call() raises Error`, or `assert value is Pattern`.
     Assert(AssertStmt),
     /// `pass` or `...`
@@ -228,6 +230,21 @@ pub struct VocabKeywordBinding {
     pub activation_namespace: String,
     pub surface_kind: incan_vocab::KeywordSurfaceKind,
     pub placement: incan_vocab::KeywordPlacement,
+    pub clause_body_kind: Option<incan_vocab::ClauseBodyKind>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VocabExpressionItemStmt {
+    pub expr: Spanned<Expr>,
+    pub alias: Option<Ident>,
+    pub modifiers: Vec<VocabExpressionItemModifierStmt>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VocabExpressionItemModifierStmt {
+    pub keyword: String,
+    pub value: Spanned<Expr>,
+    pub span: Span,
 }
 
 /// Raw vocab block statement captured before desugaring.

--- a/crates/incan_syntax/src/parser/core.rs
+++ b/crates/incan_syntax/src/parser/core.rs
@@ -28,6 +28,8 @@ struct ActiveImportedKeywordSpec {
     valid_decorators: Vec<String>,
     surface_kind: incan_vocab::KeywordSurfaceKind,
     placement: incan_vocab::KeywordPlacement,
+    clause_body_kind: Option<incan_vocab::ClauseBodyKind>,
+    expression_item_modifiers: Vec<incan_vocab::ExpressionItemModifierSurface>,
 }
 
 #[derive(Debug, Clone)]
@@ -62,6 +64,8 @@ pub struct Parser<'a> {
     active_soft_keywords: std::collections::HashSet<KeywordId>,
     active_imported_keyword_specs: std::collections::HashMap<String, Vec<ActiveImportedKeywordSpec>>,
     vocab_block_stack: Vec<String>,
+    vocab_body_kind_stack: Vec<Option<incan_vocab::ClauseBodyKind>>,
+    vocab_expression_item_modifier_stack: Vec<Vec<incan_vocab::ExpressionItemModifierSurface>>,
     module_path: Option<String>,
     library_imported_vocab: ImportedLibraryVocab,
     library_imported_dsl_surfaces: ImportedLibraryDslSurfaces,
@@ -120,6 +124,8 @@ impl<'a> Parser<'a> {
             active_soft_keywords: std::collections::HashSet::new(),
             active_imported_keyword_specs: std::collections::HashMap::new(),
             vocab_block_stack: Vec::new(),
+            vocab_body_kind_stack: Vec::new(),
+            vocab_expression_item_modifier_stack: Vec::new(),
             module_path,
             library_imported_vocab: library_imported_vocab.cloned().unwrap_or_default(),
             library_imported_dsl_surfaces: library_imported_dsl_surfaces.cloned().unwrap_or_default(),
@@ -346,6 +352,10 @@ impl<'a> Parser<'a> {
             }
 
             for keyword in &registration.keywords {
+                let (clause_body_kind, expression_item_modifiers) = self
+                    .active_clause_surface_for_keyword(library, keyword)
+                    .map(|clause| (Some(clause.body_kind), clause.expression_item_modifiers.clone()))
+                    .unwrap_or((None, Vec::new()));
                 let specs = self
                     .active_imported_keyword_specs
                     .entry(keyword.name.clone())
@@ -360,6 +370,8 @@ impl<'a> Parser<'a> {
                     valid_decorators: registration.valid_decorators.clone(),
                     surface_kind: keyword.surface_kind,
                     placement: keyword.placement.clone(),
+                    clause_body_kind,
+                    expression_item_modifiers,
                 });
                 if let Some(id) = incan_core::lang::keywords::from_str(&keyword.name)
                     && incan_core::lang::keywords::is_soft(id)
@@ -368,6 +380,38 @@ impl<'a> Parser<'a> {
                 }
             }
         }
+    }
+
+    /// Return the clause surface declared by a rich DSL surface for one imported keyword.
+    ///
+    /// Low-level keyword registrations do not carry clause-body structure. When the same library also provides the
+    /// author-facing `DslSurface`, parser-only forms such as expression-list item modifiers can be gated by the richer
+    /// public contract instead of guessed later by the AST bridge.
+    fn active_clause_surface_for_keyword(
+        &self,
+        library: &str,
+        keyword: &incan_vocab::KeywordSpec,
+    ) -> Option<&incan_vocab::ClauseSurface> {
+        let surfaces = self.library_imported_dsl_surfaces.get(library)?;
+        for surface in surfaces {
+            if !dsl_surface_applies_to_pub_import(surface, library) {
+                continue;
+            }
+            for declaration in &surface.declarations {
+                let incan_vocab::KeywordPlacement::InBlock(parents) = &keyword.placement else {
+                    continue;
+                };
+                if !parents.iter().any(|parent| parent == &declaration.keyword) {
+                    continue;
+                }
+                for clause in &declaration.clauses {
+                    if clause.keyword == keyword.name && clause.compound_tokens == keyword.compound_tokens {
+                        return Some(clause);
+                    }
+                }
+            }
+        }
+        None
     }
 }
 

--- a/crates/incan_syntax/src/parser/stmts.rs
+++ b/crates/incan_syntax/src/parser/stmts.rs
@@ -180,6 +180,8 @@ impl<'a> Parser<'a> {
         let spec_surface_kind = spec.surface_kind;
         let spec_placement = spec.placement.clone();
         let spec_valid_decorators = spec.valid_decorators.clone();
+        let spec_clause_body_kind = spec.clause_body_kind;
+        let spec_expression_item_modifiers = spec.expression_item_modifiers.clone();
 
         // Avoid committing to vocab-block parsing unless a top-level header-delimiting `:` is visible ahead. This
         // preserves `assignment_or_expr_stmt` fallback for statements like `route = "/health"`, `route(args)`, and
@@ -223,8 +225,13 @@ impl<'a> Parser<'a> {
         }
 
         self.vocab_block_stack.push(keyword_name.clone());
+        self.vocab_body_kind_stack.push(spec_clause_body_kind);
+        self.vocab_expression_item_modifier_stack
+            .push(spec_expression_item_modifiers);
         let body = self.block();
         self.vocab_block_stack.pop();
+        self.vocab_body_kind_stack.pop();
+        self.vocab_expression_item_modifier_stack.pop();
         let body = body?;
         self.expect(&TokenKind::Dedent, "Expected dedent after vocab block body")?;
 
@@ -235,6 +242,7 @@ impl<'a> Parser<'a> {
                 activation_namespace: spec_activation_namespace,
                 surface_kind: spec_surface_kind,
                 placement: spec_placement,
+                clause_body_kind: spec_clause_body_kind,
             },
             decorators,
             header_args,
@@ -803,6 +811,10 @@ impl<'a> Parser<'a> {
         // Parse the expression (could be field access like self.field or index like arr[i])
         let expr = self.expression()?;
 
+        if let Some(item) = self.vocab_expression_list_item_tail(expr.clone())? {
+            return Ok(Statement::VocabExpressionItem(item));
+        }
+
         // Check for tuple assignment: expr, expr, ... = value
         // This handles patterns like: arr[i], arr[j] = arr[j], arr[i]
         if self.match_token(&TokenKind::Punctuation(PunctuationId::Comma)) {
@@ -890,6 +902,88 @@ impl<'a> Parser<'a> {
 
         // Otherwise it's an expression statement
         Ok(Statement::Expr(expr))
+    }
+
+    /// Return whether the current vocab body is contractually an expression list.
+    fn vocab_expression_list_items_enabled(&self) -> bool {
+        matches!(
+            self.vocab_body_kind_stack.last(),
+            Some(Some(incan_vocab::ClauseBodyKind::ExpressionList))
+        )
+    }
+
+    /// Parse declared trailing keyword payloads for one expression-list item.
+    fn vocab_expression_list_item_tail(
+        &mut self,
+        expr: Spanned<Expr>,
+    ) -> Result<Option<VocabExpressionItemStmt>, CompileError> {
+        if !self.vocab_expression_list_items_enabled() {
+            return Ok(None);
+        }
+
+        let mut alias = None;
+        let mut modifiers = Vec::new();
+        let mut saw_tail = false;
+
+        while let Some(surface) = self.current_expression_item_modifier_surface() {
+            let keyword_span = self.current_span();
+            self.advance();
+            saw_tail = true;
+            match surface.kind {
+                incan_vocab::ExpressionItemModifierKind::Alias => {
+                    if alias.is_some() {
+                        return Err(CompileError::syntax(
+                            format!("Duplicate expression-list alias modifier `{}`", surface.keyword),
+                            keyword_span,
+                        ));
+                    }
+                    alias = Some(self.identifier()?);
+                }
+                incan_vocab::ExpressionItemModifierKind::Expression => {
+                    let value = self.expression()?;
+                    let span = Span::new(keyword_span.start, value.span.end);
+                    modifiers.push(VocabExpressionItemModifierStmt {
+                        keyword: surface.keyword,
+                        value,
+                        span,
+                    });
+                }
+                _ => {
+                    return Err(CompileError::syntax(
+                        format!("Unsupported expression-list modifier kind for `{}`", surface.keyword),
+                        keyword_span,
+                    ));
+                }
+            }
+        }
+
+        if saw_tail {
+            Ok(Some(VocabExpressionItemStmt {
+                expr,
+                alias,
+                modifiers,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Return the declared expression-list item modifier matching the current token.
+    fn current_expression_item_modifier_surface(&self) -> Option<incan_vocab::ExpressionItemModifierSurface> {
+        let keyword = self.current_vocab_word_token()?;
+        self.vocab_expression_item_modifier_stack
+            .last()
+            .and_then(|modifiers| modifiers.iter().find(|modifier| modifier.keyword == keyword))
+            .cloned()
+    }
+
+    /// Return the current identifier/keyword spelling when it can start a DSL-owned item modifier.
+    fn current_vocab_word_token(&self) -> Option<&str> {
+        match &self.peek().kind {
+            TokenKind::Ident(name) => Some(name.as_str()),
+            TokenKind::Keyword(id) => Some(incan_core::lang::keywords::as_str(*id)),
+            _ => None,
+        }
     }
 
     /// Convert an assignment operator token such as `+=` or `<<=` into its AST compound operator.

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -4498,6 +4498,69 @@ def has_name(name: str | None) -> bool:
     }
 
     #[test]
+    fn test_expression_list_clause_accepts_declared_item_modifiers() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "import pub::analytics\n\ndef configure() -> None:\n  query:\n    SELECT:\n      sum(amount) as total for customer with context\n      amount\n";
+        let tokens = crate::lexer::lex(source).map_err(|errs| format!("lex errors: {errs:?}"))?;
+
+        let metadata = incan_vocab::VocabRegistration::new()
+            .with_surface(
+                incan_vocab::DslSurface::on_import("analytics.query").with_declaration(
+                    incan_vocab::DeclarationSurface::named("query")
+                        .with_clause_body()
+                        .with_clause(
+                            incan_vocab::ClauseSurface::expr_list("SELECT")
+                                .with_expression_item_modifiers([
+                                    incan_vocab::ExpressionItemModifierSurface::expr("for"),
+                                    incan_vocab::ExpressionItemModifierSurface::expr("with"),
+                                ])
+                                .required(),
+                        ),
+                ),
+            )
+            .metadata();
+        let mut keyword_map = std::collections::HashMap::new();
+        keyword_map.insert("analytics".to_string(), metadata.keyword_registrations);
+        let mut surface_map = std::collections::HashMap::new();
+        surface_map.insert("analytics".to_string(), metadata.dsl_surfaces);
+
+        let program =
+            crate::parser::parse_with_context_and_surfaces(&tokens, None, Some(&keyword_map), Some(&surface_map))
+                .map_err(|errs| format!("parse errors: {errs:?}"))?;
+        let function = match &program.declarations[1].node {
+            crate::ast::Declaration::Function(function) => function,
+            other => return Err(format!("expected function declaration, got {other:?}").into()),
+        };
+        let crate::ast::Statement::VocabBlock(query_block) = &function.body[0].node else {
+            return Err(format!("expected query vocab block, got {:?}", function.body[0].node).into());
+        };
+        let crate::ast::Statement::VocabBlock(select_block) = &query_block.body[0].node else {
+            return Err(format!("expected SELECT clause block, got {:?}", query_block.body[0].node).into());
+        };
+        assert_eq!(
+            select_block.keyword_binding.clause_body_kind,
+            Some(incan_vocab::ClauseBodyKind::ExpressionList)
+        );
+        assert!(matches!(
+            &select_block.body[0].node,
+            crate::ast::Statement::VocabExpressionItem(item)
+                if item.alias.as_deref() == Some("total")
+                    && item.modifiers.len() == 2
+                    && item.modifiers[0].keyword == "for"
+                    && matches!(&item.modifiers[0].value.node, crate::ast::Expr::Ident(name) if name == "customer")
+                    && item.modifiers[1].keyword == "with"
+                    && matches!(&item.modifiers[1].value.node, crate::ast::Expr::Ident(name) if name == "context")
+                    && matches!(&item.expr.node, crate::ast::Expr::Call(callee, _, _)
+                        if matches!(&callee.node, crate::ast::Expr::Ident(name) if name == "sum"))
+        ));
+        assert!(matches!(
+            &select_block.body[1].node,
+            crate::ast::Statement::Expr(expr)
+                if matches!(&expr.node, crate::ast::Expr::Ident(name) if name == "amount")
+        ));
+        Ok(())
+    }
+
+    #[test]
     fn test_scoped_symbol_descriptor_does_not_change_call_outside_vocab_block()
     -> Result<(), Box<dyn std::error::Error>> {
         let source = "import pub::analytics\n\ndef configure() -> None:\n  sum(amount)\n";

--- a/crates/incan_vocab/README.md
+++ b/crates/incan_vocab/README.md
@@ -74,7 +74,9 @@ Version 0.2.0 is the RFC 040 release. It adds the stable library-author contract
 Companion crates should export one obvious Rust function:
 
 ```rust
-use incan_vocab::{ClauseSurface, DeclarationSurface, DslSurface, VocabRegistration};
+use incan_vocab::{
+    ClauseSurface, DeclarationSurface, DslSurface, ExpressionItemModifierSurface, VocabRegistration,
+};
 
 pub fn library_vocab() -> VocabRegistration {
     VocabRegistration::new().with_surface(
@@ -84,7 +86,10 @@ pub fn library_vocab() -> VocabRegistration {
                 .desugars_to_expression()
                 .with_clauses([
                     ClauseSurface::expr("FROM").required(),
-                    ClauseSurface::expr_list("SELECT").required().after("FROM"),
+                    ClauseSurface::expr_list("SELECT")
+                        .with_expression_item_modifier(ExpressionItemModifierSurface::expr("for"))
+                        .required()
+                        .after("FROM"),
                 ]),
         ),
     )

--- a/crates/incan_vocab/src/ast.rs
+++ b/crates/incan_vocab/src/ast.rs
@@ -124,6 +124,33 @@ pub struct VocabFieldSpec {
     pub span: Span,
 }
 
+/// One trailing keyword payload parsed after an expression-list item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct VocabExpressionItemModifier {
+    /// Keyword that introduced this payload.
+    pub keyword: String,
+    /// Expression payload captured after the keyword.
+    pub value: IncanExpr,
+    /// Source span for this modifier.
+    pub span: Span,
+}
+
+/// One expression-list entry parsed inside a DSL-owned clause body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct VocabExpressionItem {
+    /// Expression payload.
+    pub expr: IncanExpr,
+    /// Optional SQL-style alias from `expr as alias`.
+    pub alias: Option<String>,
+    /// Additional declared trailing keyword payloads, such as `expr for target with context`.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub modifiers: Vec<VocabExpressionItemModifier>,
+    /// Source span for this expression-list item.
+    pub span: Span,
+}
+
 /// A DSL-owned clause such as `FROM`, `SELECT`, `config`, or `input`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -152,8 +179,8 @@ pub enum VocabClauseBody {
     Empty,
     /// A single expression payload.
     Expression(IncanExpr),
-    /// A list of expressions, typically separated by commas or lines.
-    ExpressionList(Vec<IncanExpr>),
+    /// A list of expression entries, typically separated by commas or lines.
+    ExpressionList(Vec<VocabExpressionItem>),
     /// An opaque host-language type payload.
     Type(VocabTypeExpr),
     /// A field/config-style body.

--- a/crates/incan_vocab/src/keywords.rs
+++ b/crates/incan_vocab/src/keywords.rs
@@ -270,6 +270,48 @@ pub enum ClauseBodyKind {
     NestedItems,
 }
 
+/// Payload parser for a trailing keyword on one expression-list item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum ExpressionItemModifierKind {
+    /// The trailing keyword captures an alias identifier, such as `expr as name`.
+    #[default]
+    Alias,
+    /// The trailing keyword captures another expression, such as `expr for target`.
+    Expression,
+}
+
+/// One trailing keyword accepted after an expression-list item.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ExpressionItemModifierSurface {
+    /// Keyword spelling consumed after the leading item expression.
+    pub keyword: String,
+    /// Payload shape consumed after the keyword.
+    pub kind: ExpressionItemModifierKind,
+}
+
+impl ExpressionItemModifierSurface {
+    /// Create an alias modifier such as `expr as alias`.
+    #[must_use]
+    pub fn alias(keyword: &str) -> Self {
+        Self {
+            keyword: keyword.to_string(),
+            kind: ExpressionItemModifierKind::Alias,
+        }
+    }
+
+    /// Create an expression modifier such as `expr for target`.
+    #[must_use]
+    pub fn expr(keyword: &str) -> Self {
+        Self {
+            keyword: keyword.to_string(),
+            kind: ExpressionItemModifierKind::Expression,
+        }
+    }
+}
+
 /// Relative placement of one clause within a declaration's clause grammar.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -309,6 +351,9 @@ pub struct ClauseSurface {
     pub compound_tokens: Vec<String>,
     /// Structured body payload kind for this clause.
     pub body_kind: ClauseBodyKind,
+    /// Trailing keyword payloads accepted after expression-list items.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub expression_item_modifiers: Vec<ExpressionItemModifierSurface>,
     /// Whether the clause is required, optional, or repeatable.
     pub cardinality: ClauseCardinality,
     /// Relative ordering guidance within the owning declaration.
@@ -323,6 +368,7 @@ impl ClauseSurface {
             keyword: keyword.to_string(),
             compound_tokens: Vec::new(),
             body_kind,
+            expression_item_modifiers: default_expression_item_modifiers(body_kind),
             cardinality: ClauseCardinality::Optional,
             placement: ClausePlacement::Anywhere,
         }
@@ -335,6 +381,10 @@ impl ClauseSurface {
     }
 
     /// Create an expression-list clause from its full spelling.
+    ///
+    /// Expression-list clauses preserve each item as [`crate::VocabExpressionItem`]. They accept SQL-style `expr as
+    /// alias` by default and can declare more trailing keyword payloads with
+    /// [`Self::with_expression_item_modifier`].
     #[must_use]
     pub fn expr_list(spelling: &str) -> Self {
         Self::from_spelling(spelling, ClauseBodyKind::ExpressionList)
@@ -358,12 +408,14 @@ impl ClauseSurface {
         Self::from_spelling(spelling, ClauseBodyKind::NestedItems)
     }
 
+    /// Create a clause from a full spelling and attach any defaults implied by its body kind.
     fn from_spelling(spelling: &str, body_kind: ClauseBodyKind) -> Self {
         let (keyword, compound_tokens) = split_spelling(spelling);
         Self {
             keyword,
             compound_tokens,
             body_kind,
+            expression_item_modifiers: default_expression_item_modifiers(body_kind),
             cardinality: ClauseCardinality::Optional,
             placement: ClausePlacement::Anywhere,
         }
@@ -377,6 +429,31 @@ impl ClauseSurface {
         S: Into<String>,
     {
         self.compound_tokens = compound_tokens.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add one trailing keyword parser for expression-list items.
+    #[must_use]
+    pub fn with_expression_item_modifier(mut self, modifier: ExpressionItemModifierSurface) -> Self {
+        if !self
+            .expression_item_modifiers
+            .iter()
+            .any(|existing| existing.keyword == modifier.keyword)
+        {
+            self.expression_item_modifiers.push(modifier);
+        }
+        self
+    }
+
+    /// Add multiple trailing keyword parsers for expression-list items.
+    #[must_use]
+    pub fn with_expression_item_modifiers<I>(mut self, modifiers: I) -> Self
+    where
+        I: IntoIterator<Item = ExpressionItemModifierSurface>,
+    {
+        for modifier in modifiers {
+            self = self.with_expression_item_modifier(modifier);
+        }
         self
     }
 
@@ -413,6 +490,15 @@ impl ClauseSurface {
     pub fn after(mut self, other_clause: &str) -> Self {
         self.placement = ClausePlacement::After(other_clause.to_string());
         self
+    }
+}
+
+/// Return expression-list item modifiers that are part of the built-in high-level clause contract.
+fn default_expression_item_modifiers(body_kind: ClauseBodyKind) -> Vec<ExpressionItemModifierSurface> {
+    if matches!(body_kind, ClauseBodyKind::ExpressionList) {
+        vec![ExpressionItemModifierSurface::alias("as")]
+    } else {
+        Vec::new()
     }
 }
 

--- a/crates/incan_vocab/src/lib.rs
+++ b/crates/incan_vocab/src/lib.rs
@@ -45,8 +45,8 @@ pub use ast::{
     Decorator, DecoratorArg, DecoratorArgValue, IncanBinaryOp, IncanExpr, IncanRaceForArm, IncanRaceForBody,
     IncanRaceForExpr, IncanScopedSurfaceExpr, IncanScopedSurfaceOwner, IncanScopedSurfacePayload,
     IncanScopedSymbolCall, IncanStatement, IncanUnaryOp, Span, VocabBodyItem, VocabClause, VocabClauseBody,
-    VocabDeclaration, VocabDeclarationHead, VocabFieldSpec, VocabKeywordMetadata, VocabParameter, VocabSyntaxNode,
-    VocabTypeExpr,
+    VocabDeclaration, VocabDeclarationHead, VocabExpressionItem, VocabExpressionItemModifier, VocabFieldSpec,
+    VocabKeywordMetadata, VocabParameter, VocabSyntaxNode, VocabTypeExpr,
 };
 #[cfg(feature = "serde")]
 pub use desugar::execute_desugar_request;
@@ -56,12 +56,13 @@ pub use desugar::{
 };
 pub use keywords::{
     ClauseBodyKind, ClauseCardinality, ClausePlacement, ClauseSurface, DeclarationBodyKind, DeclarationHeadKind,
-    DeclarationSurface, DesugarTarget, DslSurface, KeywordActivation, KeywordPlacement, KeywordRegistration,
-    KeywordSpec, KeywordSurfaceKind, ScopedSurfaceChainMode, ScopedSurfaceDescriptor, ScopedSurfaceDiagnosticKind,
-    ScopedSurfaceDiagnosticTemplate, ScopedSurfaceEligibility, ScopedSurfaceFamily, ScopedSurfaceFormatHint,
-    ScopedSurfaceMisuseScope, ScopedSurfacePosition, ScopedSurfaceReceiver, ScopedSurfaceSyntax,
-    ScopedSymbolDescriptor, ScopedSymbolDiagnosticKind, ScopedSymbolDiagnosticTemplate, ScopedSymbolEligibility,
-    ScopedSymbolFamily, ScopedSymbolMisuseScope, ScopedSymbolPosition, ScopedSymbolRoleMetadata,
+    DeclarationSurface, DesugarTarget, DslSurface, ExpressionItemModifierKind, ExpressionItemModifierSurface,
+    KeywordActivation, KeywordPlacement, KeywordRegistration, KeywordSpec, KeywordSurfaceKind, ScopedSurfaceChainMode,
+    ScopedSurfaceDescriptor, ScopedSurfaceDiagnosticKind, ScopedSurfaceDiagnosticTemplate, ScopedSurfaceEligibility,
+    ScopedSurfaceFamily, ScopedSurfaceFormatHint, ScopedSurfaceMisuseScope, ScopedSurfacePosition,
+    ScopedSurfaceReceiver, ScopedSurfaceSyntax, ScopedSymbolDescriptor, ScopedSymbolDiagnosticKind,
+    ScopedSymbolDiagnosticTemplate, ScopedSymbolEligibility, ScopedSymbolFamily, ScopedSymbolMisuseScope,
+    ScopedSymbolPosition, ScopedSymbolRoleMetadata,
 };
 pub use manifest::{
     CargoDependency, CargoDependencySource, FieldExport, FunctionExport, HelperBinding, LibraryManifest,

--- a/crates/rust_inspect/src/extractor.rs
+++ b/crates/rust_inspect/src/extractor.rs
@@ -324,6 +324,20 @@ fn source_field_type_shape(field: &ra_ap_hir::Field, db: &RootDatabase, crate_na
     Some(source_type_shape(text.as_str(), crate_name, module, db))
 }
 
+/// Return the Rust source spelling for a named field, removing only Rust's raw-identifier prefix.
+///
+/// rust-analyzer may expose a raw field such as `r#type` through a safe internal name. Incan needs the source spelling
+/// instead: `type` should be accepted in Incan and later emitted as `r#type`, while an ordinary Rust field named
+/// `type_` must remain `type_`.
+fn source_field_name(field: &ra_ap_hir::Field, db: &RootDatabase) -> Option<String> {
+    let source = field.source(db)?;
+    let FieldSource::Named(field) = source.value else {
+        return None;
+    };
+    let raw = field.name()?.syntax().text().to_string();
+    Some(raw.strip_prefix("r#").unwrap_or(raw.as_str()).to_string())
+}
+
 fn normalize_variant_payload_shape(shape: RustTypeShape) -> RustTypeShape {
     match shape {
         RustTypeShape::RustPath { path, args }
@@ -694,6 +708,10 @@ fn collect_implemented_traits(ty: Type<'_>, db: &RootDatabase) -> Vec<RustImplem
     traits.into_values().collect()
 }
 
+/// Collect public Rust fields in declaration order with source-facing names and semantic type shapes.
+///
+/// Field names are taken from Rust source when possible so raw identifiers surface to Incan without `r#`, and codegen
+/// can later decide whether that source-facing name needs raw Rust emission.
 fn collect_public_fields(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget, crate_name: &str) -> Vec<RustFieldInfo> {
     if let Some(adt) = ty.as_adt() {
         let type_args: Vec<Type<'_>> = ty.type_arguments().collect();
@@ -713,7 +731,7 @@ fn collect_public_fields(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget, cra
                 type_shape = source_field_type_shape(&field, db, crate_name).unwrap_or(type_shape);
             }
             collected.push(RustFieldInfo {
-                name: field.name(db).as_str().to_owned(),
+                name: source_field_name(&field, db).unwrap_or_else(|| field.name(db).as_str().to_owned()),
                 type_display: format_ty(&field_ty, db, dt),
                 type_shape,
             });
@@ -731,7 +749,7 @@ fn collect_public_fields(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget, cra
             type_shape = source_field_type_shape(&field, db, crate_name).unwrap_or(type_shape);
         }
         fields.push(RustFieldInfo {
-            name: field.name(db).as_str().to_owned(),
+            name: source_field_name(&field, db).unwrap_or_else(|| field.name(db).as_str().to_owned()),
             type_display: format_ty(&field_ty, db, dt),
             type_shape,
         });
@@ -1076,6 +1094,39 @@ edition = "2021"
         };
         let fields = info.fields.iter().map(|field| field.name.as_str()).collect::<Vec<_>>();
         assert_eq!(fields, ["zeta", "alpha"]);
+        Ok(())
+    }
+
+    #[test]
+    fn type_metadata_unescapes_raw_keyword_fields_without_rewriting_plain_names()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        fs::create_dir_all(tmp.path().join("src"))?;
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            r#"[package]
+name = "demo_raw_field_probe"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )?;
+        fs::write(
+            tmp.path().join("src/lib.rs"),
+            r#"pub struct JoinRel {
+    pub r#type: i64,
+    pub type_: i64,
+    pub r#match: i64,
+}
+"#,
+        )?;
+
+        let workspace = RustWorkspace::load(tmp.path(), &|_| ())?;
+        let metadata = extract_rust_item(&workspace, "demo_raw_field_probe::JoinRel")?;
+        let RustItemKind::Type(info) = metadata.kind else {
+            return Err(std::io::Error::other("expected type metadata").into());
+        };
+        let fields = info.fields.iter().map(|field| field.name.as_str()).collect::<Vec<_>>();
+        assert_eq!(fields, ["type", "type_", "match"]);
         Ok(())
     }
 

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -3172,6 +3172,91 @@ pub def make_pair() -> Pair:
 
     #[cfg(feature = "rust_inspect")]
     #[test]
+    fn test_codegen_emits_raw_rust_field_names_for_keyword_fields_issue725() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::frontend::typechecker::TypeChecker;
+        use incan_core::interop::{
+            RustFieldInfo, RustItemKind, RustItemMetadata, RustTypeInfo, RustTypeShape, RustVisibility,
+        };
+
+        let source = r#"
+from rust::demo import JoinRel
+
+pub def get_type(join: JoinRel) -> int:
+  return join.type + join.match + join.type_
+
+pub def rebuild(join: JoinRel) -> JoinRel:
+  return JoinRel(type=join.type, match=join.match, type_=join.type_)
+"#;
+        let tokens = must_ok(lexer::lex(source));
+        let ast = must_ok(parser::parse(&tokens));
+
+        let tmp = seeded_rust_inspect_workspace()?;
+        let manifest_dir = tmp.path().to_path_buf();
+        let mut tc = TypeChecker::new();
+        tc.set_rust_inspect_manifest_dir(manifest_dir.clone());
+        tc.rust_inspect_cache
+            .insert_test_item(
+                &manifest_dir,
+                RustItemMetadata {
+                    canonical_path: "demo::JoinRel".to_string(),
+                    definition_path: Some("demo::JoinRel".to_string()),
+                    visibility: RustVisibility::Public,
+                    kind: RustItemKind::Type(RustTypeInfo {
+                        alias_target: None,
+                        methods: Vec::new(),
+                        implemented_traits: Vec::new(),
+                        fields: vec![
+                            RustFieldInfo {
+                                name: "type".to_string(),
+                                type_display: "i64".to_string(),
+                                type_shape: RustTypeShape::Int,
+                            },
+                            RustFieldInfo {
+                                name: "match".to_string(),
+                                type_display: "i64".to_string(),
+                                type_shape: RustTypeShape::Int,
+                            },
+                            RustFieldInfo {
+                                name: "type_".to_string(),
+                                type_display: "i64".to_string(),
+                                type_shape: RustTypeShape::Int,
+                            },
+                        ],
+                        variants: Vec::new(),
+                    }),
+                },
+            )
+            .map_err(|e| std::io::Error::other(format!("seed rust-inspect type: {e}")))?;
+        tc.check_program(&ast)
+            .map_err(|errs| std::io::Error::other(format!("typecheck failed: {errs:?}")))?;
+
+        let mut lowering = AstLowering::new_with_type_info(tc.type_info().clone());
+        let ir_program = lowering
+            .lower_program(&ast)
+            .map_err(|err| std::io::Error::other(format!("lowering failed: {err:?}")))?;
+        let mut emitter = IrEmitter::new(&ir_program.function_registry);
+        let code = emitter
+            .emit_program(&ir_program)
+            .map_err(|err| std::io::Error::other(format!("emit failed: {err:?}")))?;
+
+        assert!(
+            code.contains("join.r#type")
+                && code.contains("join.r#match")
+                && code.contains("join.type_")
+                && code.contains("r#type: join.r#type")
+                && code.contains("r#match: join.r#match")
+                && code.contains("type_: join.type_"),
+            "expected keyword fields to emit raw Rust identifiers while ordinary trailing-underscore fields stay unchanged; got:\n{code}"
+        );
+        assert!(
+            !code.contains("r#type: join.type_") && !code.contains("type_: join.r#type"),
+            "Rust keyword fields and ordinary trailing-underscore fields must not be cross-wired; got:\n{code}"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "rust_inspect")]
+    #[test]
     fn test_codegen_uses_source_field_names_for_metadata_free_rust_type_constructor()
     -> Result<(), Box<dyn std::error::Error>> {
         use crate::frontend::typechecker::TypeChecker;

--- a/src/backend/ir/emit/expressions/indexing.rs
+++ b/src/backend/ir/emit/expressions/indexing.rs
@@ -306,7 +306,7 @@ impl<'a> IrEmitter<'a> {
                     let ident = format_ident!("{}", name);
                     quote! { #ident }
                 };
-                let f = format_ident!("{}", canonical_field);
+                let f = Self::rust_ident(canonical_field);
                 return Ok(quote! { #type_ident::#f });
             }
             if Self::expr_is_type_like(object) {
@@ -318,7 +318,7 @@ impl<'a> IrEmitter<'a> {
                     let ident = format_ident!("{}", name);
                     quote! { #ident }
                 };
-                let f = format_ident!("{}", field);
+                let f = Self::rust_ident(field);
                 return Ok(quote! { #type_ident::#f });
             }
         }
@@ -331,7 +331,7 @@ impl<'a> IrEmitter<'a> {
                 .unwrap_or_else(|_| syn::Index::from(0));
             Ok(quote! { #o.#idx })
         } else {
-            let f = format_ident!("{}", field);
+            let f = Self::rust_ident(field);
             Ok(quote! { #o.#f })
         }
     }

--- a/src/backend/ir/emit/expressions/lvalue.rs
+++ b/src/backend/ir/emit/expressions/lvalue.rs
@@ -10,7 +10,7 @@
 //! - `indexing.rs`: shared negative-index handling logic
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 
 use super::super::super::expr::{IrExprKind, TypedExpr};
 use super::super::super::stmt::AssignTarget;
@@ -84,7 +84,7 @@ impl<'a> IrEmitter<'a> {
             }
             IrExprKind::Field { object, field } => {
                 let o = self.emit_lvalue_expr(object)?;
-                let f = format_ident!("{}", field);
+                let f = Self::rust_ident(field);
                 // Only parenthesize when needed.
                 //
                 // `emit_lvalue_expr` may emit a leading `*` for list indexing (`*list_get_mut(..)`).
@@ -128,7 +128,7 @@ impl<'a> IrEmitter<'a> {
             }
             AssignTarget::Field { object, field } => {
                 let o = self.emit_lvalue_expr(object)?;
-                let f = format_ident!("{}", field);
+                let f = Self::rust_ident(field);
                 // Same precedence rule as in `emit_lvalue_expr`: only parenthesize when the receiver may start with a
                 // unary `*` (e.g. list index lvalues).
                 if matches!(object.kind, IrExprKind::Index { .. }) {

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -1080,6 +1080,19 @@ impl AstLowering {
                         result_ty,
                     )
                 } else {
+                    if let Some(rust_field) = self
+                        .type_info
+                        .as_ref()
+                        .and_then(|info| info.rust_field_access_name(expr_span))
+                    {
+                        return Ok(TypedExpr::new(
+                            IrExprKind::Field {
+                                object: Box::new(obj),
+                                field: rust_field.to_string(),
+                            },
+                            IrType::Unknown,
+                        ));
+                    }
                     // RFC 021: resolve field alias to canonical name if object is a known struct type
                     let struct_name = obj.ty.nominal_type_name().or_else(|| match &obj.kind {
                         IrExprKind::Var { name, .. } if name == "self" => self.current_impl_type.as_deref(),

--- a/src/backend/ir/lower/stmt.rs
+++ b/src/backend/ir/lower/stmt.rs
@@ -1067,7 +1067,12 @@ impl AstLowering {
             ast::Statement::FieldAssignment(fa) => IrStmtKind::Assign {
                 target: AssignTarget::Field {
                     object: Box::new(self.lower_expr_spanned(&fa.object)?),
-                    field: fa.field.clone(),
+                    field: self
+                        .type_info
+                        .as_ref()
+                        .and_then(|info| info.rust_field_access_name(fa.target_span))
+                        .unwrap_or(fa.field.as_str())
+                        .to_string(),
                 },
                 value: self.lower_expr_spanned(&fa.value)?,
             },
@@ -1357,6 +1362,12 @@ impl AstLowering {
             }
 
             ast::Statement::Surface(surface_stmt) => self.lower_surface_statement(surface_stmt)?,
+            ast::Statement::VocabExpressionItem(_item) => {
+                return Err(LoweringError {
+                    message: "raw vocab expression-list item reached lowering before desugaring".to_string(),
+                    span: IrSpan::default(),
+                });
+            }
             ast::Statement::VocabBlock(vocab_block) => {
                 return Err(LoweringError {
                     message: format!(
@@ -2012,6 +2023,12 @@ impl AstLowering {
                 }
             }
             ast::Statement::Expr(expr) => self.count_expr_ident_reads(&expr.node, counts),
+            ast::Statement::VocabExpressionItem(item) => {
+                self.count_expr_ident_reads(&item.expr.node, counts);
+                for modifier in &item.modifiers {
+                    self.count_expr_ident_reads(&modifier.value.node, counts);
+                }
+            }
             ast::Statement::Break(Some(expr)) => self.count_expr_ident_reads(&expr.node, counts),
             ast::Statement::Pass | ast::Statement::Break(None) | ast::Statement::Continue => {}
             ast::Statement::CompoundAssignment(ca) => {

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -1098,6 +1098,13 @@ fn statement_references_name(stmt: &Statement, name: &str) -> bool {
         Statement::ChainedAssignment(assign) => expr_references_name(&assign.value.node, name),
         Statement::Return(None) | Statement::Pass | Statement::Break(None) | Statement::Continue => false,
         Statement::Break(Some(expr)) => expr_references_name(&expr.node, name),
+        Statement::VocabExpressionItem(item) => {
+            expr_references_name(&item.expr.node, name)
+                || item
+                    .modifiers
+                    .iter()
+                    .any(|modifier| expr_references_name(&modifier.value.node, name))
+        }
         Statement::Surface(_) | Statement::VocabBlock(_) => false,
     }
 }

--- a/src/format/formatter/statements.rs
+++ b/src/format/formatter/statements.rs
@@ -17,6 +17,20 @@ impl Formatter {
                     self.writer.newline();
                 }
             }
+            Statement::VocabExpressionItem(item) => {
+                self.format_expr(&item.expr.node);
+                if let Some(alias) = &item.alias {
+                    self.writer.write(" as ");
+                    self.writer.write(alias);
+                }
+                for modifier in &item.modifiers {
+                    self.writer.write(" ");
+                    self.writer.write(&modifier.keyword);
+                    self.writer.write(" ");
+                    self.format_expr(&modifier.value.node);
+                }
+                self.writer.newline();
+            }
             Statement::Assert(assert_stmt) => self.format_assert(assert_stmt),
             Statement::Assignment(assign) => {
                 self.format_assignment(assign);

--- a/src/frontend/ast_walk.rs
+++ b/src/frontend/ast_walk.rs
@@ -183,6 +183,13 @@ where
         }
         Statement::Return(Some(expr)) => expr_has(&expr.node, pred),
         Statement::Expr(expr) => expr_has(&expr.node, pred),
+        Statement::VocabExpressionItem(item) => {
+            expr_has(&item.expr.node, pred)
+                || item
+                    .modifiers
+                    .iter()
+                    .any(|modifier| expr_has(&modifier.value.node, pred))
+        }
         Statement::CompoundAssignment(a) => expr_has(&a.value.node, pred),
         Statement::TupleUnpack(u) => expr_has(&u.value.node, pred),
         Statement::TupleAssign(a) => {

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -13,7 +13,9 @@ use crate::frontend::typechecker::helpers::{
     option_ty, string_method_return,
 };
 use crate::frontend::typechecker::type_info::{RustMethodTraitImportUse, RustTraitImportInfo};
-use incan_core::interop::{RustCollectionFamily, RustFunctionSig, RustItemKind, metadata_free_method_signature};
+use incan_core::interop::{
+    RustCollectionFamily, RustFieldInfo, RustFunctionSig, RustItemKind, metadata_free_method_signature,
+};
 use incan_core::lang::magic_methods;
 use incan_core::lang::surface::collection_helpers::{self, BuiltinCollectionHelperId};
 use incan_core::lang::surface::types as surface_types;
@@ -75,6 +77,19 @@ fn rust_receiver_display(path: &str) -> String {
 }
 
 impl TypeChecker {
+    /// Resolve a source-facing Rust field spelling to the metadata field it names.
+    ///
+    /// Rust raw identifier fields should be written with the Rust source name at Incan field-use sites. For example, a
+    /// Rust field declared as `r#type` is accessed as `obj.type` and constructed with `TypeName(type=...)`; emission
+    /// rawifies the keyword identifier back to `r#type`. An ordinary Rust field declared as `type_` remains available
+    /// only as `obj.type_`.
+    pub(in crate::frontend::typechecker::check_expr) fn rust_field_for_source_name<'a>(
+        fields: &'a [RustFieldInfo],
+        source_name: &str,
+    ) -> Option<&'a RustFieldInfo> {
+        fields.iter().find(|field| field.name == source_name)
+    }
+
     /// Return the target display for a Rust type alias when the expected destination type names one.
     fn rust_callable_alias_target_display(&self, expected_ty: &ResolvedType) -> Option<String> {
         let ResolvedType::RustPath(path) = expected_ty else {
@@ -1489,7 +1504,7 @@ impl TypeChecker {
                     }
                     if let Some(meta) = self.rust_item_metadata_for_path(path)
                         && let RustItemKind::Type(info) = &meta.kind
-                        && let Some(rust_field) = info.fields.iter().find(|f| f.name == field)
+                        && let Some(rust_field) = Self::rust_field_for_source_name(&info.fields, field)
                     {
                         return Some(self.resolved_type_from_rust_shape(&rust_field.type_shape));
                     }
@@ -2745,8 +2760,10 @@ impl TypeChecker {
                         return ResolvedType::Function(params, Box::new(ResolvedType::RustPath(path.to_string())));
                     }
                     if let RustItemKind::Type(info) = &meta.kind
-                        && let Some(rust_field) = info.fields.iter().find(|f| f.name == field)
+                        && let Some(rust_field) = Self::rust_field_for_source_name(&info.fields, field)
                     {
+                        self.type_info
+                            .record_rust_field_access_name(span, rust_field.name.clone());
                         return self.resolved_type_from_rust_shape(&rust_field.type_shape);
                     }
                     // Metadata may still be missing constants, type aliases, trait-provided items, or private fields.

--- a/src/frontend/typechecker/check_expr/calls.rs
+++ b/src/frontend/typechecker/check_expr/calls.rs
@@ -13,7 +13,7 @@ use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::keywords::{self, KeywordId};
 use incan_core::lang::stdlib;
 use incan_core::lang::surface::types::{self as surface_types, SurfaceTypeId};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use super::TypeChecker;
 
@@ -445,11 +445,6 @@ impl TypeChecker {
         args: &[CallArg],
         span: Span,
     ) -> ResolvedType {
-        let fields_by_name: HashMap<&str, &RustFieldInfo> = type_info
-            .fields
-            .iter()
-            .map(|field| (field.name.as_str(), field))
-            .collect();
         let mut selected_fields = Vec::with_capacity(args.len());
         let mut provided = HashSet::new();
         let mut positional_index = 0usize;
@@ -483,7 +478,7 @@ impl TypeChecker {
                     selected_fields.push(field.name.clone());
                 }
                 CallArg::Named(field_name, expr) => {
-                    let Some(field) = fields_by_name.get(field_name.as_str()) else {
+                    let Some(field) = Self::rust_field_for_source_name(&type_info.fields, field_name.as_str()) else {
                         self.check_expr(expr);
                         self.errors.push(errors::missing_field(path, field_name, expr.span));
                         has_shape_error = true;

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -111,6 +111,12 @@ impl TypeChecker {
             Statement::Expr(expr) => {
                 self.check_expr(expr);
             }
+            Statement::VocabExpressionItem(_item) => {
+                self.errors.push(crate::frontend::diagnostics::CompileError::new(
+                    "raw vocab expression-list item reached typechecker before desugaring".to_string(),
+                    stmt.span,
+                ));
+            }
             Statement::Pass => {}
             Statement::Break(value) => self.check_break_stmt(value.as_ref(), stmt.span),
             Statement::Continue => self.check_continue_stmt(stmt.span),

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -2528,6 +2528,16 @@ impl TypeChecker {
             Statement::Break(Some(expr)) => {
                 self.collect_static_initializer_static_writes_from_expr(expr, current_static, visiting_functions);
             }
+            Statement::VocabExpressionItem(item) => {
+                self.collect_static_initializer_static_writes_from_expr(&item.expr, current_static, visiting_functions);
+                for modifier in &item.modifiers {
+                    self.collect_static_initializer_static_writes_from_expr(
+                        &modifier.value,
+                        current_static,
+                        visiting_functions,
+                    );
+                }
+            }
             Statement::Return(None)
             | Statement::Pass
             | Statement::Break(None)
@@ -2640,6 +2650,12 @@ impl TypeChecker {
             }
             Statement::ChainedAssignment(assign) => {
                 self.collect_static_dependencies_from_expr(&assign.value.node, deps, visiting_functions);
+            }
+            Statement::VocabExpressionItem(item) => {
+                self.collect_static_dependencies_from_expr(&item.expr.node, deps, visiting_functions);
+                for modifier in &item.modifiers {
+                    self.collect_static_dependencies_from_expr(&modifier.value.node, deps, visiting_functions);
+                }
             }
             Statement::Assert(assert_stmt) => {
                 match &assert_stmt.kind {

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -172,6 +172,12 @@ pub struct RustInteropArtifacts {
     /// resolved field names so `Range(1, 3)` can emit `Range { start: 1, end: 3 }` instead of an invalid tuple-style
     /// Rust constructor.
     pub named_field_constructor_fields: HashMap<(usize, usize), Vec<String>>,
+    /// Imported Rust field accesses keyed by full field-expression span.
+    ///
+    /// The parser may use an Incan-safe source spelling such as `type_` for a Rust field whose metadata name is the
+    /// Rust keyword `type`. Lowering consumes this resolved Rust field name so emission can use the real Rust field
+    /// identifier rather than guessing from source text.
+    pub field_access_names: HashMap<(usize, usize), String>,
     /// Rust closure parameter displays keyed by closure-expression span.
     ///
     /// This is populated when contextual Rust metadata proves a closure is being used as a Rust callable boundary
@@ -613,6 +619,19 @@ impl TypeCheckInfo {
         self.rust
             .named_field_constructor_fields
             .insert((span.start, span.end), fields);
+    }
+
+    /// Return the Rust field name resolved for one Rust field-access expression, if one was recorded.
+    pub fn rust_field_access_name(&self, span: Span) -> Option<&str> {
+        self.rust
+            .field_access_names
+            .get(&(span.start, span.end))
+            .map(String::as_str)
+    }
+
+    /// Record the Rust field name resolved for one Rust field-access expression.
+    pub(crate) fn record_rust_field_access_name(&mut self, span: Span, field: String) {
+        self.rust.field_access_names.insert((span.start, span.end), field);
     }
 
     /// Return rest-aware callable metadata recorded for the full call expression span, if any.

--- a/src/frontend/vocab_ast_bridge.rs
+++ b/src/frontend/vocab_ast_bridge.rs
@@ -149,7 +149,7 @@ fn internal_vocab_clause_to_public(
         .iter()
         .map(|arg| internal_expr_to_public(&arg.node))
         .collect::<Result<Vec<_>, _>>()?;
-    let body = internal_clause_body_to_public(&block.body)?;
+    let body = internal_clause_body_to_public(&block.body, block.keyword_binding.clause_body_kind)?;
     Ok(incan_vocab::VocabClause {
         keyword: block.keyword.clone(),
         compound_tokens: Vec::new(),
@@ -172,9 +172,13 @@ fn internal_vocab_clause_to_public(
 /// Returns the first bridge failure while probing or converting the contained statements.
 fn internal_clause_body_to_public(
     statements: &[ast::Spanned<ast::Statement>],
+    declared_body_kind: Option<incan_vocab::ClauseBodyKind>,
 ) -> Result<incan_vocab::VocabClauseBody, VocabAstBridgeError> {
     if statements.is_empty() {
         return Ok(incan_vocab::VocabClauseBody::Empty);
+    }
+    if matches!(declared_body_kind, Some(incan_vocab::ClauseBodyKind::ExpressionList)) {
+        return expression_list_body_to_public(statements);
     }
     if let Some(fields) = try_internal_field_set(statements)? {
         return Ok(incan_vocab::VocabClauseBody::FieldSet(fields));
@@ -183,30 +187,36 @@ fn internal_clause_body_to_public(
     let expression_only = statements
         .iter()
         .map(|statement| match &statement.node {
-            ast::Statement::Expr(expr) => internal_expr_to_public(&expr.node).map(Some),
+            ast::Statement::Expr(expr) => Ok(Some(incan_vocab::VocabExpressionItem {
+                expr: internal_expr_to_public(&expr.node)?,
+                alias: None,
+                modifiers: Vec::new(),
+                span: public_span(statement.span),
+            })),
             _ => Ok(None),
         })
         .collect::<Result<Vec<_>, _>>()?;
     if expression_only.iter().all(Option::is_some) {
-        let expressions = expression_only
+        let expression_items = expression_only
             .into_iter()
-            .map(|expr| {
-                expr.ok_or(VocabAstBridgeError::UnsupportedInternalStatement(
+            .map(|item| {
+                item.ok_or(VocabAstBridgeError::UnsupportedInternalStatement(
                     "clause expression extraction expected expression statements",
                 ))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        return if expressions.len() == 1 {
+        return if expression_items.len() == 1 {
             Ok(incan_vocab::VocabClauseBody::Expression(
-                expressions
+                expression_items
                     .into_iter()
                     .next()
                     .ok_or(VocabAstBridgeError::UnsupportedInternalStatement(
                         "single-expression clause conversion expected one expression item",
-                    ))?,
+                    ))?
+                    .expr,
             ))
         } else {
-            Ok(incan_vocab::VocabClauseBody::ExpressionList(expressions))
+            Ok(incan_vocab::VocabClauseBody::ExpressionList(expression_items))
         };
     }
 
@@ -215,6 +225,48 @@ fn internal_clause_body_to_public(
         .map(internal_statement_to_body_item)
         .collect::<Result<Vec<_>, _>>()?;
     Ok(incan_vocab::VocabClauseBody::Items(items))
+}
+
+/// Convert a clause body declared as `ClauseBodyKind::ExpressionList`.
+///
+/// This preserves declared trailing keyword metadata as first-class public AST rather than forcing desugarers to
+/// recover DSL item structure from ordinary statements.
+fn expression_list_body_to_public(
+    statements: &[ast::Spanned<ast::Statement>],
+) -> Result<incan_vocab::VocabClauseBody, VocabAstBridgeError> {
+    let mut items = Vec::with_capacity(statements.len());
+    for statement in statements {
+        match &statement.node {
+            ast::Statement::Expr(expr) => items.push(incan_vocab::VocabExpressionItem {
+                expr: internal_expr_to_public(&expr.node)?,
+                alias: None,
+                modifiers: Vec::new(),
+                span: public_span(statement.span),
+            }),
+            ast::Statement::VocabExpressionItem(item) => items.push(incan_vocab::VocabExpressionItem {
+                expr: internal_expr_to_public(&item.expr.node)?,
+                alias: item.alias.clone(),
+                modifiers: item
+                    .modifiers
+                    .iter()
+                    .map(|modifier| {
+                        Ok(incan_vocab::VocabExpressionItemModifier {
+                            keyword: modifier.keyword.clone(),
+                            value: internal_expr_to_public(&modifier.value.node)?,
+                            span: public_span(modifier.span),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, VocabAstBridgeError>>()?,
+                span: public_span(statement.span),
+            }),
+            _ => {
+                return Err(VocabAstBridgeError::UnsupportedInternalStatement(
+                    "expression-list clause body expected expression entries",
+                ));
+            }
+        }
+    }
+    Ok(incan_vocab::VocabClauseBody::ExpressionList(items))
 }
 
 /// Detect whether a clause body is representable as a public field-set payload.
@@ -1029,6 +1081,16 @@ mod tests {
             activation_namespace: "demo.dsl".to_string(),
             surface_kind,
             placement: incan_vocab::KeywordPlacement::TopLevel,
+            clause_body_kind: None,
+        }
+    }
+
+    fn expression_list_clause_binding() -> ast::VocabKeywordBinding {
+        ast::VocabKeywordBinding {
+            surface_kind: incan_vocab::KeywordSurfaceKind::BlockContextKeyword,
+            placement: incan_vocab::KeywordPlacement::in_block(["query"]),
+            clause_body_kind: Some(incan_vocab::ClauseBodyKind::ExpressionList),
+            ..default_keyword_binding(incan_vocab::KeywordSurfaceKind::BlockContextKeyword)
         }
     }
 
@@ -1066,6 +1128,55 @@ mod tests {
                 return Err(format!("expected clause body item, got {other:?}").into());
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn bridges_expression_list_clause_alias_items() -> Result<(), Box<dyn std::error::Error>> {
+        let clause_block = ast::VocabBlockStmt {
+            keyword: "SELECT".to_string(),
+            keyword_binding: expression_list_clause_binding(),
+            decorators: Vec::new(),
+            header_args: Vec::new(),
+            body: vec![
+                ast::Spanned::new(
+                    ast::Statement::VocabExpressionItem(ast::VocabExpressionItemStmt {
+                        expr: ast::Spanned::new(ast::Expr::Ident("amount".to_string()), ast::Span::new(10, 16)),
+                        alias: Some("total".to_string()),
+                        modifiers: vec![ast::VocabExpressionItemModifierStmt {
+                            keyword: "for".to_string(),
+                            value: ast::Spanned::new(ast::Expr::Ident("customer".to_string()), ast::Span::new(30, 38)),
+                            span: ast::Span::new(26, 38),
+                        }],
+                    }),
+                    ast::Span::new(10, 38),
+                ),
+                ast::Spanned::new(
+                    ast::Statement::Expr(ast::Spanned::new(
+                        ast::Expr::Ident("region".to_string()),
+                        ast::Span::new(30, 36),
+                    )),
+                    ast::Span::new(30, 36),
+                ),
+            ],
+        };
+
+        let clause = internal_vocab_clause_to_public(&clause_block, ast::Span::default())?;
+        let incan_vocab::VocabClauseBody::ExpressionList(items) = clause.body else {
+            return Err(format!("expected expression-list body, got {:?}", clause.body).into());
+        };
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].alias.as_deref(), Some("total"));
+        assert_eq!(items[0].modifiers.len(), 1);
+        assert_eq!(items[0].modifiers[0].keyword, "for");
+        assert_eq!(
+            items[0].modifiers[0].value,
+            incan_vocab::IncanExpr::Name("customer".to_string())
+        );
+        assert_eq!(items[0].expr, incan_vocab::IncanExpr::Name("amount".to_string()));
+        assert_eq!(items[1].alias, None);
+        assert!(items[1].modifiers.is_empty());
+        assert_eq!(items[1].expr, incan_vocab::IncanExpr::Name("region".to_string()));
         Ok(())
     }
 

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -1767,6 +1767,13 @@ fn local_signature_in_statement(
             .find_map(|target| local_signature_in_expr(target, ast, source, offset))
             .or_else(|| local_signature_in_expr(&assign.value, ast, source, offset)),
         Statement::ChainedAssignment(assignment) => local_signature_in_expr(&assignment.value, ast, source, offset),
+        Statement::VocabExpressionItem(item) => {
+            local_signature_in_expr(&item.expr, ast, source, offset).or_else(|| {
+                item.modifiers
+                    .iter()
+                    .find_map(|modifier| local_signature_in_expr(&modifier.value, ast, source, offset))
+            })
+        }
         Statement::Surface(surface) => match &surface.payload {
             crate::frontend::ast::SurfaceStmtPayload::KeywordArgs(args) => args
                 .iter()
@@ -3420,6 +3427,12 @@ fn scoped_symbol_in_statement<'a>(
         Statement::ChainedAssignment(assign) => {
             scoped_symbol_in_expr(&assign.value, ident, symbol_span, surfaces, found);
         }
+        Statement::VocabExpressionItem(item) => {
+            scoped_symbol_in_expr(&item.expr, ident, symbol_span, surfaces, found);
+            for modifier in &item.modifiers {
+                scoped_symbol_in_expr(&modifier.value, ident, symbol_span, surfaces, found);
+            }
+        }
         Statement::TupleAssign(assign) => {
             for target in &assign.targets {
                 scoped_symbol_in_expr(target, ident, symbol_span, surfaces, found);
@@ -3952,6 +3965,12 @@ fn scoped_symbol_context_in_statement(stmt: &Spanned<Statement>, offset: usize, 
         Statement::CompoundAssignment(assign) => scoped_symbol_context_in_expr(&assign.value, offset, context),
         Statement::TupleUnpack(assign) => scoped_symbol_context_in_expr(&assign.value, offset, context),
         Statement::ChainedAssignment(assign) => scoped_symbol_context_in_expr(&assign.value, offset, context),
+        Statement::VocabExpressionItem(item) => {
+            scoped_symbol_context_in_expr(&item.expr, offset, context);
+            for modifier in &item.modifiers {
+                scoped_symbol_context_in_expr(&modifier.value, offset, context);
+            }
+        }
         Statement::TupleAssign(assign) => {
             for target in &assign.targets {
                 scoped_symbol_context_in_expr(target, offset, context);

--- a/src/lsp/call_site_type_args.rs
+++ b/src/lsp/call_site_type_args.rs
@@ -341,6 +341,11 @@ fn call_site_type_in_stmt(stmt: &Statement, offset: usize) -> Option<&Spanned<Ty
             .find_map(|e| call_site_type_in_expr(e, offset))
             .or_else(|| call_site_type_in_expr(&t.value, offset)),
         Statement::ChainedAssignment(c) => call_site_type_in_expr(&c.value, offset),
+        Statement::VocabExpressionItem(item) => call_site_type_in_expr(&item.expr, offset).or_else(|| {
+            item.modifiers
+                .iter()
+                .find_map(|modifier| call_site_type_in_expr(&modifier.value, offset))
+        }),
         Statement::Assert(assert_stmt) => call_site_type_in_assert_stmt(assert_stmt, offset),
         Statement::Surface(s) => match &s.payload {
             crate::frontend::ast::SurfaceStmtPayload::KeywordArgs(exprs) => {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11314,6 +11314,53 @@ pub def display[T](data: DataSet[T]) -> None:
         Ok(())
     }
 
+    fn write_pub_library_with_querykit_select_desugarer(
+        root: &Path,
+        desugarer_bytes: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let artifact_root = root.join("deps").join("querykit").join("target").join("lib");
+        std::fs::create_dir_all(artifact_root.join("desugarers"))?;
+        write_minimal_library_crate(&artifact_root, "querykit_core")?;
+        let desugarer_path = artifact_root.join("desugarers").join("querykit_desugarer.wasm");
+        std::fs::write(&desugarer_path, desugarer_bytes)?;
+
+        let metadata = incan_vocab::VocabRegistration::new()
+            .with_surface(
+                incan_vocab::DslSurface::on_import("querykit.query").with_declaration(
+                    incan_vocab::DeclarationSurface::named("query")
+                        .with_clause_body()
+                        .with_clause(
+                            incan_vocab::ClauseSurface::expr_list("SELECT")
+                                .with_expression_item_modifiers([
+                                    incan_vocab::ExpressionItemModifierSurface::expr("for"),
+                                    incan_vocab::ExpressionItemModifierSurface::expr("with"),
+                                ])
+                                .required(),
+                        ),
+                ),
+            )
+            .metadata();
+        let mut manifest = LibraryManifest::new("querykit_core", "0.1.0");
+        manifest.vocab = Some(incan::library_manifest::VocabExports {
+            crate_path: "vocab_companion".to_string(),
+            package_name: "vocab_companion".to_string(),
+            keyword_registrations: metadata.keyword_registrations,
+            dsl_surfaces: metadata.dsl_surfaces,
+            provider_manifest: incan_vocab::LibraryManifest::default(),
+            desugarer_artifact: Some(incan::library_manifest::VocabDesugarerArtifact {
+                artifact_kind: incan_vocab::DesugarerArtifactKind::WasmModule,
+                abi_version: incan_vocab::WASM_DESUGAR_ABI_VERSION,
+                relative_path: "desugarers/querykit_desugarer.wasm".to_string(),
+                target: "wasm32-wasip1".to_string(),
+                profile: "release".to_string(),
+                entrypoint: "desugar_block".to_string(),
+                sha256: hex::encode(Sha256::digest(desugarer_bytes)),
+            }),
+        });
+        manifest.write_to_path(&artifact_root.join("querykit_core.incnlib"))?;
+        Ok(())
+    }
+
     fn write_pub_library_with_vocab_desugarer_and_filter_helper(
         root: &Path,
         dependency_key: &str,
@@ -12611,6 +12658,44 @@ def main() -> None:
             "expected desugarer failure to prove the request substring assertion was active.\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&negative_output.stdout),
             String::from_utf8_lossy(&negative_output.stderr)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn consumer_check_passes_expr_list_item_metadata_to_desugarer_issue724() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let response = incan_vocab::DesugarResponse::statements(vec![incan_vocab::IncanStatement::Let {
+            name: "query_generated".to_string(),
+            mutable: false,
+            value: incan_vocab::IncanExpr::Int(1),
+        }]);
+        let output_payload = serde_json::to_string(&response)?;
+        let wasm = compile_desugarer_wasm_requiring_request_substring(
+            &output_payload,
+            "missing expression-list modifier payload",
+            r#""keyword":"with""#,
+        )?;
+        write_pub_library_with_querykit_select_desugarer(tmp.path(), &wasm)?;
+
+        let main_path = write_project_files(
+            tmp.path(),
+            "[project]\nname = \"consumer\"\n\n[dependencies]\nquerykit = { path = \"deps/querykit\" }\n",
+            r#"import pub::querykit
+
+def main() -> None:
+  query:
+    SELECT:
+      sum(amount) as total for customer with context
+"#,
+        )?;
+
+        let output = run_check(&main_path)?;
+        assert!(
+            output.status.success(),
+            "expected check to pass expression-list item metadata to the desugarer.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
         );
         Ok(())
     }

--- a/workspaces/docs-site/docs/contributing/how-to/authoring_vocab_crates.md
+++ b/workspaces/docs-site/docs/contributing/how-to/authoring_vocab_crates.md
@@ -127,6 +127,7 @@ Key rules:
 
 - `DslSurface::on_import("routekit")` must match the consumer-facing import spelling after `pub::`.
 - Declarations own their clause grammar directly, so nested DSL structure stays close to the declaration that introduces it.
+- Use `ClauseSurface::expr_list("SELECT")` for SQL-shaped projection clauses that accept entries such as `sum(amount) as total`; add declared item modifiers with `ExpressionItemModifierSurface::expr("for")` or similar when a projection item needs metadata such as `sum(amount) for customer with context`. The desugarer receives structured expression-list items with alias and modifier metadata, while `ClauseSurface::fields(...)` remains for config-style `name = value` sections.
 - `LibraryManifest` is where you describe exported module metadata plus any Cargo dependencies or stdlib features that must travel with the library artifact.
 - `KeywordRegistration` remains available only as a lower-level escape hatch for especially simple or incremental cases.
 

--- a/workspaces/docs-site/docs/language/how-to/rust_interop.md
+++ b/workspaces/docs-site/docs/language/how-to/rust_interop.md
@@ -48,6 +48,8 @@ from rust::my_crate::proto import type as proto_type
 
 The same rule applies to path segments after `rust::` (for example `rust::substrait::proto::type::Binary`).
 
+For Rust struct fields whose real Rust identifier is a keyword, use the keyword spelling in Incan field access and named constructor arguments. For example, a Rust field declared as `r#type` is available as `value.type` and `TypeName(type=value)` in Incan source; generated Rust still uses the real raw identifier. An ordinary Rust field named `type_` remains `value.type_`.
+
 ## Dependency Management
 
 When you use `import rust::crate_name`, Incan automatically adds the dependency to your generated `Cargo.toml`. Dependencies are resolved using a three-tier precedence system:

--- a/workspaces/docs-site/docs/release_notes/0_3.md
+++ b/workspaces/docs-site/docs/release_notes/0_3.md
@@ -46,7 +46,7 @@ Use this section as the map. The release note names each larger feature, says wh
 - **Callable presets with RHS `partial` declarations**: Write `pub get = partial route(method="GET")` when a new API name is really the same callable with named defaults, not a new function body. Read [Callable presets explained](../language/explanation/callable_presets.md), then [Callable presets](../language/reference/callable_presets.md) ([RFC 084], #453).
 - **Variadics and call unpacking**: Describe call shapes that accept or forward flexible argument lists without losing static checks. Read [Functions](../language/reference/functions.md) ([RFC 038], #83).
 - **Generators and lazy iterators**: Build pipelines with generator values, lazy adapters, and explicit terminal consumers such as `collect`, `count`, `find`, and `fold`. Read [Generators](../language/how-to/generators.md) and [Generator semantics](../language/explanation/generators.md) ([RFC 006], [RFC 088], #127, #324, #386).
-- **Scoped DSL surfaces**: Let vocab crates activate scoped block, clause, glyph, leading-dot, and symbol syntax for their own DSL contexts instead of turning library-specific syntax into global parser behavior. Read [Author library DSLs with incan_vocab](../contributing/how-to/authoring_vocab_crates.md) ([RFC 040], [RFC 045]).
+- **Scoped DSL surfaces**: Let vocab crates activate scoped block, clause, glyph, leading-dot, symbol, and expression-list item syntax for their own DSL contexts instead of turning library-specific syntax into global parser behavior. Read [Author library DSLs with incan_vocab](../contributing/how-to/authoring_vocab_crates.md) ([RFC 040], [RFC 045]).
 
 ### Rust interop and API metadata
 
@@ -120,6 +120,8 @@ This section is grouped by outcome rather than by every minimized repro. Issue n
 - **Decorator helpers can inspect generic callables**: `func.__name__` works in generic `(F) -> F` decorator helpers, including imported alias and union callable signatures, so registry decorators can infer the decorated helper name instead of repeating it as a string (#694, #701).
 - **Decorated wrappers preserve defaults**: Decorated functions and methods keep source default-argument call behavior when the final decorated callable surface still matches the original declaration, including direct imports and public facade re-exports (#703).
 - **Stdlib implementation modules stay internal**: Generated stdlib source dependencies no longer leak unimported helper classes into project modules, so explicit sibling imports keep precedence over unrelated `std.*` imports (#710).
+- **Vocab expression-list clauses preserve item metadata**: `ClauseSurface::expr_list(...)` accepts `expr as alias` entries and declared trailing item modifiers such as `expr for target with context`, exposing structured metadata to desugarers instead of forcing SQL-shaped projections through field-set syntax (#724).
+- **Rust raw identifier fields emit correctly**: Rust-backed fields whose real Rust name is a keyword can be accessed with the keyword spelling, such as `value.type` and `TypeName(type=value)`, while generated Rust emits the actual raw identifier access such as `value.r#type` (#725).
 - **Script and test manifests are scoped**: Generated Cargo manifests include only reachable dependencies instead of blindly inheriting package-level heavy dependencies (#665).
 
 ### Formatter And Test Runner


### PR DESCRIPTION
## Summary

This PR fixes two v0.3 release blockers. Vocab expression-list clauses now preserve structured item metadata, so `ClauseSurface::expr_list(...)` can represent entries such as `expr as alias` and DSL-declared trailing item modifiers like `expr for target with context`. Rust raw keyword fields now use the natural Incan spelling at use sites, such as `join.type` and `JoinRel(type=...)`, while generated Rust emits `join.r#type`; ordinary Rust fields named `type_` remain `type_`. The release candidate is bumped to `0.3.0-rc33`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Vocab crate authors can attach expression-list item modifiers without forcing SQL-like projection syntax through field sets. Rust interop users can access raw keyword fields with the keyword spelling, for example `.type`, and do not need the `type_` workaround for Rust `r#type` fields.
- **Internals**: The syntax AST, formatter, typechecker, bridge payloads, LSP traversal, lowering, and test runner now preserve expression-list item modifiers. Rust field metadata now stores the Rust source-facing field name with `r#` removed, and codegen relies on the existing raw-ident emission path for keywords.
- **Risks**: The affected surfaces are parser/contextual keyword handling, vocab AST propagation, and Rust field metadata. Regression coverage includes keyword named arguments/member access, vocab item modifiers, rust-inspect raw field extraction, and raw field codegen.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p rust_inspect type_metadata_unescapes_raw_keyword_fields_without_rewriting_plain_names` passed.
- `cargo test -p incan test_codegen_emits_raw_rust_field_names_for_keyword_fields_issue725 --features rust_inspect` passed.
- `cargo test -p incan_syntax test_parse_keyword_named_args_and_member_access` passed.
- `cargo test -p incan_syntax test_expression_list_clause_accepts_declared_item_modifiers` passed.
- `cargo test -p incan --test integration_tests consumer_check_passes_expr_list_item_metadata_to_desugarer_issue724` passed.
- `make pre-commit` passed on the committed tree: 2,525 tests passed, clippy passed, cargo-deny passed, smoke-test-fast passed, examples passed, and benchmark build checks passed.
- `target/release/incan fmt --check .` was attempted as a check-only command and did not write files; it is not currently a valid repo-wide gate because existing stdlib/examples/snapshot fixtures report broad formatter drift, comment-preservation refusals, and DSL fixtures that intentionally require vocab context.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/contributing/how-to/authoring_vocab_crates.md`, `workspaces/docs-site/docs/language/how-to/rust_interop.md`, `workspaces/docs-site/docs/release_notes/0_3.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #724
Closes #725