### PR TITLE
feature - add preheat observability and build cache alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "blake2",
  "blake3",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.4.0-dev.1"
+version = "0.4.0-dev.2"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/src/backend/project/runner.rs
+++ b/src/backend/project/runner.rs
@@ -45,7 +45,7 @@ impl ProjectGenerator {
     /// nested `target/` directory, which forces Cargo to rebuild dependencies repeatedly across examples, smoke
     /// tests, and benchmark checks. Sharing a parent-scoped target dir lets those generated crates reuse compiled
     /// dependencies.
-    fn cargo_target_dir(&self) -> PathBuf {
+    pub(crate) fn cargo_target_dir(&self) -> PathBuf {
         if let Some(target_dir) = Self::generated_cargo_target_dir_override() {
             return target_dir;
         }

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -36,7 +36,7 @@ use super::common::{
 };
 #[cfg(feature = "rust_inspect")]
 use super::common::{collect_rust_inspect_query_paths, ensure_rust_inspect_workspace, prewarm_rust_inspect_workspace};
-use super::lock::{LockResolutionRequest, resolve_lock_payload};
+use super::lock::{LockResolutionRequest, resolve_lock_payload, run_generated_library_dependency_preheat};
 use super::vocab_extraction::{PendingDesugarerArtifact, collect_library_vocab_metadata};
 use crate::cli::prelude::ParsedModule;
 #[cfg(feature = "rust_inspect")]
@@ -789,6 +789,8 @@ pub fn build_library(
         #[cfg(feature = "rust_inspect")]
         rust_inspect_query_paths: &metadata_query_paths,
     })?;
+    let should_preheat_library_dependencies = lock_payload_for_typecheck.is_some()
+        && (!resolved.dependencies.is_empty() || !project_requirements.stdlib_features.is_empty());
     #[cfg(feature = "rust_inspect")]
     let rust_inspect_manifest_dir = {
         let rust_inspect_manifest_dir = ensure_rust_inspect_workspace(
@@ -971,6 +973,16 @@ pub fn build_library(
         generator
             .generate_nested(&main_code, &rust_modules)
             .map_err(|e| CliError::failure(format!("Error generating project: {e}")))?;
+    }
+
+    if should_preheat_library_dependencies {
+        run_generated_library_dependency_preheat(
+            &project_root,
+            &project_root.join("target").join("incan_lock"),
+            &cargo_features,
+            &cargo_policy,
+            &generator.cargo_target_dir(),
+        )?;
     }
 
     match generator.build() {

--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -34,6 +34,8 @@ use super::common::{collect_rust_inspect_query_paths, ensure_rust_inspect_worksp
 const LOCK_DEPENDENCY_PREHEAT_FINGERPRINT_FILE: &str = ".incan_dependency_preheat_fingerprint";
 const LOCK_DEPENDENCY_PREHEAT_LOCK_FILE: &str = ".incan_dependency_preheat.lock";
 const LOCK_DEPENDENCY_PREHEAT_STALE_LOCK_SECS: u64 = 30 * 60;
+const LIBRARY_DEPENDENCY_PREHEAT_FINGERPRINT_FILE: &str = ".incan_library_dependency_preheat_fingerprint";
+const LIBRARY_DEPENDENCY_PREHEAT_LOCK_FILE: &str = ".incan_library_dependency_preheat.lock";
 
 /// Generate or update incan.lock for a project.
 pub fn lock_project(
@@ -402,6 +404,21 @@ fn lock_dependency_preheat_stamp_matches(stamp_path: &Path, fingerprint: &str) -
         .unwrap_or(false)
 }
 
+/// Run a Cargo preheat command with inherited output so long dependency builds remain visible.
+fn run_streamed_cargo_preheat(mut command: Command, context: &str) -> CliResult<()> {
+    command.stdout(Stdio::inherit());
+    command.stderr(Stdio::inherit());
+    let status = command
+        .status()
+        .map_err(|err| CliError::failure(format!("Failed to run {context}: {err}")))?;
+    if !status.success() {
+        return Err(CliError::failure(format!(
+            "{context} failed with status {status}; Cargo output was streamed above"
+        )));
+    }
+    Ok(())
+}
+
 /// Add one lock-workspace input file to the dependency-preheat fingerprint.
 fn hash_lock_dependency_preheat_file(hasher: &mut Sha256, base: &Path, path: &Path) -> io::Result<()> {
     let relative = path.strip_prefix(base).unwrap_or(path);
@@ -412,14 +429,19 @@ fn hash_lock_dependency_preheat_file(hasher: &mut Sha256, base: &Path, path: &Pa
     Ok(())
 }
 
-/// Compute the fingerprint that decides whether lock dependency preheat can be reused.
-fn compute_lock_dependency_preheat_fingerprint(
+/// Compute the fingerprint that decides whether a dependency preheat can be reused.
+fn compute_dependency_preheat_fingerprint(
     lock_dir: &Path,
     cargo_flags: &[String],
     target_dir: &Path,
+    namespace: &[u8],
+    command_label: &str,
+    fingerprint_file: &str,
 ) -> io::Result<String> {
     let mut hasher = Sha256::new();
-    hasher.update(b"incan_lock_dependency_preheat/1\0");
+    hasher.update(namespace);
+    hasher.update(command_label.as_bytes());
+    hasher.update(b"\0");
     hasher.update(target_dir.to_string_lossy().as_bytes());
     hasher.update(b"\0");
     for flag in cargo_flags {
@@ -429,11 +451,39 @@ fn compute_lock_dependency_preheat_fingerprint(
     hash_lock_dependency_preheat_file(&mut hasher, lock_dir, &lock_dir.join("Cargo.toml"))?;
     hash_lock_dependency_preheat_file(&mut hasher, lock_dir, &lock_dir.join("Cargo.lock"))?;
     hash_lock_dependency_preheat_file(&mut hasher, lock_dir, &lock_dir.join("src").join("main.rs"))?;
-    Ok(format!(
-        "{}{}",
+    Ok(format!("{}{}", fingerprint_file, hex::encode(hasher.finalize())))
+}
+
+/// Compute the fingerprint that decides whether lock dependency preheat can be reused.
+fn compute_lock_dependency_preheat_fingerprint(
+    lock_dir: &Path,
+    cargo_flags: &[String],
+    target_dir: &Path,
+) -> io::Result<String> {
+    compute_dependency_preheat_fingerprint(
+        lock_dir,
+        cargo_flags,
+        target_dir,
+        b"incan_lock_dependency_preheat/1\0",
+        "cargo test --no-run",
         LOCK_DEPENDENCY_PREHEAT_FINGERPRINT_FILE,
-        hex::encode(hasher.finalize())
-    ))
+    )
+}
+
+/// Compute the fingerprint that decides whether generated-library dependency preheat can be reused.
+fn compute_library_dependency_preheat_fingerprint(
+    lock_dir: &Path,
+    cargo_flags: &[String],
+    target_dir: &Path,
+) -> io::Result<String> {
+    compute_dependency_preheat_fingerprint(
+        lock_dir,
+        cargo_flags,
+        target_dir,
+        b"incan_library_dependency_preheat/1\0",
+        "cargo build --release",
+        LIBRARY_DEPENDENCY_PREHEAT_FINGERPRINT_FILE,
+    )
 }
 
 /// Compile the lock workspace dependency graph into the generated-test target domain when stale.
@@ -509,18 +559,7 @@ fn run_lock_dependency_preheat(
     command.env("CARGO_TARGET_DIR", &target_dir);
     command.current_dir(project_root);
 
-    let output = command.output().map_err(|err| {
-        CliError::failure(format!(
-            "Failed to run cargo test --no-run for dependency preheat: {err}"
-        ))
-    })?;
-    if !output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(CliError::failure(format!(
-            "cargo test --no-run failed while preheating dependencies:\n{stdout}\n{stderr}"
-        )));
-    }
+    run_streamed_cargo_preheat(command, "cargo test --no-run for dependency preheat")?;
 
     fs::write(&stamp_path, &fingerprint).map_err(|err| {
         CliError::failure(format!(
@@ -529,6 +568,113 @@ fn run_lock_dependency_preheat(
         ))
     })?;
     drop(guard);
+    Ok(())
+}
+
+/// Compile the lock workspace dependency graph into the generated-library target/profile domain when stale.
+pub(crate) fn run_generated_library_dependency_preheat(
+    project_root: &Path,
+    lock_dir: &Path,
+    cargo_features: &CargoFeatureSelection,
+    cargo_policy: &CargoPolicy,
+    target_dir: &Path,
+) -> CliResult<()> {
+    if !lock_dependency_preheat_enabled() {
+        eprintln!("generated library dependency preheat: disabled by INCAN_LOCK_PREHEAT");
+        return Ok(());
+    }
+
+    let cargo_flags = cargo_command_flags(cargo_policy, cargo_features);
+    let fingerprint =
+        compute_library_dependency_preheat_fingerprint(lock_dir, &cargo_flags, target_dir).map_err(|err| {
+            CliError::failure(format!(
+                "Failed to fingerprint generated library dependency preheat: {err}"
+            ))
+        })?;
+    let stamp_path = lock_dir.join(LIBRARY_DEPENDENCY_PREHEAT_FINGERPRINT_FILE);
+    if lock_dependency_preheat_stamp_matches(&stamp_path, &fingerprint) {
+        eprintln!(
+            "generated library dependency preheat: up-to-date (target {}, profile release)",
+            target_dir.display()
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "preheating Cargo dependencies for generated library builds into {} (profile release)",
+        target_dir.display()
+    );
+    let _ = io::stderr().flush();
+
+    let lock_path = lock_dir.join(LIBRARY_DEPENDENCY_PREHEAT_LOCK_FILE);
+    let stale_after = stale_lock_dependency_preheat_after();
+    let wait_start = Instant::now();
+    let mut announced_wait = false;
+    let guard = loop {
+        if lock_dependency_preheat_stamp_matches(&stamp_path, &fingerprint) {
+            eprintln!(
+                "generated library dependency preheat: reused after waiting {:.2}s",
+                wait_start.elapsed().as_secs_f64()
+            );
+            return Ok(());
+        }
+        match try_acquire_lock_dependency_preheat(&lock_path) {
+            Ok(Some(guard)) => break guard,
+            Ok(None) => {
+                if lock_dependency_preheat_is_stale(&lock_path, stale_after) {
+                    let _ = fs::remove_file(&lock_path);
+                    continue;
+                }
+                if !announced_wait && wait_start.elapsed() >= Duration::from_secs(1) {
+                    eprintln!("waiting for another generated library dependency preheat to finish");
+                    let _ = io::stderr().flush();
+                    announced_wait = true;
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(err) => {
+                return Err(CliError::failure(format!(
+                    "Failed to acquire generated library dependency preheat lock {}: {err}",
+                    lock_path.display()
+                )));
+            }
+        }
+    };
+
+    if lock_dependency_preheat_stamp_matches(&stamp_path, &fingerprint) {
+        drop(guard);
+        eprintln!("generated library dependency preheat: up-to-date after lock acquisition");
+        return Ok(());
+    }
+
+    let start = Instant::now();
+    let mut command = Command::new("cargo");
+    command.arg("build");
+    command.arg("--release");
+    command.arg("--manifest-path");
+    command.arg(lock_dir.join("Cargo.toml"));
+    for flag in &cargo_flags {
+        command.arg(flag);
+    }
+    command.env("CARGO_TARGET_DIR", target_dir);
+    command.current_dir(project_root);
+
+    run_streamed_cargo_preheat(
+        command,
+        "cargo build --release for generated library dependency preheat",
+    )?;
+
+    fs::write(&stamp_path, &fingerprint).map_err(|err| {
+        CliError::failure(format!(
+            "Failed to write generated library dependency preheat fingerprint {}: {err}",
+            stamp_path.display()
+        ))
+    })?;
+    drop(guard);
+    eprintln!(
+        "generated library dependency preheat: ran in {:.2}s",
+        start.elapsed().as_secs_f64()
+    );
     Ok(())
 }
 
@@ -836,6 +982,34 @@ mod tests {
         let second = compute_lock_dependency_preheat_fingerprint(&temp_dir, &[], &target_dir)?;
 
         assert_ne!(first, second);
+        let _ = fs::remove_dir_all(&temp_dir);
+        Ok(())
+    }
+
+    #[test]
+    fn library_dependency_preheat_fingerprint_uses_separate_profile_domain() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = std::env::temp_dir().join(format!("incan_library_preheat_fingerprint_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(temp_dir.join("src"))?;
+        fs::write(
+            temp_dir.join("Cargo.toml"),
+            "[package]\nname = \"library_preheat\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )?;
+        fs::write(
+            temp_dir.join("Cargo.lock"),
+            "# This file is automatically @generated by Cargo.\nversion = 4\n",
+        )?;
+        fs::write(temp_dir.join("src").join("main.rs"), "fn main() {}\n")?;
+
+        let target_dir = temp_dir.join("target").join(".cargo-target");
+        let test_preheat = compute_lock_dependency_preheat_fingerprint(&temp_dir, &[], &target_dir)?;
+        let library_preheat = compute_library_dependency_preheat_fingerprint(&temp_dir, &[], &target_dir)?;
+
+        assert_ne!(
+            test_preheat, library_preheat,
+            "test-harness and generated-library preheats must not share stale stamps"
+        );
+        assert!(library_preheat.starts_with(LIBRARY_DEPENDENCY_PREHEAT_FINGERPRINT_FILE));
         let _ = fs::remove_dir_all(&temp_dir);
         Ok(())
     }

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
@@ -2671,7 +2671,7 @@ fn cargo_test_command(
 /// Run `cargo test --no-run` for one generated harness and return its elapsed time.
 fn run_generated_harness_preheat(request: &HarnessPreheatRequest<'_>) -> Result<Duration, String> {
     let start = Instant::now();
-    let command = cargo_test_command(
+    let mut command = cargo_test_command(
         request.manifest_path,
         request.cargo_flags,
         request.jobs,
@@ -2680,6 +2680,20 @@ fn run_generated_harness_preheat(request: &HarnessPreheatRequest<'_>) -> Result<
         true,
         false,
     );
+    if request.emit_progress && request.timeout.is_none() {
+        command.stdout(Stdio::inherit());
+        command.stderr(Stdio::inherit());
+        let status = command
+            .status()
+            .map_err(|err| format!("failed to run cargo test --no-run: {err}"))?;
+        if !status.success() {
+            return Err(format!(
+                "cargo test --no-run failed with status {status}; cargo output was streamed above"
+            ));
+        }
+        return Ok(start.elapsed());
+    }
+
     let (output, timed_out) = run_command_with_timeout(command, request.timeout)
         .map_err(|err| format!("failed to run cargo test --no-run: {err}"))?;
     if timed_out {
@@ -3013,7 +3027,15 @@ pub(super) fn run_file_tests_batch(
         cargo_policy,
     );
 
+    let prep_start = Instant::now();
     let prepared: Arc<PreparedTestFile> = if let Some(hit) = prep_cache.prepared_files.get(&cache_key) {
+        if options.verbose && options.emit_progress {
+            println!(
+                "test prep phase: cache hit for {} file(s) in {:.2}s",
+                seen_files.len(),
+                prep_start.elapsed().as_secs_f64()
+            );
+        }
         Arc::clone(hit)
     } else {
         // ---- Context: cold prep — inline imports, resolve and merge Cargo deps, lock + rust-inspect workspace ----
@@ -3230,6 +3252,13 @@ pub(super) fn run_file_tests_batch(
         };
         let arc = Arc::new(prepared);
         prep_cache.prepared_files.insert(cache_key, Arc::clone(&arc));
+        if options.verbose && options.emit_progress {
+            println!(
+                "test prep phase: cache miss prepared {} source module(s) in {:.2}s",
+                arc.source_modules.len(),
+                prep_start.elapsed().as_secs_f64()
+            );
+        }
         arc
     };
 
@@ -3398,11 +3427,12 @@ pub(super) fn run_file_tests_batch(
     };
     if options.verbose && options.emit_progress {
         println!(
-            "preheat phase: {} in {:.2}s (wait {:.2}s, generated changed: {})",
+            "preheat phase: {} in {:.2}s (wait {:.2}s, generated changed: {}, target: {})",
             preheat_status_label(preheat_outcome.status),
             preheat_outcome.elapsed.as_secs_f64(),
             preheat_outcome.waited.as_secs_f64(),
-            generated_changed
+            generated_changed,
+            shared_target_dir.display()
         );
     }
 
@@ -3416,6 +3446,14 @@ pub(super) fn run_file_tests_batch(
         options.no_capture,
     );
 
+    if options.verbose && options.emit_progress {
+        println!(
+            "cargo test phase: running generated harness {}",
+            manifest_path.display()
+        );
+        let _ = io::stdout().flush();
+    }
+    let cargo_test_start = Instant::now();
     let (output, timed_out) = match run_command_with_timeout(command, options.timeout) {
         Ok(result) => result,
         Err(e) => {
@@ -3430,6 +3468,12 @@ pub(super) fn run_file_tests_batch(
                 .collect();
         }
     };
+    if options.verbose && options.emit_progress {
+        println!(
+            "cargo test phase: completed in {:.2}s",
+            cargo_test_start.elapsed().as_secs_f64()
+        );
+    }
 
     let elapsed = start.elapsed();
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/src/cli/test_runner/mod.rs
+++ b/src/cli/test_runner/mod.rs
@@ -1251,7 +1251,15 @@ pub fn run_tests(config: TestRunConfig<'_>) -> CliResult<ExitCode> {
     let mut xfailed = 0;
     let mut xpassed = 0;
 
+    let planning_start = Instant::now();
     let units = build_execution_units(&filtered_tests, path, default_timeout, stop_on_fail, jobs);
+    if report_format == TestOutputFormat::Console && verbose {
+        println!(
+            "planned {} generated harness unit(s) in {:.2}s",
+            units.len(),
+            planning_start.elapsed().as_secs_f64()
+        );
+    }
     if report_format == TestOutputFormat::Console && !stop_on_fail {
         for unit in &units {
             let files = unit
@@ -1284,6 +1292,12 @@ pub fn run_tests(config: TestRunConfig<'_>) -> CliResult<ExitCode> {
         verbose,
         report_format == TestOutputFormat::Console,
     );
+    if report_format == TestOutputFormat::Console && verbose {
+        println!(
+            "generated harness execution phase completed in {:.2}s",
+            start_time.elapsed().as_secs_f64()
+        );
+    }
     raw_batch_results.sort_by_key(|(index, _)| *index);
     let mut raw_results_by_id: HashMap<String, TestResult> = HashMap::new();
     for (_, batch_results) in raw_batch_results {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -362,6 +362,58 @@ def main() -> None:
     Ok(())
 }
 
+#[test]
+fn build_lib_preheats_dependency_graph_for_generated_library_target() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let helper_dir = tmp.path().join("library_preheat_helper");
+    fs::create_dir_all(helper_dir.join("src"))?;
+    fs::write(
+        helper_dir.join("Cargo.toml"),
+        "[package]\nname = \"library_preheat_helper\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(helper_dir.join("src").join("lib.rs"), "pub fn value() -> i64 { 7 }\n")?;
+
+    let _main_path = write_minimal_project(
+        tmp.path(),
+        "cli_library_preheat_project",
+        r#"
+[rust-dependencies.library_preheat_helper]
+path = "library_preheat_helper"
+"#,
+    )?;
+    fs::write(
+        tmp.path().join("src").join("lib.incn"),
+        r#"from rust::library_preheat_helper import value
+
+pub def exported_value() -> int:
+  return value()
+"#,
+    )?;
+
+    let first = run_incan(tmp.path(), &["build", "--lib"])?;
+    assert_success(&first, "first incan build --lib with dependency preheat");
+    let first_stderr = String::from_utf8_lossy(&first.stderr);
+    assert!(
+        first_stderr.contains("preheating Cargo dependencies for generated library builds"),
+        "build --lib should explain generated-library dependency preheat work, got:\n{first_stderr}"
+    );
+    assert!(
+        tmp.path()
+            .join("target/incan_lock/.incan_library_dependency_preheat_fingerprint")
+            .is_file(),
+        "generated-library dependency preheat should write a fingerprint stamp"
+    );
+
+    let second = run_incan(tmp.path(), &["build", "--lib"])?;
+    assert_success(&second, "second incan build --lib with dependency preheat");
+    let second_stderr = String::from_utf8_lossy(&second.stderr);
+    assert!(
+        second_stderr.contains("generated library dependency preheat: up-to-date"),
+        "second build --lib should report generated-library dependency preheat reuse, got:\n{second_stderr}"
+    );
+    Ok(())
+}
+
 fn stale_lockfile_without_changing_cargo_payload(root: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let lock_path = root.join("incan.lock");
     let original = fs::read_to_string(&lock_path)?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7496,6 +7496,16 @@ def test_preheat() -> None:
             "expected first run to preheat stale harness.\nstdout:\n{}",
             first_stdout,
         );
+        assert!(
+            first_stdout.contains("planned 1 generated harness unit(s)"),
+            "expected verbose run to report generated harness planning.\nstdout:\n{}",
+            first_stdout,
+        );
+        assert!(
+            first_stdout.contains("cargo test phase: completed"),
+            "expected verbose run to report cargo test phase timing.\nstdout:\n{}",
+            first_stdout,
+        );
 
         let second = run_incan_test_with_args(&dir, &["-v"]);
         let second_stdout = String::from_utf8_lossy(&second.stdout);

--- a/workspaces/docs-site/docs/release_notes/0_4.md
+++ b/workspaces/docs-site/docs/release_notes/0_4.md
@@ -27,6 +27,8 @@ The 0.4 release is not the home for `std.web`, `std.http`, Hees.ai product imple
 - **Boundary parity fixtures**: 0.4 now starts with a compact regression lane for package-boundary helper calls that move through provider, facade, and consumer modules. The fixture exercises dependency-owned union values, public helper aliases, method calls, list arguments, and generated Rust ownership so future import/reexport regressions fail inside Incan before downstream packages rediscover them.
 - **Checked API identity reuse**: public import resolution and backend method lookup now reuse checked API metadata when manifest aliases point through facades. That keeps public helper/type identity attached to the provider declaration instead of reconstructing a second answer from stale manifest-only surfaces.
 - **Partial preset const metadata**: model-constructor partials can now materialize const metadata values when their preset and call-site arguments are named and const-valid. This includes the `FrozenStr`/`str` compatibility needed by metadata builder presets without turning partial calls into a separate const-evaluator path.
+- `incan test -v` now reports generated-harness planning, preparation-cache hits or misses, preheat timing, Cargo target directories, and Cargo execution timing, while ordinary console output remains focused on collected tests and visible long-running preheat work.
+- `incan build --lib` now preheats generated-library dependencies into the same release-profile Cargo target directory as the real generated library build, so unchanged lock/profile/target inputs can reuse warmed Cargo artifacts instead of compiling the same dependency graph in a separate preheat domain.
 
 ## Tracking issues
 

--- a/workspaces/docs-site/docs/tooling/how-to/dependencies.md
+++ b/workspaces/docs-site/docs/tooling/how-to/dependencies.md
@@ -113,7 +113,9 @@ If `incan.lock` doesn't exist and you run `incan build` or `incan test` without 
 
 If `incan.lock` already exists but is stale, default `incan build` and `incan test` warn and reuse the existing embedded `Cargo.lock` payload without rewriting `incan.lock`. Run `incan lock` when you intentionally want to refresh the committed lock file.
 
-For `incan test`, a generated or changed lock can make the generated Rust harness stale. The runner preheats stale harnesses before executing tests so later test commands can reuse the compiled Cargo state. When lock generation sees Rust dependency inputs or stdlib feature requirements, it also preheats those dependencies with `cargo test --no-run` into the generated test target domain before writing `incan.lock`; unchanged relocks reuse a dependency preheat fingerprint.
+For `incan test`, a generated or changed lock can make the generated Rust harness stale. The runner preheats stale harnesses before executing tests so later test commands can reuse the compiled Cargo state. When lock generation sees Rust dependency inputs or stdlib feature requirements, it also preheats those dependencies with `cargo test --no-run` into the generated test target domain before writing `incan.lock`; unchanged relocks reuse a dependency preheat fingerprint, while cold preheats stream Cargo's own progress instead of leaving the terminal silent.
+
+For `incan build --lib`, the compiler also preheats the generated lock workspace into the same release-profile Cargo target directory used by the generated library build. This matters for packages with stable but expensive Rust dependency graphs: a warmed lock workspace should make the following library build reuse the dependency artifacts instead of compiling the same graph in a different target/profile domain. Cold generated-library preheats print the target/profile domain before invoking Cargo and stream Cargo's progress until the preheat completes. Set `INCAN_LOCK_PREHEAT=0` only when you deliberately want to disable both lock/test dependency preheat and generated-library dependency preheat while debugging.
 
 ### Strict mode for CI
 

--- a/workspaces/docs-site/docs/tooling/how-to/testing.md
+++ b/workspaces/docs-site/docs/tooling/how-to/testing.md
@@ -49,6 +49,8 @@ Run tests:
 incan test tests/
 ```
 
+For long suites, use `incan test -v` to see generated-harness planning, preparation-cache hits or misses, preheat timing, and Cargo test phase timing. Ordinary console runs still show the collected test count and any generated-harness preheat that has to run; when a cold preheat invokes Cargo, Cargo's own progress is streamed instead of hidden until the end. Verbose mode is the better troubleshooting view when you need to tell whether time is going into package preparation, Rust metadata prewarm, Cargo preheat, or actual test execution.
+
 ## Test Discovery
 
 Tests are discovered automatically from two sources:

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -86,12 +86,15 @@ Dependency flags:
 
 Without `--locked` or `--frozen`, `incan build` creates `incan.lock` when it is missing. If an existing lockfile is stale, the command warns and reuses the embedded `Cargo.lock` payload without rewriting `incan.lock`; run `incan lock` to refresh the committed lockfile intentionally.
 
+For `incan build --lib`, dependency preheat uses the generated lock workspace and the same release-profile Cargo target directory as the real generated library build. If the dependency graph is unchanged, the preheat stamp is reused; if it has to run, the command prints the target/profile domain before invoking Cargo and streams Cargo's progress while the preheat compiles.
+
 Environment defaults:
 
 - `INCAN_OFFLINE=1`, `INCAN_LOCKED=1`, and `INCAN_FROZEN=1` behave like their matching flags.
 - `INCAN_FROZEN=1` implies offline and locked mode.
 - CLI flags take precedence over these defaults. Use the `--no-*` forms to disable a policy default set by the environment.
 - `INCAN_CARGO_ARGS="..."` is split on whitespace and used when no Cargo args were supplied on the CLI.
+- `INCAN_LOCK_PREHEAT=0` disables dependency preheat for lock/test and generated-library build paths.
 
 Examples:
 
@@ -198,7 +201,7 @@ Without `--locked` or `--frozen`, `incan test` creates `incan.lock` when it is m
 
 Timeouts apply to generated test batches. `--timeout` sets the default batch timeout and `@timeout("duration")` from `std.testing` can override the batch containing one test. Fixtures, including async fixtures, do not have separate per-fixture timeout configuration. The runner awaits async fixture teardown after ordinary assertion failures and panics while the worker remains alive. If timeout enforcement terminates a worker process, remaining teardown is best-effort.
 
-Before executing a stale generated test harness, `incan test` preheats it with `cargo test --no-run` and stores a fingerprint next to the generated project. A normal console run prints a preheat line only when this work is needed; `-v` also shows the preheat phase timing and whether another Incan process was already doing the same preheat. Lock generation also preheats non-trivial dependency graphs into the same generated test target domain before writing `incan.lock`, so the next harness run can reuse dependency artifacts instead of discovering a subzero Cargo graph on the hot path.
+Before executing a stale generated test harness, `incan test` preheats it with `cargo test --no-run` and stores a fingerprint next to the generated project. A normal console run prints a preheat line only when this work is needed and streams Cargo's progress for cold preheats; `-v` also shows generated-harness planning, preparation-cache hits or misses, preheat timing, Cargo target directory, and Cargo test phase timing. Lock generation also preheats non-trivial dependency graphs into the same generated test target domain before writing `incan.lock`, so the next harness run can reuse dependency artifacts instead of discovering a cold Cargo graph on the hot path.
 
 Examples:
 


### PR DESCRIPTION
## Summary

- Add visible preheat/planning/cache timing for long `incan test` phases, including generated harness planning, prep-cache hit/miss output, preheat target/timing, and generated Cargo test timing.
- Stream Cargo output during cold dependency and generated harness preheats so expensive compile phases no longer look silent.
- Align `incan build --lib` dependency preheat with the actual generated-library release-profile Cargo target directory and add a separate fingerprint/stamp domain for reuse.
- Update docs, release notes, and active dev version to `0.4.0-dev.2`.

Closes #697.
Closes #707.
Closes #723.

## Verification

- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `make docs-build`
- `cargo test --locked library_dependency_preheat_fingerprint_uses_separate_profile_domain --lib -- --nocapture`
- `cargo test --locked build_lib_preheats_dependency_graph_for_generated_library_target --test cli_integration -- --nocapture`
- `cargo test --locked e2e_generated_harness_preheat_is_fingerprinted --test integration_tests -- --nocapture`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `make pre-commit`

## Notes

- Regression coverage uses a tiny synthetic path dependency rather than DataFusion or another heavyweight downstream crate.
- The branch is rebased on the merged Stage 1 boundary-parity work and advances the dev line from `0.4.0-dev.1` to `0.4.0-dev.2`.