### PR TITLE
bugfix - preserve facade import metadata (#57)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.3.0-rc44"
+version = "0.3.0-rc45"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -27,15 +27,16 @@
 //! The `generate*` methods are convenience wrappers that return error comments
 //! on failure (useful for debugging but not recommended for production).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::env;
 #[cfg(feature = "rust_inspect")]
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::frontend::ast::Program;
+use crate::frontend::ast::{Declaration, ImportKind, Program};
 use crate::frontend::diagnostics::CompileError;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
+use crate::frontend::module::canonicalize_source_module_segments;
 use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
 
 use super::emit::CallableNameResolution;
@@ -173,6 +174,8 @@ pub struct IrCodegen<'a> {
     public_ordinal_type_identities: HashMap<String, String>,
     /// Whether non-stdlib dependency modules keep public items that are not otherwise reachable.
     preserve_dependency_public_items: bool,
+    /// Dependency module paths that should typecheck with source-visible public import rules.
+    public_typecheck_module_paths: HashSet<Vec<String>>,
     /// Shared stdlib source metadata cache reused across the repeated internal typecheck/lowering passes that codegen
     /// performs for multi-module builds.
     stdlib_cache: StdlibAstCache,
@@ -199,10 +202,109 @@ impl<'a> IrCodegen<'a> {
             externally_reachable_items_by_module: HashMap::new(),
             public_ordinal_type_identities: HashMap::new(),
             preserve_dependency_public_items: true,
+            public_typecheck_module_paths: HashSet::new(),
             stdlib_cache: StdlibAstCache::new(),
             #[cfg(feature = "rust_inspect")]
             rust_inspect_manifest_dir: None,
         }
+    }
+
+    /// Return the stable module key used by source imports and CLI collection for one dependency module.
+    fn dependency_module_key(name: &str, path_segments: &Option<Vec<String>>) -> String {
+        path_segments
+            .as_deref()
+            .map(canonicalize_source_module_segments)
+            .map(|segments| segments.join("_"))
+            .unwrap_or_else(|| name.to_string())
+    }
+
+    /// Return the transitive local source dependency subset needed to typecheck one program.
+    ///
+    /// Codegen typechecking must mirror the CLI checker: a module should see its declared local imports and their
+    /// transitive signature dependencies, not every module collected for the output project. Importing the whole
+    /// dependency universe lets same-name public helpers from unrelated modules collide before `from ... import ... as
+    /// ...` collection, which changes behavior between `--check` and `--emit-rust`.
+    fn imported_dependency_modules_for_program(
+        program: &Program,
+        dependencies: &[(&'a str, &'a Program, Option<Vec<String>>)],
+        self_key: Option<&str>,
+    ) -> Vec<(&'a str, &'a Program)> {
+        let mut module_idx_by_key = HashMap::new();
+        for (idx, (name, _, path_segments)) in dependencies.iter().enumerate() {
+            module_idx_by_key.insert(Self::dependency_module_key(name, path_segments), idx);
+        }
+
+        let mut selected = BTreeSet::new();
+        let mut pending = Self::direct_imported_dependency_indexes(program, &module_idx_by_key, self_key);
+        while let Some(idx) = pending.pop() {
+            let (name, ast, path_segments) = &dependencies[idx];
+            let dep_key = Self::dependency_module_key(name, path_segments);
+            if self_key == Some(dep_key.as_str()) || !selected.insert(idx) {
+                continue;
+            }
+            pending.extend(Self::direct_imported_dependency_indexes(
+                ast,
+                &module_idx_by_key,
+                Some(dep_key.as_str()),
+            ));
+        }
+
+        selected
+            .into_iter()
+            .map(|idx| {
+                let (name, ast, _) = dependencies[idx];
+                (name, ast)
+            })
+            .collect()
+    }
+
+    /// Return direct dependency-module indexes named by source imports in one program.
+    fn direct_imported_dependency_indexes(
+        program: &Program,
+        module_idx_by_key: &HashMap<String, usize>,
+        self_key: Option<&str>,
+    ) -> Vec<usize> {
+        let mut dep_indexes = BTreeSet::new();
+        for decl in &program.declarations {
+            let Declaration::Import(import) = &decl.node else {
+                continue;
+            };
+            match &import.kind {
+                ImportKind::From { module, .. } => {
+                    if module.parent_levels > 0 || module.segments.is_empty() {
+                        continue;
+                    }
+                    let key = canonicalize_source_module_segments(&module.segments).join("_");
+                    if self_key != Some(key.as_str())
+                        && let Some(dep_idx) = module_idx_by_key.get(&key).copied()
+                    {
+                        dep_indexes.insert(dep_idx);
+                    }
+                }
+                ImportKind::Module(path) => {
+                    if path.parent_levels > 0 || path.segments.is_empty() {
+                        continue;
+                    }
+                    let full_key = canonicalize_source_module_segments(&path.segments).join("_");
+                    if self_key != Some(full_key.as_str())
+                        && let Some(dep_idx) = module_idx_by_key.get(&full_key).copied()
+                    {
+                        dep_indexes.insert(dep_idx);
+                    }
+                    if path.segments.len() > 1 {
+                        let parent_key =
+                            canonicalize_source_module_segments(&path.segments[..path.segments.len() - 1]).join("_");
+                        if self_key != Some(parent_key.as_str())
+                            && let Some(dep_idx) = module_idx_by_key.get(&parent_key).copied()
+                        {
+                            dep_indexes.insert(dep_idx);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        dep_indexes.into_iter().collect()
     }
 
     /// Build a registry for explicit canonical cross-module calls.
@@ -310,6 +412,15 @@ impl<'a> IrCodegen<'a> {
         self.preserve_dependency_public_items = enabled;
     }
 
+    /// Set dependency module paths that should typecheck with public source import rules.
+    ///
+    /// CLI test batches can emit individual test files as generated dependency modules so each file keeps its own Rust
+    /// module scope. Those test files are still user source and must typecheck like focused `incan test file.incn`
+    /// runs, not like compiler-internal source dependencies that may inspect private module items.
+    pub fn set_public_typecheck_module_paths(&mut self, paths: HashSet<Vec<String>>) {
+        self.public_typecheck_module_paths = paths;
+    }
+
     /// Seed codegen with stdlib metadata already collected by an earlier typecheck phase.
     pub(crate) fn set_stdlib_cache(&mut self, cache: StdlibAstCache) {
         self.stdlib_cache = cache;
@@ -362,6 +473,14 @@ impl<'a> IrCodegen<'a> {
         if let Some(dir) = self.rust_inspect_manifest_dir.clone() {
             tc.set_rust_inspect_manifest_dir(dir);
         }
+    }
+
+    /// Prefix internal codegen typecheck diagnostics with the module being lowered.
+    fn typecheck_errors_for_module(module: &str, mut errors: Vec<CompileError>) -> GenerationError {
+        for error in &mut errors {
+            error.message = format!("in module `{module}`: {}", error.message);
+        }
+        GenerationError::TypeCheck(errors)
     }
 
     /// Preserve stdlib metadata warmed by an internal typechecker pass for later codegen passes.
@@ -578,7 +697,8 @@ impl<'a> IrCodegen<'a> {
             use crate::frontend::typechecker::TypeChecker;
             let mut tc = TypeChecker::new();
             self.configure_typechecker(&mut tc);
-            let result = match tc.check_with_imports(program, &deps) {
+            let typecheck_deps = Self::imported_dependency_modules_for_program(program, &dependency_modules, None);
+            let result = match tc.check_with_imports(program, &typecheck_deps) {
                 Ok(()) => tc.type_info().clone(),
                 Err(errs) => return Err(GenerationError::TypeCheck(errs)),
             };
@@ -637,9 +757,12 @@ impl<'a> IrCodegen<'a> {
                 use crate::frontend::typechecker::TypeChecker;
                 let mut tc = TypeChecker::new();
                 self.configure_typechecker(&mut tc);
-                let result = match tc.check_with_imports_allow_private(dep_ast, &deps) {
+                let dep_key = Self::dependency_module_key(dep_name, &dep_path_segments);
+                let typecheck_deps =
+                    Self::imported_dependency_modules_for_program(dep_ast, &dependency_modules, Some(&dep_key));
+                let result = match tc.check_with_imports_allow_private(dep_ast, &typecheck_deps) {
                     Ok(()) => tc.type_info().clone(),
-                    Err(errs) => return Err(GenerationError::TypeCheck(errs)),
+                    Err(errs) => return Err(Self::typecheck_errors_for_module(&dep_key, errs)),
                 };
                 self.capture_typechecker_stdlib_cache(&tc);
                 result
@@ -886,9 +1009,12 @@ impl<'a> IrCodegen<'a> {
                 use crate::frontend::typechecker::TypeChecker;
                 let mut tc = TypeChecker::new();
                 self.configure_typechecker(&mut tc);
-                let result = match tc.check_with_imports_allow_private(ast, &deps) {
+                let module_key = Self::dependency_module_key(name, &path_segments);
+                let typecheck_deps =
+                    Self::imported_dependency_modules_for_program(ast, &dependency_modules, Some(&module_key));
+                let result = match tc.check_with_imports_allow_private(ast, &typecheck_deps) {
                     Ok(()) => tc.type_info().clone(),
-                    Err(errs) => return Err(GenerationError::TypeCheck(errs)),
+                    Err(errs) => return Err(Self::typecheck_errors_for_module(&module_key, errs)),
                 };
                 self.capture_typechecker_stdlib_cache(&tc);
                 result
@@ -1120,9 +1246,19 @@ impl<'a> IrCodegen<'a> {
                     use crate::frontend::typechecker::TypeChecker;
                     let mut tc = TypeChecker::new();
                     self.configure_typechecker(&mut tc);
-                    let result = match tc.check_with_imports_allow_private(ast, &deps) {
+                    let self_key = canonicalize_source_module_segments(path).join("_");
+                    let typecheck_deps =
+                        Self::imported_dependency_modules_for_program(ast, &dependency_modules, Some(&self_key));
+                    let result = if self.public_typecheck_module_paths.contains(path) {
+                        tc.check_with_imports(ast, &typecheck_deps)
+                    } else {
+                        tc.check_with_imports_allow_private(ast, &typecheck_deps)
+                    };
+                    let result = match result {
                         Ok(()) => tc.type_info().clone(),
-                        Err(errs) => return Err(GenerationError::TypeCheck(errs)),
+                        Err(errs) => {
+                            return Err(Self::typecheck_errors_for_module(&path.join("."), errs));
+                        }
                     };
                     self.capture_typechecker_stdlib_cache(&tc);
                     result

--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -338,7 +338,7 @@ impl<'a> IrEmitter<'a> {
     }
 
     /// Return the dependency qualifier for generated anonymous union wrappers referenced through a public library call.
-    fn pub_library_union_qualifier(canonical_path: Option<&[String]>) -> Option<Vec<String>> {
+    pub(in super::super) fn pub_library_union_qualifier(canonical_path: Option<&[String]>) -> Option<Vec<String>> {
         canonical_path.and_then(|path| {
             if path.first().map(String::as_str) == Some("pub") {
                 path.get(1).map(|library| vec![library.clone()])
@@ -852,7 +852,13 @@ impl<'a> IrEmitter<'a> {
                 let target_aware_union_widening_arg = target_ty
                     .is_some_and(|target_ty| self.union_widening_needed(&widening_source_ty, target_ty))
                     && !matches!(use_site, ValueUseSite::ExternalCallArg { .. });
-                let target_aware_value_arg = target_aware_aggregate_literal_arg || target_aware_union_widening_arg;
+                let (list_widening_source_ty, _) = self.list_element_widening_source_for_expr(a);
+                let target_aware_list_element_widening_arg = target_ty
+                    .is_some_and(|target_ty| self.list_element_widening_needed(&list_widening_source_ty, target_ty))
+                    && !matches!(use_site, ValueUseSite::ExternalCallArg { .. });
+                let target_aware_value_arg = target_aware_aggregate_literal_arg
+                    || target_aware_union_widening_arg
+                    || target_aware_list_element_widening_arg;
                 let arg_plan = ArgumentPassingPlan::for_use_site(a, use_site);
                 let previous_qualify = if *from_default {
                     Some(self.qualify_internal_canonical_paths.replace(true))

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -367,6 +367,121 @@ impl<'a> IrEmitter<'a> {
         }
     }
 
+    /// Return the semantic list type and owner qualifier that should drive element-level union widening.
+    ///
+    /// Imported public calls can carry dependency-owned generated union wrappers inside a list. This mirrors scalar
+    /// union widening source discovery so non-literal list arguments do not fall back to a caller-owned wrapper shape.
+    pub(in super::super) fn list_element_widening_source_for_expr(
+        &self,
+        expr: &TypedExpr,
+    ) -> (IrType, Option<Vec<String>>) {
+        match &expr.kind {
+            IrExprKind::Call {
+                callable_signature: Some(signature),
+                canonical_path,
+                ..
+            } if self
+                .list_element_union_type(&signature.return_type)
+                .is_some_and(|elem| elem.union_members().is_some()) =>
+            {
+                (
+                    signature.return_type.clone(),
+                    Self::pub_library_union_qualifier(canonical_path.as_deref()),
+                )
+            }
+            IrExprKind::MethodCall {
+                callable_signature: Some(signature),
+                ..
+            } if self
+                .list_element_union_type(&signature.return_type)
+                .is_some_and(|elem| elem.union_members().is_some()) =>
+            {
+                (signature.return_type.clone(), None)
+            }
+            _ => (expr.ty.clone(), None),
+        }
+    }
+
+    /// Return the resolved element type for a list shape.
+    fn list_element_union_type(&self, ty: &IrType) -> Option<IrType> {
+        match self.resolve_type_aliases_for_emit(ty) {
+            IrType::List(elem) => Some(*elem),
+            _ => None,
+        }
+    }
+
+    /// Return whether `List[S]` needs an element-wise union conversion to satisfy `List[T]`.
+    pub(in super::super) fn list_element_widening_needed(&self, source_ty: &IrType, target_ty: &IrType) -> bool {
+        let source_ty = self.resolve_type_aliases_for_emit(source_ty);
+        let target_ty = self.resolve_type_aliases_for_emit(target_ty);
+        let (IrType::List(source_elem), IrType::List(target_elem)) = (&source_ty, &target_ty) else {
+            return false;
+        };
+        if source_elem == target_elem {
+            return false;
+        }
+        target_elem.union_variant_index_for_member(source_elem).is_some()
+            || self.union_widening_needed(source_elem, target_elem)
+    }
+
+    /// Emit an element-wise conversion from `List[S]` to `List[Union[...S...]]` or a wider union list.
+    fn emit_list_element_widening_value(
+        &self,
+        source_ty: &IrType,
+        target_ty: &IrType,
+        source_tokens: TokenStream,
+        source_qualifier: Option<&[String]>,
+        target_qualifier: Option<&[String]>,
+    ) -> Result<Option<TokenStream>, EmitError> {
+        let source_ty = self.resolve_type_aliases_for_emit(source_ty);
+        let target_ty = self.resolve_type_aliases_for_emit(target_ty);
+        let (IrType::List(source_elem), IrType::List(target_elem)) = (&source_ty, &target_ty) else {
+            return Ok(None);
+        };
+        if source_elem == target_elem {
+            return Ok(None);
+        }
+
+        if let Some(converted_item) = self.emit_union_widening_value(
+            source_elem,
+            target_elem,
+            quote! { __incan_item },
+            source_qualifier,
+            target_qualifier,
+        )? {
+            return Ok(Some(quote! {
+                (#source_tokens).into_iter().map(|__incan_item| #converted_item).collect::<Vec<_>>()
+            }));
+        }
+
+        let Some(variant_index) = target_elem.union_variant_index_for_member(source_elem) else {
+            return Ok(None);
+        };
+        let Some(members) = target_elem.union_members() else {
+            return Ok(None);
+        };
+        let Some(member_ty) = members.get(variant_index) else {
+            return Ok(None);
+        };
+        let item_tokens = if matches!(member_ty, IrType::String)
+            && matches!(
+                source_elem.as_ref(),
+                IrType::StaticStr | IrType::StrRef | IrType::FrozenStr
+            ) {
+            quote! { __incan_item.to_string() }
+        } else {
+            quote! { __incan_item }
+        };
+        let variant_ident = quote::format_ident!("{}", IrType::union_variant_name(variant_index));
+        let union_path = self.emit_union_type_path_with_qualifier(target_elem, target_qualifier);
+        Ok(Some(quote! {
+            (#source_tokens)
+                .into_iter()
+                .map(|__incan_item| #union_path :: #variant_ident(#item_tokens))
+                .collect::<Vec<_>>()
+        }))
+    }
+
     /// Return the `Result[output, error]` target type for the inner expression of `output?`.
     fn try_inner_target_type(&self, output_ty: &IrType, inner: &TypedExpr) -> Option<IrType> {
         if matches!(output_ty, IrType::Unknown) {
@@ -549,6 +664,16 @@ impl<'a> IrEmitter<'a> {
                     site,
                 )?;
                 if let Some(target_ty) = resolved_target_ty.as_ref() {
+                    let (source_ty, source_qualifier) = self.list_element_widening_source_for_expr(expr);
+                    if let Some(converted) = self.emit_list_element_widening_value(
+                        &source_ty,
+                        target_ty,
+                        emitted.clone(),
+                        source_qualifier.as_deref(),
+                        target_union_qualifier,
+                    )? {
+                        return Ok(converted);
+                    }
                     let (source_ty, source_qualifier) = self.union_widening_source_for_expr(expr);
                     if let Some(converted) = self.emit_union_widening_value(
                         &source_ty,
@@ -583,6 +708,16 @@ impl<'a> IrEmitter<'a> {
                     target_site,
                 )?;
                 if let Some(target_ty) = resolved_target_ty.as_ref() {
+                    let (source_ty, source_qualifier) = self.list_element_widening_source_for_expr(expr);
+                    if let Some(converted) = self.emit_list_element_widening_value(
+                        &source_ty,
+                        target_ty,
+                        emitted.clone(),
+                        source_qualifier.as_deref(),
+                        target_union_qualifier,
+                    )? {
+                        return Ok(converted);
+                    }
                     let (source_ty, source_qualifier) = self.union_widening_source_for_expr(expr);
                     if let Some(converted) = self.emit_union_widening_value(
                         &source_ty,
@@ -603,6 +738,16 @@ impl<'a> IrEmitter<'a> {
         let plan = plan_value_use(expr, site);
         let emitted = plan.apply(emitted);
         if let Some(target_ty) = resolved_target_ty.as_ref() {
+            let (source_ty, source_qualifier) = self.list_element_widening_source_for_expr(expr);
+            if let Some(converted) = self.emit_list_element_widening_value(
+                &source_ty,
+                target_ty,
+                emitted.clone(),
+                source_qualifier.as_deref(),
+                target_union_qualifier,
+            )? {
+                return Ok(converted);
+            }
             let (source_ty, source_qualifier) = self.union_widening_source_for_expr(expr);
             if let Some(converted) = self.emit_union_widening_value(
                 &source_ty,

--- a/src/backend/project/generator.rs
+++ b/src/backend/project/generator.rs
@@ -262,6 +262,28 @@ impl ProjectGenerator {
         }
     }
 
+    /// Return the generated filename for a top-level Rust module leaf.
+    ///
+    /// Cargo treats `src/main.rs` and `src/lib.rs` as crate roots. Generated library projects can still have source
+    /// modules named `main` or `lib`, so those module leaves use explicit `#[path]` declarations and non-root
+    /// filenames.
+    fn top_level_leaf_module_file_name(module_name: &str) -> String {
+        match module_name {
+            "main" | "lib" => format!("__incan_mod_{module_name}.rs"),
+            _ => format!("{module_name}.rs"),
+        }
+    }
+
+    /// Return whether a top-level generated module name would otherwise create a Cargo crate-root file.
+    fn is_special_top_level_leaf_module(module_name: &str) -> bool {
+        matches!(module_name, "main" | "lib")
+    }
+
+    /// Return the path used in a top-level module declaration for a generated leaf module.
+    fn top_level_leaf_module_relative_path(module_name: &str) -> String {
+        Self::top_level_leaf_module_file_name(module_name)
+    }
+
     /// Render a Rust module declaration for a generated module file or directory.
     ///
     /// Keyword-named modules use raw identifiers in Rust (`r#type`) while keeping the on-disk layout clean
@@ -269,7 +291,10 @@ impl ProjectGenerator {
     /// matches the RFC 023 closeout contract for keyword-named module paths.
     fn render_module_decl(name: &str, relative_path: &str, visibility: &str) -> String {
         let escaped_name = rust_keywords::escape_keyword(name);
-        if rust_keywords::is_keyword(name) {
+        let default_leaf_path = format!("{name}.rs");
+        let default_dir_path = format!("{name}/mod.rs");
+        if rust_keywords::is_keyword(name) || (relative_path != default_leaf_path && relative_path != default_dir_path)
+        {
             return format!("#[path = \"{relative_path}\"]\n{visibility}mod {escaped_name};");
         }
         format!("{visibility}mod {escaped_name};")
@@ -307,6 +332,9 @@ impl ProjectGenerator {
 
         for module_name in modules.keys() {
             changed |= Self::remove_conflicting_module_artifact(&src_dir.join(module_name))?;
+            if Self::is_special_top_level_leaf_module(module_name) {
+                changed |= Self::remove_conflicting_module_artifact(&src_dir.join(format!("{module_name}.rs")))?;
+            }
         }
 
         // Write Cargo.toml
@@ -316,7 +344,7 @@ impl ProjectGenerator {
 
         // Write each module file
         for (module_name, module_code) in modules {
-            let module_file = src_dir.join(format!("{}.rs", module_name));
+            let module_file = src_dir.join(Self::top_level_leaf_module_file_name(module_name));
             changed |= Self::write_file_if_changed(&module_file, module_code)?;
         }
 
@@ -333,7 +361,7 @@ impl ProjectGenerator {
             let visibility = if self.is_binary { "" } else { "pub " };
             let mods: String = module_names
                 .iter()
-                .map(|m| Self::render_module_decl(m, &format!("{m}.rs"), visibility))
+                .map(|m| Self::render_module_decl(m, &Self::top_level_leaf_module_relative_path(m), visibility))
                 .collect::<Vec<_>>()
                 .join("\n")
                 + "\n";
@@ -440,6 +468,12 @@ impl ProjectGenerator {
                 changed |= Self::remove_conflicting_module_artifact(&module_path.with_extension("rs"))?;
             } else {
                 changed |= Self::remove_conflicting_module_artifact(&module_path)?;
+                if path_segments.len() == 1
+                    && let Some(module_name) = path_segments.first()
+                    && Self::is_special_top_level_leaf_module(module_name)
+                {
+                    changed |= Self::remove_conflicting_module_artifact(&module_path.with_extension("rs"))?;
+                }
             }
         }
 
@@ -509,7 +543,11 @@ impl ProjectGenerator {
             let file_stem = path_segments
                 .last()
                 .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "empty module path"))?;
-            let file_name = format!("{file_stem}.rs");
+            let file_name = if path_segments.len() == 1 {
+                Self::top_level_leaf_module_file_name(file_stem)
+            } else {
+                format!("{file_stem}.rs")
+            };
             file_path = file_path.join(file_name);
 
             changed |= Self::write_file_if_changed(&file_path, module_code)?;
@@ -532,7 +570,7 @@ impl ProjectGenerator {
                     let relative_path = if modules_with_submodules.contains(&top_level_path) {
                         format!("{m}/mod.rs")
                     } else {
-                        format!("{m}.rs")
+                        Self::top_level_leaf_module_relative_path(m)
                     };
                     Self::render_module_decl(m, &relative_path, visibility)
                 })
@@ -787,6 +825,33 @@ mod tests {
 
         let type_mod_rs_content = fs::read_to_string(temp_dir.join("src/type/mod.rs"))?;
         assert!(type_mod_rs_content.contains("pub mod helpers;"));
+
+        let _ = fs::remove_dir_all(&temp_dir);
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_nested_avoids_cargo_root_filenames_for_top_level_modules() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = std::env::temp_dir().join("incan_test_special_top_modules");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        let generator = ProjectGenerator::new(&temp_dir, "test_special_top_modules", false);
+
+        let mut modules = HashMap::new();
+        modules.insert(vec!["main".to_string()], "pub fn from_main() {}".to_string());
+        modules.insert(vec!["lib".to_string()], "pub fn from_lib() {}".to_string());
+        generator.generate_nested("pub fn root() {}", &modules)?;
+
+        let lib_rs = fs::read_to_string(temp_dir.join("src/lib.rs"))?;
+        assert!(lib_rs.contains("#[path = \"__incan_mod_main.rs\"]\npub mod main;"));
+        assert!(lib_rs.contains("#[path = \"__incan_mod_lib.rs\"]\npub mod lib;"));
+        assert!(temp_dir.join("src/__incan_mod_main.rs").exists());
+        assert!(temp_dir.join("src/__incan_mod_lib.rs").exists());
+        assert!(
+            !temp_dir.join("src/main.rs").exists(),
+            "top-level generated module must not create a Cargo binary root"
+        );
 
         let _ = fs::remove_dir_all(&temp_dir);
         Ok(())

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -36,6 +36,7 @@ use super::types::{FixtureScope, TestInfo, TestResult};
 
 /// Generated `#[cfg(test)]` module that wraps Incan test functions as Rust `#[test]` cases.
 const INCAN_FILE_TEST_MOD: &str = "__incan_file_tests";
+const INCAN_SESSION_FIXTURE_MOD: &str = "__incan_session_fixtures";
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct TestExecutionOptions {
@@ -540,7 +541,7 @@ fn parse_test_batch_sources(
     })
 }
 
-struct InlineSourceModuleBatch {
+struct IsolatedSourceModuleBatch {
     ast: Program,
     source_modules: Vec<ParsedModule>,
     harnesses: Vec<PreparedModuleHarness>,
@@ -554,14 +555,6 @@ fn empty_test_batch_root(first_path: &Path) -> Program {
         rust_module_path: None,
         warnings: Vec::new(),
     }
-}
-
-/// Return whether a program contains inline test modules.
-fn program_has_inline_test_module(program: &Program) -> bool {
-    program
-        .declarations
-        .iter()
-        .any(|decl| matches!(decl.node, Declaration::TestModule(_)))
 }
 
 /// Prepare the runner AST and fixture metadata for a test module.
@@ -616,6 +609,34 @@ fn module_name_for_segments(segments: &[String]) -> String {
     format!("{stem}_{}", &digest[..8])
 }
 
+/// Derive a stable generated module path for one test source file.
+///
+/// Normal package files use their project-relative path, such as `tests.foo`. If a caller supplies an unusual file
+/// path outside the known roots, keep the multi-file batch isolated by assigning a synthetic path instead of falling
+/// back to concatenating independent test files into one frontend scope.
+fn test_module_segments_for_file(project_root: &Path, source_root: &Path, path: &Path) -> Vec<String> {
+    let absolute_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    };
+    if let Some(module_path) = logical_module_segments_from_file(source_root, &absolute_path)
+        .or_else(|| logical_module_segments_from_file(project_root, &absolute_path))
+    {
+        return module_path;
+    }
+
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or("test");
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_path_for_cache_key(path).to_string_lossy().as_bytes());
+    let digest = hex::encode(hasher.finalize());
+    vec!["tests".to_string(), format!("{stem}_{}", &digest[..8])]
+}
+
 /// Read conftest source files for a test batch.
 fn read_conftest_sources(paths: &[PathBuf]) -> Result<Vec<(PathBuf, String)>, String> {
     let mut sources = Vec::new();
@@ -627,15 +648,19 @@ fn read_conftest_sources(paths: &[PathBuf]) -> Result<Vec<(PathBuf, String)>, St
     Ok(sources)
 }
 
-/// Prepare a collision-aware batch of inline source modules.
-fn prepare_inline_source_module_batch(
+/// Prepare a multi-file test batch that keeps each test file in its own generated Rust module.
+///
+/// Concatenating independent test files into one frontend program leaks file-local imports and aliases across the
+/// whole batch. Module-isolated batching preserves source-file scope while still compiling one shared Cargo harness.
+fn prepare_isolated_source_module_batch(
     sources_by_file: &[(PathBuf, String)],
     conftest_files_by_file: &HashMap<PathBuf, Vec<PathBuf>>,
+    project_root: &Path,
     source_root: &Path,
     library_manifest_index: &LibraryManifestIndex,
     library_imported_vocab: &parser::ImportedLibraryVocab,
     library_imported_dsl_surfaces: &parser::ImportedLibraryDslSurfaces,
-) -> Result<Option<InlineSourceModuleBatch>, String> {
+) -> Result<Option<IsolatedSourceModuleBatch>, String> {
     if sources_by_file.len() <= 1 {
         return Ok(None);
     }
@@ -647,18 +672,13 @@ fn prepare_inline_source_module_batch(
     let mut parsed_sources = Vec::new();
 
     for (path, source) in sources_by_file {
-        let Some(module_path) = logical_module_segments_from_file(source_root, path) else {
-            return Ok(None);
-        };
+        let module_path = test_module_segments_for_file(project_root, source_root, path);
         let ast = parse_and_desugar_test_sources(
             &[(path.clone(), source.clone())],
             library_manifest_index,
             library_imported_vocab,
             library_imported_dsl_surfaces,
         )?;
-        if !program_has_inline_test_module(&ast) {
-            return Ok(None);
-        }
         batch_files.insert(canonical_path_for_cache_key(path));
         parsed_sources.push((path.clone(), source.clone(), module_path, ast));
     }
@@ -725,7 +745,7 @@ fn prepare_inline_source_module_batch(
         .first()
         .map(|(path, _)| path.as_path())
         .unwrap_or_else(|| Path::new("."));
-    Ok(Some(InlineSourceModuleBatch {
+    Ok(Some(IsolatedSourceModuleBatch {
         ast: empty_test_batch_root(first_path),
         source_modules,
         harnesses,
@@ -1685,6 +1705,35 @@ fn fixture_cache_static_name(name: &str) -> String {
     format!("__INCAN_FIXTURE_CACHE_{}", safe_name.to_ascii_uppercase())
 }
 
+/// Return the Rust path used to access one generated fixture cache static.
+fn fixture_cache_static_ref(name: &str, fixture: &FixtureExecutionInfo, session_cache_module: Option<&str>) -> String {
+    let static_name = fixture_cache_static_name(name);
+    if fixture.scope == FixtureScope::Session
+        && let Some(module) = session_cache_module
+    {
+        return format!("crate::{module}::{static_name}");
+    }
+    static_name
+}
+
+/// Render one generated cache static for a module- or session-scoped fixture.
+fn render_fixture_cache_static(name: &str, fixture: &FixtureExecutionInfo, visibility: &str) -> Option<String> {
+    if fixture.scope == FixtureScope::Function {
+        return None;
+    }
+    let static_name = fixture_cache_static_name(name);
+    if fixture.has_teardown {
+        let state_rust_type = fixture.state_rust_type.as_ref()?;
+        return Some(format!(
+            "{visibility}static {static_name}: std::sync::OnceLock<std::sync::Mutex<Option<{state_rust_type}>>> = std::sync::OnceLock::new();\n"
+        ));
+    }
+    fixture.return_rust_type.as_ref()?;
+    Some(format!(
+        "{visibility}static {static_name}: std::sync::OnceLock<std::sync::Mutex<Option<Box<dyn std::any::Any + Send>>>> = std::sync::OnceLock::new();\n"
+    ))
+}
+
 /// Return the local generated Rust binding that stores one fixture's setup/teardown state.
 fn fixture_state_ident(index: usize, name: &str) -> String {
     format!("__incan_fixture_state_{index}_{}", safe_fixture_ident(name))
@@ -1762,124 +1811,123 @@ fn test_runner_stdlib_features_for_batch(
     features.into_iter().collect()
 }
 
-/// Generate an expression that calls a fixture, recursively filling fixture dependencies.
-fn fixture_arg(
-    name: &str,
-    index: usize,
-    setup: &mut String,
-    fixtures: &HashMap<String, FixtureExecutionInfo>,
-    created_builtins: &mut HashSet<String>,
-    teardown_steps: &mut Vec<String>,
-    visiting: &mut Vec<String>,
-) -> String {
-    if let Some(expr) = builtin_fixture_arg(name, index, setup, created_builtins) {
-        return expr;
-    }
+struct FixtureArgRender<'a> {
+    setup: &'a mut String,
+    fixtures: &'a HashMap<String, FixtureExecutionInfo>,
+    created_builtins: &'a mut HashSet<String>,
+    teardown_steps: &'a mut Vec<String>,
+    session_cache_module: Option<&'a str>,
+}
 
-    if visiting.iter().any(|existing| existing == name) {
-        return format!("super::{name}()");
-    }
-    visiting.push(name.to_string());
-    let args = fixtures
-        .get(name)
-        .map(|fixture| {
-            fixture
-                .params
-                .iter()
-                .map(|param| {
-                    fixture_arg(
-                        param,
-                        index,
-                        setup,
-                        fixtures,
-                        created_builtins,
-                        teardown_steps,
-                        visiting,
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(", ")
-        })
-        .unwrap_or_default();
-    let _ = visiting.pop();
-    let Some(fixture) = fixtures.get(name) else {
-        return format!("super::{name}({args})");
-    };
-    let setup_call = fixture_setup_call(name, &args, fixture);
-    let Some(return_rust_type) = fixture.return_rust_type.as_ref() else {
-        return setup_call;
-    };
-    if fixture.has_teardown {
-        let Some(teardown) = &fixture.teardown else {
+impl FixtureArgRender<'_> {
+    /// Generate an expression that calls a fixture, recursively filling fixture dependencies.
+    fn arg(&mut self, name: &str, index: usize, visiting: &mut Vec<String>) -> String {
+        if let Some(expr) = builtin_fixture_arg(name, index, self.setup, self.created_builtins) {
+            return expr;
+        }
+
+        if visiting.iter().any(|existing| existing == name) {
+            return format!("super::{name}()");
+        }
+        visiting.push(name.to_string());
+        let params = self
+            .fixtures
+            .get(name)
+            .map(|fixture| fixture.params.clone())
+            .unwrap_or_default();
+        let args = params
+            .iter()
+            .map(|param| self.arg(param, index, visiting))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = visiting.pop();
+        let Some(fixture) = self.fixtures.get(name).cloned() else {
+            return format!("super::{name}({args})");
+        };
+        let setup_call = fixture_setup_call(name, &args, &fixture);
+        let Some(return_rust_type) = fixture.return_rust_type.as_ref() else {
             return setup_call;
         };
-        if fixture.scope == FixtureScope::Function {
-            let state_ident = fixture_state_ident(index, name);
-            let value_ident = fixture_value_ident(index, name);
-            setup.push_str(&format!("        let {state_ident} = {setup_call};\n"));
-            if teardown.captures.is_empty() {
-                setup.push_str(&format!("        let {value_ident} = {state_ident};\n"));
-                teardown_steps.push(fixture_teardown_call(fixture, &teardown.teardown_function, ""));
-            } else {
-                let capture_names = teardown
-                    .captures
-                    .iter()
-                    .map(|capture| format!("__incan_fixture_capture_{}_{}", safe_fixture_ident(name), capture.name))
-                    .collect::<Vec<_>>();
-                setup.push_str(&format!(
-                    "        let ({value_ident}, {}) = {state_ident};\n",
-                    capture_names.join(", ")
-                ));
-                teardown_steps.push(fixture_teardown_call(
-                    fixture,
-                    &teardown.teardown_function,
-                    &capture_names.join(", "),
-                ));
+        if fixture.has_teardown {
+            let Some(teardown) = &fixture.teardown else {
+                return setup_call;
+            };
+            if fixture.scope == FixtureScope::Function {
+                let state_ident = fixture_state_ident(index, name);
+                let value_ident = fixture_value_ident(index, name);
+                self.setup
+                    .push_str(&format!("        let {state_ident} = {setup_call};\n"));
+                if teardown.captures.is_empty() {
+                    self.setup
+                        .push_str(&format!("        let {value_ident} = {state_ident};\n"));
+                    self.teardown_steps
+                        .push(fixture_teardown_call(&fixture, &teardown.teardown_function, ""));
+                } else {
+                    let capture_names = teardown
+                        .captures
+                        .iter()
+                        .map(|capture| format!("__incan_fixture_capture_{}_{}", safe_fixture_ident(name), capture.name))
+                        .collect::<Vec<_>>();
+                    self.setup.push_str(&format!(
+                        "        let ({value_ident}, {}) = {state_ident};\n",
+                        capture_names.join(", ")
+                    ));
+                    self.teardown_steps.push(fixture_teardown_call(
+                        &fixture,
+                        &teardown.teardown_function,
+                        &capture_names.join(", "),
+                    ));
+                }
+                return value_ident;
             }
-            return value_ident;
-        }
-        let static_name = fixture_cache_static_name(name);
-        if teardown.captures.is_empty() {
+            let static_name = fixture_cache_static_ref(name, &fixture, self.session_cache_module);
+            if teardown.captures.is_empty() {
+                return format!(
+                    "{{\n\
+                         let __incan_cache = {static_name}.get_or_init(|| std::sync::Mutex::new(None));\n\
+                         let Ok(mut __incan_guard) = __incan_cache.lock() else {{ panic!(\"fixture cache `{name}` is poisoned\"); }};\n\
+                         if __incan_guard.is_none() {{ *__incan_guard = Some({setup_call}); }}\n\
+                         let Some(__incan_value) = __incan_guard.as_ref() else {{ panic!(\"fixture cache `{name}` was not initialized\"); }};\n\
+                         __incan_value.clone()\n\
+                     }}"
+                );
+            }
             return format!(
                 "{{\n\
-                     let __incan_cache = {static_name}.get_or_init(|| std::sync::Mutex::new(None));\n\
-                     let Ok(mut __incan_guard) = __incan_cache.lock() else {{ panic!(\"fixture cache `{name}` is poisoned\"); }};\n\
-                     if __incan_guard.is_none() {{ *__incan_guard = Some({setup_call}); }}\n\
-                     let Some(__incan_value) = __incan_guard.as_ref() else {{ panic!(\"fixture cache `{name}` was not initialized\"); }};\n\
-                     __incan_value.clone()\n\
-                 }}"
+                         let __incan_cache = {static_name}.get_or_init(|| std::sync::Mutex::new(None));\n\
+                         let Ok(mut __incan_guard) = __incan_cache.lock() else {{ panic!(\"fixture cache `{name}` is poisoned\"); }};\n\
+                         if __incan_guard.is_none() {{ *__incan_guard = Some({setup_call}); }}\n\
+                         let Some(__incan_state) = __incan_guard.as_ref() else {{ panic!(\"fixture cache `{name}` was not initialized\"); }};\n\
+                         let __incan_value: &{return_rust_type} = &__incan_state.0;\n\
+                         __incan_value.clone()\n\
+                     }}"
             );
         }
-        return format!(
+        if fixture.scope == FixtureScope::Function {
+            return setup_call;
+        }
+
+        let static_name = fixture_cache_static_ref(name, &fixture, self.session_cache_module);
+        format!(
             "{{\n\
                      let __incan_cache = {static_name}.get_or_init(|| std::sync::Mutex::new(None));\n\
                      let Ok(mut __incan_guard) = __incan_cache.lock() else {{ panic!(\"fixture cache `{name}` is poisoned\"); }};\n\
-                     if __incan_guard.is_none() {{ *__incan_guard = Some({setup_call}); }}\n\
-                     let Some(__incan_state) = __incan_guard.as_ref() else {{ panic!(\"fixture cache `{name}` was not initialized\"); }};\n\
-                     let __incan_value: &{return_rust_type} = &__incan_state.0;\n\
+                     if __incan_guard.is_none() {{ *__incan_guard = Some(Box::new({setup_call})); }}\n\
+                     let Some(__incan_boxed) = __incan_guard.as_ref() else {{ panic!(\"fixture cache `{name}` was not initialized\"); }};\n\
+                     let Some(__incan_value) = __incan_boxed.downcast_ref::<{return_rust_type}>() else {{ panic!(\"fixture cache `{name}` had an unexpected type\"); }};\n\
                      __incan_value.clone()\n\
                  }}"
-        );
+        )
     }
-    if fixture.scope == FixtureScope::Function {
-        return setup_call;
-    }
-
-    let static_name = fixture_cache_static_name(name);
-    format!(
-        "{{\n\
-                 let __incan_cache = {static_name}.get_or_init(|| std::sync::Mutex::new(None));\n\
-                 let Ok(mut __incan_guard) = __incan_cache.lock() else {{ panic!(\"fixture cache `{name}` is poisoned\"); }};\n\
-                 if __incan_guard.is_none() {{ *__incan_guard = Some(Box::new({setup_call})); }}\n\
-                 let Some(__incan_boxed) = __incan_guard.as_ref() else {{ panic!(\"fixture cache `{name}` was not initialized\"); }};\n\
-                 let Some(__incan_value) = __incan_boxed.downcast_ref::<{return_rust_type}>() else {{ panic!(\"fixture cache `{name}` had an unexpected type\"); }};\n\
-                 __incan_value.clone()\n\
-             }}"
-    )
 }
 
 /// Generate the body statement that invokes one collected test case.
-fn harness_call(test: &TestInfo, index: usize, fixtures: &HashMap<String, FixtureExecutionInfo>) -> String {
+fn harness_call(
+    test: &TestInfo,
+    index: usize,
+    fixtures: &HashMap<String, FixtureExecutionInfo>,
+    session_cache_module: Option<&str>,
+) -> String {
     let mut setup = String::new();
     let mut args = Vec::new();
     let mut teardown_steps = Vec::new();
@@ -1887,59 +1935,45 @@ fn harness_call(test: &TestInfo, index: usize, fixtures: &HashMap<String, Fixtur
     let mut created_builtins = HashSet::new();
     let parametrize = test.parametrize_call.as_ref();
 
-    for param_name in &test.parameter_names {
-        if let Some(call) = parametrize
-            && let Some(pos) = call.argument_names.iter().position(|name| name == param_name)
-            && let Some(value) = call.rust_arguments.get(pos)
-        {
-            args.push(value.clone());
-            continue;
+    {
+        let mut fixture_render = FixtureArgRender {
+            setup: &mut setup,
+            fixtures,
+            created_builtins: &mut created_builtins,
+            teardown_steps: &mut teardown_steps,
+            session_cache_module,
+        };
+
+        for param_name in &test.parameter_names {
+            if let Some(call) = parametrize
+                && let Some(pos) = call.argument_names.iter().position(|name| name == param_name)
+                && let Some(value) = call.rust_arguments.get(pos)
+            {
+                args.push(value.clone());
+                continue;
+            }
+
+            if test.required_fixtures.iter().any(|fixture| fixture == param_name) {
+                used_fixtures.insert(param_name.clone());
+                args.push(fixture_render.arg(param_name, index, &mut Vec::new()));
+            }
         }
 
-        if test.required_fixtures.iter().any(|fixture| fixture == param_name) {
-            used_fixtures.insert(param_name.clone());
-            args.push(fixture_arg(
-                param_name,
-                index,
-                &mut setup,
-                fixtures,
-                &mut created_builtins,
-                &mut teardown_steps,
-                &mut Vec::new(),
-            ));
+        if test.parameter_names.is_empty() {
+            if let Some(call) = parametrize {
+                args.extend(call.rust_arguments.clone());
+            }
+            for fixture in &test.required_fixtures {
+                used_fixtures.insert(fixture.clone());
+                args.push(fixture_render.arg(fixture, index, &mut Vec::new()));
+            }
         }
-    }
 
-    if test.parameter_names.is_empty() {
-        if let Some(call) = parametrize {
-            args.extend(call.rust_arguments.clone());
-        }
         for fixture in &test.required_fixtures {
-            used_fixtures.insert(fixture.clone());
-            args.push(fixture_arg(
-                fixture,
-                index,
-                &mut setup,
-                fixtures,
-                &mut created_builtins,
-                &mut teardown_steps,
-                &mut Vec::new(),
-            ));
-        }
-    }
-
-    for fixture in &test.required_fixtures {
-        if !used_fixtures.contains(fixture) {
-            let expr = fixture_arg(
-                fixture,
-                index,
-                &mut setup,
-                fixtures,
-                &mut created_builtins,
-                &mut teardown_steps,
-                &mut Vec::new(),
-            );
-            setup.push_str(&format!("        let _ = {expr};\n"));
+            if !used_fixtures.contains(fixture) {
+                let expr = fixture_render.arg(fixture, index, &mut Vec::new());
+                fixture_render.setup.push_str(&format!("        let _ = {expr};\n"));
+            }
         }
     }
 
@@ -2093,7 +2127,26 @@ fn inject_file_test_harness(
     fixtures: &HashMap<String, FixtureExecutionInfo>,
 ) -> String {
     let test_indices = (0..tests.len()).collect::<Vec<_>>();
-    inject_file_test_harness_with_indices(rust_code, tests, &test_indices, project_root, fixtures)
+    inject_file_test_harness_with_indices(rust_code, tests, &test_indices, project_root, fixtures, None)
+}
+
+/// Render the shared session-fixture cache module used by isolated multi-file test batches.
+fn render_shared_session_fixture_cache_module(module_harnesses: &[PreparedModuleHarness]) -> Option<String> {
+    let mut statics = BTreeSet::new();
+    for harness in module_harnesses {
+        for (name, fixture) in &harness.fixtures {
+            if fixture.scope != FixtureScope::Session {
+                continue;
+            }
+            if let Some(static_decl) = render_fixture_cache_static(name, fixture, "pub(crate) ") {
+                statics.insert(static_decl);
+            }
+        }
+    }
+    if statics.is_empty() {
+        return None;
+    }
+    Some(statics.into_iter().collect::<Vec<_>>().join(""))
 }
 
 /// Inject generated Rust test harness entries using stable test indices.
@@ -2103,6 +2156,7 @@ fn inject_file_test_harness_with_indices(
     test_indices: &[usize],
     project_root: &Path,
     fixtures: &HashMap<String, FixtureExecutionInfo>,
+    session_cache_module: Option<&str>,
 ) -> String {
     let mut out = rust_code.to_string();
     let project_root_literal = project_root.to_string_lossy().to_string();
@@ -2110,23 +2164,13 @@ fn inject_file_test_harness_with_indices(
     out.push_str(INCAN_FILE_TEST_MOD);
     out.push_str(" {\n");
     for (name, fixture) in fixtures {
-        if fixture.scope == FixtureScope::Function {
+        if fixture.scope == FixtureScope::Function
+            || (fixture.scope == FixtureScope::Session && session_cache_module.is_some())
+        {
             continue;
         }
-        if fixture.has_teardown {
-            if let Some(state_rust_type) = &fixture.state_rust_type {
-                out.push_str("static ");
-                out.push_str(&fixture_cache_static_name(name));
-                out.push_str(": std::sync::OnceLock<std::sync::Mutex<Option<");
-                out.push_str(state_rust_type);
-                out.push_str(">>> = std::sync::OnceLock::new();\n");
-            }
-        } else if fixture.return_rust_type.is_some() {
-            out.push_str("static ");
-            out.push_str(&fixture_cache_static_name(name));
-            out.push_str(
-                ": std::sync::OnceLock<std::sync::Mutex<Option<Box<dyn std::any::Any + Send>>>> = std::sync::OnceLock::new();\n",
-            );
+        if let Some(static_decl) = render_fixture_cache_static(name, fixture, "") {
+            out.push_str(&static_decl);
         }
     }
     out.push_str(
@@ -2180,7 +2224,7 @@ fn inject_file_test_harness_with_indices(
     let teardown_fixtures = ordered_teardown_fixtures(tests, fixtures);
     for (index, t) in test_indices.iter().copied().zip(tests.iter()) {
         let fname = harness_fn_name(t, index);
-        let call = harness_call(t, index, fixtures);
+        let call = harness_call(t, index, fixtures, session_cache_module);
         out.push_str("    #[test]\n    fn ");
         out.push_str(&fname);
         out.push_str("() {\n");
@@ -2211,7 +2255,7 @@ fn inject_file_test_harness_with_indices(
             let Some(teardown) = &fixture.teardown else {
                 continue;
             };
-            let static_name = fixture_cache_static_name(name);
+            let static_name = fixture_cache_static_ref(name, fixture, session_cache_module);
             out.push_str(&format!(
                 "        if let Some(__incan_cache) = {static_name}.get() {{\n\
                          let Ok(mut __incan_guard) = __incan_cache.lock() else {{ panic!(\"fixture cache `{name}` is poisoned\"); }};\n\
@@ -2854,9 +2898,10 @@ pub(super) fn run_file_tests_batch(
     let project_root = absolute_project_root(&project_root);
     let source_root = common::resolve_source_root(&project_root, manifest.as_ref());
 
-    let inline_module_batch = match prepare_inline_source_module_batch(
+    let isolated_module_batch = match prepare_isolated_source_module_batch(
         &sources_by_file,
         conftest_files_by_file,
+        &project_root,
         &source_root,
         &library_manifest_index,
         &library_imported_vocab,
@@ -2871,7 +2916,7 @@ pub(super) fn run_file_tests_batch(
         }
     };
 
-    let (runner_ast, fixtures, source_modules, module_harnesses) = if let Some(batch) = inline_module_batch {
+    let (runner_ast, fixtures, source_modules, module_harnesses) = if let Some(batch) = isolated_module_batch {
         (batch.ast, HashMap::new(), batch.source_modules, batch.harnesses)
     } else {
         if batch_has_cross_file_top_level_collision(
@@ -3204,6 +3249,13 @@ pub(super) fn run_file_tests_batch(
     if prepared.module_harnesses.is_empty() {
         codegen.set_externally_reachable_items(collect_harness_entrypoints(tests, &fixtures));
     } else {
+        codegen.set_public_typecheck_module_paths(
+            prepared
+                .module_harnesses
+                .iter()
+                .map(|harness| harness.module_path.clone())
+                .collect(),
+        );
         let reachable_by_module = prepared
             .module_harnesses
             .iter()
@@ -3284,6 +3336,14 @@ pub(super) fn run_file_tests_batch(
                 Ok(result) => result,
                 Err(e) => return gen_err(format!("Code generation error: {}", e)),
             };
+        let session_cache_module = if prepared.module_harnesses.is_empty() {
+            None
+        } else {
+            render_shared_session_fixture_cache_module(&prepared.module_harnesses).map(|module_code| {
+                rust_modules.insert(vec![INCAN_SESSION_FIXTURE_MOD.to_string()], module_code);
+                INCAN_SESSION_FIXTURE_MOD
+            })
+        };
         if prepared.module_harnesses.is_empty() {
             main_code = inject_file_test_harness(&main_code, tests, &prepared.project_root, &fixtures);
         } else {
@@ -3310,6 +3370,7 @@ pub(super) fn run_file_tests_batch(
                     &test_indices,
                     &prepared.project_root,
                     &harness.fixtures,
+                    session_cache_module,
                 );
             }
         }

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -230,6 +230,10 @@ impl TypeChecker {
                 ));
                 continue;
             }
+            if let Some(kind) = self.imported_source_dependency_symbol_kind(module, item) {
+                self.define_resolved_source_import_symbol(item, kind, span);
+                continue;
+            }
             if self.preserve_existing_from_import_symbol(item, span) {
                 continue;
             }
@@ -566,6 +570,24 @@ impl TypeChecker {
     /// Define one imported item under its local alias after root namespace validation.
     fn define_from_import_symbol(&mut self, item: &ImportItem, kind: SymbolKind, span: Span) {
         let local_name = Self::import_item_local_name(item);
+        self.define_named_import_symbol(local_name, kind, span);
+    }
+
+    /// Return the exact source dependency member targeted by a `from module import item` declaration.
+    fn imported_source_dependency_symbol_kind(&self, module: &ImportPath, item: &ImportItem) -> Option<SymbolKind> {
+        self.dependency_member_symbol_for_path(module, &item.name)
+    }
+
+    /// Define a source-imported dependency symbol under its local import name.
+    fn define_resolved_source_import_symbol(&mut self, item: &ImportItem, mut kind: SymbolKind, span: Span) {
+        let local_name = Self::import_item_local_name(item);
+        if let SymbolKind::Static(info) = &mut kind {
+            info.is_imported = true;
+            self.type_info.declarations.static_bindings.insert(
+                local_name.clone(),
+                crate::frontend::typechecker::StaticBindingInfo { is_imported: true },
+            );
+        }
         self.define_named_import_symbol(local_name, kind, span);
     }
 

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -72,7 +72,7 @@ use std::sync::Arc;
 use crate::frontend::ast::*;
 use crate::frontend::diagnostics::{CompileError, ErrorKind, errors};
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
-use crate::frontend::module::{ExportedSymbol, exported_symbols};
+use crate::frontend::module::{ExportedSymbol, canonicalize_source_module_segments, exported_symbols};
 use crate::frontend::resolved_type_subst::{substitute_resolved_type, type_param_subst_map};
 use crate::frontend::surface_semantics::SurfaceContext;
 use crate::frontend::symbols::*;
@@ -197,6 +197,17 @@ pub struct TypeChecker {
     pub(crate) type_info: TypeCheckInfo,
     /// Public exports for imported dependency modules, keyed by module name.
     pub(crate) dependency_exports: HashMap<String, Vec<ExportedSymbol>>,
+    /// Exact source-module member symbols collected from dependencies, keyed by canonical module name.
+    ///
+    /// Direct source imports use this map before falling back to ambient symbol lookup so `from module import name as
+    /// alias` binds `module.name`, not an unrelated same-name symbol imported earlier from a sibling dependency.
+    pub(crate) dependency_member_symbols: HashMap<String, HashMap<String, SymbolKind>>,
+    /// Module-owned direct dependency members captured while that module is being imported.
+    ///
+    /// Dependency re-export refresh runs after all modules have been imported, when the ambient symbol table may
+    /// contain unrelated same-name declarations from sibling modules. Direct members must therefore come from this
+    /// per-module snapshot rather than a later global `lookup_symbol(...)`.
+    pub(crate) dependency_direct_member_symbols: HashMap<String, HashMap<String, SymbolKind>>,
     /// RFC 024 derivable-module metadata from imported source modules, keyed by module path.
     pub(crate) dependency_derivable_modules: HashMap<String, Vec<String>>,
     /// RFC 024/user-module trait metadata from imported source modules, keyed by module-qualified trait name.
@@ -318,6 +329,8 @@ impl TypeChecker {
             const_eval_cache: HashMap::new(),
             type_info: TypeCheckInfo::default(),
             dependency_exports: HashMap::new(),
+            dependency_member_symbols: HashMap::new(),
+            dependency_direct_member_symbols: HashMap::new(),
             dependency_derivable_modules: HashMap::new(),
             dependency_module_traits: HashMap::new(),
             dependency_trait_rust_derive_paths: HashMap::new(),
@@ -3583,6 +3596,8 @@ impl TypeChecker {
         }
         self.resolve_pending_trait_supertraits();
         self.register_dependency_derivable_metadata(_module_name, module_ast);
+        self.cache_dependency_direct_member_symbols(_module_name, module_ast, true);
+        self.cache_dependency_member_symbols(_module_name, module_ast, true);
         self.surface_context = previous_surface_context;
         self.import_aliases = previous_import_aliases;
     }
@@ -3614,8 +3629,130 @@ impl TypeChecker {
         }
         self.resolve_pending_trait_supertraits();
         self.register_dependency_derivable_metadata(_module_name, module_ast);
+        self.cache_dependency_direct_member_symbols(_module_name, module_ast, false);
+        self.cache_dependency_member_symbols(_module_name, module_ast, false);
         self.surface_context = previous_surface_context;
         self.import_aliases = previous_import_aliases;
+    }
+
+    /// Rebuild exact dependency-member caches after all dependency modules have been collected.
+    ///
+    /// Public facade modules may re-export items from sibling modules. Importing a facade before the underlying
+    /// sibling has been fully collected can leave the facade cache with a placeholder type shell. A final cache pass
+    /// after dependency collection lets re-exports resolve through the now-complete target module metadata.
+    fn refresh_dependency_member_symbols(&mut self, dependencies: &[(&str, &Program)], public_only: bool) {
+        for (name, dep_ast) in dependencies {
+            if Self::is_generated_stdlib_dependency_module(name) {
+                continue;
+            }
+            self.cache_dependency_member_symbols(name, dep_ast, public_only);
+        }
+    }
+
+    /// Cache exact member symbols exported by one dependency module for source `from ... import ...` resolution.
+    fn cache_dependency_member_symbols(&mut self, module_name: &str, module_ast: &Program, public_only: bool) {
+        let mut member_symbols = HashMap::new();
+        if let Some(direct_symbols) = self.dependency_direct_member_symbols.get(module_name) {
+            member_symbols.extend(direct_symbols.clone());
+        } else {
+            self.cache_dependency_direct_member_symbols(module_name, module_ast, public_only);
+            if let Some(direct_symbols) = self.dependency_direct_member_symbols.get(module_name) {
+                member_symbols.extend(direct_symbols.clone());
+            }
+        }
+        for (exported_name, module, item_name) in Self::dependency_source_reexport_targets(module_ast) {
+            if let Some(kind) = self.dependency_member_symbol_for_path(&module, &item_name) {
+                member_symbols.insert(exported_name, kind);
+            }
+        }
+        self.dependency_member_symbols
+            .insert(module_name.to_string(), member_symbols);
+    }
+
+    /// Cache direct declarations owned by one dependency module.
+    fn cache_dependency_direct_member_symbols(&mut self, module_name: &str, module_ast: &Program, public_only: bool) {
+        let mut direct_symbols = HashMap::new();
+        for name in Self::dependency_direct_member_names(module_ast, public_only) {
+            if let Some(symbol) = self.lookup_symbol(name.as_str()) {
+                direct_symbols.insert(name, symbol.kind.clone());
+            }
+        }
+        self.dependency_direct_member_symbols
+            .insert(module_name.to_string(), direct_symbols);
+    }
+
+    /// Return direct declaration names owned by a dependency module, excluding import re-exports.
+    fn dependency_direct_member_names(module_ast: &Program, public_only: bool) -> HashSet<String> {
+        if public_only {
+            return exported_symbols(module_ast)
+                .into_iter()
+                .filter_map(|symbol| match symbol {
+                    ExportedSymbol::Const(name)
+                    | ExportedSymbol::Static(name)
+                    | ExportedSymbol::Type(name)
+                    | ExportedSymbol::Trait(name)
+                    | ExportedSymbol::Function(name) => Some(name),
+                    ExportedSymbol::Variant { variant_name, .. } => Some(variant_name),
+                    ExportedSymbol::Reexported(_) => None,
+                })
+                .collect();
+        }
+
+        module_ast
+            .declarations
+            .iter()
+            .filter_map(|decl| match &decl.node {
+                Declaration::Const(decl) => Some(decl.name.clone()),
+                Declaration::Static(decl) => Some(decl.name.clone()),
+                Declaration::Model(decl) => Some(decl.name.clone()),
+                Declaration::Class(decl) => Some(decl.name.clone()),
+                Declaration::Trait(decl) => Some(decl.name.clone()),
+                Declaration::Alias(decl) => Some(decl.name.clone()),
+                Declaration::Partial(decl) => Some(decl.name.clone()),
+                Declaration::TypeAlias(decl) => Some(decl.name.clone()),
+                Declaration::Newtype(decl) => Some(decl.name.clone()),
+                Declaration::Enum(decl) => Some(decl.name.clone()),
+                Declaration::Function(decl) => Some(decl.name.clone()),
+                Declaration::Import(_) | Declaration::Docstring(_) | Declaration::TestModule(_) => None,
+            })
+            .collect()
+    }
+
+    /// Return source-module import targets that a dependency module makes visible as member bindings.
+    fn dependency_source_reexport_targets(module_ast: &Program) -> Vec<(String, ImportPath, String)> {
+        module_ast
+            .declarations
+            .iter()
+            .filter_map(|decl| match &decl.node {
+                Declaration::Import(import) => Some(import),
+                _ => None,
+            })
+            .filter_map(|import| match &import.kind {
+                ImportKind::From { module, items } => Some((module, items.as_slice())),
+                _ => None,
+            })
+            .flat_map(|(module, items)| {
+                items.iter().map(move |item| {
+                    (
+                        item.alias.as_ref().unwrap_or(&item.name).clone(),
+                        module.clone(),
+                        item.name.clone(),
+                    )
+                })
+            })
+            .collect()
+    }
+
+    /// Return the exact symbol kind for one dependency module member path.
+    pub(crate) fn dependency_member_symbol_for_path(&self, module: &ImportPath, item_name: &str) -> Option<SymbolKind> {
+        if module.parent_levels > 0 || module.segments.is_empty() {
+            return None;
+        }
+        let module_name = canonicalize_source_module_segments(&module.segments).join("_");
+        self.dependency_member_symbols
+            .get(&module_name)?
+            .get(item_name)
+            .cloned()
     }
 
     /// Register RFC 024 metadata exported by a dependency source module.
@@ -3869,6 +4006,8 @@ impl TypeChecker {
         dependencies: &[(&str, &Program)],
     ) -> Result<(), Vec<CompileError>> {
         self.dependency_exports.clear();
+        self.dependency_member_symbols.clear();
+        self.dependency_direct_member_symbols.clear();
         self.dependency_derivable_modules.clear();
         self.dependency_module_traits.clear();
         self.dependency_trait_rust_derive_paths.clear();
@@ -3887,6 +4026,7 @@ impl TypeChecker {
             }
             self.import_module(dep_ast, name);
         }
+        self.refresh_dependency_member_symbols(dependencies, true);
 
         // Then check the main program
         self.check_program(program)
@@ -3903,6 +4043,8 @@ impl TypeChecker {
     ) -> Result<(), Vec<CompileError>> {
         // Skip populating dependency exports so visibility checks are bypassed.
         self.dependency_exports.clear();
+        self.dependency_member_symbols.clear();
+        self.dependency_direct_member_symbols.clear();
         self.dependency_derivable_modules.clear();
         self.dependency_module_traits.clear();
         self.dependency_trait_rust_derive_paths.clear();
@@ -3913,6 +4055,7 @@ impl TypeChecker {
             }
             self.import_module_all(dep_ast, name);
         }
+        self.refresh_dependency_member_symbols(dependencies, false);
         self.check_program(program)
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -3682,6 +3682,409 @@ def test_decorated_default_probe() -> None:
 }
 
 #[test]
+fn test_facade_reexport_preserves_declared_source_import_alias_target_issue57() -> Result<(), Box<dyn std::error::Error>>
+{
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "facade_reexport_import_alias_target", "")?;
+    let src_dir = main_path.parent().ok_or("main path had no parent")?;
+    let references_dir = src_dir.join("functions").join("references");
+    let aggregates_dir = src_dir.join("functions").join("aggregates");
+    fs::create_dir_all(&references_dir)?;
+    fs::create_dir_all(&aggregates_dir)?;
+    fs::write(
+        src_dir.join("projection_builders.incn"),
+        r#"pub model ColumnRefExpr:
+    pub name: str
+
+
+pub model ScalarFunctionExpr:
+    pub name: str
+
+
+pub type ColumnExpr = Union[ColumnRefExpr, ScalarFunctionExpr]
+
+
+pub def col(name: str) -> ColumnRefExpr:
+    return ColumnRefExpr(name=name)
+"#,
+    )?;
+    fs::write(
+        src_dir.join("aggregate_builders.incn"),
+        r#"from projection_builders import ColumnExpr, ScalarFunctionExpr
+
+
+pub model AggregateMeasure:
+    pub has_expr: bool
+
+
+pub def col(name: str) -> ColumnExpr:
+    return ScalarFunctionExpr(name=name)
+
+
+pub def count(expr: Option[ColumnExpr] = None) -> AggregateMeasure:
+    if let Some(_) = expr:
+        return AggregateMeasure(has_expr=true)
+    return AggregateMeasure(has_expr=false)
+"#,
+    )?;
+    fs::write(
+        references_dir.join("col.incn"),
+        r#"from projection_builders import ColumnRefExpr, col as col_builder
+
+
+pub def col(name: str) -> ColumnRefExpr:
+    return col_builder(name)
+"#,
+    )?;
+    fs::write(
+        aggregates_dir.join("count.incn"),
+        r#"from aggregate_builders import AggregateMeasure, count as count_builder
+from projection_builders import ColumnExpr
+
+
+pub def count(expr: Option[ColumnExpr] = None) -> AggregateMeasure:
+    return count_builder(expr)
+
+
+pub def count_expr(expr: ColumnExpr) -> AggregateMeasure:
+    return count(expr)
+"#,
+    )?;
+    fs::write(
+        src_dir.join("functions.incn"),
+        r#"pub from functions.references.col import col
+pub from functions.aggregates.count import count, count_expr
+"#,
+    )?;
+
+    let facade_path = src_dir.join("functions.incn");
+    let emit_output = run_incan(
+        tmp.path(),
+        &[
+            "--emit-rust",
+            facade_path.to_str().ok_or("facade path was not valid UTF-8")?,
+        ],
+    )?;
+    assert_success(
+        &emit_output,
+        "emit-rust for facade re-export with colliding source import alias target",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_facade_reexport_preserves_decorated_helper_signature_issue57() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "facade_decorated_helper_signature", "")?;
+    let src_dir = main_path.parent().ok_or("main path did not have a parent")?;
+    let functions_dir = src_dir.join("functions");
+    let operators_dir = functions_dir.join("operators");
+    let references_dir = functions_dir.join("references");
+    fs::create_dir_all(&operators_dir)?;
+    fs::create_dir_all(&references_dir)?;
+    fs::write(
+        src_dir.join("projection_builders.incn"),
+        r#"pub model ColumnRefExpr:
+    pub name: str
+
+
+pub model StringLiteralExpr:
+    pub value: str
+
+
+pub type ColumnExpr = Union[ColumnRefExpr, StringLiteralExpr]
+
+
+pub def col(name: str) -> ColumnRefExpr:
+    return ColumnRefExpr(name=name)
+"#,
+    )?;
+    fs::write(
+        src_dir.join("registry.incn"),
+        r#"pub def register[F]() -> (F) -> F:
+    return (func) => func
+"#,
+    )?;
+    fs::write(
+        src_dir.join("filter_builders.incn"),
+        r#"from projection_builders import ColumnExpr
+
+
+pub def eq(left: ColumnExpr, right: ColumnExpr) -> ColumnExpr:
+    return left
+"#,
+    )?;
+    fs::write(
+        src_dir.join("functions").join("inputs.incn"),
+        r#"from projection_builders import ColumnExpr
+
+
+pub type ScalarValueOrColumn = Union[ColumnExpr, str]
+"#,
+    )?;
+    fs::write(
+        references_dir.join("col.incn"),
+        r#"from projection_builders import ColumnRefExpr, col as col_builder
+from registry import register
+
+
+@register()
+pub def col(name: str) -> ColumnRefExpr:
+    return col_builder(name)
+"#,
+    )?;
+    fs::write(
+        operators_dir.join("eq.incn"),
+        r#"from functions.inputs import ScalarValueOrColumn
+from registry import register
+
+
+@register()
+pub def eq(left: ScalarValueOrColumn, right: ScalarValueOrColumn) -> None:
+    return
+"#,
+    )?;
+    fs::write(
+        src_dir.join("functions").join("mod.incn"),
+        r#"pub from functions.inputs import ScalarValueOrColumn
+pub from functions.references.col import col
+pub from functions.operators.eq import eq
+pub from filter_builders import eq as filter_eq
+"#,
+    )?;
+    let scratch_dir = tmp.path().join(".agents").join("tmp");
+    fs::create_dir_all(&scratch_dir)?;
+    let scratch_path = scratch_dir.join("repro_facade_eq.incn");
+    fs::write(
+        &scratch_path,
+        r#"from functions import col, eq
+
+
+pub def repro() -> None:
+    eq(col("status"), "paid")
+"#,
+    )?;
+
+    let check_output = run_incan(
+        tmp.path(),
+        &[
+            "--check",
+            scratch_path.to_str().ok_or("scratch path was not valid UTF-8")?,
+        ],
+    )?;
+    assert_success(
+        &check_output,
+        "incan check for facade re-export preserving decorated helper signature",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_incan_call_widens_list_elements_to_union_argument_issue57() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "incan_list_element_union_arg", "")?;
+    fs::write(
+        &main_path,
+        r#"pub model ColumnRefExpr:
+    pub name: str
+
+
+pub model StringColumnExpr:
+    pub name: str
+
+
+pub type ColumnExpr = Union[ColumnRefExpr, StringColumnExpr]
+
+
+pub def registered_application(arguments: list[ColumnExpr]) -> ColumnExpr:
+    return arguments[0]
+
+
+pub def str_col(name: str) -> StringColumnExpr:
+    return StringColumnExpr(name=name)
+
+
+pub def concat(first: str) -> ColumnExpr:
+    mut arguments = [str_col(first)]
+    arguments.append(str_col("tail"))
+    return registered_application(arguments)
+
+
+pub def concat_direct(first: str) -> ColumnExpr:
+    return registered_application([str_col(first)])
+
+
+def main() -> None:
+    concat("name")
+    concat_direct("name")
+"#,
+    )?;
+
+    let build_output = run_incan(
+        tmp.path(),
+        &["build", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(
+        &build_output,
+        "incan build for list element union widening at an Incan call boundary",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_incan_call_widens_imported_list_elements_to_union_argument_issue57() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "incan_imported_list_element_union_arg", "")?;
+    let src_dir = main_path.parent().ok_or("main path did not have a parent")?;
+    fs::write(
+        src_dir.join("types.incn"),
+        r#"pub model A:
+    pub value: str
+
+
+pub model B:
+    pub value: str
+
+
+pub type U = Union[A, B]
+
+
+pub type Outer = Union[U, int]
+"#,
+    )?;
+    fs::write(
+        src_dir.join("helpers.incn"),
+        r#"from types import A
+
+
+pub def a(value: str) -> A:
+    return A(value=value)
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from helpers import a
+from types import Outer, U
+
+
+pub def repro(name: str) -> int:
+    return takes([a(name)])
+
+
+pub def repro_nested(name: str) -> int:
+    return takes_nested([a(name)])
+
+
+pub def takes(values: list[U]) -> int:
+    return len(values)
+
+
+pub def takes_nested(values: list[Outer]) -> int:
+    return len(values)
+
+
+def main() -> None:
+    repro("name")
+    repro_nested("name")
+"#,
+    )?;
+
+    let build_output = run_incan(
+        tmp.path(),
+        &["build", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(
+        &build_output,
+        "incan build for imported list element union widening at an Incan call boundary",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_multi_file_test_batch_keeps_file_local_import_scopes_issue57() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "test_batch_file_local_import_scopes", "")?;
+    let src_dir = main_path.parent().ok_or("main path had no parent")?;
+    let tests_dir = tmp.path().join("tests");
+    fs::create_dir_all(&tests_dir)?;
+    fs::write(
+        src_dir.join("projection_builders.incn"),
+        r#"pub model ColumnRefExpr:
+    pub name: str
+
+
+pub model ScalarFunctionExpr:
+    pub name: str
+
+
+pub type ColumnExpr = Union[ColumnRefExpr, ScalarFunctionExpr]
+
+
+pub def col(name: str) -> ColumnRefExpr:
+    return ColumnRefExpr(name=name)
+"#,
+    )?;
+    fs::write(
+        src_dir.join("aggregate_builders.incn"),
+        r#"from projection_builders import ColumnExpr, ScalarFunctionExpr
+
+
+pub def col(name: str) -> ColumnExpr:
+    return ScalarFunctionExpr(name=name)
+"#,
+    )?;
+    fs::write(
+        tests_dir.join("test_projection_col.incn"),
+        r#"from projection_builders import ColumnRefExpr, col
+
+
+def test_projection_col_keeps_concrete_return_type() -> None:
+    ref: ColumnRefExpr = col("customer_id")
+    assert ref.name == "customer_id"
+"#,
+    )?;
+    fs::write(
+        tests_dir.join("test_aggregate_col.incn"),
+        r#"from aggregate_builders import col
+from projection_builders import ColumnExpr
+
+
+def test_aggregate_col_keeps_union_return_type() -> None:
+    expr: ColumnExpr = col("customer_id")
+    assert true
+"#,
+    )?;
+
+    let test_output = run_incan(tmp.path(), &["test", "tests"])?;
+    assert_success(
+        &test_output,
+        "incan test multi-file batch with same local import name from different modules",
+    );
+    let test_batches_dir = tmp.path().join("target").join("incan_tests");
+    let isolated_projection_module = fs::read_dir(&test_batches_dir)?.filter_map(Result::ok).any(|entry| {
+        entry
+            .path()
+            .join("src")
+            .join("tests")
+            .join("test_projection_col.rs")
+            .exists()
+    });
+    let isolated_aggregate_module = fs::read_dir(&test_batches_dir)?.filter_map(Result::ok).any(|entry| {
+        entry
+            .path()
+            .join("src")
+            .join("tests")
+            .join("test_aggregate_col.rs")
+            .exists()
+    });
+    assert!(
+        isolated_projection_module && isolated_aggregate_module,
+        "multi-file test batch should emit each test file as its own Rust module"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_decorator_callable_exposes_source_name_issue694() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "decorator_callable_name", "")?;


### PR DESCRIPTION
## Summary

This PR fixes the remaining import-boundary metadata drift exposed by downstream InQL typed scalar validation. Facade re-exports now preserve the exact decorated helper signatures and source import alias targets instead of resolving through later ambient same-name symbols from sibling modules, and list literals passed through Incan call boundaries now widen concrete union members into the expected list element union type. The same slice also keeps multi-file `incan test` batches isolated by source module, shares session fixture caches across those isolated harness modules, and avoids generated top-level `main`/`lib` module files being mistaken for Cargo crate roots.

Downstream context: [InQL issue 57](https://github.com/dannys-code-corner/InQL/issues/57).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Public facades preserve decorated helper signatures across import boundaries, including alias-based scalar helper inputs. Concrete union members inside list literals are widened when an Incan callee expects `list[Union[...]]`.
- **Internals**: Dependency source-import resolution now uses exact per-module member metadata plus a direct-member snapshot captured during module import, so facade refreshes cannot be polluted by unrelated same-name sibling symbols. IR/codegen dependency typechecking imports only the modules a generated program actually depends on. Test-runner batches now emit isolated source modules for multi-file tests while sharing session fixture cache statics through one generated support module.
- **Risks**: This touches source dependency metadata, union coercion emission, generated project layout, and the test runner. The broadest risk is accidental import-scope or fixture-cache behavior drift in unusual multi-file packages.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test --test cli_integration issue57 --features lsp -- --nocapture` passed: 5 issue-57 regressions.
- `cargo test -p incan test_generate_nested_avoids_cargo_root_filenames_for_top_level_modules --features lsp -- --nocapture` passed.
- `cargo build --bin incan --features lsp` passed.
- InQL focused facade repro: `target/debug/incan --check .agents/tmp/repro_facade_eq.incn` passed.
- InQL full library verification: `target/debug/incan build --lib` passed in `/Users/danny/Development/encero/tmp/inql-57-typed-scalar-validation`.
- `cargo fmt -- --check` passed.
- `git diff --check` passed.
- `make pre-commit` passed, including 2,571 nextest tests, clippy, cargo-deny, smoke-test-fast, examples, and benchmark build checks.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
