### PR TITLE
bugfix - reuse rust-inspect metadata for InQL CI (#707, #723)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc43"
+version = "0.3.0-rc44"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/rust_inspect/src/cache.rs
+++ b/crates/rust_inspect/src/cache.rs
@@ -129,6 +129,7 @@ fn legacy_versioned_workspace_fingerprint(root: &Path, inspector_version: &str) 
     Ok(hex::encode(hasher.finalize()))
 }
 
+/// Hash the workspace files that affect rust-inspect extraction results for this generated Cargo workspace.
 fn hash_workspace_fingerprint_inputs(hasher: &mut Sha256, root: &Path) -> Result<(), RustMetadataError> {
     hasher.update(fs::read(root.join("Cargo.toml"))?);
     match fs::read(root.join("Cargo.lock")) {
@@ -139,6 +140,7 @@ fn hash_workspace_fingerprint_inputs(hasher: &mut Sha256, root: &Path) -> Result
     Ok(())
 }
 
+/// Accept either the current cache-format fingerprint or the legacy version-labeled fingerprint for one cache file.
 fn disk_cache_fingerprint_matches(
     root: &Path,
     envelope: &DiskCacheEnvelope,
@@ -418,6 +420,7 @@ fn cached_definition_alias(inner: &CacheInner, root: &Path, canonical_path: &str
     None
 }
 
+/// Normalize Cargo package and Rust crate spellings to the cache key used for dependency-route lookups.
 fn normalized_crate_cache_key(crate_name: &str) -> String {
     crate_name.replace('-', "_")
 }
@@ -438,6 +441,7 @@ fn resolve_dependency_manifest_dir(
     resolved
 }
 
+/// Read and normalize a string field from a Cargo manifest table.
 fn manifest_string_field(value: &toml::Value, table: &str, key: &str) -> Option<String> {
     value
         .get(table)
@@ -446,6 +450,7 @@ fn manifest_string_field(value: &toml::Value, table: &str, key: &str) -> Option<
         .map(normalized_crate_cache_key)
 }
 
+/// Load the crate names declared by the generated root workspace so root out-dir extraction only runs for root items.
 fn load_root_crate_names(root: &Path) -> Vec<String> {
     let Ok(payload) = fs::read_to_string(root.join("Cargo.toml")) else {
         return Vec::new();
@@ -472,6 +477,7 @@ fn load_root_crate_names(root: &Path) -> Vec<String> {
     names
 }
 
+/// Resolve the root crate's library source path from `Cargo.toml`, defaulting to `src/lib.rs`.
 fn manifest_lib_source_path(root: &Path, manifest: &toml::Value) -> PathBuf {
     manifest
         .get("lib")
@@ -480,6 +486,7 @@ fn manifest_lib_source_path(root: &Path, manifest: &toml::Value) -> PathBuf {
         .map_or_else(|| root.join("src").join("lib.rs"), |path| root.join(path))
 }
 
+/// Convert a rust-analyzer syntax path into ordered textual path segments.
 fn rust_path_segments(path: &ast::Path) -> Vec<String> {
     let mut segments = Vec::new();
     let mut current = Some(path.clone());
@@ -493,6 +500,7 @@ fn rust_path_segments(path: &ast::Path) -> Vec<String> {
     segments
 }
 
+/// Extract a plain `pub use crate_name` or `pub use crate_name as alias` mapping from one use tree.
 fn crate_reexport_alias_from_use_tree(tree: &ast::UseTree) -> Option<(String, String)> {
     if tree.star_token().is_some() || tree.use_tree_list().is_some() {
         return None;
@@ -510,6 +518,7 @@ fn crate_reexport_alias_from_use_tree(tree: &ast::UseTree) -> Option<(String, St
     Some((alias, target))
 }
 
+/// Return whether a use item is exactly public at crate level, excluding restricted visibility such as `pub(crate)`.
 fn use_item_is_plain_public(use_item: &ast::Use) -> bool {
     let mut significant = use_item
         .syntax()
@@ -520,6 +529,7 @@ fn use_item_is_plain_public(use_item: &ast::Use) -> bool {
         && matches!(significant.next().map(|token| token.kind()), Some(T![use]))
 }
 
+/// Load root-level public crate re-export aliases from a dependency crate's library source.
 fn load_crate_reexport_aliases(root: &Path) -> HashMap<String, String> {
     let Ok(payload) = fs::read_to_string(root.join("Cargo.toml")) else {
         return HashMap::new();
@@ -550,6 +560,7 @@ fn load_crate_reexport_aliases(root: &Path) -> HashMap<String, String> {
     aliases
 }
 
+/// Return the canonical target path for a dependency-owned item addressed through a public crate re-export.
 fn dependency_reexport_alias_candidate(
     inner: &mut CacheInner,
     dep_root: &Path,
@@ -574,6 +585,7 @@ fn dependency_reexport_alias_candidate(
     }
 }
 
+/// Return whether the generated root workspace itself declares the crate segment used by a query path.
 fn root_workspace_declares_crate(inner: &mut CacheInner, root: &Path, crate_name: &str) -> bool {
     let names = inner
         .root_crate_names

--- a/crates/rust_inspect/src/cache.rs
+++ b/crates/rust_inspect/src/cache.rs
@@ -14,6 +14,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use incan_core::interop::RustItemMetadata;
+use ra_ap_syntax::{
+    AstNode, Edition, SourceFile, SyntaxKind, T,
+    ast::{self, HasModuleItem, HasName},
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -22,8 +26,6 @@ use crate::cache_timing::{CallTrace, log_timing_stage, rust_inspect_timing_enabl
 use crate::error::RustMetadataError;
 use crate::extractor::extract_rust_item;
 use crate::loader::RustWorkspace;
-
-const INSPECTOR_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Cache for [`RustWorkspace`] instances and extracted [`RustItemMetadata`].
 ///
@@ -44,6 +46,9 @@ struct CacheInner {
     workspaces: HashMap<(PathBuf, bool), RustWorkspace>,
     items: HashMap<(PathBuf, String), Arc<RustItemMetadata>>,
     definition_aliases: HashMap<(PathBuf, String), String>,
+    dependency_manifest_dirs: HashMap<(PathBuf, String), Option<PathBuf>>,
+    root_crate_names: HashMap<PathBuf, Vec<String>>,
+    crate_reexport_aliases: HashMap<PathBuf, HashMap<String, String>>,
     failed_items: HashMap<(PathBuf, String), NegativeLookup>,
     disk_cache_state: HashMap<PathBuf, DiskCacheState>,
 }
@@ -111,14 +116,39 @@ fn legacy_disk_cache_path(root: &Path) -> PathBuf {
 fn workspace_fingerprint(root: &Path) -> Result<String, RustMetadataError> {
     let mut hasher = Sha256::new();
     hasher.update(format!("cache_format:{DISK_CACHE_FORMAT}\n").as_bytes());
-    hasher.update(format!("inspector_version:{INSPECTOR_VERSION}\n").as_bytes());
+    hash_workspace_fingerprint_inputs(&mut hasher, root)?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Historical fingerprint used before cache compatibility was decoupled from the package version.
+fn legacy_versioned_workspace_fingerprint(root: &Path, inspector_version: &str) -> Result<String, RustMetadataError> {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("cache_format:{DISK_CACHE_FORMAT}\n").as_bytes());
+    hasher.update(format!("inspector_version:{inspector_version}\n").as_bytes());
+    hash_workspace_fingerprint_inputs(&mut hasher, root)?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn hash_workspace_fingerprint_inputs(hasher: &mut Sha256, root: &Path) -> Result<(), RustMetadataError> {
     hasher.update(fs::read(root.join("Cargo.toml"))?);
     match fs::read(root.join("Cargo.lock")) {
         Ok(lock) => hasher.update(lock),
         Err(err) if err.kind() == ErrorKind::NotFound => {}
         Err(err) => return Err(err.into()),
     }
-    Ok(hex::encode(hasher.finalize()))
+    Ok(())
+}
+
+fn disk_cache_fingerprint_matches(
+    root: &Path,
+    envelope: &DiskCacheEnvelope,
+    current_fingerprint: &str,
+) -> Result<bool, RustMetadataError> {
+    if envelope.workspace_fingerprint == current_fingerprint {
+        return Ok(true);
+    }
+    let legacy_fingerprint = legacy_versioned_workspace_fingerprint(root, envelope.inspector_version.as_str())?;
+    Ok(envelope.workspace_fingerprint == legacy_fingerprint)
 }
 
 fn read_json_cache(path: &Path) -> Result<Option<DiskCacheEnvelope>, RustMetadataError> {
@@ -183,8 +213,7 @@ fn load_disk_cache_into_memory(inner: &mut CacheInner, root: &Path) -> Result<Op
         return Ok(Some(fingerprint));
     };
     if envelope.cache_format != DISK_CACHE_FORMAT
-        || envelope.inspector_version != INSPECTOR_VERSION
-        || envelope.workspace_fingerprint != fingerprint
+        || !disk_cache_fingerprint_matches(root, &envelope, fingerprint.as_str())?
     {
         return Ok(Some(fingerprint));
     }
@@ -232,7 +261,7 @@ fn disk_cache_envelope(inner: &CacheInner, root: &Path) -> Result<DiskCacheEnvel
     }
     Ok(DiskCacheEnvelope {
         cache_format: DISK_CACHE_FORMAT,
-        inspector_version: INSPECTOR_VERSION.to_string(),
+        inspector_version: format!("cache-format-{DISK_CACHE_FORMAT}"),
         workspace_fingerprint: fingerprint,
         items,
         misses,
@@ -389,7 +418,174 @@ fn cached_definition_alias(inner: &CacheInner, root: &Path, canonical_path: &str
     None
 }
 
-/// Attempt extraction through primary workspace, out-dirs workspace, then resolved dependency workspace.
+fn normalized_crate_cache_key(crate_name: &str) -> String {
+    crate_name.replace('-', "_")
+}
+
+/// Resolve a dependency manifest directory once per generated lock workspace and crate spelling.
+fn resolve_dependency_manifest_dir(
+    inner: &mut CacheInner,
+    root: &Path,
+    crate_name: &str,
+    registry_src_roots: Option<&[PathBuf]>,
+) -> Option<PathBuf> {
+    let key = (root.to_path_buf(), normalized_crate_cache_key(crate_name));
+    if let Some(cached) = inner.dependency_manifest_dirs.get(&key) {
+        return cached.clone();
+    }
+    let resolved = dependency_manifest_dir_for_crate(root, crate_name, registry_src_roots);
+    inner.dependency_manifest_dirs.insert(key, resolved.clone());
+    resolved
+}
+
+fn manifest_string_field(value: &toml::Value, table: &str, key: &str) -> Option<String> {
+    value
+        .get(table)
+        .and_then(|section| section.get(key))
+        .and_then(toml::Value::as_str)
+        .map(normalized_crate_cache_key)
+}
+
+fn load_root_crate_names(root: &Path) -> Vec<String> {
+    let Ok(payload) = fs::read_to_string(root.join("Cargo.toml")) else {
+        return Vec::new();
+    };
+    let Ok(manifest) = toml::from_str::<toml::Value>(payload.as_str()) else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    if let Some(name) = manifest_string_field(&manifest, "package", "name") {
+        names.push(name);
+    }
+    if let Some(name) = manifest_string_field(&manifest, "lib", "name") {
+        names.push(name);
+    }
+    if let Some(bins) = manifest.get("bin").and_then(toml::Value::as_array) {
+        for bin in bins {
+            if let Some(name) = bin.get("name").and_then(toml::Value::as_str) {
+                names.push(normalized_crate_cache_key(name));
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn manifest_lib_source_path(root: &Path, manifest: &toml::Value) -> PathBuf {
+    manifest
+        .get("lib")
+        .and_then(|section| section.get("path"))
+        .and_then(toml::Value::as_str)
+        .map_or_else(|| root.join("src").join("lib.rs"), |path| root.join(path))
+}
+
+fn rust_path_segments(path: &ast::Path) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = Some(path.clone());
+    while let Some(path) = current {
+        if let Some(segment) = path.segment().and_then(|segment| segment.name_ref()) {
+            segments.push(segment.to_string());
+        }
+        current = path.qualifier();
+    }
+    segments.reverse();
+    segments
+}
+
+fn crate_reexport_alias_from_use_tree(tree: &ast::UseTree) -> Option<(String, String)> {
+    if tree.star_token().is_some() || tree.use_tree_list().is_some() {
+        return None;
+    }
+    let segments = rust_path_segments(&tree.path()?);
+    if segments.len() != 1 {
+        return None;
+    }
+    let target = normalized_crate_cache_key(segments[0].trim_start_matches("r#"));
+    let alias = tree
+        .rename()
+        .and_then(|rename| rename.name())
+        .map(|name| normalized_crate_cache_key(name.to_string().trim_start_matches("r#")))
+        .unwrap_or_else(|| target.clone());
+    Some((alias, target))
+}
+
+fn use_item_is_plain_public(use_item: &ast::Use) -> bool {
+    let mut significant = use_item
+        .syntax()
+        .descendants_with_tokens()
+        .filter_map(|element| element.into_token())
+        .filter(|token| !matches!(token.kind(), SyntaxKind::COMMENT | SyntaxKind::WHITESPACE));
+    matches!(significant.next().map(|token| token.kind()), Some(T![pub]))
+        && matches!(significant.next().map(|token| token.kind()), Some(T![use]))
+}
+
+fn load_crate_reexport_aliases(root: &Path) -> HashMap<String, String> {
+    let Ok(payload) = fs::read_to_string(root.join("Cargo.toml")) else {
+        return HashMap::new();
+    };
+    let Ok(manifest) = toml::from_str::<toml::Value>(payload.as_str()) else {
+        return HashMap::new();
+    };
+    let source_path = manifest_lib_source_path(root, &manifest);
+    let Ok(source) = fs::read_to_string(source_path) else {
+        return HashMap::new();
+    };
+    let parsed = SourceFile::parse(source.as_str(), Edition::CURRENT).tree();
+    let mut aliases = HashMap::new();
+    for item in parsed.items() {
+        let ast::Item::Use(use_item) = item else {
+            continue;
+        };
+        if !use_item_is_plain_public(&use_item) {
+            continue;
+        }
+        let Some(tree) = use_item.use_tree() else {
+            continue;
+        };
+        if let Some((alias, target)) = crate_reexport_alias_from_use_tree(&tree) {
+            aliases.insert(alias, target);
+        }
+    }
+    aliases
+}
+
+fn dependency_reexport_alias_candidate(
+    inner: &mut CacheInner,
+    dep_root: &Path,
+    canonical_path: &str,
+) -> Option<String> {
+    let mut segments = canonical_path.split("::").collect::<Vec<_>>();
+    if segments.len() < 3 {
+        return None;
+    }
+    let reexport_alias = normalized_crate_cache_key(segments[1].trim_start_matches("r#"));
+    let aliases = inner
+        .crate_reexport_aliases
+        .entry(dep_root.to_path_buf())
+        .or_insert_with(|| load_crate_reexport_aliases(dep_root));
+    let target = aliases.get(&reexport_alias)?;
+    segments[1] = target.as_str();
+    let candidate = segments[1..].join("::");
+    if candidate == canonical_path {
+        None
+    } else {
+        Some(candidate)
+    }
+}
+
+fn root_workspace_declares_crate(inner: &mut CacheInner, root: &Path, crate_name: &str) -> bool {
+    let names = inner
+        .root_crate_names
+        .entry(root.to_path_buf())
+        .or_insert_with(|| load_root_crate_names(root));
+    names
+        .iter()
+        .any(|name| name == normalized_crate_cache_key(crate_name).as_str())
+}
+
+/// Attempt extraction through one planned route: primary workspace, dependency workspace, then root out-dir workspace
+/// only for root-package items.
 fn extract_in_workspace_set(
     inner: &mut CacheInner,
     root: &Path,
@@ -479,6 +675,97 @@ fn extract_in_workspace_set(
         }
     }
 
+    let crate_name = crate_name_for_path(canonical_path);
+    let dep_resolve_started = Instant::now();
+    let dep_root = resolve_dependency_manifest_dir(inner, root, crate_name, registry_src_roots);
+    log_timing_stage(
+        timing_enabled,
+        root,
+        canonical_path,
+        "dependency.resolve_manifest_dir",
+        dep_resolve_started.elapsed(),
+        crate_name,
+    );
+    if let Some(dep_root) = dep_root {
+        if let Some(reexported_path) = dependency_reexport_alias_candidate(inner, &dep_root, canonical_path) {
+            let alias_started = Instant::now();
+            match extract_in_workspace_set(
+                inner,
+                root,
+                reexported_path.as_str(),
+                registry_src_roots,
+                progress,
+                timing_enabled,
+            ) {
+                Ok(meta) => {
+                    log_timing_stage(
+                        timing_enabled,
+                        root,
+                        canonical_path,
+                        "extract.dependency.reexport_alias",
+                        alias_started.elapsed(),
+                        reexported_path.as_str(),
+                    );
+                    return Ok(meta);
+                }
+                Err(
+                    err @ (RustMetadataError::CrateNotFound(_)
+                    | RustMetadataError::PathNotResolved(_)
+                    | RustMetadataError::UnsupportedMacro(_)),
+                ) => {
+                    log_timing_stage(
+                        timing_enabled,
+                        root,
+                        canonical_path,
+                        "extract.dependency.reexport_alias",
+                        alias_started.elapsed(),
+                        "status=miss short_circuit=true",
+                    );
+                    // A public crate re-export is an identity path. If the target crate misses, extracting
+                    // the wrapper dependency cannot discover a different item for the same path; it only
+                    // repeats the expensive semantic lookup through another surface.
+                    return Err(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        let dep_root_display = dep_root.display().to_string();
+        let dep_workspace = match inner.workspaces.entry((dep_root.clone(), true)) {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(v) => {
+                let load_started = Instant::now();
+                let workspace = RustWorkspace::load_with_options(&dep_root, progress, true)?;
+                log_timing_stage(
+                    timing_enabled,
+                    root,
+                    canonical_path,
+                    "workspace.load.dependency.out_dirs",
+                    load_started.elapsed(),
+                    dep_root_display.as_str(),
+                );
+                v.insert(workspace)
+            }
+        };
+        let extract_started = Instant::now();
+        let meta = extract_rust_item(dep_workspace, canonical_path);
+        log_timing_stage(
+            timing_enabled,
+            root,
+            canonical_path,
+            "extract.workspace.dependency",
+            extract_started.elapsed(),
+            dep_root_display.as_str(),
+        );
+        return meta;
+    }
+
+    if !root_workspace_declares_crate(inner, root, crate_name) {
+        if let Some(err) = deferred_load_error {
+            return Err(err);
+        }
+        return Err(RustMetadataError::CrateNotFound(crate_name.to_string()));
+    }
+
     match inner.workspaces.entry((root.to_path_buf(), true)) {
         Entry::Occupied(o) => {
             let started = Instant::now();
@@ -558,48 +845,6 @@ fn extract_in_workspace_set(
                 }
             }
         }
-    }
-
-    let crate_name = crate_name_for_path(canonical_path);
-    let dep_resolve_started = Instant::now();
-    let dep_root = dependency_manifest_dir_for_crate(root, crate_name, registry_src_roots);
-    log_timing_stage(
-        timing_enabled,
-        root,
-        canonical_path,
-        "dependency.resolve_manifest_dir",
-        dep_resolve_started.elapsed(),
-        crate_name,
-    );
-    if let Some(dep_root) = dep_root {
-        let dep_root_display = dep_root.display().to_string();
-        let dep_workspace = match inner.workspaces.entry((dep_root.clone(), true)) {
-            Entry::Occupied(o) => o.into_mut(),
-            Entry::Vacant(v) => {
-                let load_started = Instant::now();
-                let workspace = RustWorkspace::load_with_options(&dep_root, progress, true)?;
-                log_timing_stage(
-                    timing_enabled,
-                    root,
-                    canonical_path,
-                    "workspace.load.dependency.out_dirs",
-                    load_started.elapsed(),
-                    dep_root_display.as_str(),
-                );
-                v.insert(workspace)
-            }
-        };
-        let extract_started = Instant::now();
-        let meta = extract_rust_item(dep_workspace, canonical_path);
-        log_timing_stage(
-            timing_enabled,
-            root,
-            canonical_path,
-            "extract.workspace.dependency",
-            extract_started.elapsed(),
-            dep_root_display.as_str(),
-        );
-        return meta;
     }
 
     if let Some(err) = deferred_load_error {
@@ -927,6 +1172,15 @@ impl RustMetadataCache {
         inner
             .definition_aliases
             .retain(|(workspace_root, _), _| workspace_root != &root);
+        inner
+            .dependency_manifest_dirs
+            .retain(|(workspace_root, _), _| workspace_root != &root);
+        inner
+            .root_crate_names
+            .retain(|workspace_root, _| workspace_root != &root);
+        inner
+            .crate_reexport_aliases
+            .retain(|workspace_root, _| workspace_root != &root);
         inner
             .failed_items
             .retain(|(workspace_root, _), _| workspace_root != &root);

--- a/crates/rust_inspect/src/cache_tests.rs
+++ b/crates/rust_inspect/src/cache_tests.rs
@@ -116,7 +116,7 @@ fn disk_cache_invalidates_when_workspace_fingerprint_changes() -> Result<(), Box
         tmp.path(),
         &DiskCacheEnvelope {
             cache_format: DISK_CACHE_FORMAT,
-            inspector_version: INSPECTOR_VERSION.to_string(),
+            inspector_version: format!("cache-format-{DISK_CACHE_FORMAT}"),
             workspace_fingerprint: fingerprint,
             items: HashMap::from([("demo::Thing".to_string(), dummy_type_metadata("demo::Thing"))]),
             misses: HashMap::new(),
@@ -150,6 +150,67 @@ fn malformed_disk_cache_is_treated_as_miss() -> Result<(), Box<dyn std::error::E
     let mut inner = CacheInner::default();
     ensure_disk_cache_loaded(&mut inner, tmp.path())?;
     assert!(inner.items.is_empty());
+    Ok(())
+}
+
+#[test]
+fn disk_cache_does_not_invalidate_on_package_version_label() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    let fingerprint = workspace_fingerprint(tmp.path())?;
+    write_disk_cache(
+        tmp.path(),
+        &DiskCacheEnvelope {
+            cache_format: DISK_CACHE_FORMAT,
+            inspector_version: "0.3.0-old-rc-label".to_string(),
+            workspace_fingerprint: fingerprint,
+            items: HashMap::from([("demo::Thing".to_string(), dummy_type_metadata("demo::Thing"))]),
+            misses: HashMap::new(),
+        },
+    )?;
+
+    let mut inner = CacheInner::default();
+    ensure_disk_cache_loaded(&mut inner, tmp.path())?;
+    assert!(
+        inner
+            .items
+            .contains_key(&(tmp.path().to_path_buf(), "demo::Thing".to_string())),
+        "rust-inspect metadata compatibility is controlled by DISK_CACHE_FORMAT, not package version labels"
+    );
+    Ok(())
+}
+
+#[test]
+fn disk_cache_accepts_legacy_versioned_workspace_fingerprint() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    let old_version = "0.3.0-rc43";
+    let fingerprint = legacy_versioned_workspace_fingerprint(tmp.path(), old_version)?;
+    write_disk_cache(
+        tmp.path(),
+        &DiskCacheEnvelope {
+            cache_format: DISK_CACHE_FORMAT,
+            inspector_version: old_version.to_string(),
+            workspace_fingerprint: fingerprint,
+            items: HashMap::from([("demo::Thing".to_string(), dummy_type_metadata("demo::Thing"))]),
+            misses: HashMap::new(),
+        },
+    )?;
+
+    let mut inner = CacheInner::default();
+    ensure_disk_cache_loaded(&mut inner, tmp.path())?;
+    assert!(
+        inner
+            .items
+            .contains_key(&(tmp.path().to_path_buf(), "demo::Thing".to_string())),
+        "rc-bumped toolchains should reuse old versioned rust-inspect caches when dependency inputs still match"
+    );
     Ok(())
 }
 
@@ -280,6 +341,170 @@ fn repeated_missing_lookup_hits_negative_cache_without_new_workspace_load()
     assert_eq!(
         workspaces_after_second, workspaces_after_first,
         "negative-cache hit should avoid loading additional workspaces on repeated misses"
+    );
+    Ok(())
+}
+
+#[test]
+fn dependency_manifest_resolution_is_cached_per_manifest_root() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+
+    let root = tmp.path().canonicalize()?;
+    let mut inner = CacheInner::default();
+    let crate_name = "definitely_missing_dependency";
+
+    assert!(resolve_dependency_manifest_dir(&mut inner, &root, crate_name, Some(&[])).is_none());
+    assert!(inner
+        .dependency_manifest_dirs
+        .contains_key(&(root.clone(), crate_name.to_string())));
+    let cached_entries = inner.dependency_manifest_dirs.len();
+
+    assert!(resolve_dependency_manifest_dir(&mut inner, &root, crate_name, Some(&[])).is_none());
+    assert_eq!(
+        inner.dependency_manifest_dirs.len(),
+        cached_entries,
+        "repeat dependency-root lookups should use the in-memory resolution cache"
+    );
+    Ok(())
+}
+
+#[test]
+fn dependency_manifest_resolution_cache_normalizes_crate_spelling() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+
+    let root = tmp.path().canonicalize()?;
+    let mut inner = CacheInner::default();
+
+    assert!(resolve_dependency_manifest_dir(&mut inner, &root, "foo_bar", Some(&[])).is_none());
+    let cached_entries = inner.dependency_manifest_dirs.len();
+    assert!(resolve_dependency_manifest_dir(&mut inner, &root, "foo-bar", Some(&[])).is_none());
+    assert_eq!(
+        inner.dependency_manifest_dirs.len(),
+        cached_entries,
+        "hyphen and underscore crate spellings should share dependency-root resolution cache entries"
+    );
+    assert!(inner
+        .dependency_manifest_dirs
+        .contains_key(&(root, "foo_bar".to_string())));
+    Ok(())
+}
+
+#[test]
+fn root_out_dir_workspace_is_skipped_for_non_root_crate_misses() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"root-probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::create_dir_all(tmp.path().join("src"))?;
+    fs::write(tmp.path().join("src/lib.rs"), "pub fn keep() {}\n")?;
+
+    let cache = RustMetadataCache::new();
+    let query = "external_crate::Missing";
+
+    let result = cache.get_or_extract(tmp.path(), query, &|_| ());
+    assert!(matches!(
+        result,
+        Err(RustMetadataError::CrateNotFound(_))
+            | Err(RustMetadataError::PathNotResolved(_))
+            | Err(RustMetadataError::UnsupportedMacro(_))
+    ));
+
+    let root = tmp.path().canonicalize()?;
+    let inner = cache
+        .inner
+        .lock()
+        .map_err(|_| std::io::Error::other("poisoned cache"))?;
+    assert!(
+        !inner.workspaces.contains_key(&(root, true)),
+        "a dependency or stdlib miss should not force the expensive root out-dir workspace route"
+    );
+    Ok(())
+}
+
+#[test]
+fn dependency_reexport_alias_candidate_uses_public_crate_reexports() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let dep_root = tmp.path().join("wrapper-crate");
+    fs::create_dir_all(dep_root.join("src"))?;
+    fs::write(
+        dep_root.join("Cargo.toml"),
+        "[package]\nname = \"wrapper-crate\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\nname = \"wrapper_crate\"\n",
+    )?;
+    fs::write(
+        dep_root.join("src").join("lib.rs"),
+        "// re-exported dependency\npub use inner_crate;\npub use renamed_crate as renamed;\nuse private_crate;\n",
+    )?;
+
+    let mut inner = CacheInner::default();
+    assert_eq!(
+        dependency_reexport_alias_candidate(&mut inner, dep_root.as_path(), "wrapper_crate::inner_crate::Thing")
+            .as_deref(),
+        Some("inner_crate::Thing")
+    );
+    assert_eq!(
+        dependency_reexport_alias_candidate(&mut inner, dep_root.as_path(), "wrapper_crate::renamed::Thing")
+            .as_deref(),
+        Some("renamed_crate::Thing")
+    );
+    assert_eq!(
+        dependency_reexport_alias_candidate(&mut inner, dep_root.as_path(), "wrapper_crate::private_crate::Thing"),
+        None,
+        "private use declarations must not become public re-export identity aliases"
+    );
+    Ok(())
+}
+
+#[test]
+fn dependency_reexport_alias_miss_skips_wrapper_workspace() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().join("root");
+    let wrapper_root = tmp.path().join("wrapper-crate");
+    let inner_root = tmp.path().join("inner-crate");
+    fs::create_dir_all(root.join("src"))?;
+    fs::create_dir_all(wrapper_root.join("src"))?;
+    fs::create_dir_all(inner_root.join("src"))?;
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"root\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nwrapper-crate = { path = \"../wrapper-crate\" }\n",
+    )?;
+    fs::write(root.join("src").join("lib.rs"), "pub fn keep() {}\n")?;
+    fs::write(
+        wrapper_root.join("Cargo.toml"),
+        "[package]\nname = \"wrapper-crate\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\nname = \"wrapper_crate\"\n\n[dependencies]\ninner-crate = { path = \"../inner-crate\" }\n",
+    )?;
+    fs::write(wrapper_root.join("src").join("lib.rs"), "pub use inner_crate;\n")?;
+    fs::write(
+        inner_root.join("Cargo.toml"),
+        "[package]\nname = \"inner-crate\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\nname = \"inner_crate\"\n",
+    )?;
+    fs::write(inner_root.join("src").join("lib.rs"), "pub struct Present;\n")?;
+
+    let cache = RustMetadataCache::new();
+    let result = cache.get_or_extract(&root, "wrapper_crate::inner_crate::Missing", &|_| ());
+    assert!(matches!(
+        result,
+        Err(RustMetadataError::CrateNotFound(_))
+            | Err(RustMetadataError::PathNotResolved(_))
+            | Err(RustMetadataError::UnsupportedMacro(_))
+    ));
+
+    let wrapper_root = wrapper_root.canonicalize()?;
+    let inner = cache
+        .inner
+        .lock()
+        .map_err(|_| std::io::Error::other("poisoned cache"))?;
+    assert!(
+        !inner.workspaces.contains_key(&(wrapper_root, true)),
+        "a miss through a public crate re-export should not repeat the lookup through the wrapper dependency"
     );
     Ok(())
 }

--- a/crates/rust_inspect/src/cache_tests.rs
+++ b/crates/rust_inspect/src/cache_tests.rs
@@ -104,6 +104,7 @@ fn disk_cache_round_trips_inserted_items() -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
+/// Disk-cache entries are ignored when the generated workspace inputs change.
 #[test]
 fn disk_cache_invalidates_when_workspace_fingerprint_changes() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
@@ -153,6 +154,7 @@ fn malformed_disk_cache_is_treated_as_miss() -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
+/// Package version labels do not invalidate a cache when the format and workspace inputs still match.
 #[test]
 fn disk_cache_does_not_invalidate_on_package_version_label() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
@@ -183,6 +185,7 @@ fn disk_cache_does_not_invalidate_on_package_version_label() -> Result<(), Box<d
     Ok(())
 }
 
+/// Legacy rc-versioned fingerprints remain readable so rc bumps do not force needless re-extraction.
 #[test]
 fn disk_cache_accepts_legacy_versioned_workspace_fingerprint() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
@@ -345,6 +348,7 @@ fn repeated_missing_lookup_hits_negative_cache_without_new_workspace_load()
     Ok(())
 }
 
+/// Dependency manifest root lookup misses are cached per generated workspace.
 #[test]
 fn dependency_manifest_resolution_is_cached_per_manifest_root() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
@@ -372,6 +376,7 @@ fn dependency_manifest_resolution_is_cached_per_manifest_root() -> Result<(), Bo
     Ok(())
 }
 
+/// Dependency manifest lookup cache keys normalize hyphenated package names and underscored crate names.
 #[test]
 fn dependency_manifest_resolution_cache_normalizes_crate_spelling() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
@@ -397,6 +402,7 @@ fn dependency_manifest_resolution_cache_normalizes_crate_spelling() -> Result<()
     Ok(())
 }
 
+/// Non-root crate misses do not force the generated root workspace to reload with build-script out-dirs.
 #[test]
 fn root_out_dir_workspace_is_skipped_for_non_root_crate_misses() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
@@ -430,6 +436,7 @@ fn root_out_dir_workspace_is_skipped_for_non_root_crate_misses() -> Result<(), B
     Ok(())
 }
 
+/// Public crate re-exports are recognized as identity routes while private imports are ignored.
 #[test]
 fn dependency_reexport_alias_candidate_uses_public_crate_reexports() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
@@ -463,6 +470,7 @@ fn dependency_reexport_alias_candidate_uses_public_crate_reexports() -> Result<(
     Ok(())
 }
 
+/// Missing items reached through a public crate re-export do not repeat the same lookup in the wrapper workspace.
 #[test]
 fn dependency_reexport_alias_miss_skips_wrapper_workspace() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -349,6 +349,7 @@ impl<'a> IrCodegen<'a> {
         self.needs_serde
     }
 
+    /// Apply codegen's shared project context to an internal typechecker pass.
     fn configure_typechecker(&self, tc: &mut crate::frontend::typechecker::TypeChecker) {
         tc.stdlib_cache = self.stdlib_cache.clone();
         if let Some(names) = self.declared_crate_names.clone() {
@@ -363,10 +364,12 @@ impl<'a> IrCodegen<'a> {
         }
     }
 
+    /// Preserve stdlib metadata warmed by an internal typechecker pass for later codegen passes.
     fn capture_typechecker_stdlib_cache(&mut self, tc: &crate::frontend::typechecker::TypeChecker) {
         self.stdlib_cache = tc.stdlib_cache.clone();
     }
 
+    /// Apply codegen's shared metadata context to one AST lowering pass.
     fn configure_lowering(&self, lowering: &mut AstLowering) {
         lowering.set_stdlib_cache(self.stdlib_cache.clone());
         lowering.set_library_manifest_index(self.library_manifest_index.clone());

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 use crate::frontend::ast::Program;
 use crate::frontend::diagnostics::CompileError;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
+use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
 
 use super::emit::CallableNameResolution;
 use super::scanners::{
@@ -172,6 +173,9 @@ pub struct IrCodegen<'a> {
     public_ordinal_type_identities: HashMap<String, String>,
     /// Whether non-stdlib dependency modules keep public items that are not otherwise reachable.
     preserve_dependency_public_items: bool,
+    /// Shared stdlib source metadata cache reused across the repeated internal typecheck/lowering passes that codegen
+    /// performs for multi-module builds.
+    stdlib_cache: StdlibAstCache,
     /// Manifest/workspace root for rust-inspect-backed typechecking during IR generation.
     #[cfg(feature = "rust_inspect")]
     rust_inspect_manifest_dir: Option<PathBuf>,
@@ -195,6 +199,7 @@ impl<'a> IrCodegen<'a> {
             externally_reachable_items_by_module: HashMap::new(),
             public_ordinal_type_identities: HashMap::new(),
             preserve_dependency_public_items: true,
+            stdlib_cache: StdlibAstCache::new(),
             #[cfg(feature = "rust_inspect")]
             rust_inspect_manifest_dir: None,
         }
@@ -305,6 +310,11 @@ impl<'a> IrCodegen<'a> {
         self.preserve_dependency_public_items = enabled;
     }
 
+    /// Seed codegen with stdlib metadata already collected by an earlier typecheck phase.
+    pub(crate) fn set_stdlib_cache(&mut self, cache: StdlibAstCache) {
+        self.stdlib_cache = cache;
+    }
+
     /// Set declared Rust crate names from `incan.toml [rust-dependencies]`. (RFC 031)
     ///
     /// This is used for validating `rust.module()` paths during the internal typechecking that precedes IR lowering.
@@ -340,6 +350,7 @@ impl<'a> IrCodegen<'a> {
     }
 
     fn configure_typechecker(&self, tc: &mut crate::frontend::typechecker::TypeChecker) {
+        tc.stdlib_cache = self.stdlib_cache.clone();
         if let Some(names) = self.declared_crate_names.clone() {
             tc.set_declared_crate_names(names);
         }
@@ -350,6 +361,15 @@ impl<'a> IrCodegen<'a> {
         if let Some(dir) = self.rust_inspect_manifest_dir.clone() {
             tc.set_rust_inspect_manifest_dir(dir);
         }
+    }
+
+    fn capture_typechecker_stdlib_cache(&mut self, tc: &crate::frontend::typechecker::TypeChecker) {
+        self.stdlib_cache = tc.stdlib_cache.clone();
+    }
+
+    fn configure_lowering(&self, lowering: &mut AstLowering) {
+        lowering.set_stdlib_cache(self.stdlib_cache.clone());
+        lowering.set_library_manifest_index(self.library_manifest_index.clone());
     }
 
     /// Add a dependency module (for multi-file compilation)
@@ -520,7 +540,7 @@ impl<'a> IrCodegen<'a> {
 
     /// Generate code via the IR pipeline (fallible version)
     fn try_generate_via_ir(
-        &self,
+        &mut self,
         program: &Program,
         internal_module_roots: &HashSet<String>,
     ) -> Result<String, GenerationError> {
@@ -529,7 +549,7 @@ impl<'a> IrCodegen<'a> {
 
     /// Generate code via the IR pipeline with optional crate-root union sharing for multi-file source modules.
     fn try_generate_via_ir_with_union_config(
-        &self,
+        &mut self,
         program: &Program,
         internal_module_roots: &HashSet<String>,
         generated_union_types: HashMap<String, super::types::IrType>,
@@ -537,17 +557,14 @@ impl<'a> IrCodegen<'a> {
         mut callable_name_resolutions: Option<&mut HashMap<String, CallableNameResolution>>,
         mut callable_name_used_signature_keys: Option<&mut HashSet<String>>,
     ) -> Result<String, GenerationError> {
-        let deps: Vec<(&str, &Program)> = self
-            .dependency_modules
-            .iter()
-            .map(|(name, ast, _)| (*name, *ast))
-            .collect();
+        let dependency_modules = self.dependency_modules.clone();
+        let deps: Vec<(&str, &Program)> = dependency_modules.iter().map(|(name, ast, _)| (*name, *ast)).collect();
 
         // RFC 021: Make alias-aware lowering work across module boundaries by seeding alias maps
         // for models declared in dependency modules as well.
         let global_aliases = collect_model_field_aliases(program, &deps);
-        let dependency_symbol_metadata = collect_dependency_symbol_metadata(&self.dependency_modules);
-        let uses_std_ordinal_contract = compilation_imports_std_ordinal_contract(program, &self.dependency_modules);
+        let dependency_symbol_metadata = collect_dependency_symbol_metadata(&dependency_modules);
+        let uses_std_ordinal_contract = compilation_imports_std_ordinal_contract(program, &dependency_modules);
         let ordinal_bridge = self.ordinal_bridge_config(uses_std_ordinal_contract);
         let (needs_serialize, needs_deserialize) = collect_serde_derives(program, &deps);
 
@@ -558,22 +575,24 @@ impl<'a> IrCodegen<'a> {
             use crate::frontend::typechecker::TypeChecker;
             let mut tc = TypeChecker::new();
             self.configure_typechecker(&mut tc);
-            match tc.check_with_imports(program, &deps) {
+            let result = match tc.check_with_imports(program, &deps) {
                 Ok(()) => tc.type_info().clone(),
                 Err(errs) => return Err(GenerationError::TypeCheck(errs)),
-            }
+            };
+            self.capture_typechecker_stdlib_cache(&tc);
+            result
         };
 
         // Lower AST to IR using typechecker output when available
         let mut lowering = AstLowering::new_with_type_info(type_info_opt);
-        lowering.set_library_manifest_index(self.library_manifest_index.clone());
+        self.configure_lowering(&mut lowering);
         lowering.set_current_source_module_name(
             program
                 .source_path
                 .as_deref()
                 .and_then(crate::frontend::module::logical_module_name_from_source_path),
         );
-        lowering.seed_dependency_trait_decls(&self.dependency_modules);
+        lowering.seed_dependency_trait_decls(&dependency_modules);
         lowering.seed_struct_field_aliases(global_aliases.clone());
         let mut ir_program = lowering.lower_program(program)?;
         if self.needs_serde {
@@ -610,17 +629,20 @@ impl<'a> IrCodegen<'a> {
         }
 
         let mut dependency_ir_programs = Vec::new();
-        for (dep_name, dep_ast, dep_path_segments) in &self.dependency_modules {
+        for (dep_name, dep_ast, dep_path_segments) in dependency_modules.clone() {
             let dep_type_info = {
                 use crate::frontend::typechecker::TypeChecker;
                 let mut tc = TypeChecker::new();
                 self.configure_typechecker(&mut tc);
-                match tc.check_with_imports_allow_private(dep_ast, &deps) {
+                let result = match tc.check_with_imports_allow_private(dep_ast, &deps) {
                     Ok(()) => tc.type_info().clone(),
                     Err(errs) => return Err(GenerationError::TypeCheck(errs)),
-                }
+                };
+                self.capture_typechecker_stdlib_cache(&tc);
+                result
             };
             let mut dep_lowering = AstLowering::new_with_type_info(dep_type_info);
+            self.configure_lowering(&mut dep_lowering);
             dep_lowering.set_current_source_module_name(
                 dep_path_segments
                     .clone()
@@ -632,13 +654,11 @@ impl<'a> IrCodegen<'a> {
                             .and_then(crate::frontend::module::logical_module_name_from_source_path)
                     }),
             );
-            dep_lowering.seed_dependency_trait_decls(&self.dependency_modules);
+            dep_lowering.seed_dependency_trait_decls(&dependency_modules);
             dep_lowering.seed_struct_field_aliases(global_aliases.clone());
             let mut dep_ir = dep_lowering.lower_program(dep_ast)?;
             super::trait_bound_inference::infer_trait_bounds(&mut dep_ir);
-            let module_path = dep_path_segments
-                .clone()
-                .unwrap_or_else(|| vec![(*dep_name).to_string()]);
+            let module_path = dep_path_segments.clone().unwrap_or_else(|| vec![dep_name.to_string()]);
             dependency_ir_programs.push((module_path, dep_ir));
         }
         let dependency_programs = dependency_ir_programs
@@ -723,27 +743,28 @@ impl<'a> IrCodegen<'a> {
     /// Returns `GenerationError::Lowering` if AST lowering fails, or
     /// `GenerationError::Emission` if IR emission fails.
     pub fn try_generate_module(&mut self, module_name: &str, program: &Program) -> Result<String, GenerationError> {
+        let dependency_modules = self.dependency_modules.clone();
         // Use the IR pipeline for module generation too
         let mut lowering = AstLowering::new();
-        lowering.set_library_manifest_index(self.library_manifest_index.clone());
+        self.configure_lowering(&mut lowering);
         lowering.set_current_source_module_name(
             program
                 .source_path
                 .as_deref()
                 .and_then(crate::frontend::module::logical_module_name_from_source_path),
         );
-        lowering.seed_dependency_trait_decls(&self.dependency_modules);
+        lowering.seed_dependency_trait_decls(&dependency_modules);
         let mut ir_program = lowering.lower_program(program)?;
 
         // RFC 023: Infer trait bounds for generic functions.
         super::trait_bound_inference::infer_trait_bounds(&mut ir_program);
         let mut dependency_ir_programs = Vec::new();
-        for (dep_name, dep_ast, dep_path_segments) in &self.dependency_modules {
-            if *dep_name == module_name {
+        for (dep_name, dep_ast, dep_path_segments) in dependency_modules.clone() {
+            if dep_name == module_name {
                 continue;
             }
             let mut dep_lowering = AstLowering::new();
-            dep_lowering.set_library_manifest_index(self.library_manifest_index.clone());
+            self.configure_lowering(&mut dep_lowering);
             dep_lowering.set_current_source_module_name(
                 dep_path_segments
                     .clone()
@@ -755,7 +776,7 @@ impl<'a> IrCodegen<'a> {
                             .and_then(crate::frontend::module::logical_module_name_from_source_path)
                     }),
             );
-            dep_lowering.seed_dependency_trait_decls(&self.dependency_modules);
+            dep_lowering.seed_dependency_trait_decls(&dependency_modules);
             let mut dep_ir = dep_lowering.lower_program(dep_ast)?;
             super::trait_bound_inference::infer_trait_bounds(&mut dep_ir);
             dependency_ir_programs.push(dep_ir);
@@ -844,42 +865,40 @@ impl<'a> IrCodegen<'a> {
 
         let internal_roots: HashSet<String> = module_names.iter().map(|s| (*s).to_string()).collect();
 
-        let deps: Vec<(&str, &Program)> = self
-            .dependency_modules
-            .iter()
-            .map(|(name, ast, _)| (*name, *ast))
-            .collect();
+        let dependency_modules = self.dependency_modules.clone();
+        let deps: Vec<(&str, &Program)> = dependency_modules.iter().map(|(name, ast, _)| (*name, *ast)).collect();
         let global_aliases = collect_model_field_aliases(program, &deps);
-        let dependency_symbol_metadata = collect_dependency_symbol_metadata(&self.dependency_modules);
-        let uses_std_ordinal_contract = compilation_imports_std_ordinal_contract(program, &self.dependency_modules);
+        let dependency_symbol_metadata = collect_dependency_symbol_metadata(&dependency_modules);
+        let uses_std_ordinal_contract = compilation_imports_std_ordinal_contract(program, &dependency_modules);
         let ordinal_bridge = OrdinalBridgeConfig::for_internal_module(uses_std_ordinal_contract);
-        let dependency_reachable_items =
-            collect_externally_reachable_items_by_module(program, &self.dependency_modules);
+        let dependency_reachable_items = collect_externally_reachable_items_by_module(program, &dependency_modules);
 
         // Generate module files
         let mut lowered_modules = Vec::new();
-        for (name, ast, path_segments) in &self.dependency_modules {
-            if !module_names.contains(name) {
+        for (name, ast, path_segments) in dependency_modules.clone() {
+            if !module_names.contains(&name) {
                 continue;
             }
             let module_type_info = {
                 use crate::frontend::typechecker::TypeChecker;
                 let mut tc = TypeChecker::new();
                 self.configure_typechecker(&mut tc);
-                match tc.check_with_imports_allow_private(ast, &deps) {
+                let result = match tc.check_with_imports_allow_private(ast, &deps) {
                     Ok(()) => tc.type_info().clone(),
                     Err(errs) => return Err(GenerationError::TypeCheck(errs)),
-                }
+                };
+                self.capture_typechecker_stdlib_cache(&tc);
+                result
             };
             let mut lowering = AstLowering::new_with_type_info(module_type_info);
-            lowering.set_library_manifest_index(self.library_manifest_index.clone());
+            self.configure_lowering(&mut lowering);
             lowering.set_current_source_module_name(Some(
                 path_segments
                     .clone()
                     .unwrap_or_else(|| vec![name.to_string()])
                     .join("."),
             ));
-            lowering.seed_dependency_trait_decls(&self.dependency_modules);
+            lowering.seed_dependency_trait_decls(&dependency_modules);
             lowering.seed_struct_field_aliases(global_aliases.clone());
             let mut ir = lowering.lower_program(ast)?;
             // Do not auto-add serde derives to dependency modules.
@@ -1075,22 +1094,18 @@ impl<'a> IrCodegen<'a> {
 
         let internal_roots: HashSet<String> = module_paths.iter().filter_map(|p| p.first().cloned()).collect();
 
-        let deps: Vec<(&str, &Program)> = self
-            .dependency_modules
-            .iter()
-            .map(|(name, ast, _)| (*name, *ast))
-            .collect();
+        let dependency_modules = self.dependency_modules.clone();
+        let deps: Vec<(&str, &Program)> = dependency_modules.iter().map(|(name, ast, _)| (*name, *ast)).collect();
         let global_aliases = collect_model_field_aliases(program, &deps);
-        let dependency_symbol_metadata = collect_dependency_symbol_metadata(&self.dependency_modules);
-        let uses_std_ordinal_contract = compilation_imports_std_ordinal_contract(program, &self.dependency_modules);
+        let dependency_symbol_metadata = collect_dependency_symbol_metadata(&dependency_modules);
+        let uses_std_ordinal_contract = compilation_imports_std_ordinal_contract(program, &dependency_modules);
         let ordinal_bridge = OrdinalBridgeConfig::for_internal_module(uses_std_ordinal_contract);
-        let dependency_reachable_items =
-            collect_externally_reachable_items_by_module(program, &self.dependency_modules);
+        let dependency_reachable_items = collect_externally_reachable_items_by_module(program, &dependency_modules);
 
         // Generate module files by path
         let mut lowered_modules = Vec::new();
-        for (name, ast, stored_path_segments) in &self.dependency_modules {
-            let matching_path = if let Some(stored_path_segments) = stored_path_segments {
+        for (name, ast, stored_path_segments) in dependency_modules.clone() {
+            let matching_path = if let Some(stored_path_segments) = &stored_path_segments {
                 module_paths.iter().find(|path| *path == stored_path_segments)
             } else {
                 // Legacy callers may still register only a flat module name. Prefer explicit path segments when they
@@ -1102,15 +1117,17 @@ impl<'a> IrCodegen<'a> {
                     use crate::frontend::typechecker::TypeChecker;
                     let mut tc = TypeChecker::new();
                     self.configure_typechecker(&mut tc);
-                    match tc.check_with_imports_allow_private(ast, &deps) {
+                    let result = match tc.check_with_imports_allow_private(ast, &deps) {
                         Ok(()) => tc.type_info().clone(),
                         Err(errs) => return Err(GenerationError::TypeCheck(errs)),
-                    }
+                    };
+                    self.capture_typechecker_stdlib_cache(&tc);
+                    result
                 };
                 let mut lowering = AstLowering::new_with_type_info(module_type_info);
-                lowering.set_library_manifest_index(self.library_manifest_index.clone());
+                self.configure_lowering(&mut lowering);
                 lowering.set_current_source_module_name(Some(path.join(".")));
-                lowering.seed_dependency_trait_decls(&self.dependency_modules);
+                lowering.seed_dependency_trait_decls(&dependency_modules);
                 lowering.seed_struct_field_aliases(global_aliases.clone());
                 let mut ir = lowering.lower_program(ast)?;
                 // Do not auto-add serde derives to dependency modules.

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -267,6 +267,12 @@ impl AstLowering {
         self.current_source_module_name = name;
     }
 
+    /// Provide a warmed stdlib metadata cache for lowering stages that need stdlib-backed decorator or helper
+    /// metadata.
+    pub(crate) fn set_stdlib_cache(&mut self, cache: StdlibAstCache) {
+        self.stdlib_cache = cache;
+    }
+
     /// Provide public dependency manifests for lowering metadata-backed call signatures.
     pub fn set_library_manifest_index(&mut self, index: Option<Arc<LibraryManifestIndex>>) {
         self.library_manifest_index = index;

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -20,6 +20,7 @@ use crate::frontend::contract_metadata::{ContractMetadataPackage, read_project_m
 use crate::frontend::library_exports::{CheckedExportKind, CheckedNamedExport, collect_checked_public_exports};
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::module::canonicalize_source_module_segments;
+use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
 use crate::frontend::{diagnostics, typechecker};
 use crate::library_manifest::LibraryManifest;
 #[cfg(feature = "rust_inspect")]
@@ -788,10 +789,12 @@ pub fn build_library(
     let mut checked_exports_by_module: HashMap<String, HashMap<String, CheckedNamedExport>> = HashMap::new();
     let mut api_metadata_modules = Vec::new();
     let module_idx_by_key = module_key_index(&modules);
+    let mut stdlib_cache = StdlibAstCache::new();
 
     for (idx, module) in modules.iter().enumerate() {
         let deps_for_module = imported_module_deps_for_with_index(&modules, idx, &module_idx_by_key);
         let mut checker = typechecker::TypeChecker::new();
+        checker.stdlib_cache = stdlib_cache.clone();
         checker.set_current_module_path(Some(module.path_segments.clone()));
         checker.set_declared_crate_names(declared.clone());
         checker.set_library_manifest_index(library_manifest_index.clone());
@@ -819,8 +822,10 @@ pub fn build_library(
                         .map(|export| (export.name.clone(), export))
                         .collect(),
                 );
+                stdlib_cache = checker.stdlib_cache.clone();
             }
             Err(errs) => {
+                stdlib_cache = checker.stdlib_cache.clone();
                 for err in &errs {
                     all_errors.push_str(&diagnostics::format_error(
                         module.file_path.to_string_lossy().as_ref(),
@@ -914,6 +919,7 @@ pub fn build_library(
 
     let mut codegen = IrCodegen::new();
     codegen.set_preserve_dependency_public_items(true);
+    codegen.set_stdlib_cache(stdlib_cache);
     codegen.set_declared_crate_names(declared);
     codegen.set_library_manifest_index(library_manifest_index.clone());
     codegen.set_public_ordinal_type_identities(public_ordinal_type_identities(
@@ -929,31 +935,8 @@ pub fn build_library(
     generator.set_include_dev_dependencies(false);
     generator.set_rust_edition(manifest.build.as_ref().and_then(|build| build.rust_edition.clone()));
     #[cfg(feature = "rust_inspect")]
-    let lock_payload = resolve_lock_payload(LockResolutionRequest {
-        project_root: &project_root,
-        project_name: project_name.as_str(),
-        manifest: Some(&manifest),
-        resolved: &resolved,
-        project_requirements: &project_requirements,
-        cargo_features: &cargo_features,
-        cargo_policy: &cargo_policy,
-        #[cfg(feature = "rust_inspect")]
-        rust_inspect_query_paths: &metadata_query_paths,
-    })?;
-    #[cfg(feature = "rust_inspect")]
-    {
-        let rust_inspect_manifest_dir = ensure_rust_inspect_workspace(
-            &project_root,
-            project_name.as_str(),
-            manifest.build.as_ref().and_then(|build| build.rust_edition.clone()),
-            &resolved,
-            &project_requirements,
-            lock_payload.clone(),
-        )?;
-        prewarm_rust_inspect_workspace(&rust_inspect_manifest_dir, &metadata_query_paths)?;
-        codegen.set_rust_inspect_manifest_dir(rust_inspect_manifest_dir);
-    }
-    generator.set_cargo_lock_payload(lock_payload);
+    codegen.set_rust_inspect_manifest_dir(rust_inspect_manifest_dir.clone());
+    generator.set_cargo_lock_payload(lock_payload_for_typecheck);
     generator.set_cargo_policy_flags(cargo_command_flags(&cargo_policy, &cargo_features));
     generator.set_dependencies(resolved.dependencies);
     generator.set_dev_dependencies(resolved.dev_dependencies);

--- a/src/frontend/typechecker/stdlib_loader.rs
+++ b/src/frontend/typechecker/stdlib_loader.rs
@@ -72,7 +72,7 @@ pub(crate) struct TraitMeta {
 }
 
 /// Cached stdlib module signatures keyed by dot-joined module path (e.g. `"std.testing"`).
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct StdlibAstCache {
     /// Map from module path (dot-joined) to extracted stdlib module data.
     cache: HashMap<String, StdlibModuleData>,


### PR DESCRIPTION
## Summary

This PR reduces InQL CI runtime pressure by making rust-inspect reuse stable metadata work across rc bumps, build-library phases, dependency re-export routes, and generated test batches. It keeps extraction centralized in rust-inspect/build preparation rather than adding another ad hoc metadata path, and bumps the release candidate to `0.3.0-rc44`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: InQL and other Rust-heavy packages should spend far less time in repeated rust-inspect metadata prewarm/extraction during warm builds and generated test batches.
- **Internals**: `build --lib` now shares warmed stdlib AST metadata through typechecking, codegen, and lowering; rust-inspect disk-cache compatibility is tied to cache format and lock inputs rather than rc version labels; dependency manifest roots, root crate names, and public crate re-export aliases are cached; public re-export misses now short-circuit instead of repeating the same failed lookup through wrapper crates.
- **Risks**: The rust-inspect route planner now treats plain public crate re-exports as identity paths for stable misses. The new tests cover this route, but unusual re-export structures should still be watched in downstream Rust interop packages.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed, including rustdoc, 2,565 nextest tests, clippy, cargo-deny, `smoke-test-fast`, examples, and benchmark build checks.
- `cargo test -p rust_inspect` passed with 22 tests.
- `cargo check --bin incan --features lsp` passed.
- `cargo build --bin incan --features lsp` passed.
- `git diff --check` passed.
- InQL warm `make build` with the worker compiler passed in 36.90s, with rust-inspect prewarm at 45ms.
- InQL `make registry-metadata` passed in 40.54s, with rust-inspect prewarm at 5ms.
- InQL `make test` passed: 217 tests in 272.95s, with repeated generated-batch prewarm phases hitting cache in tens of ms.
- Fresh InQL probe improved from the earlier 184s route probe to 117.94s, and the DataFusion/Substrait wrapper miss dropped from about 47s to about 4s.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): …

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Related to #707 and #723.