### PR TITLE
bugfix - add incan-lsp version output (#428)

### DIFF
--- a/src/bin/lsp.rs
+++ b/src/bin/lsp.rs
@@ -31,6 +31,7 @@ async fn main() -> ExitCode {
     ExitCode::SUCCESS
 }
 
+/// Handle standalone CLI flags before falling back to the stdio LSP server.
 fn handle_cli_args(args: &[OsString]) -> Option<ExitCode> {
     match args {
         [] => None,

--- a/src/bin/lsp.rs
+++ b/src/bin/lsp.rs
@@ -2,13 +2,24 @@
 //!
 //! Run with: incan-lsp
 //!
+//! `--version` and `--help` are handled before the server starts so install docs
+//! and tooling can verify the binary without speaking LSP over stdio.
+//!
 //! The LSP communicates via stdin/stdout using the Language Server Protocol.
 
 use incan::lsp::IncanLanguageServer;
+use incan::version::INCAN_VERSION;
+use std::ffi::OsString;
+use std::process::ExitCode;
 use tower_lsp::{LspService, Server};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
+    let args = std::env::args_os().skip(1).collect::<Vec<_>>();
+    if let Some(exit_code) = handle_cli_args(&args) {
+        return exit_code;
+    }
+
     // Create LSP service
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
@@ -17,4 +28,57 @@ async fn main() {
 
     // Run server
     Server::new(stdin, stdout, socket).serve(service).await;
+    ExitCode::SUCCESS
+}
+
+fn handle_cli_args(args: &[OsString]) -> Option<ExitCode> {
+    match args {
+        [] => None,
+        [arg] if arg == "--version" || arg == "-V" => {
+            println!("incan-lsp {INCAN_VERSION}");
+            Some(ExitCode::SUCCESS)
+        }
+        [arg] if arg == "--help" || arg == "-h" => {
+            println!("Usage: incan-lsp [--version|--help]");
+            println!();
+            println!("Starts the Incan language server over stdio when no options are supplied.");
+            Some(ExitCode::SUCCESS)
+        }
+        _ => {
+            eprintln!("error: unsupported incan-lsp option");
+            eprintln!("usage: incan-lsp [--version|--help]");
+            Some(ExitCode::from(2))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arg(value: &str) -> OsString {
+        OsString::from(value)
+    }
+
+    #[test]
+    fn no_args_start_lsp_stdio_server() {
+        assert_eq!(handle_cli_args(&[]), None);
+    }
+
+    #[test]
+    fn version_and_help_exit_successfully() {
+        assert_eq!(handle_cli_args(&[arg("--version")]), Some(ExitCode::SUCCESS));
+        assert_eq!(handle_cli_args(&[arg("-V")]), Some(ExitCode::SUCCESS));
+        assert_eq!(handle_cli_args(&[arg("--help")]), Some(ExitCode::SUCCESS));
+        assert_eq!(handle_cli_args(&[arg("-h")]), Some(ExitCode::SUCCESS));
+    }
+
+    #[test]
+    fn unknown_args_exit_with_usage_error() {
+        assert_eq!(handle_cli_args(&[arg("--bogus")]), Some(ExitCode::from(2)));
+        assert_eq!(
+            handle_cli_args(&[arg("--version"), arg("--help")]),
+            Some(ExitCode::from(2))
+        );
+    }
 }

--- a/workspaces/docs-site/docs/start_here/coming_from_rust.md
+++ b/workspaces/docs-site/docs/start_here/coming_from_rust.md
@@ -9,7 +9,7 @@ If you already use Cargo and want a source-built compiler, install the release s
 ```bash
 cargo install --git https://github.com/dannys-code-corner/incan.git --tag v0.4.0 --locked --features lsp --bin incan --bin incan-lsp
 incan --version
-command -v incan-lsp
+incan-lsp --version
 ```
 
 If you want the faster binary toolchain path instead, use the release installer:
@@ -18,7 +18,7 @@ If you want the faster binary toolchain path instead, use the release installer:
 curl -fsSL https://github.com/dannys-code-corner/incan/releases/latest/download/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"
 incan --version
-command -v incan-lsp
+incan-lsp --version
 ```
 
 After installation, create a project and run the normal first-contact loop:

--- a/workspaces/docs-site/docs/start_here/coming_from_typescript_javascript.md
+++ b/workspaces/docs-site/docs/start_here/coming_from_typescript_javascript.md
@@ -9,7 +9,7 @@ If you already use Node-based tooling, install the npm adapter. It installs comm
 ```bash
 npm install -g @incan/toolchain
 incan --version
-command -v incan-lsp
+incan-lsp --version
 ```
 
 The direct installer is the same release path without npm in the middle, which is useful for shell scripts, CI images, and environments where you want explicit control over the toolchain manifest:
@@ -18,7 +18,7 @@ The direct installer is the same release path without npm in the middle, which i
 curl -fsSL https://github.com/dannys-code-corner/incan/releases/latest/download/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"
 incan --version
-command -v incan-lsp
+incan-lsp --version
 ```
 
 After installation, create a project and run the normal first-contact loop:

--- a/workspaces/docs-site/docs/tooling/how-to/install_and_run.md
+++ b/workspaces/docs-site/docs/tooling/how-to/install_and_run.md
@@ -29,7 +29,7 @@ The installer reads the release manifest, selects the archive for your host targ
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 incan --version
-command -v incan-lsp
+incan-lsp --version
 ```
 
 Package-manager installs use the same toolchain archive contract while fitting into the command manager you already use:


### PR DESCRIPTION
## Summary

This PR adds minimal `--version` / `--help` handling to the `incan-lsp` binary so install docs and package-manager verification can use the same expected command shape as `incan --version`. The LSP still starts over stdio when invoked without arguments, and unsupported options now fail with a small usage error instead of silently starting the server.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan-lsp --version` now prints `incan-lsp <version>`, `--help` prints a minimal usage message, and no-argument invocation keeps the existing LSP stdio behavior.
- **Internals**: the LSP entrypoint handles a small argument preflight before creating the `tower-lsp` service, using the shared `INCAN_VERSION` constant.
- **Risks**: very low. The only behavior change is for explicit command-line options; ordinary editor/LSP startup with no arguments is preserved and covered by a unit test.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo fmt --check`
- `cargo test --locked --features lsp --bin incan-lsp`
- `cargo build --locked --features lsp --bin incan-lsp`
- `cargo clippy --locked --features lsp --bin incan-lsp -- -D warnings`
- `target/debug/incan-lsp --version`
- `target/debug/incan-lsp --help`
- `target/debug/incan-lsp --bogus` exits with code 2 and usage text
- `make docs-build`
- `git diff --check`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/tooling/how-to/install_and_run.md`, `workspaces/docs-site/docs/start_here/coming_from_rust.md`, `workspaces/docs-site/docs/start_here/coming_from_typescript_javascript.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #428