### PR TITLE
bugfix - report backend default and emit invariant failures (#794)

### DIFF
--- a/src/backend/ir/emit/errors.rs
+++ b/src/backend/ir/emit/errors.rs
@@ -11,6 +11,7 @@
 #[derive(Debug)]
 pub enum EmitError {
     SynParse(String),
+    InternalInvariant(String),
     Unsupported(String),
 }
 
@@ -18,9 +19,26 @@ impl std::fmt::Display for EmitError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EmitError::SynParse(msg) => write!(f, "syn parse error: {}", msg),
+            EmitError::InternalInvariant(msg) => write!(f, "internal code generation invariant failed: {}", msg),
             EmitError::Unsupported(msg) => write!(f, "unsupported: {}", msg),
         }
     }
 }
 
 impl std::error::Error for EmitError {}
+
+#[cfg(test)]
+mod tests {
+    use super::EmitError;
+
+    #[test]
+    fn internal_invariant_errors_are_not_reported_as_unsupported_constructs() {
+        let error = EmitError::InternalInvariant("filtered comprehension plan requires a filter".to_string());
+        let message = error.to_string();
+        assert_eq!(
+            message,
+            "internal code generation invariant failed: filtered comprehension plan requires a filter"
+        );
+        assert!(!message.starts_with("unsupported:"));
+    }
+}

--- a/src/backend/ir/emit/expressions/comprehensions.rs
+++ b/src/backend/ir/emit/expressions/comprehensions.rs
@@ -140,8 +140,8 @@ impl<'a> IrEmitter<'a> {
         match plan {
             ComprehensionIterationPlan::RangeFilter => {
                 let Some(filter) = filter else {
-                    return Err(EmitError::Unsupported(
-                        "internal error: range comprehension filter plan requires a filter".to_string(),
+                    return Err(EmitError::InternalInvariant(
+                        "range comprehension filter plan requires a filter".to_string(),
                     ));
                 };
                 let filter_tokens = self.emit_expr(filter)?;
@@ -154,8 +154,8 @@ impl<'a> IrEmitter<'a> {
             }),
             ComprehensionIterationPlan::FilterMapCloneBinding => {
                 let Some(filter) = filter else {
-                    return Err(EmitError::Unsupported(
-                        "internal error: filtered comprehension plan requires a filter".to_string(),
+                    return Err(EmitError::InternalInvariant(
+                        "filtered comprehension plan requires a filter".to_string(),
                     ));
                 };
                 let filter_tokens = self.emit_expr(filter)?;
@@ -176,8 +176,8 @@ impl<'a> IrEmitter<'a> {
             }
             ComprehensionIterationPlan::FilterMapCopyBinding => {
                 let Some(filter) = filter else {
-                    return Err(EmitError::Unsupported(
-                        "internal error: filtered comprehension plan requires a filter".to_string(),
+                    return Err(EmitError::InternalInvariant(
+                        "filtered comprehension plan requires a filter".to_string(),
                     ));
                 };
                 let filter_tokens = self.emit_expr(filter)?;
@@ -262,8 +262,8 @@ impl<'a> IrEmitter<'a> {
         match plan {
             ComprehensionIterationPlan::FilterMapCloneBinding => {
                 let Some(filter) = filter else {
-                    return Err(EmitError::Unsupported(
-                        "internal error: filtered dict comprehension plan requires a filter".to_string(),
+                    return Err(EmitError::InternalInvariant(
+                        "filtered dict comprehension plan requires a filter".to_string(),
                     ));
                 };
                 let filter_tokens = self.emit_expr(filter)?;
@@ -284,8 +284,8 @@ impl<'a> IrEmitter<'a> {
             }
             ComprehensionIterationPlan::FilterMapCopyBinding => {
                 let Some(filter) = filter else {
-                    return Err(EmitError::Unsupported(
-                        "internal error: filtered dict comprehension plan requires a filter".to_string(),
+                    return Err(EmitError::InternalInvariant(
+                        "filtered dict comprehension plan requires a filter".to_string(),
                     ));
                 };
                 let filter_tokens = self.emit_expr(filter)?;

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -233,8 +233,8 @@ impl<'a> IrEmitter<'a> {
                     IrListEntry::Element(item) => {
                         self.emit_list_literal_item(item, item_target_ty, target_union_qualifier)
                     }
-                    IrListEntry::Spread(_) => Err(EmitError::Unsupported(
-                        "internal error: unexpected list spread in direct-only literal emission".to_string(),
+                    IrListEntry::Spread(_) => Err(EmitError::InternalInvariant(
+                        "unexpected list spread in direct-only literal emission".to_string(),
                     )),
                 })
                 .collect::<Result<_, _>>()?;
@@ -306,8 +306,8 @@ impl<'a> IrEmitter<'a> {
                         )?;
                         Ok(quote! { (#key_tokens, #value_tokens) })
                     }
-                    IrDictEntry::Spread(_) => Err(EmitError::Unsupported(
-                        "internal error: unexpected dict spread in direct-only literal emission".to_string(),
+                    IrDictEntry::Spread(_) => Err(EmitError::InternalInvariant(
+                        "unexpected dict spread in direct-only literal emission".to_string(),
                     )),
                 })
                 .collect::<Result<_, EmitError>>()?;

--- a/src/backend/ir/lower/decl/functions.rs
+++ b/src/backend/ir/lower/decl/functions.rs
@@ -384,7 +384,7 @@ impl AstLowering {
                 if p.node.is_mut {
                     self.mutable_vars.insert(p.node.name.clone(), true);
                 }
-                FunctionParam {
+                Ok(FunctionParam {
                     name: p.node.name.clone(),
                     ty: param_ty, // Store the emitted parameter type (emit will add &mut for mutable params)
                     mutability: if p.node.is_mut {
@@ -394,13 +394,10 @@ impl AstLowering {
                     },
                     is_self: false,
                     kind: p.node.kind,
-                    default: match &p.node.default {
-                        Some(default_expr) => self.lower_expr_spanned(default_expr).ok(),
-                        None => None,
-                    },
-                }
+                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                })
             })
-            .collect();
+            .collect::<Result<_, LoweringError>>()?;
 
         let return_type = self.lower_callable_return_type(&f.return_type.node, Some(&type_param_names));
         let is_generator = return_type_is_generator(&return_type) && body_contains_yield(&f.body);

--- a/src/backend/ir/lower/decl/methods.rs
+++ b/src/backend/ir/lower/decl/methods.rs
@@ -387,7 +387,7 @@ impl AstLowering {
             _ => Vec::new(),
         };
         let defaults =
-            self.decorated_param_defaults_for_surface(surface_params, &original_surface_params, &method.params);
+            self.decorated_param_defaults_for_surface(surface_params, &original_surface_params, &method.params)?;
         let mut wrapper_params = Vec::with_capacity(surface_params.len() + 1);
         let receiver = method.receiver.unwrap_or(ast::Receiver::Immutable);
         wrapper_params.push(FunctionParam {
@@ -1044,7 +1044,7 @@ impl AstLowering {
                     &mut hidden_counter,
                 );
                 let param_ty = Self::lower_param_container_type(p.node.kind, base_ty);
-                FunctionParam {
+                Ok(FunctionParam {
                     name: p.node.name.clone(),
                     ty: param_ty,
                     mutability: if p.node.is_mut {
@@ -1054,13 +1054,10 @@ impl AstLowering {
                     },
                     is_self: false,
                     kind: p.node.kind,
-                    default: match &p.node.default {
-                        Some(default_expr) => self.lower_expr_spanned(default_expr).ok(),
-                        None => None,
-                    },
-                }
+                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                })
             })
-            .collect();
+            .collect::<Result<_, LoweringError>>()?;
         params.extend(other_params);
 
         let return_type = self.lower_callable_return_type(&m.return_type.node, Some(&combined_type_param_names));
@@ -1277,7 +1274,7 @@ impl AstLowering {
                 if p.node.is_mut {
                     self.mutable_vars.insert(p.node.name.clone(), true);
                 }
-                FunctionParam {
+                Ok(FunctionParam {
                     name: p.node.name.clone(),
                     ty: param_ty,
                     mutability: if p.node.is_mut {
@@ -1287,13 +1284,10 @@ impl AstLowering {
                     },
                     is_self: p.node.name == keywords::as_str(KeywordId::SelfKw),
                     kind: p.node.kind,
-                    default: match &p.node.default {
-                        Some(default_expr) => self.lower_expr_spanned(default_expr).ok(),
-                        None => None,
-                    },
-                }
+                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                })
             })
-            .collect();
+            .collect::<Result<_, LoweringError>>()?;
         params.extend(other_params);
 
         let return_type = self.lower_callable_return_type(&m.return_type.node, Some(&combined_type_param_names));

--- a/src/backend/ir/lower/decl/traits.rs
+++ b/src/backend/ir/lower/decl/traits.rs
@@ -96,7 +96,7 @@ impl AstLowering {
                             &mut hidden_counter,
                         );
                         let ty = Self::lower_param_container_type(p.node.kind, base_ty);
-                        FunctionParam {
+                        Ok(FunctionParam {
                             name: p.node.name.clone(),
                             ty,
                             mutability: if p.node.is_mut {
@@ -106,13 +106,10 @@ impl AstLowering {
                             },
                             is_self: false,
                             kind: p.node.kind,
-                            default: match &p.node.default {
-                                Some(default_expr) => self.lower_expr_spanned(default_expr).ok(),
-                                None => None,
-                            },
-                        }
+                            default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                        })
                     })
-                    .collect();
+                    .collect::<Result<_, LoweringError>>()?;
                 params.extend(other_params);
 
                 let return_type =

--- a/src/backend/ir/lower/expr/calls.rs
+++ b/src/backend/ir/lower/expr/calls.rs
@@ -87,15 +87,18 @@ impl AstLowering {
 
     /// Rebuild a callable signature directly from a stdlib method declaration so default expressions survive import
     /// metadata boundaries.
-    fn callable_signature_from_stdlib_method_decl(&mut self, method: &ast::MethodDecl) -> FunctionSignature {
-        FunctionSignature {
+    fn callable_signature_from_stdlib_method_decl(
+        &mut self,
+        method: &ast::MethodDecl,
+    ) -> Result<FunctionSignature, LoweringError> {
+        Ok(FunctionSignature {
             params: method
                 .params
                 .iter()
                 .map(|param| {
                     let base_ty = self.lower_type(&param.node.ty.node);
                     let ty = Self::lower_param_container_type(param.node.kind, base_ty);
-                    FunctionParam {
+                    Ok(FunctionParam {
                         name: param.node.name.clone(),
                         ty,
                         mutability: if param.node.is_mut {
@@ -105,29 +108,28 @@ impl AstLowering {
                         },
                         is_self: false,
                         kind: param.node.kind,
-                        default: param
-                            .node
-                            .default
-                            .as_ref()
-                            .and_then(|default_expr| self.lower_expr_spanned(default_expr).ok()),
-                    }
+                        default: self.lower_param_default_expr(param.node.default.as_ref())?,
+                    })
                 })
-                .collect(),
+                .collect::<Result<_, LoweringError>>()?,
             return_type: self.lower_type(&method.return_type.node),
-        }
+        })
     }
 
     /// Rebuild a callable signature directly from a stdlib function declaration so default expressions survive import
     /// metadata boundaries.
-    fn callable_signature_from_stdlib_function_decl(&mut self, func: &ast::FunctionDecl) -> FunctionSignature {
-        FunctionSignature {
+    fn callable_signature_from_stdlib_function_decl(
+        &mut self,
+        func: &ast::FunctionDecl,
+    ) -> Result<FunctionSignature, LoweringError> {
+        Ok(FunctionSignature {
             params: func
                 .params
                 .iter()
                 .map(|param| {
                     let base_ty = self.lower_type(&param.node.ty.node);
                     let ty = Self::lower_param_container_type(param.node.kind, base_ty);
-                    FunctionParam {
+                    Ok(FunctionParam {
                         name: param.node.name.clone(),
                         ty,
                         mutability: if param.node.is_mut {
@@ -137,16 +139,12 @@ impl AstLowering {
                         },
                         is_self: false,
                         kind: param.node.kind,
-                        default: param
-                            .node
-                            .default
-                            .as_ref()
-                            .and_then(|default_expr| self.lower_expr_spanned(default_expr).ok()),
-                    }
+                        default: self.lower_param_default_expr(param.node.default.as_ref())?,
+                    })
                 })
-                .collect(),
+                .collect::<Result<_, LoweringError>>()?,
             return_type: self.lower_type(&func.return_type.node),
-        }
+        })
     }
 
     /// Resolve a callable signature from a public dependency manifest, including materialized default expressions.
@@ -507,15 +505,19 @@ impl AstLowering {
         &mut self,
         path: &[String],
         method_name: &str,
-    ) -> Option<FunctionSignature> {
+    ) -> Result<Option<FunctionSignature>, LoweringError> {
         if path.len() < 3 || path.first().map(String::as_str) != Some(incan_core::lang::stdlib::STDLIB_ROOT) {
-            return None;
+            return Ok(None);
         }
-        let type_name = path.last()?;
+        let Some(type_name) = path.last() else {
+            return Ok(None);
+        };
         let module_path = &path[..path.len() - 1];
         let mut cache = crate::frontend::typechecker::stdlib_loader::StdlibAstCache::new();
-        let method = cache.lookup_type_method_decl(module_path, type_name, method_name)?;
-        Some(self.callable_signature_from_stdlib_method_decl(&method))
+        let Some(method) = cache.lookup_type_method_decl(module_path, type_name, method_name) else {
+            return Ok(None);
+        };
+        self.callable_signature_from_stdlib_method_decl(&method).map(Some)
     }
 
     /// Resolve an imported public dependency model/class method signature from the provider manifest.
@@ -675,15 +677,19 @@ impl AstLowering {
     pub(in crate::backend::ir::lower) fn callable_signature_for_imported_stdlib_path(
         &mut self,
         path: &[String],
-    ) -> Option<FunctionSignature> {
+    ) -> Result<Option<FunctionSignature>, LoweringError> {
         if path.len() < 2 || path.first().map(String::as_str) != Some(incan_core::lang::stdlib::STDLIB_ROOT) {
-            return None;
+            return Ok(None);
         }
-        let function_name = path.last()?;
+        let Some(function_name) = path.last() else {
+            return Ok(None);
+        };
         let module_path = &path[..path.len() - 1];
         let mut cache = crate::frontend::typechecker::stdlib_loader::StdlibAstCache::new();
-        let func = cache.lookup_function_decl(module_path, function_name)?;
-        Some(self.callable_signature_from_stdlib_function_decl(&func))
+        let Some(func) = cache.lookup_function_decl(module_path, function_name) else {
+            return Ok(None);
+        };
+        self.callable_signature_from_stdlib_function_decl(&func).map(Some)
     }
 
     /// Resolve a callable signature from the callee expression's type information.
@@ -2281,10 +2287,13 @@ impl AstLowering {
         };
         let callable_signature = imported_callee_path
             .as_deref()
-            .and_then(|path| {
-                self.callable_signature_for_imported_stdlib_path(path)
-                    .or_else(|| self.callable_signature_for_imported_pub_path(path))
+            .map(|path| {
+                Ok(self
+                    .callable_signature_for_imported_stdlib_path(path)?
+                    .or_else(|| self.callable_signature_for_imported_pub_path(path)))
             })
+            .transpose()?
+            .flatten()
             .or(call_site_signature)
             .or(local_callable_signature)
             .or_else(|| self.callable_signature_for_callee_span(f.span));
@@ -2589,7 +2598,7 @@ impl AstLowering {
                 type_args: Vec::new(),
                 args: args_ir,
                 callable_signature: self
-                    .callable_signature_for_imported_stdlib_type_method_path(&type_path, TYPE_CONSTRUCTOR_HOOK),
+                    .callable_signature_for_imported_stdlib_type_method_path(&type_path, TYPE_CONSTRUCTOR_HOOK)?,
                 arg_policy: MethodCallArgPolicy::Default,
             },
             ret_ty,

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -103,7 +103,10 @@ impl AstLowering {
     }
 
     /// Return the source-defined `std.logging.Logger.<method>` signature, including default expressions.
-    fn std_logging_logger_method_signature(&mut self, method: &str) -> Option<super::super::FunctionSignature> {
+    fn std_logging_logger_method_signature(
+        &mut self,
+        method: &str,
+    ) -> Result<Option<super::super::FunctionSignature>, LoweringError> {
         self.callable_signature_for_imported_stdlib_type_method_path(
             &["std".to_string(), "logging".to_string(), "Logger".to_string()],
             method,
@@ -118,9 +121,9 @@ impl AstLowering {
         &mut self,
         span: ast::Span,
         method: &str,
-    ) -> Option<super::super::FunctionSignature> {
+    ) -> Result<Option<super::super::FunctionSignature>, LoweringError> {
         let call_site = self.callable_signature_for_call_span(span);
-        let stdlib = self.std_logging_logger_method_signature(method);
+        let stdlib = self.std_logging_logger_method_signature(method)?;
         match (call_site, stdlib) {
             (Some(mut call_site), Some(stdlib)) => {
                 for (param, stdlib_param) in call_site.params.iter_mut().zip(stdlib.params.iter()) {
@@ -128,10 +131,10 @@ impl AstLowering {
                         param.default = stdlib_param.default.clone();
                     }
                 }
-                Some(call_site)
+                Ok(Some(call_site))
             }
-            (Some(call_site), None) => Some(call_site),
-            (None, stdlib) => stdlib,
+            (Some(call_site), None) => Ok(Some(call_site)),
+            (None, stdlib) => Ok(stdlib),
         }
     }
 
@@ -666,7 +669,7 @@ impl AstLowering {
                                 "std".to_string(),
                                 "logging".to_string(),
                                 "get_logger".to_string(),
-                            ]),
+                            ])?,
                             canonical_path: Some(vec![
                                 "std".to_string(),
                                 "logging".to_string(),
@@ -1098,13 +1101,13 @@ impl AstLowering {
                         expr_ty,
                     )
                 } else {
-                    let imported_type_method_signature =
-                        match &o.node {
-                            ast::Expr::Ident(name) => self.import_aliases.get(name).cloned().and_then(|path| {
-                                self.callable_signature_for_imported_stdlib_type_method_path(&path, m)
-                            }),
-                            _ => None,
-                        };
+                    let imported_type_method_signature = match &o.node {
+                        ast::Expr::Ident(name) => match self.import_aliases.get(name).cloned() {
+                            Some(path) => self.callable_signature_for_imported_stdlib_type_method_path(&path, m)?,
+                            None => None,
+                        },
+                        _ => None,
+                    };
                     let public_receiver_library = self.public_library_for_method_receiver(&receiver);
                     let imported_pub_method_signature = public_receiver_library.as_deref().and_then(|library| {
                         self.callable_signature_for_imported_pub_type_method(library, &receiver.ty, m)
@@ -1114,7 +1117,7 @@ impl AstLowering {
                         &receiver.ty,
                         IrType::Struct(name) | IrType::NamedGeneric(name, _) if name.rsplit("::").next() == Some("Logger")
                     ) {
-                        self.std_logging_callable_signature_for_call(expr_span, m)
+                        self.std_logging_callable_signature_for_call(expr_span, m)?
                     } else {
                         None
                     };

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -2772,7 +2772,9 @@ def add(a: int, b: int) -> int:
             Ok(_) => panic!("expected default parameter lowering to fail"),
             Err(errors) => errors,
         };
-        let first = errors.first().expect("expected at least one lowering error");
+        let Some(first) = errors.first() else {
+            panic!("expected at least one lowering error");
+        };
         assert!(
             first.message.contains("failed to lower default parameter expression"),
             "unexpected lowering message: {}",

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -186,6 +186,26 @@ impl AstLowering {
         }
     }
 
+    /// Lower a source-owned parameter default expression.
+    ///
+    /// Parameter defaults participate in the callable surface used by direct calls, decorated wrappers, aliases,
+    /// imports, and stdlib source rehydration. Dropping a lowering error here silently changes that callable surface,
+    /// so every source-backed default must either lower successfully or report the original lowering failure.
+    pub(in crate::backend::ir::lower) fn lower_param_default_expr(
+        &mut self,
+        default_expr: Option<&ast::Spanned<ast::Expr>>,
+    ) -> Result<Option<TypedExpr>, LoweringError> {
+        let Some(default_expr) = default_expr else {
+            return Ok(None);
+        };
+        self.lower_expr_spanned(default_expr)
+            .map(Some)
+            .map_err(|err| LoweringError {
+                message: format!("failed to lower default parameter expression: {}", err.message),
+                span: err.span,
+            })
+    }
+
     /// Select the canonical RFC 017 checked-construction hook for a newtype.
     fn select_newtype_checked_ctor(n: &ast::NewtypeDecl) -> Option<String> {
         /// Return whether an AST type is `Result[Newtype, ValidationError]`.
@@ -378,7 +398,7 @@ impl AstLowering {
         &mut self,
         callable_params: &[CallableParam],
         source_params: &[ast::Spanned<ast::Param>],
-    ) -> Vec<FunctionParam> {
+    ) -> Result<Vec<FunctionParam>, LoweringError> {
         callable_params
             .iter()
             .enumerate()
@@ -390,13 +410,11 @@ impl AstLowering {
                     .unwrap_or(idx);
                 let source_param = source_params.get(source_idx);
                 let default = if param.has_default {
-                    source_param
-                        .and_then(|source| source.node.default.as_ref())
-                        .and_then(|default_expr| self.lower_expr_spanned(default_expr).ok())
+                    self.lower_param_default_expr(source_param.and_then(|source| source.node.default.as_ref()))?
                 } else {
                     None
                 };
-                FunctionParam {
+                Ok(FunctionParam {
                     name: param.name.clone().unwrap_or_else(|| format!("__incan_arg_{idx}")),
                     ty: Self::lower_param_container_type(param.kind, self.lower_resolved_type(&param.ty)),
                     mutability: if source_param.is_some_and(|source| source.node.is_mut) {
@@ -407,7 +425,7 @@ impl AstLowering {
                     is_self: false,
                     kind: param.kind,
                     default,
-                }
+                })
             })
             .collect()
     }
@@ -1482,7 +1500,7 @@ impl AstLowering {
                     .and_then(|info| info.function_emitted_name(decl.span))
                     .unwrap_or(&f.name)
                     .to_string();
-                let source_params: Vec<FunctionParam> = function_binding
+                let source_params: Vec<FunctionParam> = match function_binding
                     .as_ref()
                     .map(|binding| self.function_params_from_source_callable_surface(&binding.params, &f.params))
                     .unwrap_or_else(|| {
@@ -1492,7 +1510,7 @@ impl AstLowering {
                                 let base_ty =
                                     self.lower_type_with_type_params(&p.node.ty.node, Some(&type_param_names));
                                 let param_ty = Self::lower_param_container_type(p.node.kind, base_ty);
-                                FunctionParam {
+                                Ok(FunctionParam {
                                     name: p.node.name.clone(),
                                     ty: param_ty,
                                     mutability: if p.node.is_mut {
@@ -1502,14 +1520,17 @@ impl AstLowering {
                                     },
                                     is_self: false,
                                     kind: p.node.kind,
-                                    default: match &p.node.default {
-                                        Some(default_expr) => self.lower_expr_spanned(default_expr).ok(),
-                                        None => None,
-                                    },
-                                }
+                                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                                })
                             })
                             .collect()
-                    });
+                    }) {
+                    Ok(params) => params,
+                    Err(err) => {
+                        errors.push(err);
+                        continue;
+                    }
+                };
                 if let Some(binding) = self
                     .type_info
                     .as_ref()
@@ -1521,7 +1542,13 @@ impl AstLowering {
                         _ => &[],
                     };
                     let defaults =
-                        self.decorated_param_defaults_for_surface(&callable_params, original_params, &f.params);
+                        match self.decorated_param_defaults_for_surface(&callable_params, original_params, &f.params) {
+                            Ok(defaults) => defaults,
+                            Err(err) => {
+                                errors.push(err);
+                                continue;
+                            }
+                        };
                     let params = self.function_params_from_callable_surface(&callable_params, &defaults);
                     let return_type = self.lower_resolved_type(&callable_ret);
                     ir_program.function_registry.register(
@@ -1571,14 +1598,14 @@ impl AstLowering {
                     Ok(wrapper) => {
                         let type_param_names: std::collections::HashSet<&str> =
                             wrapper.type_params.iter().map(|tp| tp.name.as_str()).collect();
-                        let params: Vec<FunctionParam> = wrapper
+                        let params: Vec<FunctionParam> = match wrapper
                             .params
                             .iter()
                             .map(|p| {
                                 let base_ty =
                                     self.lower_type_with_type_params(&p.node.ty.node, Some(&type_param_names));
                                 let param_ty = Self::lower_param_container_type(p.node.kind, base_ty);
-                                FunctionParam {
+                                Ok(FunctionParam {
                                     name: p.node.name.clone(),
                                     ty: param_ty,
                                     mutability: if p.node.is_mut {
@@ -1588,14 +1615,17 @@ impl AstLowering {
                                     },
                                     is_self: false,
                                     kind: p.node.kind,
-                                    default: p
-                                        .node
-                                        .default
-                                        .as_ref()
-                                        .and_then(|default_expr| self.lower_expr_spanned(default_expr).ok()),
-                                }
+                                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                                })
                             })
-                            .collect();
+                            .collect()
+                        {
+                            Ok(params) => params,
+                            Err(err) => {
+                                errors.push(err);
+                                continue;
+                            }
+                        };
                         let return_type =
                             self.lower_type_with_type_params(&wrapper.return_type.node, Some(&type_param_names));
                         ir_program.function_registry.register(
@@ -2118,7 +2148,7 @@ impl AstLowering {
             &callable_params,
             &original_params,
             callable_ret.as_ref(),
-        );
+        )?;
 
         Ok(vec![
             IrDecl::new(IrDeclKind::Function(original)),
@@ -2152,7 +2182,7 @@ impl AstLowering {
         type_params: Vec<IrTypeParam>,
         decorated_ty: IrType,
     ) -> Result<super::decl::IrFunction, LoweringError> {
-        let defaults = self.decorated_param_defaults_for_surface(callable_params, original_params, &f.params);
+        let defaults = self.decorated_param_defaults_for_surface(callable_params, original_params, &f.params)?;
         let params = self.function_params_from_callable_surface(callable_params, &defaults);
         let return_type = self.lower_resolved_type(callable_ret);
         let type_args = type_params
@@ -2278,8 +2308,8 @@ impl AstLowering {
         callable_params: &[CallableParam],
         original_params: &[CallableParam],
         callable_ret: &crate::frontend::symbols::ResolvedType,
-    ) -> super::decl::IrFunction {
-        let defaults = self.decorated_param_defaults_for_surface(callable_params, original_params, &f.params);
+    ) -> Result<super::decl::IrFunction, LoweringError> {
+        let defaults = self.decorated_param_defaults_for_surface(callable_params, original_params, &f.params)?;
         let params = self.function_params_from_callable_surface(callable_params, &defaults);
         let return_type = self.lower_resolved_type(callable_ret);
         let static_func = TypedExpr::new(
@@ -2306,7 +2336,7 @@ impl AstLowering {
             return_type.clone(),
         );
 
-        super::decl::IrFunction {
+        Ok(super::decl::IrFunction {
             name: wrapper_name.to_string(),
             docstring: callable_docstring(&f.body),
             params,
@@ -2319,7 +2349,7 @@ impl AstLowering {
             is_extern: false,
             rust_attributes: Vec::new(),
             lint_allows: Vec::new(),
-        }
+        })
     }
 
     /// Lower source defaults for a decorated callable wrapper when the final callable surface still maps to the
@@ -2336,7 +2366,7 @@ impl AstLowering {
         surface_params: &[CallableParam],
         original_params: &[CallableParam],
         source_params: &[ast::Spanned<ast::Param>],
-    ) -> Vec<Option<TypedExpr>> {
+    ) -> Result<Vec<Option<TypedExpr>>, LoweringError> {
         let positional_shapes_match = Self::decorated_positional_param_shapes_match(surface_params, original_params);
 
         surface_params
@@ -2357,19 +2387,19 @@ impl AstLowering {
                                 .then(|| source_params.get(source_idx))
                                 .flatten()
                         })
-                        .and_then(|source_param| source_param.node.default.clone())
+                        .and_then(|source_param| source_param.node.default.as_ref())
                 } else if positional_shapes_match {
                     original_params
                         .get(idx)
                         .is_some_and(|original_param| original_param.has_default)
                         .then(|| source_params.get(idx))
                         .flatten()
-                        .and_then(|source_param| source_param.node.default.clone())
+                        .and_then(|source_param| source_param.node.default.as_ref())
                 } else {
                     None
                 };
 
-                default_expr.and_then(|expr| self.lower_expr_spanned(&expr).ok())
+                self.lower_param_default_expr(default_expr)
             })
             .collect()
     }
@@ -2677,6 +2707,10 @@ mod tests {
         lowering.lower_program(&ast)
     }
 
+    fn spanned<T>(node: T) -> ast::Spanned<T> {
+        ast::Spanned::new(node, ast::Span::default())
+    }
+
     #[test]
     fn test_lower_simple_function() {
         let ir = must_ok(lower_source(
@@ -2692,6 +2726,65 @@ def add(a: int, b: int) -> int:
         } else {
             panic!("Expected function declaration");
         }
+    }
+
+    #[test]
+    fn lowering_reports_default_parameter_expression_failures() {
+        let raw_vocab_default = spanned(ast::Expr::VocabBlock(Box::new(ast::VocabBlockStmt {
+            keyword: "query".to_string(),
+            keyword_binding: ast::VocabKeywordBinding {
+                dependency_key: "fixture".to_string(),
+                activation_namespace: "fixture".to_string(),
+                surface_kind: incan_vocab::KeywordSurfaceKind::BlockDeclaration,
+                compound_tokens: Vec::new(),
+                placement: incan_vocab::KeywordPlacement::TopLevel,
+                clause_body_kind: None,
+            },
+            decorators: Vec::new(),
+            header_args: Vec::new(),
+            body: Vec::new(),
+            body_item_trailing_commas: Vec::new(),
+        })));
+        let program = ast::Program {
+            declarations: vec![spanned(ast::Declaration::Function(ast::FunctionDecl {
+                visibility: ast::Visibility::Private,
+                decorators: Vec::new(),
+                surface_modifiers: Vec::new(),
+                name: "uses_default".to_string(),
+                type_params: Vec::new(),
+                params: vec![spanned(ast::Param {
+                    is_mut: false,
+                    kind: ast::ParamKind::Normal,
+                    name: "value".to_string(),
+                    ty: spanned(ast::Type::Simple("int".to_string())),
+                    default: Some(raw_vocab_default),
+                })],
+                return_type: spanned(ast::Type::Unit),
+                body: Vec::new(),
+            }))],
+            source_path: None,
+            rust_module_path: None,
+            warnings: Vec::new(),
+        };
+
+        let mut lowering = AstLowering::new();
+        let errors = match lowering.lower_program(&program) {
+            Ok(_) => panic!("expected default parameter lowering to fail"),
+            Err(errors) => errors,
+        };
+        let first = errors.first().expect("expected at least one lowering error");
+        assert!(
+            first.message.contains("failed to lower default parameter expression"),
+            "unexpected lowering message: {}",
+            first.message
+        );
+        assert!(
+            first
+                .message
+                .contains("vocab expression declaration `query` reached lowering before desugaring"),
+            "unexpected lowering message: {}",
+            first.message
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR hardens backend diagnostic behavior for two community-reviewed gaps: source-owned parameter defaults now propagate lowering failures instead of silently disappearing from callable signatures, and internal IR emission invariant failures are reported separately from unsupported user constructs.

Credit to @princeaka140 for spotting and clearly reporting these backend diagnostic gaps during review.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: backend failures that used to appear as missing defaults or misleading `unsupported: internal error` messages now surface as lowering errors or internal code generation invariant failures.
- **Internals**: added one source-default lowering helper and routed function, method, trait, decorated wrapper, and stdlib source signature paths through it; added `EmitError::InternalInvariant` for impossible emitter states.
- **Risks**: this changes error propagation in backend lowering. Invalid source-backed defaults should now fail earlier instead of compiling with a default removed from the callable surface.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo fmt --check`
- `cargo check --locked --bin incan`
- `cargo test --locked lowering_reports_default_parameter_expression_failures`
- `cargo test --locked internal_invariant_errors_are_not_reported_as_unsupported_constructs`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #794