### PR TITLE
feature - add contextual type mismatch diagnostics (#790)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -610,27 +610,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
+checksum = "3867f7a56768640a79fc660d2f60298251dc6d65b5d1c907706cd1afff024957"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
+checksum = "a0661d63dcf8fc4a6538c1ee4d523917c5b27e9fce7a4114cdf9e2b30b4043cf"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
+checksum = "a8d535b489159ea63e3c40dfbe8d0e12bfb71f2a14845ef2407353e06c5a697c"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
+checksum = "c3af4f7d421b2354deb01d714266022f38fcdbebc9f5f1ec6d310d3c27286d9e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
+checksum = "09fe4c289e67e0221d1705734a57f95e25c289ed0ead7728743ea21285fc4cf1"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
+checksum = "b3063e5363dc5ee6ee8edd930314582c08eb91c209b9564da1cd667f6424b9b3"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -690,24 +690,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
+checksum = "c34b9c8dbc9edf37744918e56898d4979ef1e764e8e4bbe8b4d50250838ddfe8"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
+checksum = "4eed9dc54204dc99aad19669bca50142659ed583396d9a99a2aef34d7c136ef4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
+checksum = "9aa2846b239a046217ecf95cfed0e31be4e86843785d07438ad33f456871e888"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
+checksum = "144f70fa9cd07efb83497c12dc8fb73f360a690cd990c44e8ceebc293d8c13b5"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -729,15 +729,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
+checksum = "0733ca5b2aaa5f6d5d6a1439e3c44280d34730d4d5c262ca08c6775c8d83f191"
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
+checksum = "75b1290d6193b171172d5fe9a6e42326edf487a79f211fbf1e76f912a4aed035"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
+checksum = "ce0d5c2b4d719566816a0f1c9a9712d35d61e27df0ffd6c72a9afec9048db6c0"
 
 [[package]]
 name = "crc32fast"
@@ -948,7 +948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2015,7 +2015,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2057,7 +2057,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2308,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff0ead8b4616f81b3d3efd41ce41bcf9ea364a5d8df8be8a8a1f98b50104349"
+checksum = "34dff5fd3d9ac4845939fcb4597cd413cb244bc530448ed4766d11b1725e53d0"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2320,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4389e5820b1b39810ac12a27aa665320cab3caa51913a79637c06f284cfe223"
+checksum = "6c60fb1c885bdb1efd7c50e8e973714de558b75a65f20c3e9a41398c652aa44b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3249,7 +3249,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3547,7 +3547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3655,7 +3655,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4322,9 +4322,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4eccc0728f061979efa8ff4c962cff7041fead4baadb74973f01b9c47158a4"
+checksum = "d807f646bfecc1dbb4990d8c864beebccbdb3f2cd1b39b2b82957b4e294c6058"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -4364,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e84dbe3208c1336a41546beb75927b3b37e2e4fce06653d214b407136fbe295"
+checksum = "48b945309908f22473ebcd585ac2993948044228491cd96941d367aa81a49c3f"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -4395,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c223bd503db76df8d74d1fcca39e734d25f7a0c1dcaf1509b67f3855d1b0f803"
+checksum = "7307dec6251a18ffa9df03120d2945ac2476ce150b5b099f39b199e8f81464dc"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4410,15 +4410,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab123ad511483a1b918399789d0cc7dea7c5c6476743df73949007b5b225fc74"
+checksum = "7a3d899b0270bcf04852f141bd9538cb162a436e7f56b2c6e0f4e57ecc70743a"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
+checksum = "aedd3947487d0afdd37accb981466fcd60571e898004c8955111f88686581dfc"
 dependencies = [
  "hashbrown 0.16.1",
  "libm",
@@ -4427,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a3bc28a172037c7864128bb208017a02bba659a59c27acacc048c09e25c1fc"
+checksum = "512fd846630c064bfc42909eeba90a7d26703b6ded09ad4778ff6afcbdc868dd"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4454,9 +4454,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c90a899a47d3da6e384e7b4cad61fdcb27535a395742b32440bdf9980ea83fa"
+checksum = "15629ea71394be5812a52cb8fbc6cd039484ab1dd48fce5e1ef58ae89606289a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4469,9 +4469,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f364747aa74c686b18925918e5cfd615a73c9613c7a31fc1cd86f42df12fbe"
+checksum = "f5fce5fedc1c952a64cdf3c87e4632af072d2aca0bc2c460d53296fb2654757d"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -4479,9 +4479,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ba98c1492f530833e0d3cc17dbb0c3c57c9f1bb3b078ae44bb55a233e43eba"
+checksum = "10005b038e662775ac002f233e429447a58892e89918580fa67ce8cdd9192d0a"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4491,9 +4491,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b8f8a89e8f3660646f820c7d8310a67094156bb866e9d56f1b00892e011206"
+checksum = "03f3e0f474281b405a3e9d97239f83f643b572324d292e1ef9dc5e3e0ab04c68"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4504,9 +4504,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a12754f1ffc4a3300d56d324c418b8b32cf029606618da22c7d076213882a3f"
+checksum = "910e5393af4aca456113581a5913b8d499cd2189013e983f8764d06ebc42b2ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4515,9 +4515,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b06e4ed07adc579645e5c55c67b3138c49da2e468fad52d3db7b7a098ecc733"
+checksum = "55481651bea5b8336fb200fa49914ccf802f5e7617ba9ab0b4691f16d4f97ff8"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -4532,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f08787948e3c983799d616ef7dd57463253e9ca8bab6607eef8134f12353f70"
+checksum = "d890c3804d0e46000fa901c86ac1a9fdedf684e72dfd64e582b56bb4a78a6746"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -4545,9 +4545,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2f19834bc6edbc31ac95fdcfd5ddcd7643759265a1d545dec36ac6cc788ca8"
+checksum = "5aa7f927779d92863a1447c1d88192b2242080608cb91ece69c177321488948b"
 dependencies = [
  "async-trait",
  "bitflags 2.11.0",
@@ -4575,9 +4575,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e0c6efdbaf90906016be9ed9ff17b7b58f393876287beebe5bd7fa1de54dbb"
+checksum = "d6fd8b702c2aa82bb4907da5ad44120b4385048f6a20731908a6e2485ea7567e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4619,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b644ab90da80bbca28973192978ac452cbd876955bb209e6ff2cd1955e43a7"
+checksum = "165512f7870210d0fd45911990b832782b5fb82d40f4ce28cf86b40aaecd453c"
 dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
@@ -4633,9 +4633,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521f9d558365357274d960340eb9eb4f4d768fafdc79f381fd2e13a85b925ebc"
+checksum = "f7f63d06fdf2e9a133407b318574574f66ea6590ea7a42c4a7554c029824454a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4647,9 +4647,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a386e86021363c9f0abd1e189e8f8a729d9b5aab2bb7172a3e40f2ab647a936"
+checksum = "1b976b7285ca32a637e21721021442691a2d7938ab4650cb99472a672e9def6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4663,14 +4663,14 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "winch-codegen"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16496e92d2b232f9d195ae74f71a674aabae7b7fa722d39068836723d3b653c"
+checksum = "436a7fa4109b13b0e555d01ec615ab8b928b7834639aca7b2fdc1f55d70a1f0c"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -303,6 +303,69 @@ pub fn type_mismatch(expected: &str, found: &str, span: Span) -> CompileError {
     error
 }
 
+/// Build a type mismatch diagnostic for a return expression.
+pub fn return_type_mismatch(expected: &str, found: &str, span: Span) -> CompileError {
+    add_type_mismatch_hints(
+        CompileError::type_error(
+            format!("Return type mismatch: expected '{}', found '{}'", expected, found),
+            span,
+        )
+        .with_note(format!(
+            "This return expression must match the function return type '{}'",
+            expected
+        )),
+        expected,
+        found,
+    )
+}
+
+/// Build a type mismatch diagnostic for assigning to a known binding.
+pub fn assignment_type_mismatch(binding: &str, expected: &str, found: &str, span: Span) -> CompileError {
+    add_type_mismatch_hints(
+        CompileError::type_error(
+            format!(
+                "Assignment to '{}' has type mismatch: expected '{}', found '{}'",
+                binding, expected, found
+            ),
+            span,
+        )
+        .with_note(format!("'{}' is declared as '{}'", binding, expected)),
+        expected,
+        found,
+    )
+}
+
+/// Build a type mismatch diagnostic for a function call argument.
+pub fn call_argument_type_mismatch(
+    callee: &str,
+    parameter: Option<&str>,
+    expected: &str,
+    found: &str,
+    span: Span,
+) -> CompileError {
+    let message = match parameter {
+        Some(parameter) => format!(
+            "Argument '{}' of '{}' has type mismatch: expected '{}', found '{}'",
+            parameter, callee, expected, found
+        ),
+        None => format!(
+            "Argument to '{}' has type mismatch: expected '{}', found '{}'",
+            callee, expected, found
+        ),
+    };
+    let note = match parameter {
+        Some(parameter) => format!(
+            "Parameter '{}' of '{}' is declared as '{}'",
+            parameter, callee, expected
+        ),
+        None => format!(
+            "This argument is checked against '{}' when calling '{}'",
+            expected, callee
+        ),
+    };
+    add_type_mismatch_hints(CompileError::type_error(message, span).with_note(note), expected, found)
+}
+
 /// Add smart hints based on the expected and found types.
 fn add_type_mismatch_hints(mut error: CompileError, expected: &str, found: &str) -> CompileError {
     // Result/Option unwrapping hints

--- a/src/frontend/typechecker/check_expr/calls/args.rs
+++ b/src/frontend/typechecker/check_expr/calls/args.rs
@@ -241,11 +241,11 @@ impl TypeChecker {
                     if let Some((_, param)) = normal_params.get(positional_index) {
                         normal_bound_spans[positional_index] = Some(arg_span);
                         self.infer_type_param_bindings(&param.ty, arg_ty, type_bindings);
-                        self.emit_arg_type_mismatch_if_needed(&param.ty, arg_ty, arg_span);
+                        self.emit_arg_type_mismatch_if_needed(callee, param.name(), &param.ty, arg_ty, arg_span);
                         positional_index += 1;
                     } else if let Some(param) = rest_positional {
                         self.infer_type_param_bindings(&param.ty, arg_ty, type_bindings);
-                        self.emit_arg_type_mismatch_if_needed(&param.ty, arg_ty, arg_span);
+                        self.emit_arg_type_mismatch_if_needed(callee, param.name(), &param.ty, arg_ty, arg_span);
                     } else {
                         unexpected_positional += 1;
                     }
@@ -267,11 +267,23 @@ impl TypeChecker {
                             if let Some((_, param)) = normal_params.get(positional_index) {
                                 normal_bound_spans[positional_index] = Some(item_span);
                                 self.infer_type_param_bindings(&param.ty, item_ty, type_bindings);
-                                self.emit_arg_type_mismatch_if_needed(&param.ty, item_ty, item_span);
+                                self.emit_arg_type_mismatch_if_needed(
+                                    callee,
+                                    param.name(),
+                                    &param.ty,
+                                    item_ty,
+                                    item_span,
+                                );
                                 positional_index += 1;
                             } else if let Some(param) = rest_positional {
                                 self.infer_type_param_bindings(&param.ty, item_ty, type_bindings);
-                                self.emit_arg_type_mismatch_if_needed(&param.ty, item_ty, item_span);
+                                self.emit_arg_type_mismatch_if_needed(
+                                    callee,
+                                    param.name(),
+                                    &param.ty,
+                                    item_ty,
+                                    item_span,
+                                );
                             } else {
                                 unexpected_positional += 1;
                             }
@@ -282,11 +294,23 @@ impl TypeChecker {
                             if let Some((_, param)) = normal_params.get(positional_index) {
                                 normal_bound_spans[positional_index] = Some(arg_span);
                                 self.infer_type_param_bindings(&param.ty, item_ty, type_bindings);
-                                self.emit_arg_type_mismatch_if_needed(&param.ty, item_ty, arg_span);
+                                self.emit_arg_type_mismatch_if_needed(
+                                    callee,
+                                    param.name(),
+                                    &param.ty,
+                                    item_ty,
+                                    arg_span,
+                                );
                                 positional_index += 1;
                             } else if let Some(param) = rest_positional {
                                 self.infer_type_param_bindings(&param.ty, item_ty, type_bindings);
-                                self.emit_arg_type_mismatch_if_needed(&param.ty, item_ty, arg_span);
+                                self.emit_arg_type_mismatch_if_needed(
+                                    callee,
+                                    param.name(),
+                                    &param.ty,
+                                    item_ty,
+                                    arg_span,
+                                );
                             } else {
                                 unexpected_positional += 1;
                             }
@@ -294,7 +318,7 @@ impl TypeChecker {
                     } else if let Some(param) = rest_positional {
                         let expected = list_ty(param.ty.clone());
                         self.infer_type_param_bindings(&expected, arg_ty, type_bindings);
-                        self.emit_arg_type_mismatch_if_needed(&expected, arg_ty, arg_span);
+                        self.emit_arg_type_mismatch_if_needed(callee, param.name(), &expected, arg_ty, arg_span);
                     } else {
                         self.errors
                             .push(errors::call_unpack_without_rest(callee, "*", arg_span));
@@ -318,10 +342,10 @@ impl TypeChecker {
                         }
                         normal_bound_spans[normal_idx] = Some(arg_span);
                         self.infer_type_param_bindings(&param.ty, arg_ty, type_bindings);
-                        self.emit_arg_type_mismatch_if_needed(&param.ty, arg_ty, arg_span);
+                        self.emit_arg_type_mismatch_if_needed(callee, param.name(), &param.ty, arg_ty, arg_span);
                     } else if let Some(param) = rest_keyword {
                         self.infer_type_param_bindings(&param.ty, arg_ty, type_bindings);
-                        self.emit_arg_type_mismatch_if_needed(&param.ty, arg_ty, arg_span);
+                        self.emit_arg_type_mismatch_if_needed(callee, param.name(), &param.ty, arg_ty, arg_span);
                     } else {
                         self.errors
                             .push(errors::unknown_keyword_argument(callee, name, arg_span));
@@ -368,17 +392,35 @@ impl TypeChecker {
                                     }
                                     normal_bound_spans[normal_idx] = Some(value.span);
                                     self.infer_type_param_bindings(&param.ty, value_ty, type_bindings);
-                                    self.emit_arg_type_mismatch_if_needed(&param.ty, value_ty, value.span);
+                                    self.emit_arg_type_mismatch_if_needed(
+                                        callee,
+                                        param.name(),
+                                        &param.ty,
+                                        value_ty,
+                                        value.span,
+                                    );
                                 } else if let Some(param) = rest_keyword {
                                     self.infer_type_param_bindings(&param.ty, value_ty, type_bindings);
-                                    self.emit_arg_type_mismatch_if_needed(&param.ty, value_ty, value.span);
+                                    self.emit_arg_type_mismatch_if_needed(
+                                        callee,
+                                        param.name(),
+                                        &param.ty,
+                                        value_ty,
+                                        value.span,
+                                    );
                                 } else {
                                     self.errors
                                         .push(errors::unknown_keyword_argument(callee, name, key.span));
                                 }
                             } else if let Some(param) = rest_keyword {
                                 self.infer_type_param_bindings(&param.ty, value_ty, type_bindings);
-                                self.emit_arg_type_mismatch_if_needed(&param.ty, value_ty, value.span);
+                                self.emit_arg_type_mismatch_if_needed(
+                                    callee,
+                                    param.name(),
+                                    &param.ty,
+                                    value_ty,
+                                    value.span,
+                                );
                             } else {
                                 self.errors
                                     .push(errors::call_unpack_without_rest(callee, "**", key.span));
@@ -387,7 +429,7 @@ impl TypeChecker {
                     } else if let Some(param) = rest_keyword {
                         let expected = dict_ty(ResolvedType::Str, param.ty.clone());
                         self.infer_type_param_bindings(&expected, arg_ty, type_bindings);
-                        self.emit_arg_type_mismatch_if_needed(&expected, arg_ty, arg_span);
+                        self.emit_arg_type_mismatch_if_needed(callee, param.name(), &expected, arg_ty, arg_span);
                     } else {
                         self.errors
                             .push(errors::call_unpack_without_rest(callee, "**", arg_span));
@@ -417,13 +459,25 @@ impl TypeChecker {
     }
 
     /// Emit a call-argument mismatch unless RFC 017 allows a validated-newtype coercion at this argument span.
-    fn emit_arg_type_mismatch_if_needed(&mut self, expected: &ResolvedType, actual: &ResolvedType, span: Span) {
+    fn emit_arg_type_mismatch_if_needed(
+        &mut self,
+        callee: &str,
+        parameter: Option<&str>,
+        expected: &ResolvedType,
+        actual: &ResolvedType,
+        span: Span,
+    ) {
         if !self.types_compatible(actual, expected) {
             if self.record_validated_newtype_coercion_if_possible(actual, expected, span) {
                 return;
             }
-            self.errors
-                .push(errors::type_mismatch(&expected.to_string(), &actual.to_string(), span));
+            self.errors.push(errors::call_argument_type_mismatch(
+                callee,
+                parameter,
+                &expected.to_string(),
+                &actual.to_string(),
+                span,
+            ));
         }
     }
 }

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -654,7 +654,8 @@ impl TypeChecker {
                 self.errors.push(errors::mutation_without_mut(&assign.name, span));
             }
             if !self.types_compatible(&value_ty, &var_ty) {
-                self.errors.push(errors::type_mismatch(
+                self.errors.push(errors::assignment_type_mismatch(
+                    &assign.name,
                     &var_ty.to_string(),
                     &value_ty.to_string(),
                     assign.value.span,
@@ -713,7 +714,8 @@ impl TypeChecker {
             if !self.types_compatible(&value_ty, &ann_ty)
                 && !self.record_validated_newtype_coercion_if_possible(&value_ty, &ann_ty, assign.value.span)
             {
-                self.errors.push(errors::type_mismatch(
+                self.errors.push(errors::assignment_type_mismatch(
+                    &assign.name,
                     &ann_ty.to_string(),
                     &value_ty.to_string(),
                     assign.value.span,
@@ -757,7 +759,7 @@ impl TypeChecker {
         if let Some(expected) = self.symbols.current_return_type()
             && !self.types_compatible(&return_ty, expected)
         {
-            self.errors.push(errors::type_mismatch(
+            self.errors.push(errors::return_type_mismatch(
                 &expected.to_string(),
                 &return_ty.to_string(),
                 span,

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -1283,8 +1283,17 @@ def main(data: bytes) -> None:
 "#;
     let errs = check_str_err(source, "owned bytes should not satisfy an Incan &bytes parameter");
     assert!(
-        errs.iter().any(|err| err.message.contains("Type mismatch")),
-        "expected type mismatch, got {errs:?}"
+        errs.iter().any(|err| err
+            .message
+            .contains("Argument 'data' of 'borrowed' has type mismatch: expected '&bytes', found 'bytes'")),
+        "expected call argument type mismatch, got {errs:?}"
+    );
+    assert!(
+        errs.iter().any(|err| err
+            .notes
+            .iter()
+            .any(|note| note.contains("Parameter 'data' of 'borrowed' is declared as '&bytes'"))),
+        "expected call argument context note, got {errs:?}"
     );
 }
 
@@ -2511,6 +2520,77 @@ def foo() -> int:
 "#;
     let result = check_str(source);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_return_type_mismatch_names_return_context() {
+    let source = r#"
+def foo() -> int:
+  return "hello"
+"#;
+    let errs = check_str_err(source, "expected return type mismatch");
+    assert!(
+        errs.iter().any(|err| err
+            .message
+            .contains("Return type mismatch: expected 'int', found 'str'")),
+        "expected contextual return mismatch, got: {errs:?}"
+    );
+    assert!(
+        errs.iter().any(|err| err
+            .notes
+            .iter()
+            .any(|note| note.contains("return expression must match the function return type 'int'"))),
+        "expected return-context note, got: {errs:?}"
+    );
+}
+
+#[test]
+fn test_assignment_type_mismatch_names_binding_context() {
+    let source = r#"
+def main() -> None:
+  annotated: int = "hello"
+"#;
+    let errs = check_str_err(source, "expected assignment type mismatch");
+    assert!(
+        errs.iter().any(|err| {
+            err.message
+                .contains("Assignment to 'annotated' has type mismatch: expected 'int', found 'str'")
+        }),
+        "expected contextual assignment mismatch, got: {errs:?}"
+    );
+    assert!(
+        errs.iter().any(|err| err
+            .notes
+            .iter()
+            .any(|note| note.contains("'annotated' is declared as 'int'"))),
+        "expected assignment-context note, got: {errs:?}"
+    );
+}
+
+#[test]
+fn test_call_argument_type_mismatch_names_parameter_context() {
+    let source = r#"
+def takes_int(value: int) -> None:
+  pass
+
+def main() -> None:
+  takes_int("hello")
+"#;
+    let errs = check_str_err(source, "expected call argument type mismatch");
+    assert!(
+        errs.iter().any(|err| {
+            err.message
+                .contains("Argument 'value' of 'takes_int' has type mismatch: expected 'int', found 'str'")
+        }),
+        "expected contextual call argument mismatch, got: {errs:?}"
+    );
+    assert!(
+        errs.iter().any(|err| err
+            .notes
+            .iter()
+            .any(|note| note.contains("Parameter 'value' of 'takes_int' is declared as 'int'"))),
+        "expected call-argument-context note, got: {errs:?}"
+    );
 }
 
 #[test]
@@ -7013,9 +7093,9 @@ model Account:
 "#;
     let errors = check_str_err(source, "expected computed property return mismatch");
     assert!(
-        errors
-            .iter()
-            .any(|error| error.message.contains("Type mismatch: expected 'int', found 'str'")),
+        errors.iter().any(|error| error
+            .message
+            .contains("Return type mismatch: expected 'int', found 'str'")),
         "expected property return mismatch diagnostic, got {errors:?}"
     );
 }
@@ -11112,7 +11192,9 @@ def foo(value: str) -> None:
 "#;
     let errs = check_str_err(source, "runtime str should not typecheck as FrozenStr");
     assert!(
-        errs.iter().any(|err| err.message.contains("Type mismatch")),
+        errs.iter().any(|err| err
+            .message
+            .contains("Argument 'value' of 'accept_frozen' has type mismatch: expected 'FrozenStr', found 'str'")),
         "expected type mismatch for runtime str to FrozenStr, got {errs:?}"
     );
 }
@@ -11128,7 +11210,9 @@ def foo(value: bytes) -> None:
 "#;
     let errs = check_str_err(source, "runtime bytes should not typecheck as FrozenBytes");
     assert!(
-        errs.iter().any(|err| err.message.contains("Type mismatch")),
+        errs.iter().any(|err| err
+            .message
+            .contains("Argument 'value' of 'accept_frozen' has type mismatch: expected 'FrozenBytes', found 'bytes'")),
         "expected type mismatch for runtime bytes to FrozenBytes, got {errs:?}"
     );
 }


### PR DESCRIPTION
## Summary

This PR improves high-frequency type mismatch diagnostics so returns, assignments, and function-call arguments report the local context that caused the mismatch instead of only the generic expected/found pair. It also updates the locked Wasmtime patch set to `44.0.3` so the PR clears the current `wasmtime-wasi` RustSec advisory.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Type mismatches at common sites now name the relevant construct: return expressions identify the function return type, assignments identify the declared binding, and call arguments identify the callee parameter. Existing smart hints are preserved.
- **Internals**: Added context-specific diagnostic constructors and threaded binding/callee/parameter context through the typechecker paths that emit return, assignment, and call-argument mismatches. `Cargo.lock` now uses `wasmtime-wasi 44.0.3` and matching Wasmtime/Cranelift patch releases.
- **Risks**: Exact diagnostic wording changed for these mismatch sites. Downstream tests or tooling that match the old generic string may need to update expected output. The lockfile update is patch-level within the existing manifest constraints.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test type_mismatch_names` passed after the diagnostic commit and again after the lockfile patch.
- `cargo test owned_value_does_not_satisfy_incan_shared_ref_parameter` passed.
- `cargo test test_computed_property_body_return_type_is_checked` passed.
- `cargo deny check` passed after updating `wasmtime-wasi` from `44.0.2` to `44.0.3`.
- Earlier `make pre-commit` ran formatting, rustdoc, full nextest, and clippy successfully before the lockfile patch; it failed only on the now-patched `wasmtime-wasi 44.0.2` advisory.
- Manual CLI repro against `/private/tmp/incan790_lsp_repro.incn` showed the improved return, assignment, call-argument, and existing condition diagnostics.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): …

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #790