### PR TITLE
chore - centralize Rust interop seam planning (#785)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "blake2",
  "blake3",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1536,14 +1536,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1552,14 +1552,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "axum",
  "incan_core",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.4.0-dev.7"
+version = "0.4.0-dev.8"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.92"

--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -303,6 +303,136 @@ pub enum RustTypeShape {
     Unknown,
 }
 
+/// Fallback for a parsed Rust type name after structured primitives, wrappers, and path resolution have failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RustTypeShapePathFallback {
+    /// Leave unresolved names as unknown. Use this when an extractor has an authoritative name resolver.
+    Unknown,
+    /// Preserve unresolved names as Rust paths. Use this for generated Rust surfaces that already canonicalized text.
+    RustPath,
+}
+
+/// Parse a Rust type display into the shared structural shape used by Rust interop consumers.
+///
+/// Callers own path resolution because HIR extraction can resolve source-relative names, while generated Rust fallback
+/// surfaces have already normalized module paths textually. Keeping the parser here prevents those two routes from
+/// reimplementing primitive, wrapper, tuple, reference, and byte-buffer classification independently.
+#[must_use]
+pub fn parse_rust_type_shape_text<F>(
+    text: &str,
+    mut resolve_path: F,
+    fallback: RustTypeShapePathFallback,
+) -> RustTypeShape
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    parse_rust_type_shape_text_inner(text, &mut resolve_path, fallback)
+}
+
+/// Parse normalized Rust type-display text recursively while preserving the caller's path-resolution policy.
+fn parse_rust_type_shape_text_inner<F>(
+    text: &str,
+    resolve_path: &mut F,
+    fallback: RustTypeShapePathFallback,
+) -> RustTypeShape
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let text = strip_rust_borrow_lifetimes(text).trim().replace(' ', "");
+    if text.is_empty() {
+        return RustTypeShape::Unknown;
+    }
+    match text.as_str() {
+        "bool" => return RustTypeShape::Bool,
+        "f32" | "f64" => return RustTypeShape::Float,
+        "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
+            return RustTypeShape::Int;
+        }
+        "str" | "String" | "std::string::String" | "alloc::string::String" => return RustTypeShape::Str,
+        "()" => return RustTypeShape::Unit,
+        "[u8]" => return RustTypeShape::Bytes,
+        _ => {}
+    }
+
+    if let Some(inner) = text.strip_prefix('&') {
+        let inner = inner.strip_prefix("mut").unwrap_or(inner).trim();
+        return RustTypeShape::Ref(Box::new(parse_rust_type_shape_text_inner(
+            inner,
+            resolve_path,
+            fallback,
+        )));
+    }
+
+    if text.starts_with('(') && text.ends_with(')') {
+        let inner = &text[1..text.len() - 1];
+        if inner.is_empty() {
+            return RustTypeShape::Unit;
+        }
+        return RustTypeShape::Tuple(
+            split_top_level_rust_args(inner)
+                .into_iter()
+                .map(|arg| parse_rust_type_shape_text_inner(arg, resolve_path, fallback))
+                .collect(),
+        );
+    }
+
+    if let Some(start) = text.find('<')
+        && text.ends_with('>')
+    {
+        let raw_base = &text[..start];
+        let base = resolve_path(raw_base).unwrap_or_else(|| raw_base.to_string());
+        let inner = &text[start + 1..text.len() - 1];
+        let args: Vec<RustTypeShape> = split_top_level_rust_args(inner)
+            .into_iter()
+            .map(|arg| parse_rust_type_shape_text_inner(arg, resolve_path, fallback))
+            .collect();
+        match base.as_str() {
+            "Option" | "std::option::Option" | "core::option::Option" => {
+                return RustTypeShape::Option(Box::new(args.into_iter().next().unwrap_or(RustTypeShape::Unknown)));
+            }
+            "Result" | "std::result::Result" | "core::result::Result" => {
+                let mut it = args.into_iter();
+                return RustTypeShape::Result(
+                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
+                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
+                );
+            }
+            "Vec" | "std::vec::Vec" | "alloc::vec::Vec"
+                if matches!(args.first(), Some(RustTypeShape::Int)) && text.ends_with("<u8>") =>
+            {
+                return RustTypeShape::Bytes;
+            }
+            _ => {}
+        }
+        return RustTypeShape::RustPath { path: base, args };
+    }
+
+    if let Some(path) = resolve_path(text.as_str()) {
+        return RustTypeShape::RustPath { path, args: Vec::new() };
+    }
+
+    if rust_type_shape_text_looks_like_type_param(text.as_str()) {
+        return RustTypeShape::TypeParam(text);
+    }
+
+    match fallback {
+        RustTypeShapePathFallback::Unknown => RustTypeShape::Unknown,
+        RustTypeShapePathFallback::RustPath => RustTypeShape::RustPath {
+            path: text,
+            args: Vec::new(),
+        },
+    }
+}
+
+/// Return whether unresolved type text has the shape of a Rust generic type parameter.
+fn rust_type_shape_text_looks_like_type_param(text: &str) -> bool {
+    !text.is_empty()
+        && !text.contains("::")
+        && !text.contains(['<', '>', '(', ')', '[', ']', '&', ' '])
+        && text.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && text.chars().next().is_some_and(|ch| ch.is_ascii_uppercase())
+}
+
 /// Render `path` with generic arguments as `path<A, B, ...>` for stable Rust-like display.
 #[must_use]
 pub fn render_rust_type_shape_path(path: &str, args: &[RustTypeShape]) -> String {
@@ -577,5 +707,44 @@ mod tests {
         assert!(!RustCollectionFamily::HashMap.preserves_lookup_arg_shape("insert"));
         assert!(RustCollectionFamily::HashSet.preserves_lookup_arg_shape("contains"));
         assert!(!RustCollectionFamily::HashSet.preserves_lookup_arg_shape("insert"));
+    }
+
+    #[test]
+    fn parse_rust_type_shape_text_classifies_shared_structural_shapes() {
+        let shape = parse_rust_type_shape_text(
+            "&'static Result<Vec<u8>, demo::Error>",
+            |path| (path == "demo::Error").then(|| "demo::Error".to_string()),
+            RustTypeShapePathFallback::Unknown,
+        );
+
+        assert_eq!(
+            shape,
+            RustTypeShape::Ref(Box::new(RustTypeShape::Result(
+                Box::new(RustTypeShape::Bytes),
+                Box::new(RustTypeShape::RustPath {
+                    path: "demo::Error".to_string(),
+                    args: Vec::new(),
+                }),
+            )))
+        );
+    }
+
+    #[test]
+    fn parse_rust_type_shape_text_keeps_source_and_generated_fallbacks_distinct() {
+        assert_eq!(
+            parse_rust_type_shape_text("missing_type", |_| None, RustTypeShapePathFallback::Unknown),
+            RustTypeShape::Unknown,
+        );
+        assert_eq!(
+            parse_rust_type_shape_text("missing_type", |_| None, RustTypeShapePathFallback::RustPath),
+            RustTypeShape::RustPath {
+                path: "missing_type".to_string(),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            parse_rust_type_shape_text("T", |_| None, RustTypeShapePathFallback::RustPath),
+            RustTypeShape::TypeParam("T".to_string()),
+        );
     }
 }

--- a/crates/incan_core/src/interop/mod.rs
+++ b/crates/incan_core/src/interop/mod.rs
@@ -18,6 +18,7 @@ pub use metadata::{
     MetadataFreeMethodSignatureRule, MetadataFreeReceiverClass, RustCollectionFamily, RustFieldInfo, RustFunctionSig,
     RustImplementedTrait, RustItemKind, RustItemMetadata, RustMethodSig, RustModuleChild, RustModuleChildKind,
     RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo, RustTypeMetadataCompleteness,
-    RustTypeShape, RustVariantInfo, RustVisibility, metadata_free_method_signature, render_rust_type_shape,
-    render_rust_type_shape_path, split_top_level_rust_args, strip_rust_borrow_lifetimes,
+    RustTypeShape, RustTypeShapePathFallback, RustVariantInfo, RustVisibility, metadata_free_method_signature,
+    parse_rust_type_shape_text, render_rust_type_shape, render_rust_type_shape_path, split_top_level_rust_args,
+    strip_rust_borrow_lifetimes,
 };

--- a/crates/incan_stdlib/stdlib/async/task.incn
+++ b/crates/incan_stdlib/stdlib/async/task.incn
@@ -34,7 +34,7 @@ Examples:
 """
 
 import std.async
-from rust::incan_stdlib::async::task import JoinHandle, TaskJoinError, RuntimeFuture, RuntimeFnOnce
+from rust::incan_stdlib::async::task import JoinHandle, RuntimeFuture, RuntimeFnOnce
 from rust::incan_stdlib::async::task import spawn as rust_spawn
 from rust::incan_stdlib::async::task import spawn_blocking as rust_spawn_blocking
 from rust::incan_stdlib::async::task import yield_now as rust_yield_now

--- a/crates/rust_inspect/src/cache.rs
+++ b/crates/rust_inspect/src/cache.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use incan_core::interop::{
     RustFieldInfo, RustItemKind, RustItemMetadata, RustTypeInfo, RustTypeMetadataCompleteness, RustTypeShape,
-    RustVariantInfo, RustVisibility, split_top_level_rust_args,
+    RustTypeShapePathFallback, RustVariantInfo, RustVisibility, parse_rust_type_shape_text, split_top_level_rust_args,
 };
 use incan_core::lang::types::collections::{self, CollectionTypeId};
 use ra_ap_syntax::{
@@ -960,67 +960,7 @@ fn generated_field_info(
 
 /// Convert a normalized generated Rust type display into the structural shape used by boundary coercion planning.
 fn generated_type_shape(text: &str) -> RustTypeShape {
-    let text = text.trim().replace(' ', "");
-    match text.as_str() {
-        "bool" => return RustTypeShape::Bool,
-        "f32" | "f64" => return RustTypeShape::Float,
-        "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
-            return RustTypeShape::Int;
-        }
-        "str" | "String" | "std::string::String" | "alloc::string::String" => return RustTypeShape::Str,
-        "()" => return RustTypeShape::Unit,
-        "[u8]" => return RustTypeShape::Bytes,
-        _ => {}
-    }
-
-    if let Some(inner) = text.strip_prefix('&') {
-        let inner = inner.strip_prefix("mut").unwrap_or(inner).trim();
-        return RustTypeShape::Ref(Box::new(generated_type_shape(inner)));
-    }
-    if text.starts_with('(') && text.ends_with(')') {
-        let inner = &text[1..text.len() - 1];
-        if inner.is_empty() {
-            return RustTypeShape::Unit;
-        }
-        return RustTypeShape::Tuple(
-            split_top_level_rust_args(inner)
-                .into_iter()
-                .map(generated_type_shape)
-                .collect(),
-        );
-    }
-    if let Some(start) = text.find('<')
-        && text.ends_with('>')
-    {
-        let base = text[..start].to_string();
-        let inner = &text[start + 1..text.len() - 1];
-        let args: Vec<RustTypeShape> = split_top_level_rust_args(inner)
-            .into_iter()
-            .map(generated_type_shape)
-            .collect();
-        match base.as_str() {
-            "Option" | "std::option::Option" | "core::option::Option" => {
-                return RustTypeShape::Option(Box::new(args.into_iter().next().unwrap_or(RustTypeShape::Unknown)));
-            }
-            "Result" | "std::result::Result" | "core::result::Result" => {
-                let mut it = args.into_iter();
-                return RustTypeShape::Result(
-                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
-                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
-                );
-            }
-            "Vec" | "std::vec::Vec" | "alloc::vec::Vec" if text.ends_with("<u8>") => return RustTypeShape::Bytes,
-            _ => {}
-        }
-        return RustTypeShape::RustPath { path: base, args };
-    }
-    if text.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()) && !text.contains("::") {
-        return RustTypeShape::TypeParam(text);
-    }
-    RustTypeShape::RustPath {
-        path: text,
-        args: Vec::new(),
-    }
+    parse_rust_type_shape_text(text, |_| None, RustTypeShapePathFallback::RustPath)
 }
 
 /// Build metadata for a public generated Rust struct discovered in build-script output.

--- a/crates/rust_inspect/src/extractor.rs
+++ b/crates/rust_inspect/src/extractor.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use incan_core::interop::{
     RustFieldInfo, RustFunctionSig, RustImplementedTrait, RustItemKind, RustItemMetadata, RustMethodSig,
     RustModuleChild, RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo,
-    RustTypeShape, RustVariantInfo, RustVisibility, render_rust_type_shape, split_top_level_rust_args,
-    strip_rust_borrow_lifetimes,
+    RustTypeShape, RustTypeShapePathFallback, RustVariantInfo, RustVisibility, parse_rust_type_shape_text,
+    render_rust_type_shape, strip_rust_borrow_lifetimes,
 };
 use ra_ap_hir::{
     Adt, AssocItem, Crate, DisplayTarget, Enum, FieldSource, Function, HasSource, HasVisibility, HirDisplay, Impl,
@@ -235,83 +235,11 @@ fn resolve_source_path(text: &str, crate_name: &str, module: Module, db: &RootDa
 
 /// Classify the source-level shape represented by a Rust display type.
 fn source_type_shape(text: &str, crate_name: &str, module: Module, db: &RootDatabase) -> RustTypeShape {
-    let text = normalize_source_type_text(text);
-    if text.is_empty() {
-        return RustTypeShape::Unknown;
-    }
-    match text.as_str() {
-        "bool" => return RustTypeShape::Bool,
-        "f32" | "f64" => return RustTypeShape::Float,
-        "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
-            return RustTypeShape::Int;
-        }
-        "str" | "String" | "std::string::String" | "alloc::string::String" => return RustTypeShape::Str,
-        "()" => return RustTypeShape::Unit,
-        _ => {}
-    }
-
-    if let Some(inner) = text.strip_prefix('&') {
-        let inner = inner.strip_prefix("mut").unwrap_or(inner).trim();
-        return RustTypeShape::Ref(Box::new(source_type_shape(inner, crate_name, module, db)));
-    }
-
-    if text == "[u8]" {
-        return RustTypeShape::Bytes;
-    }
-
-    if text.starts_with('(') && text.ends_with(')') {
-        let inner = &text[1..text.len() - 1];
-        if inner.is_empty() {
-            return RustTypeShape::Unit;
-        }
-        return RustTypeShape::Tuple(
-            split_top_level_rust_args(inner)
-                .into_iter()
-                .map(|arg| source_type_shape(arg, crate_name, module, db))
-                .collect(),
-        );
-    }
-
-    if let Some(start) = text.find('<')
-        && text.ends_with('>')
-    {
-        let base =
-            resolve_source_path(&text[..start], crate_name, module, db).unwrap_or_else(|| text[..start].to_string());
-        let inner = &text[start + 1..text.len() - 1];
-        let args: Vec<RustTypeShape> = split_top_level_rust_args(inner)
-            .into_iter()
-            .map(|arg| source_type_shape(arg, crate_name, module, db))
-            .collect();
-        match base.as_str() {
-            "Option" | "std::option::Option" | "core::option::Option" => {
-                return RustTypeShape::Option(Box::new(args.into_iter().next().unwrap_or(RustTypeShape::Unknown)));
-            }
-            "Result" | "std::result::Result" | "core::result::Result" => {
-                let mut it = args.into_iter();
-                return RustTypeShape::Result(
-                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
-                    Box::new(it.next().unwrap_or(RustTypeShape::Unknown)),
-                );
-            }
-            "Vec" | "std::vec::Vec" | "alloc::vec::Vec"
-                if matches!(args.first(), Some(RustTypeShape::Int)) && text.ends_with("<u8>") =>
-            {
-                return RustTypeShape::Bytes;
-            }
-            _ => {}
-        }
-        return RustTypeShape::RustPath { path: base, args };
-    }
-
-    if let Some(path) = resolve_source_path(text.as_str(), crate_name, module, db) {
-        return RustTypeShape::RustPath { path, args: Vec::new() };
-    }
-
-    if display_looks_like_type_param(text.as_str()) {
-        return RustTypeShape::TypeParam(text);
-    }
-
-    RustTypeShape::Unknown
+    parse_rust_type_shape_text(
+        text,
+        |path| resolve_source_path(path, crate_name, module, db),
+        RustTypeShapePathFallback::Unknown,
+    )
 }
 
 fn source_field_type_shape(field: &ra_ap_hir::Field, db: &RootDatabase, crate_name: &str) -> Option<RustTypeShape> {

--- a/src/backend/ir/emit/expressions/interop_coercions.rs
+++ b/src/backend/ir/emit/expressions/interop_coercions.rs
@@ -2,6 +2,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::backend::ir::expr::{IrExprKind, Literal as IrLiteral, TypedExpr};
+use crate::backend::ir::ownership::{is_byte_buffer_type, is_string_buffer_type};
 use crate::backend::ir::types::IrType;
 
 /// Emit a typechecker-selected Rust borrow coercion without re-planning ownership at the call site.
@@ -61,26 +62,12 @@ fn expr_already_materializes_owned_bytes(expr: &TypedExpr) -> bool {
 
 /// Return whether a Rust boundary target is an owned Rust string value.
 fn is_owned_rust_string_target(ty: &IrType) -> bool {
-    matches!(ty, IrType::String)
-        || matches!(
-            ty,
-            IrType::Struct(name) if matches!(
-                name.as_str(),
-                "String" | "std::string::String" | "alloc::string::String"
-            )
-        )
+    is_string_buffer_type(ty)
 }
 
 /// Return whether a Rust boundary target is an owned Rust byte vector.
 fn is_owned_rust_bytes_target(ty: &IrType) -> bool {
-    matches!(ty, IrType::Bytes)
-        || matches!(
-            ty,
-            IrType::Struct(name) if matches!(
-                name.as_str(),
-                "Vec<u8>" | "std::vec::Vec<u8>" | "alloc::vec::Vec<u8>"
-            )
-        )
+    is_byte_buffer_type(ty)
 }
 
 /// Emit a projection from a referenced source item into a Rust-boundary target item.

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -14,7 +14,8 @@ use super::super::super::expr::{
 };
 use super::super::super::ownership::{
     ArgumentPassingPlan, AssociatedFunctionArgumentContext, RegularMethodArgumentContext, ValueUseSite,
-    associated_function_argument_use_site, is_byte_buffer_type, regular_method_argument_use_site,
+    associated_function_argument_use_site, is_byte_buffer_type, is_string_buffer_type,
+    regular_method_argument_use_site,
 };
 use super::super::super::reference_shape::{expr_has_rust_reference_shape, type_has_rust_reference_shape};
 use super::super::super::types::IrType;
@@ -499,7 +500,7 @@ impl<'a> IrEmitter<'a> {
     /// Return whether an argument type matches without relying on metadata.
     fn metadata_free_arg_matches(arg_ty: &IrType, class: MetadataFreeArgClass) -> bool {
         match class {
-            MetadataFreeArgClass::StringBuffer => Self::is_string_buffer_type(arg_ty),
+            MetadataFreeArgClass::StringBuffer => is_string_buffer_type(arg_ty),
             MetadataFreeArgClass::ByteBuffer => is_byte_buffer_type(arg_ty),
             MetadataFreeArgClass::Any => true,
         }
@@ -546,16 +547,6 @@ impl<'a> IrEmitter<'a> {
                     name == *expected_name || short_name == expected_name.rsplit("::").next().unwrap_or(expected_name)
                 })
             })
-    }
-
-    /// Return whether an IR type can stand in for a mutable Rust string buffer.
-    fn is_string_buffer_type(ty: &IrType) -> bool {
-        matches!(ty, IrType::String)
-            || matches!(
-                ty,
-                IrType::Struct(name)
-                    if matches!(name.as_str(), "String" | "std::string::String" | "alloc::string::String")
-            )
     }
 
     /// Return whether a std.fs method takes `Path | str` as its first user argument.

--- a/src/backend/ir/ownership.rs
+++ b/src/backend/ir/ownership.rs
@@ -7,6 +7,7 @@
 //! Keep emitter modules calling this planner instead of open-coding ad hoc `.clone()`, `&`, `&mut`, `.to_string()`, or
 //! `.into()` decisions.
 
+use incan_core::interop::{RustTypeShape, RustTypeShapePathFallback, parse_rust_type_shape_text};
 use proc_macro2::TokenStream;
 use quote::quote;
 
@@ -380,9 +381,9 @@ fn external_buf_arg_needs_bytes_as_slice(expr: &IrExpr, target_ty: Option<&IrTyp
 fn is_rust_buf_like_target(ty: &IrType) -> bool {
     match ty {
         IrType::Generic(name) | IrType::Struct(name) | IrType::Trait(name) | IrType::RustDisplay(name) => {
-            rust_type_leaf(name) == "Buf" || name == "implBuf"
+            rust_type_shape_is_buf(&rust_display_type_shape(name))
         }
-        IrType::ImplTrait(bound) => rust_type_leaf(&bound.trait_path) == "Buf",
+        IrType::ImplTrait(bound) => rust_type_shape_is_buf(&rust_display_type_shape(&bound.trait_path)),
         _ => false,
     }
 }
@@ -391,7 +392,9 @@ fn is_rust_buf_like_target(ty: &IrType) -> bool {
 pub fn is_byte_buffer_type(ty: &IrType) -> bool {
     match ty {
         IrType::Bytes | IrType::FrozenBytes => true,
-        IrType::Struct(name) | IrType::RustDisplay(name) => rust_vec_u8_shape(name),
+        IrType::Struct(name) | IrType::RustDisplay(name) => {
+            rust_type_shape_is_byte_buffer(&rust_display_type_shape(name))
+        }
         IrType::NamedGeneric(name, args)
             if matches!(name.as_str(), "Vec" | "std::vec::Vec" | "alloc::vec::Vec")
                 && matches!(
@@ -405,18 +408,42 @@ pub fn is_byte_buffer_type(ty: &IrType) -> bool {
     }
 }
 
-/// Return the final path segment of a Rust type display or path.
-fn rust_type_leaf(name: &str) -> &str {
-    name.rsplit("::").next().unwrap_or(name)
+/// Return whether an IR type is represented as an owned mutable Rust string buffer at Rust boundaries.
+pub fn is_string_buffer_type(ty: &IrType) -> bool {
+    matches!(ty, IrType::String)
+        || matches!(
+            ty,
+            IrType::Struct(name) | IrType::RustDisplay(name)
+                if matches!(name.as_str(), "String" | "std::string::String" | "alloc::string::String")
+        )
 }
 
-/// Return whether a Rust type display denotes a `Vec<u8>` byte buffer.
-fn rust_vec_u8_shape(name: &str) -> bool {
-    let compact: String = name.chars().filter(|ch| !ch.is_whitespace()).collect();
-    matches!(
-        compact.as_str(),
-        "Vec<u8>" | "std::vec::Vec<u8>" | "alloc::vec::Vec<u8>"
-    )
+/// Parse a Rust display type through the same shared shape parser rust-inspect uses for textual fallbacks.
+fn rust_display_type_shape(name: &str) -> RustTypeShape {
+    parse_rust_type_shape_text(name, |_| None, RustTypeShapePathFallback::RustPath)
+}
+
+/// Return whether a parsed Rust display type is the `Buf` trait shape used by inspected decode APIs.
+fn rust_type_shape_is_buf(shape: &RustTypeShape) -> bool {
+    let Some(path) = rust_type_shape_path(shape) else {
+        return false;
+    };
+    let path = path.strip_prefix("impl ").unwrap_or(path);
+    let leaf = path.rsplit("::").next().unwrap_or(path);
+    leaf == "Buf" || leaf == "implBuf"
+}
+
+/// Return whether a parsed Rust display type denotes an owned byte-buffer value.
+fn rust_type_shape_is_byte_buffer(shape: &RustTypeShape) -> bool {
+    matches!(shape, RustTypeShape::Bytes)
+}
+
+/// Return the display path from a path-like Rust type shape.
+fn rust_type_shape_path(shape: &RustTypeShape) -> Option<&str> {
+    match shape {
+        RustTypeShape::RustPath { path, .. } | RustTypeShape::TypeParam(path) => Some(path.as_str()),
+        _ => None,
+    }
 }
 
 /// Return whether the source already called `.as_slice()` for this argument.
@@ -990,6 +1017,44 @@ mod tests {
             },
         );
         assert_eq!(render(plan.apply_full(quote! { encoded })), "(encoded).as_slice()");
+    }
+
+    #[test]
+    fn rust_display_byte_buffer_detection_uses_shared_type_shape_parser() {
+        assert!(is_byte_buffer_type(&IrType::RustDisplay("Vec < u8 >".to_string())));
+        assert!(is_byte_buffer_type(&IrType::RustDisplay(
+            "std::vec::Vec<u8>".to_string()
+        )));
+        assert!(is_byte_buffer_type(&IrType::RustDisplay(
+            "alloc::vec::Vec<u8>".to_string()
+        )));
+        assert!(!is_byte_buffer_type(&IrType::RustDisplay(
+            "std::io::Cursor<Vec<u8>>".to_string()
+        )));
+    }
+
+    #[test]
+    fn rust_display_buf_detection_uses_shared_type_shape_parser() {
+        assert!(is_rust_buf_like_target(&IrType::RustDisplay("prost::Buf".to_string())));
+        assert!(is_rust_buf_like_target(&IrType::RustDisplay(
+            "impl prost::Buf".to_string()
+        )));
+        assert!(!is_rust_buf_like_target(&IrType::RustDisplay(
+            "demo::Buffer".to_string()
+        )));
+    }
+
+    #[test]
+    fn rust_string_buffer_detection_is_owned_string_only() {
+        assert!(is_string_buffer_type(&IrType::String));
+        assert!(is_string_buffer_type(&IrType::RustDisplay(
+            "std::string::String".to_string()
+        )));
+        assert!(is_string_buffer_type(&IrType::Struct(
+            "alloc::string::String".to_string()
+        )));
+        assert!(!is_string_buffer_type(&IrType::StrRef));
+        assert!(!is_string_buffer_type(&IrType::FrozenStr));
     }
 
     #[test]

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -1060,7 +1060,9 @@ fn write_rust_inspect_cargo_config(manifest_dir: &Path, target_dir: &Path) -> Cl
 /// Detect Cargo's stale-lockfile failure so prewarm can retry with an offline lock refresh instead of silently
 /// skipping.
 fn rust_inspect_locked_prewarm_needs_lock_update(stderr: &str) -> bool {
-    stderr.contains("cannot update the lock file") && stderr.contains("because --locked was passed")
+    stderr.contains("--locked was passed")
+        && stderr.contains("lock file")
+        && (stderr.contains("cannot update") || stderr.contains("needs to be updated"))
 }
 
 #[cfg(feature = "rust_inspect")]
@@ -3382,10 +3384,17 @@ pub def main() -> int:
     #[cfg(feature = "rust_inspect")]
     #[test]
     fn rust_inspect_locked_prewarm_detects_stale_generated_lockfile() {
-        let stderr = "error: cannot update the lock file /tmp/target/incan_lock/rust_inspect/demo/Cargo.lock because --locked was passed to prevent this";
-        assert!(super::rust_inspect_locked_prewarm_needs_lock_update(stderr));
+        let cannot_update = "error: cannot update the lock file /tmp/target/incan_lock/rust_inspect/demo/Cargo.lock because --locked was passed to prevent this";
+        assert!(super::rust_inspect_locked_prewarm_needs_lock_update(cannot_update));
+
+        let needs_update = "error: the lock file /tmp/target/incan_lock/rust_inspect/demo/Cargo.lock needs to be updated but --locked was passed to prevent this";
+        assert!(super::rust_inspect_locked_prewarm_needs_lock_update(needs_update));
+
         assert!(!super::rust_inspect_locked_prewarm_needs_lock_update(
             "error: failed to select a version for `demo`"
+        ));
+        assert!(!super::rust_inspect_locked_prewarm_needs_lock_update(
+            "error: package selected but no lock file policy was involved"
         ));
     }
 

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -14,15 +14,15 @@
     },
     {
       "path": "crates/incan_core/src/interop/metadata.rs",
-      "category": "registry-backed Rust collection metadata policy",
-      "expected_count": 14,
-      "expected_fingerprint": "0x5da489b106a16ae2"
+      "category": "registry-backed Rust collection metadata policy and shared Rust type-shape parsing",
+      "expected_count": 23,
+      "expected_fingerprint": "0xa552cf64d66c9211"
     },
     {
       "path": "crates/rust_inspect/src/cache.rs",
       "category": "rust-inspect cache migration and generated Rust syntax metadata compatibility",
-      "expected_count": 20,
-      "expected_fingerprint": "0xaee7fb876de04bcc"
+      "expected_count": 11,
+      "expected_fingerprint": "0x6b6a57b5d48d379f"
     },
     {
       "path": "crates/rust_inspect/src/cache_tests.rs",
@@ -39,8 +39,8 @@
     {
       "path": "crates/rust_inspect/src/extractor.rs",
       "category": "rust-inspect display-shape normalization",
-      "expected_count": 18,
-      "expected_fingerprint": "0xfdfffcbe8f5fc285"
+      "expected_count": 9,
+      "expected_fingerprint": "0xfe72d3181174ad90"
     },
     {
       "path": "crates/rust_inspect/src/lib.rs",
@@ -117,8 +117,8 @@
     {
       "path": "src/backend/ir/emit/expressions/methods.rs",
       "category": "quarantined metadata-free method compatibility",
-      "expected_count": 7,
-      "expected_fingerprint": "0xd980f50534954c82"
+      "expected_count": 6,
+      "expected_fingerprint": "0x8e7a10a90b5bbd3f"
     },
     {
       "path": "src/backend/ir/emit/expressions/methods/fast_paths.rs",
@@ -218,9 +218,9 @@
     },
     {
       "path": "src/backend/ir/ownership.rs",
-      "category": "central external Rust duckborrower byte-buffer planning",
+      "category": "central external Rust duckborrower buffer planning",
       "expected_count": 4,
-      "expected_fingerprint": "0xa001bd9bca8bb353"
+      "expected_fingerprint": "0xe78ae9c1c06afb76"
     },
     {
       "path": "src/backend/ir/reference_shape.rs",

--- a/workspaces/release/npm/package.json
+++ b/workspaces/release/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incan-sdk",
-  "version": "0.4.0-dev.7",
+  "version": "0.4.0-dev.8",
   "description": "Thin installer package for the Incan SDK",
   "license": "Apache-2.0",
   "homepage": "https://github.com/dannys-code-corner/incan",

--- a/workspaces/release/pip/pyproject.toml
+++ b/workspaces/release/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "incan-sdk"
-version = "0.4.0.dev7"
+version = "0.4.0.dev8"
 description = "Thin installer package for the Incan SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/workspaces/release/pip/src/incan_sdk/__init__.py
+++ b/workspaces/release/pip/src/incan_sdk/__init__.py
@@ -1,4 +1,4 @@
 """Thin Python installer package for the Incan SDK."""
 
 __all__ = ["__version__"]
-__version__ = "0.4.0.dev7"
+__version__ = "0.4.0.dev8"


### PR DESCRIPTION
## Summary

This PR pays down the post-#780 compiler seam debt tracked in #785 by moving Rust type-display fallback parsing and Rust boundary buffer classification into canonical planning surfaces instead of repeating string/path dispatch in rust-inspect and backend emitters. It also removes a stale `std.async.task` runtime import that produced a generated unused-import warning without adding lint suppression.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Generated stdlib Rust no longer imports `TaskJoinError` privately when `std.async.task` does not use it. The intended `TaskJoinError` consumer import path remains covered.
- **Internals**: `incan_core::interop::parse_rust_type_shape_text(...)` now owns shared textual Rust type-shape parsing for source and generated rust-inspect fallbacks. Backend ownership planning now owns byte-buffer, Buf-target, and owned string-buffer classification; interop coercion and metadata-free method fallback consume those predicates instead of rediscovering Rust spelling locally.
- **Risks**: This affects Rust interop metadata fallback and backend duckborrowing decisions. The focused Buf/byte-vector/string-buffer checks, generated Rust snapshots, full pre-commit gate, and InQL acceptance run are intended to catch regressions in those paths.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test --locked -p incan_core parse_rust_type_shape_text -- --nocapture` — passed
- `cargo test --locked -p rust_inspect dependency_generated_out_dir_items_resolve_through_root_workspace -- --nocapture` — passed
- `cargo test --locked -p incan argument_plan_external_buf_param -- --nocapture` — passed
- `cargo test --locked -p incan metadata_free -- --nocapture` — passed
- `cargo test --locked -p incan borrowed_vec -- --nocapture` — passed
- `cargo test --locked --test codegen_snapshot_tests test_std_async_task_compiled_codegen -- --nocapture` — passed
- `cargo test --locked --test codegen_snapshot_tests test_awaitable_wrapper_delegation_codegen -- --nocapture` — passed
- `cargo test --locked --test vocab_guardrails semantic_string_checks_are_classified -- --nocapture` — passed
- `cargo check --locked -p incan_core -p rust_inspect -p incan --tests` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
- `make pre-commit` — passed after final commit; 2,666 tests, clippy, cargo-deny, smoke-test-fast, examples, benchmark build checks
- `make -C /Users/danny/Development/encero/InQL build INCAN=/Users/danny/Development/encero/tmp/incan-0.4-seam-paydown/target/release/incan` — passed
- `make -C /Users/danny/Development/encero/InQL test INCAN=/Users/danny/Development/encero/tmp/incan-0.4-seam-paydown/target/release/incan` — passed, 89 tests

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #785