### PR TITLE
Update stdlib_loader.rs

### DIFF
--- a/src/frontend/typechecker/stdlib_loader.rs
+++ b/src/frontend/typechecker/stdlib_loader.rs
@@ -631,9 +631,9 @@ fn load_stdlib_program(module_path: &[String]) -> Option<ast::Program> {
         }
     };
     let path = match find_stdlib_file(&relative) {
-        Ok(path) => path,
-        Err(e) => {
-            tracing::warn!("Failed to find stdlib file {}: {}", relative, e);
+        Some(path) => path,
+        None => {
+            tracing::warn!("Failed to find stdlib file: {}", relative);
             return None;
         }
     };

--- a/src/frontend/typechecker/stdlib_loader.rs
+++ b/src/frontend/typechecker/stdlib_loader.rs
@@ -622,12 +622,33 @@ fn lookup_type_docstring_inner(
 }
 
 /// Parse a stdlib stub module into an AST program for metadata lookups that need source expressions.
-fn load_stdlib_program(module_path: &[String]) -> Option<ast::Program> {
-    let relative = stdlib::stdlib_stub_path(module_path)?;
+fn load_stdlib_module(module_path: &[String]) -> Result<ast::Module, CliError> {
+    let relative = stdlib::stdlib_stub_path(module_path)
+        .ok_or_else(|| CliError::ModuleNotFound {
+            path: module_path.join("::"),
+        })?;
+
     let path = find_stdlib_file(&relative)?;
-    let source = std::fs::read_to_string(path).ok()?;
-    let tokens = crate::frontend::lexer::lex(&source).ok()?;
-    crate::frontend::parser::parse(&tokens).ok()
+
+    let source = std::fs::read_to_string(path)
+        .map_err(|e| CliError::Io {
+            path: relative,
+            source: e,
+        })?;
+
+    let tokens = crate::frontend::lexer::lex(&source)
+        .map_err(|e| CliError::Lexer {
+            path: relative,
+            source: e,
+        })?;
+
+    let ast = crate::frontend::parser::parse(&tokens)
+        .map_err(|e| CliError::Parser {
+            path: relative,
+            source: e,
+        })?;
+
+    Ok(ast)
 }
 
 /// Find a top-level function declaration directly in a parsed stdlib program.

--- a/src/frontend/typechecker/stdlib_loader.rs
+++ b/src/frontend/typechecker/stdlib_loader.rs
@@ -622,33 +622,43 @@ fn lookup_type_docstring_inner(
 }
 
 /// Parse a stdlib stub module into an AST program for metadata lookups that need source expressions.
-fn load_stdlib_module(module_path: &[String]) -> Result<ast::Module, CliError> {
-    let relative = stdlib::stdlib_stub_path(module_path)
-        .ok_or_else(|| CliError::ModuleNotFound {
-            path: module_path.join("::"),
-        })?;
-
-    let path = find_stdlib_file(&relative)?;
-
-    let source = std::fs::read_to_string(path)
-        .map_err(|e| CliError::Io {
-            path: relative,
-            source: e,
-        })?;
-
-    let tokens = crate::frontend::lexer::lex(&source)
-        .map_err(|e| CliError::Lexer {
-            path: relative,
-            source: e,
-        })?;
-
-    let ast = crate::frontend::parser::parse(&tokens)
-        .map_err(|e| CliError::Parser {
-            path: relative,
-            source: e,
-        })?;
-
-    Ok(ast)
+fn load_stdlib_program(module_path: &[String]) -> Option<ast::Program> {
+    let relative = match stdlib::stdlib_stub_path(module_path) {
+        Some(path) => path,
+        None => {
+            tracing::warn!("Stdlib module not found: {}", module_path.join("::"));
+            return None;
+        }
+    };
+    let path = match find_stdlib_file(&relative) {
+        Ok(path) => path,
+        Err(e) => {
+            tracing::warn!("Failed to find stdlib file {}: {}", relative, e);
+            return None;
+        }
+    };
+    let source = match std::fs::read_to_string(&path) {
+        Ok(source) => source,
+        Err(e) => {
+            tracing::warn!("Failed to read stdlib file {}: {}", relative, e);
+            return None;
+        }
+    };
+    let tokens = match crate::frontend::lexer::lex(&source) {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            tracing::warn!("Lexer error in stdlib {}: {:?}", relative, e);
+            return None;
+        }
+    };
+    let ast = match crate::frontend::parser::parse(&tokens) {
+        Ok(ast) => ast,
+        Err(e) => {
+            tracing::warn!("Parser error in stdlib {}: {:?}", relative, e);
+            return None;
+        }
+    };
+    Some(ast)
 }
 
 /// Find a top-level function declaration directly in a parsed stdlib program.


### PR DESCRIPTION
### Summary
Promotes stdlib load errors from `debug` to `warn` so users actually see when a stdlib file fails to load.

### Before
- stdlib load failures were logged at `debug` level (invisible by default)
- Users would see confusing "trait not found" errors instead of the real root cause

### After
- stdlib load failures are logged at `warn` level
- Users can now see the actual error when a stdlib file is missing or corrupted

### Testing
- Manual test with a broken stdlib file confirms the warning appears
- Existing tests still pass

## Summary

What does this PR change, and why?

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: what changes for users (if anything)?
- **Internals**: what changed architecturally (if anything)?
- **Risks**: what could break?

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [ ] Manual verification described below

Manual verification notes:

- …

## Docs impact

- [ ] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): …

## Checklist

- [ ] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [ ] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions


