### PR TITLE
bugfix - wrap public union option payloads (#745)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc42"
+version = "0.3.0-rc43"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -134,6 +134,25 @@ impl<'a> IrEmitter<'a> {
         inner_ty: &IrType,
         union_qualifier: Option<&[String]>,
     ) -> Result<Option<TokenStream>, EmitError> {
+        let (source_ty, _) = self.union_widening_source_for_expr(arg);
+        let source_ty_resolved = self.resolve_type_aliases_for_emit(&source_ty);
+        let inner_ty_resolved = self.resolve_type_aliases_for_emit(inner_ty);
+        if source_ty_resolved.union_members().is_some()
+            && inner_ty_resolved.union_members().is_some()
+            && (source_ty_resolved == inner_ty_resolved || self.union_widening_needed(&source_ty, inner_ty))
+        {
+            let emitted = self.emit_expr_for_use_with_union_qualifier(
+                arg,
+                ValueUseSite::IncanCallArg {
+                    target_ty: Some(inner_ty),
+                    callee_param: None,
+                    in_return: false,
+                },
+                union_qualifier,
+            )?;
+            return Ok(Some(quote! { Some(#emitted) }));
+        }
+
         if let Some(variant_index) = inner_ty.union_variant_index_for_member(&arg.ty) {
             let Some(members) = inner_ty.union_members() else {
                 return Ok(None);
@@ -1720,6 +1739,66 @@ mod tests {
             render(tokens),
             "lit(__IncanUnion43fbd19e99c1db05::V0(\"open\".to_string()))"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn emit_public_union_call_result_as_option_payload_issue745() -> Result<(), Box<dyn std::error::Error>> {
+        let union_ty = IrType::NamedGeneric(IR_UNION_TYPE_NAME.to_string(), vec![IrType::Int, IrType::String]);
+        let public_union_ty = IrType::RustDisplay(format!(
+            "querykit::{}",
+            union_ty.union_type_name().ok_or("expected anonymous union type name")?
+        ));
+        let lit_signature = FunctionSignature {
+            params: Vec::new(),
+            return_type: union_ty.clone(),
+        };
+        let lit = TypedExpr::new(
+            IrExprKind::Call {
+                func: Box::new(local_arg(
+                    "lit",
+                    IrType::Function {
+                        params: Vec::new(),
+                        ret: Box::new(public_union_ty.clone()),
+                    },
+                )),
+                type_args: Vec::new(),
+                args: Vec::new(),
+                callable_signature: Some(lit_signature),
+                canonical_path: Some(vec!["pub".to_string(), "querykit".to_string(), "lit".to_string()]),
+            },
+            public_union_ty.clone(),
+        );
+        let accept_signature = FunctionSignature {
+            params: vec![FunctionParam {
+                name: "value".to_string(),
+                ty: IrType::Option(Box::new(union_ty)),
+                mutability: Mutability::Immutable,
+                is_self: false,
+                kind: ParamKind::Normal,
+                default: None,
+            }],
+            return_type: IrType::Unit,
+        };
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let accept = local_arg(
+            "accept_optional",
+            IrType::Function {
+                params: vec![IrType::Option(Box::new(public_union_ty))],
+                ret: Box::new(IrType::Unit),
+            },
+        );
+        let path = vec!["pub".to_string(), "querykit".to_string(), "accept_optional".to_string()];
+        let tokens = emitter
+            .emit_call_expr(&accept, &[], &[pos_arg(lit)], Some(&accept_signature), Some(&path))
+            .map_err(|err| {
+                std::io::Error::other(format!(
+                    "public union call result should emit as an Option payload: {err:?}"
+                ))
+            })?;
+
+        assert_eq!(render(tokens), "querykit::accept_optional(Some(querykit::lit()))");
         Ok(())
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -721,6 +721,107 @@ def main() -> None:
 }
 
 #[test]
+fn build_pub_helper_wraps_union_call_result_as_option_payload_issue745() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let producer_root = tmp.path().join("querykit");
+    let producer_src = producer_root.join("src");
+    fs::create_dir_all(&producer_src)?;
+    fs::write(
+        producer_root.join("incan.toml"),
+        r#"[project]
+name = "querykit"
+version = "0.1.0"
+"#,
+    )?;
+    fs::write(
+        producer_src.join("defs.incn"),
+        r#"
+pub model IntExpr:
+    value: int
+
+
+pub model TextExpr:
+    value: str
+
+
+pub type Value = Union[IntExpr, TextExpr]
+
+
+pub def lit(value: int) -> Value:
+    return IntExpr(value=value)
+
+
+pub def fallback() -> Value:
+    return TextExpr(value="fallback")
+
+
+pub def accept_optional(value: Option[Value] = None) -> Value:
+    return fallback()
+
+
+pub def combine(first: Value, second: Option[Value] = None) -> Value:
+    return first
+"#,
+    )?;
+    fs::write(
+        producer_src.join("lib.incn"),
+        r#"pub from defs import accept_optional, combine, fallback, lit
+"#,
+    )?;
+    let producer_build = run_incan(&producer_root, &["build", "--lib"])?;
+    assert_success(
+        &producer_build,
+        "producer build --lib for optional union helper issue745",
+    );
+
+    let consumer_root = tmp.path().join("consumer");
+    let consumer_main = write_minimal_project(
+        &consumer_root,
+        "optional_union_consumer",
+        r#"
+[dependencies]
+querykit = { path = "../querykit" }
+"#,
+    )?;
+    fs::write(
+        &consumer_main,
+        r#"from pub::querykit import accept_optional, combine, lit
+
+
+def main() -> None:
+    accept_optional(lit(2))
+    combine(lit(1), lit(2))
+    combine(lit(1), second=lit(3))
+    return
+"#,
+    )?;
+    let consumer_build = run_incan(
+        &consumer_root,
+        &[
+            "build",
+            consumer_main.to_str().ok_or("consumer main path was not valid UTF-8")?,
+        ],
+    )?;
+    assert_success(&consumer_build, "pub consumer build for optional union helper issue745");
+
+    let generated_consumer =
+        fs::read_to_string(consumer_root.join("target/incan/optional_union_consumer/src/main.rs"))?;
+    assert!(
+        generated_consumer.contains("querykit::accept_optional(Some(querykit::lit(2)))"),
+        "expected public optional helper call to wrap the dependency-owned union result in Some, got:\n{generated_consumer}"
+    );
+    assert!(
+        generated_consumer.contains("querykit::combine(querykit::lit(1), Some(querykit::lit(2)))"),
+        "expected positional optional union argument to be wrapped in Some, got:\n{generated_consumer}"
+    );
+    assert!(
+        generated_consumer.contains("querykit::combine(querykit::lit(1), Some(querykit::lit(3)))"),
+        "expected named optional union argument to be wrapped in Some, got:\n{generated_consumer}"
+    );
+    Ok(())
+}
+
+#[test]
 fn build_narrowed_union_fallback_helper_calls_issue743() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "narrowed_fallback_call", "")?;


### PR DESCRIPTION
## Summary

This PR fixes public helper calls where an argument expression returns a dependency-owned anonymous union and the callee parameter expects `Option[that union]`. The shared call emitter now uses the callable signature's semantic union source when planning `Option[T]` payloads, so provider-owned union results are emitted as `Some(pub_lib::helper(...))` instead of a bare union value.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Public dependency helpers can now accept `lit(...)`-style union-returning helper calls for optional union parameters without requiring downstream source workarounds.
- **Internals**: `Option[T]` argument planning now recovers semantic union metadata for call results before deciding whether to emit `Some(...)`, reusing the same union source path used by widening logic.
- **Risks**: This touches central call emission for option payloads. The change is limited to semantic union payloads and covered by unit plus package-boundary regressions.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan --lib emit_public_union_call_result_as_option_payload_issue745` passed after commit.
- `cargo test --test cli_integration build_pub_helper_wraps_union_call_result_as_option_payload_issue745` passed after commit.
- `make pre-commit` passed before commit on the same tree: fmt, rustdoc, 2,557 tests, clippy, cargo-deny, smoke-test-fast, examples, and benchmark build checks.
- `target/debug/incan --version` reported `incan 0.3.0-rc43`.
- InQL detached acceptance at `f320deb`: `incan test tests/test_substrait_plan.incn` passed, 33 tests.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #745