### PR TITLE
chore - add 0.4 release direction notes (#223, #554, #592)

### DIFF
--- a/workspaces/docs-site/docs/RFCs/TEMPLATE.md
+++ b/workspaces/docs-site/docs/RFCs/TEMPLATE.md
@@ -99,6 +99,18 @@ Describe which compiler and tooling layers this RFC impacts, and what each layer
 - **CLI / tooling** — …
 - **LSP / formatter** — …
 
+## Inspectability and tooling surface
+
+Name how users, tools, CI, editors, and agents can see what this feature did. Keep this section short, but be concrete.
+
+- **Artifact or metadata:** What manifest, checked metadata, report, generated output, runtime registry, or other artifact exposes this behavior?
+- **Inspection command:** What command or tooling path inspects it? If an existing command already covers it, name that command instead of inventing a new one.
+- **Diagnostics:** What diagnostic is emitted when the feature is invalid, ambiguous, unsupported, or unsafe?
+- **Provenance:** Which source span, declaration, package, dependency, or generated-output breadcrumb anchors the behavior?
+- **Not implicit:** Which behavior is intentionally not hidden magic, inferred side effect, or undocumented generated-Rust detail?
+
+Tiny clarifications may answer “covered by existing surface X.” Larger language, stdlib, metadata, or tooling features should name a real surface that can be tested without reading compiler internals.
+
 ## Unresolved questions
 
 Open questions to decide before implementation lands.

--- a/workspaces/docs-site/docs/contributing/how-to/writing_rfcs.md
+++ b/workspaces/docs-site/docs/contributing/how-to/writing_rfcs.md
@@ -38,6 +38,7 @@ Write an RFC when the *user-facing meaning* of the language changes, for example
     - precise rules (semantics/type rules/edge cases)
     - alternatives considered
     - migration/compatibility
+    - inspectability: metadata, diagnostics, provenance, generated output, or command surface
     - acceptance criteria (“done when…”)
     - implementation plan + touchpoints (frontend/backend/stdlib/tooling/tests)
 
@@ -67,5 +68,6 @@ When an RFC is superseded or rejected, move it into the appropriate `closed/` fo
 
 - Prefer concrete examples over abstract prose.
 - Write the *reference-level rules* as if someone will implement them.
+- Name the inspection surface. A feature should not require reading compiler internals or guessing from generated Rust to understand what happened.
 - Call out non-goals explicitly.
 - If it’s too big: split it into a sequence of smaller RFCs.

--- a/workspaces/docs-site/docs/release_notes/0_4.md
+++ b/workspaces/docs-site/docs/release_notes/0_4.md
@@ -1,0 +1,38 @@
+# Release 0.4
+
+This page is the development draft for the Incan 0.4 release notes. It records the intended release shape early so release notes, feature inventory updates, and docs changes can land alongside the implementation work rather than being reconstructed at freeze.
+
+0.4 is a tooling, inspection, installer, starter, and first-contact release. The working thesis is:
+
+> 0.3 made real programs credible. 0.4 makes the stack tryable.
+
+0.4 should make it practical for someone outside the repository to install Incan, create a small project, run it, test it, understand failures, inspect generated artifacts, and hand compiler facts to humans, editors, CI, and agents. It should not reopen broad language/runtime scope unless the change directly supports that tooling path.
+
+## Planned release surface
+
+- **Install and first run**: a canonical SDK installer, release manifest, checksum verification, and a zero-clone starter flow.
+- **Diagnostics**: stable JSON diagnostics and an `incan explain` catalog backed by shared diagnostic data rather than terminal prose.
+- **Build and generated output inspection**: build reports and intentional generated Rust inspection commands that explain current backend output without promising a stable Rust ABI.
+- **Semantic inspection**: a compiler-backed codegraph export for files, modules, declarations, imports, exports, diagnostics, spans, and degraded-state facts.
+- **Performance and observability**: visible phase timings and cache/preheat evidence for long-running test and build phases.
+- **Boundary parity**: compact regression fixtures that cover import, reexport, package, test-batch, dependency vocab, and generated-Rust boundaries before downstream packages rediscover the same class of issue.
+- **First-contact docs**: quickstart and positioning pages that explain what Incan is good for, what it is not trying to replace, and how it fits alongside Python and Rust.
+
+## Scope guard
+
+The 0.4 release is not the home for `std.web`, `std.http`, Hees.ai product implementation, broad InQL/Pallay SDK work, source-local feature metadata, Rust caller/ABI architecture, or backend replacement. Those directions remain important, but they belong to later release lanes unless a small piece directly supports the install, starter, diagnostics, inspection, build-report, or codegraph path.
+
+## Tracking issues
+
+- [#223](https://github.com/dannys-code-corner/incan/issues/223): 0.4 umbrella.
+- [#554](https://github.com/dannys-code-corner/incan/issues/554): release direction notes.
+- [#592](https://github.com/dannys-code-corner/incan/issues/592): RFC inspectability prompts.
+- [#760](https://github.com/dannys-code-corner/incan/issues/760): compact boundary parity fixture suite.
+- [#699](https://github.com/dannys-code-corner/incan/issues/699): unified symbol identity across import and package boundaries.
+- [#753](https://github.com/dannys-code-corner/incan/issues/753): partial presets constructing const metadata values.
+- [#707](https://github.com/dannys-code-corner/incan/issues/707) and [#723](https://github.com/dannys-code-corner/incan/issues/723): preheat/progress observability.
+- [#697](https://github.com/dannys-code-corner/incan/issues/697): generated-library dependency preheat when timing evidence requires it.
+- [#589](https://github.com/dannys-code-corner/incan/issues/589) and [#590](https://github.com/dannys-code-corner/incan/issues/590): stable diagnostics and explain catalog.
+- [#591](https://github.com/dannys-code-corner/incan/issues/591) and [#567](https://github.com/dannys-code-corner/incan/issues/567): build reports and generated Rust inspection.
+- [#666](https://github.com/dannys-code-corner/incan/issues/666) and [#573](https://github.com/dannys-code-corner/incan/issues/573): semantic inspection and codegraph export.
+- [#428](https://github.com/dannys-code-corner/incan/issues/428), [#553](https://github.com/dannys-code-corner/incan/issues/553), and [#551](https://github.com/dannys-code-corner/incan/issues/551): installer, starter flow, and first-contact docs.

--- a/workspaces/docs-site/docs/release_notes/index.md
+++ b/workspaces/docs-site/docs/release_notes/index.md
@@ -9,6 +9,7 @@ This section tracks user-facing changes in Incan across releases.
 
 ## Releases
 
+- [Release 0.4](0_4.md)
 - [Release 0.3](0_3.md)
 - [Release 0.2](0_2.md)
 - [Release 0.1](0_1.md)

--- a/workspaces/docs-site/docs/roadmap.md
+++ b/workspaces/docs-site/docs/roadmap.md
@@ -35,34 +35,58 @@ The near-term roadmap is therefore split into six release lanes:
 
 ## Release Milestones
 
-### 0.4 Release: tooling and inspection
+### 0.4 Release: tooling, inspection, and first contact
 
-The 0.4 milestone is the tooling and inspection release. It focuses on:
+The 0.4 release direction is:
 
-- canonical SDK install path;
-- zero-clone starter flow;
-- first-contact docs and positioning;
-- stable machine-readable diagnostics;
-- diagnostic explain catalog;
-- codegraph export for agent/maintainer code intelligence;
-- generated Rust and emitted artifact inspection;
-- build reports.
+> 0.3 made real programs credible. 0.4 makes the stack tryable.
 
-New language/runtime feature work is out of scope unless it directly supports that tooling path.
+The release is deliberately not a broad language/runtime reopening. It should make Incan easier to install, start, inspect, diagnose, and debug without requiring users or agents to clone the repository or reverse-engineer compiler internals. The release succeeds when a new evaluator can install Incan, create a starter project, understand failures through stable diagnostics, inspect generated artifacts and semantic graph facts, and see where Incan fits in the Encero stack.
 
-Core tracking issues:
+0.4 should land in seven stages:
 
-- [#223](https://github.com/dannys-code-corner/incan/issues/223): 0.4 tooling, inspection, and first-contact umbrella.
+1. Scope guard, direction notes, and RFC inspectability prompts.
+2. Boundary identity and compact release-parity fixtures.
+3. Test runner and Rust preheat observability.
+4. Stable machine-readable diagnostics and `incan explain`.
+5. Build reports and generated Rust inspection.
+6. Semantic inspection and codegraph export.
+7. Installer, starter flow, first-contact docs, and release hardening.
+
+#### Release-gating work
+
+These issues define the minimum coherent 0.4 release surface:
+
+- [#223](https://github.com/dannys-code-corner/incan/issues/223): umbrella delivery issue for the tooling, inspection, and first-contact release.
+- [#554](https://github.com/dannys-code-corner/incan/issues/554): release direction notes and scope guard.
+- [#592](https://github.com/dannys-code-corner/incan/issues/592): RFC inspectability prompts, so new designs name their metadata, diagnostic, provenance, artifact, or command surface.
+- [#760](https://github.com/dannys-code-corner/incan/issues/760): compact boundary parity fixture suite, focused on the import/package/vocab/test-batch failures that made 0.3 expensive to stabilize.
+- [#699](https://github.com/dannys-code-corner/incan/issues/699): unified symbol identity across import and package boundaries.
+- [#753](https://github.com/dannys-code-corner/incan/issues/753): partial presets constructing const metadata values, handled as part of callable identity and metadata parity.
+- [#707](https://github.com/dannys-code-corner/incan/issues/707) and [#723](https://github.com/dannys-code-corner/incan/issues/723): visible test/preheat progress and performance evidence, so long-running phases are explainable instead of silent.
+- [#589](https://github.com/dannys-code-corner/incan/issues/589): stable machine-readable diagnostics output.
+- [#590](https://github.com/dannys-code-corner/incan/issues/590): diagnostic explain command and help catalog.
+- [#591](https://github.com/dannys-code-corner/incan/issues/591): build artifact reports.
+- [#567](https://github.com/dannys-code-corner/incan/issues/567): generated Rust inspection tooling and quality gates.
+- [#666](https://github.com/dannys-code-corner/incan/issues/666): RFC 102 semantic inspection umbrella, used to keep the inspection surfaces coherent.
+- [#573](https://github.com/dannys-code-corner/incan/issues/573): compiler-backed codegraph export for agent and maintainer workflows.
 - [#428](https://github.com/dannys-code-corner/incan/issues/428): canonical SDK installer and release manifest.
 - [#553](https://github.com/dannys-code-corner/incan/issues/553): zero-clone starter project flow.
 - [#551](https://github.com/dannys-code-corner/incan/issues/551): first-contact quickstart and positioning docs.
-- [#554](https://github.com/dannys-code-corner/incan/issues/554): release direction notes and scope guard.
-- [#573](https://github.com/dannys-code-corner/incan/issues/573): codegraph export.
-- [#589](https://github.com/dannys-code-corner/incan/issues/589): stable JSON diagnostics.
-- [#590](https://github.com/dannys-code-corner/incan/issues/590): diagnostic explain catalog.
-- [#591](https://github.com/dannys-code-corner/incan/issues/591): build artifact report.
-- [#567](https://github.com/dannys-code-corner/incan/issues/567): generated Rust inspection tooling and quality gates.
-- [#592](https://github.com/dannys-code-corner/incan/issues/592): RFC template inspectability prompts, if tiny and opportunistic.
+
+#### Useful but evidence-dependent work
+
+- [#697](https://github.com/dannys-code-corner/incan/issues/697): preheating generated library dependencies into the build cache. This belongs in 0.4 if timing evidence shows it is necessary for the starter/downstream experience; otherwise it should remain a measured optimization rather than a mandatory rewrite.
+
+#### Explicit 0.4 exclusions
+
+The following are design constraints and future lanes, not 0.4 implementation slices unless the milestone is deliberately changed:
+
+- RFC 037 `std.web` and RFC 066 `std.http` implementation work.
+- Source-local feature metadata beyond maintaining the generated feature inventory for public 0.4 capabilities.
+- Rust caller, Rust-hosted consumption, ABI, and backend-replacement architecture.
+- Hees.ai, InQL, and Pallay product work beyond proof lanes that validate frozen 0.4 commands.
+- Broad language/runtime features that are not required by the installer, starter, diagnostics, inspection, build-report, or codegraph path.
 
 ### 0.5 Release: backend foundation and Hees.ai proof lane
 

--- a/workspaces/docs-site/mkdocs.yml
+++ b/workspaces/docs-site/mkdocs.yml
@@ -292,6 +292,7 @@ nav:
       - RFCs: RFCs/index.md
   - Release notes:
       - Overview: release_notes/index.md
+      - Release 0.4: release_notes/0_4.md
       - Release 0.3: release_notes/0_3.md
       - Release 0.2: release_notes/0_2.md
       - Release 0.1: release_notes/0_1.md


### PR DESCRIPTION
## Summary

This PR starts the 0.4 implementation line with the Stage 0 scope guard: the roadmap now states the 0.4 thesis, classifies the milestone work, records explicit exclusions, and links a development draft of the 0.4 release notes. It also adds a compact RFC inspectability section so future RFCs name the metadata, diagnostic, provenance, generated-output, or command surface that exposes new behavior.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: no compiler behavior changes. The public docs now explain what 0.4 is trying to ship and what remains outside the milestone.
- **Internals**: no runtime/compiler internals changed. The RFC template now requires an inspectability/tooling-surface section.
- **Risks**: editorial drift remains possible if later 0.4 implementation PRs do not keep the release-note draft and feature inventory current.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `git diff --check`
- `python3 -m mkdocs build --strict` from `workspaces/docs-site`
- `cargo metadata --locked --format-version 1 --no-deps` confirmed the branch remains on `0.4.0-dev.0`
- `make pre-commit` passed after cleaning only this worktree's generated `target/` artifacts to recover from an initial `No space left on device` failure

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/roadmap.md`, `workspaces/docs-site/docs/release_notes/0_4.md`, `workspaces/docs-site/docs/RFCs/TEMPLATE.md`, `workspaces/docs-site/docs/contributing/how-to/writing_rfcs.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #223
Closes #554
Closes #592