### PR TITLE
bugfix - resolve installed testing marker lookup (#809)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "blake2",
  "blake3",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1525,14 +1525,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1541,14 +1541,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "axum",
  "incan_core",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.4.0-rc5"
+version = "0.4.0-rc6"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/frontend/testing_markers.rs
+++ b/src/frontend/testing_markers.rs
@@ -270,8 +270,9 @@ fn load_testing_marker_semantics_from_stdlib() -> Result<TestingMarkerSemantics,
 /// Search order:
 /// 1. `$INCAN_STDLIB_DIR/<relative>` if the env var is set (runtime)
 /// 2. `$CARGO_MANIFEST_DIR/crates/incan_stdlib/<relative>` (compile-time workspace path)
-/// 3. `$CWD/crates/incan_stdlib/<relative>`
-/// 4. `$CWD/<relative>`
+/// 3. Toolchain-relative paths from the current executable, including symlinked launchers
+/// 4. `$CWD/crates/incan_stdlib/<relative>`
+/// 5. `$CWD/<relative>`
 fn find_stdlib_file(relative: &str) -> Option<PathBuf> {
     // 1. Explicit override root (runtime).
     if let Ok(dir) = std::env::var("INCAN_STDLIB_DIR") {
@@ -290,19 +291,35 @@ fn find_stdlib_file(relative: &str) -> Option<PathBuf> {
         return Some(workspace_path);
     }
 
-    // 3-4. Relative to current working directory.
-    if let Ok(cwd) = std::env::current_dir() {
-        let crate_local = cwd.join("crates/incan_stdlib").join(relative);
+    // 3. Relative to executable location, covering installed toolchains, symlinked launchers, and local target builds.
+    if let Some(path) = find_stdlib_file_in_bases(relative, crate::toolchain_layout::current_executable_search_bases())
+    {
+        return Some(path);
+    }
+
+    // 4-5. Relative to current working directory.
+    if let Ok(cwd) = std::env::current_dir()
+        && let Some(path) = find_stdlib_file_in_bases(relative, [cwd])
+    {
+        return Some(path);
+    }
+
+    tracing::debug!(relative_path = %relative, "stdlib file not found in any search path");
+    None
+}
+
+/// Find a stdlib file under candidate base directories.
+fn find_stdlib_file_in_bases(relative: &str, bases: impl IntoIterator<Item = PathBuf>) -> Option<PathBuf> {
+    for base in bases {
+        let crate_local = base.join("crates/incan_stdlib").join(relative);
         if crate_local.exists() {
             return Some(crate_local);
         }
-        let local = cwd.join(relative);
+        let local = base.join(relative);
         if local.exists() {
             return Some(local);
         }
     }
-
-    tracing::debug!(relative_path = %relative, "stdlib file not found in any search path");
     None
 }
 
@@ -584,6 +601,21 @@ mod tests {
         runtime_names.sort_unstable();
 
         assert_eq!(metadata_names, runtime_names);
+        Ok(())
+    }
+
+    #[test]
+    fn testing_marker_source_lookup_accepts_installed_toolchain_base() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let toolchain_root = tmp.path().join("toolchains/0.4.0-test");
+        let stdlib_dir = toolchain_root.join("stdlib");
+        std::fs::create_dir_all(&stdlib_dir)?;
+        std::fs::write(stdlib_dir.join("testing.incn"), "")?;
+
+        let found = find_stdlib_file_in_bases("stdlib/testing.incn", [toolchain_root])
+            .ok_or("expected installed stdlib/testing.incn to be resolved")?;
+
+        assert!(found.ends_with("stdlib/testing.incn"));
         Ok(())
     }
 

--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -644,14 +644,14 @@ fn homebrew_formula_is_rendered_from_the_toolchain_manifest() -> Result<(), Box<
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let checksum = fs::read_to_string(dist.join("incan-v0.4.0-rc5-x86_64-unknown-linux-gnu.tar.gz.sha256"))?
+    let checksum = fs::read_to_string(dist.join("incan-v0.4.0-rc6-x86_64-unknown-linux-gnu.tar.gz.sha256"))?
         .trim()
         .to_string();
     let formula = fs::read_to_string(dist.join("incan.rb"))?;
-    assert!(formula.contains(r#"version "0.4.0-rc5""#));
+    assert!(formula.contains(r#"version "0.4.0-rc6""#));
     assert!(formula.contains("Homebrew installs the prebuilt Incan commands and bundled stdlib sources"));
     assert!(formula.contains(
-        r#"url "https://github.com/encero-systems/incan/releases/download/v0.4.0-rc5/incan-v0.4.0-rc5-x86_64-unknown-linux-gnu.tar.gz""#
+        r#"url "https://github.com/encero-systems/incan/releases/download/v0.4.0-rc6/incan-v0.4.0-rc6-x86_64-unknown-linux-gnu.tar.gz""#
     ));
     assert!(formula.contains(&format!(r#"sha256 "{checksum}""#)));
     assert!(formula.contains("def staged_files"));

--- a/workspaces/release/npm/package.json
+++ b/workspaces/release/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incan/toolchain",
-  "version": "0.4.0-rc5",
+  "version": "0.4.0-rc6",
   "description": "Thin installer package for the Incan toolchain",
   "license": "Apache-2.0",
   "homepage": "https://incan.io",

--- a/workspaces/release/pip/pyproject.toml
+++ b/workspaces/release/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "incan"
-version = "0.4.0rc5"
+version = "0.4.0rc6"
 description = "Thin installer package for the Incan toolchain"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/workspaces/release/pip/src/incan_toolchain/__init__.py
+++ b/workspaces/release/pip/src/incan_toolchain/__init__.py
@@ -1,4 +1,4 @@
 """Thin Python installer package for the Incan toolchain."""
 
 __all__ = ["__version__"]
-__version__ = "0.4.0rc5"
+__version__ = "0.4.0rc6"


### PR DESCRIPTION
## Summary

This PR fixes the remaining zero-clone installer failure where an installed Incan toolchain could run a starter project but `incan test` could not load `std.testing` marker semantics. The testing marker loader now searches the installed toolchain layout through the same executable-relative bases used by the rest of the packaged stdlib/support-crate lookup path, and the release package metadata is advanced to `0.4.0-rc6` for the next publishable candidate.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `incan new hello && incan run && incan test && incan build --release` should work from a packaged installed toolchain without requiring a source checkout.
- **Internals**: `std.testing` marker source discovery now checks executable-relative installed-toolchain bases before falling back to the current working directory, matching the broader toolchain layout lookup introduced for support crates and stdlib sources.
- **Risks**: This touches test-marker metadata loading. The main risk is search-order drift, covered by focused marker lookup tests and the packaged direct-install smoke.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo check -p incan --lib`
- `cargo fmt --check`
- `make rustdoc-gate-ci`
- `cargo test -p incan testing_marker -- --nocapture`
- `cargo test -p incan toolchain_layout -- --nocapture`
- `cargo test --test toolchain_installer_tests -- --nocapture`
- `git diff --check`
- `TOOLCHAIN_DIST=/private/tmp/incan-809-rc6-local-test make toolchain-release-build toolchain-release-package toolchain-release-assets toolchain-release-smoke-direct` passed after rerunning the smoke step with network access for Cargo dependency resolution.
- Non-tag artifact workflow run `28538654056` completed successfully for package artifacts without publishing npm/PyPI/GitHub release assets.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #809
