### PR TITLE
bugfix - keep Rust Into generic string args inferable (#804)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "blake2",
  "blake3",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1525,14 +1525,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1541,14 +1541,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "axum",
  "incan_core",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -37,6 +37,15 @@ use fast_paths::emit_registered_method_fast_path;
 use iterator_methods::emit_iterator_method;
 use string_methods::emit_string_method;
 
+/// Shared settings for emitting one method call's argument list.
+#[derive(Clone, Copy)]
+struct MethodCallArgEmission<'sig, 'site> {
+    callable_signature: Option<&'sig FunctionSignature>,
+    base_use_site: ValueUseSite<'site>,
+    result_target_ty: Option<&'site IrType>,
+    infer_unresolved_generic_args: bool,
+}
+
 /// Return the trait path used for type-level reflection.
 fn type_reflection_trait_path(method: &str) -> Option<&'static str> {
     match magic_methods::from_str(method) {
@@ -255,33 +264,49 @@ impl<'a> IrEmitter<'a> {
         type_has_rust_reference_shape(arg_ty)
     }
 
+    /// Return whether an external Rust generic parameter should infer from this argument's original string shape.
+    fn unresolved_external_generic_should_infer_from_string_arg(arg: &TypedExpr, param_ty: &IrType) -> bool {
+        matches!(param_ty, IrType::Generic(_))
+            && (matches!(
+                arg.kind,
+                IrExprKind::String(_) | IrExprKind::Literal(super::super::super::expr::Literal::StaticStr(_))
+            ) || matches!(
+                arg.ty,
+                IrType::String | IrType::StaticStr | IrType::StrRef | IrType::FrozenStr
+            ) || is_string_buffer_type(&arg.ty))
+    }
+
     /// Emit method-call arguments with Rust-boundary borrowing and union wrapping applied from callable metadata.
+    ///
+    /// The context's `infer_unresolved_generic_args` flag is enabled only for calls without explicit call-site type
+    /// arguments. It lets string-like arguments keep their original Rust shape for unresolved external generics such as
+    /// `E: Into<_>`, while explicit calls like `encode[str](...)` stay target-driven.
     fn emit_method_call_args(
         &self,
         method: &str,
         receiver: &TypedExpr,
         args: &[IrCallArg],
-        callable_signature: Option<&FunctionSignature>,
-        base_use_site: ValueUseSite<'_>,
-        result_target_ty: Option<&IrType>,
+        context: MethodCallArgEmission<'_, '_>,
     ) -> Result<Vec<TokenStream>, EmitError> {
-        let receiver_target_ty = match result_target_ty {
+        let receiver_target_ty = match context.result_target_ty {
             Some(IrType::Result(ok_ty, _)) => Some(ok_ty.as_ref()),
             other => other,
         };
         let receiver_specialized_signature = self.specialized_method_signature_for_receiver(&receiver.ty, method);
         let target_specialized_signature =
             receiver_target_ty.and_then(|ty| self.specialized_method_signature_for_receiver(ty, method));
-        let result_specialized_call_signature = callable_signature.and_then(|signature| {
-            result_target_ty.and_then(|ty| Self::specialize_signature_by_result_target(signature, ty))
+        let result_specialized_call_signature = context.callable_signature.and_then(|signature| {
+            context
+                .result_target_ty
+                .and_then(|ty| Self::specialize_signature_by_result_target(signature, ty))
         });
-        let receiver_specialized_call_signature = callable_signature.and_then(|signature| {
+        let receiver_specialized_call_signature = context.callable_signature.and_then(|signature| {
             receiver_target_ty.and_then(|ty| Self::specialize_signature_by_receiver_args(signature, ty))
         });
         let callable_signature = result_specialized_call_signature
             .as_ref()
             .or(receiver_specialized_call_signature.as_ref())
-            .or(callable_signature);
+            .or(context.callable_signature);
         let receiver_signature = receiver_specialized_signature
             .as_ref()
             .or_else(|| self.method_signature_for_receiver(&receiver.ty, method))
@@ -347,10 +372,18 @@ impl<'a> IrEmitter<'a> {
             .map(|(idx, (arg, from_default))| {
                 let param = callable_signature.as_ref().and_then(|sig| sig.params.get(idx));
                 let external_method_shape = matches!(
-                    base_use_site,
+                    context.base_use_site,
                     ValueUseSite::ExternalCallArg { .. } | ValueUseSite::MethodArg
                 );
-                let arg_use_site = match (base_use_site, param) {
+                let arg_use_site = match (context.base_use_site, param) {
+                    (ValueUseSite::ExternalCallArg { .. }, Some(param))
+                        if context.infer_unresolved_generic_args
+                            && Self::unresolved_external_generic_should_infer_from_string_arg(arg, &param.ty) =>
+                    {
+                        ValueUseSite::ExternalInferredGenericArg {
+                            target_ty: Some(&param.ty),
+                        }
+                    }
                     (ValueUseSite::ExternalCallArg { .. }, Some(param)) => ValueUseSite::ExternalCallArg {
                         target_ty: Some(&param.ty),
                     },
@@ -359,7 +392,7 @@ impl<'a> IrEmitter<'a> {
                         callee_param: Some(param),
                         in_return,
                     },
-                    _ => base_use_site,
+                    _ => context.base_use_site,
                 };
                 let previous_qualify = if *from_default {
                     Some(self.qualify_internal_canonical_paths.replace(true))
@@ -1041,8 +1074,17 @@ impl<'a> IrEmitter<'a> {
                     },
                     None,
                 );
-                let arg_tokens =
-                    self.emit_method_call_args(method, receiver, args, callable_signature, use_site, result_target_ty)?;
+                let arg_tokens = self.emit_method_call_args(
+                    method,
+                    receiver,
+                    args,
+                    MethodCallArgEmission {
+                        callable_signature,
+                        base_use_site: use_site,
+                        result_target_ty,
+                        infer_unresolved_generic_args: type_args.is_empty(),
+                    },
+                )?;
                 return Ok(quote! { #type_path::#m (#(#arg_tokens),*) });
             }
         }
@@ -1073,8 +1115,17 @@ impl<'a> IrEmitter<'a> {
             } else {
                 ValueUseSite::MethodArg
             };
-            let arg_tokens =
-                self.emit_method_call_args(method, receiver, args, callable_signature, use_site, result_target_ty)?;
+            let arg_tokens = self.emit_method_call_args(
+                method,
+                receiver,
+                args,
+                MethodCallArgEmission {
+                    callable_signature,
+                    base_use_site: use_site,
+                    result_target_ty,
+                    infer_unresolved_generic_args: false,
+                },
+            )?;
             return Ok(quote! { #trait_tokens::#m(&#r, #(#arg_tokens),*) });
         }
 
@@ -1108,8 +1159,17 @@ impl<'a> IrEmitter<'a> {
             },
             None,
         );
-        let arg_tokens =
-            self.emit_method_call_args(method, receiver, args, callable_signature, use_site, result_target_ty)?;
+        let arg_tokens = self.emit_method_call_args(
+            method,
+            receiver,
+            args,
+            MethodCallArgEmission {
+                callable_signature,
+                base_use_site: use_site,
+                result_target_ty,
+                infer_unresolved_generic_args: type_args.is_empty(),
+            },
+        )?;
         Ok(quote! { #r.#m #method_turbofish (#(#arg_tokens),*) })
     }
 

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -385,6 +385,7 @@ impl<'a> IrEmitter<'a> {
                 in_return,
             },
             ValueUseSite::ExternalCallArg { .. } => ValueUseSite::ExternalCallArg { target_ty },
+            ValueUseSite::ExternalInferredGenericArg { .. } => ValueUseSite::ExternalInferredGenericArg { target_ty },
             ValueUseSite::StructField { .. } => ValueUseSite::StructField { target_ty },
             ValueUseSite::CollectionElement { .. } => ValueUseSite::CollectionElement { target_ty },
             ValueUseSite::Assignment { .. } => ValueUseSite::Assignment { target_ty },
@@ -1697,6 +1698,156 @@ mod tests {
         assert!(
             !rendered.contains("FileDescriptorSet :: decode (& cursor)"),
             "generic by-value Rust method params must not borrow the argument, got `{rendered}`"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn external_rust_method_generic_string_arg_keeps_inferable_shape() -> Result<(), String> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let tokenizer_ty = IrType::Struct("tokenizers::Tokenizer".to_string());
+        let encoding_ty = IrType::Struct("tokenizers::Encoding".to_string());
+        let error_ty = IrType::Struct("tokenizers::Error".to_string());
+        let encode_signature = FunctionSignature {
+            params: vec![
+                FunctionParam {
+                    name: "sequence".to_string(),
+                    ty: IrType::Generic("E".to_string()),
+                    mutability: Mutability::Immutable,
+                    is_self: false,
+                    kind: crate::frontend::ast::ParamKind::Normal,
+                    default: None,
+                },
+                FunctionParam {
+                    name: "add_special_tokens".to_string(),
+                    ty: IrType::Bool,
+                    mutability: Mutability::Immutable,
+                    is_self: false,
+                    kind: crate::frontend::ast::ParamKind::Normal,
+                    default: None,
+                },
+            ],
+            return_type: IrType::Result(Box::new(encoding_ty), Box::new(error_ty)),
+        };
+        let expr = TypedExpr::new(
+            IrExprKind::MethodCall {
+                receiver: Box::new(TypedExpr::new(
+                    IrExprKind::Var {
+                        name: "tokenizer".to_string(),
+                        access: VarAccess::Read,
+                        ref_kind: VarRefKind::Value,
+                    },
+                    tokenizer_ty,
+                )),
+                method: "encode".to_string(),
+                dispatch: None,
+                type_args: Vec::new(),
+                args: vec![
+                    IrCallArg {
+                        name: None,
+                        kind: IrCallArgKind::Positional,
+                        expr: TypedExpr::new(IrExprKind::String("hello world".to_string()), IrType::String),
+                    },
+                    IrCallArg {
+                        name: None,
+                        kind: IrCallArgKind::Positional,
+                        expr: TypedExpr::new(IrExprKind::Bool(false), IrType::Bool),
+                    },
+                ],
+                callable_signature: Some(encode_signature),
+                arg_policy: MethodCallArgPolicy::Default,
+            },
+            IrType::Result(
+                Box::new(IrType::Struct("tokenizers::Encoding".to_string())),
+                Box::new(IrType::Struct("tokenizers::Error".to_string())),
+            ),
+        );
+
+        let emitted = emitter
+            .emit_expr(&expr)
+            .map_err(|err| format!("expected successful expression emission, got {err:?}"))?;
+        let rendered = emitted.to_string();
+        assert!(
+            rendered.contains("tokenizer . encode (\"hello world\" , false)"),
+            "unresolved Rust method generics should infer from the direct string literal shape, got `{rendered}`"
+        );
+        assert!(
+            !rendered.contains("\"hello world\" . into ()"),
+            "unresolved Rust method generics must not force an ambiguous `.into()` around string literals, got `{rendered}`"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn external_rust_method_explicit_generic_string_arg_keeps_turbofish() -> Result<(), String> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let tokenizer_ty = IrType::Struct("tokenizers::Tokenizer".to_string());
+        let expr = TypedExpr::new(
+            IrExprKind::MethodCall {
+                receiver: Box::new(TypedExpr::new(
+                    IrExprKind::Var {
+                        name: "tokenizer".to_string(),
+                        access: VarAccess::Read,
+                        ref_kind: VarRefKind::Value,
+                    },
+                    tokenizer_ty,
+                )),
+                method: "encode".to_string(),
+                dispatch: None,
+                type_args: vec![IrType::String],
+                args: vec![
+                    IrCallArg {
+                        name: None,
+                        kind: IrCallArgKind::Positional,
+                        expr: TypedExpr::new(IrExprKind::String("hello world".to_string()), IrType::String),
+                    },
+                    IrCallArg {
+                        name: None,
+                        kind: IrCallArgKind::Positional,
+                        expr: TypedExpr::new(IrExprKind::Bool(false), IrType::Bool),
+                    },
+                ],
+                callable_signature: Some(FunctionSignature {
+                    params: vec![
+                        FunctionParam {
+                            name: "sequence".to_string(),
+                            ty: IrType::Generic("E".to_string()),
+                            mutability: Mutability::Immutable,
+                            is_self: false,
+                            kind: crate::frontend::ast::ParamKind::Normal,
+                            default: None,
+                        },
+                        FunctionParam {
+                            name: "add_special_tokens".to_string(),
+                            ty: IrType::Bool,
+                            mutability: Mutability::Immutable,
+                            is_self: false,
+                            kind: crate::frontend::ast::ParamKind::Normal,
+                            default: None,
+                        },
+                    ],
+                    return_type: IrType::Result(
+                        Box::new(IrType::Struct("tokenizers::Encoding".to_string())),
+                        Box::new(IrType::Struct("tokenizers::Error".to_string())),
+                    ),
+                }),
+                arg_policy: MethodCallArgPolicy::Default,
+            },
+            IrType::Result(
+                Box::new(IrType::Struct("tokenizers::Encoding".to_string())),
+                Box::new(IrType::Struct("tokenizers::Error".to_string())),
+            ),
+        );
+
+        let emitted = emitter
+            .emit_expr(&expr)
+            .map_err(|err| format!("expected successful expression emission, got {err:?}"))?;
+        let rendered = emitted.to_string();
+        assert!(
+            rendered.contains("tokenizer . encode :: < String >"),
+            "explicit Incan method type args must still emit a Rust turbofish, got `{rendered}`"
         );
         Ok(())
     }

--- a/src/backend/ir/ownership.rs
+++ b/src/backend/ir/ownership.rs
@@ -17,6 +17,7 @@ use super::conversions::{
 };
 use super::decl::FunctionParam;
 use super::expr::{IrExpr, IrExprKind, MethodCallArgPolicy, VarAccess, VarRefKind};
+use super::reference_shape::expr_has_rust_reference_shape;
 use super::types::IrType;
 
 /// A typed sink/source boundary that needs an ownership/coercion decision.
@@ -41,6 +42,15 @@ pub enum ValueUseSite<'a> {
     /// use `.into()` rather than forcing Incan-owned `String` storage.
     ExternalCallArg {
         /// The external parameter type when Rust inspection provided one.
+        target_ty: Option<&'a IrType>,
+    },
+    /// Argument passed to an external Rust callable whose parameter is an unresolved method-level generic.
+    ///
+    /// Rust can often infer an `E: Into<_>` parameter from the original argument shape. For string-like arguments,
+    /// emitting `"literal".into()` removes that evidence and leaves `E` unconstrained, so method emission selects this
+    /// use site only when no explicit call-site type arguments were provided.
+    ExternalInferredGenericArg {
+        /// The unresolved external parameter type.
         target_ty: Option<&'a IrType>,
     },
     /// Value stored into a generated struct field.
@@ -180,6 +190,9 @@ pub fn plan_value_use(expr: &IrExpr, site: ValueUseSite<'_>) -> OwnershipPlan {
         ValueUseSite::ExternalCallArg { target_ty } => {
             determine_conversion(expr, target_ty, ConversionContext::ExternalFunctionArg)
         }
+        ValueUseSite::ExternalInferredGenericArg { target_ty } => {
+            determine_external_inferred_generic_arg_conversion(expr, target_ty)
+        }
         ValueUseSite::StructField { target_ty } => {
             determine_conversion(expr, target_ty, ConversionContext::StructField)
         }
@@ -214,6 +227,7 @@ pub fn value_use_site_target_ty<'a>(site: ValueUseSite<'a>) -> Option<&'a IrType
     match site {
         ValueUseSite::IncanCallArg { target_ty, .. }
         | ValueUseSite::ExternalCallArg { target_ty }
+        | ValueUseSite::ExternalInferredGenericArg { target_ty }
         | ValueUseSite::StructField { target_ty }
         | ValueUseSite::CollectionElement { target_ty }
         | ValueUseSite::Assignment { target_ty }
@@ -348,6 +362,43 @@ impl ArgumentPassingPlan {
     /// value.
     pub fn apply_after_value_plan(&self, tokens: TokenStream) -> TokenStream {
         self.passing.apply(self.value.apply_after_value_plan(tokens))
+    }
+}
+
+/// Choose the value conversion for an unresolved external Rust generic argument that should infer from its source.
+///
+/// This intentionally differs from the broad external-call policy: metadata-free Rust string arguments use `.into()`
+/// because the target may be a crate-owned string type, but an inspected method parameter like `E: Into<_>` needs the
+/// original string shape so Rust can infer `E`. Non-moved owned strings still clone to preserve Incan value semantics.
+fn determine_external_inferred_generic_arg_conversion(expr: &IrExpr, target_ty: Option<&IrType>) -> OwnershipPlan {
+    if !matches!(target_ty, Some(IrType::Generic(_))) {
+        return determine_conversion(expr, target_ty, ConversionContext::ExternalFunctionArg);
+    }
+
+    match &expr.kind {
+        IrExprKind::String(_) | IrExprKind::Literal(super::expr::Literal::StaticStr(_)) => OwnershipPlan::None,
+        IrExprKind::StaticRead { .. } if matches!(expr.ty, IrType::StaticStr | IrType::StrRef | IrType::FrozenStr) => {
+            OwnershipPlan::None
+        }
+        IrExprKind::Var { .. } if matches!(expr.ty, IrType::StaticStr | IrType::StrRef | IrType::FrozenStr) => {
+            OwnershipPlan::None
+        }
+        IrExprKind::Var { access, .. } if matches!(expr.ty, IrType::String) => {
+            if expr_has_rust_reference_shape(expr) || matches!(access, VarAccess::Move) {
+                OwnershipPlan::None
+            } else {
+                OwnershipPlan::Clone
+            }
+        }
+        IrExprKind::Field { .. } if matches!(expr.ty, IrType::String) => {
+            if expr_has_rust_reference_shape(expr) {
+                OwnershipPlan::None
+            } else {
+                OwnershipPlan::Clone
+            }
+        }
+        _ if matches!(expr.ty, IrType::String) => OwnershipPlan::None,
+        _ => determine_conversion(expr, target_ty, ConversionContext::ExternalFunctionArg),
     }
 }
 
@@ -902,6 +953,62 @@ mod tests {
         );
         assert_eq!(render(plan.apply_full(quote! { thing })), "&thing");
         assert_eq!(render(plan.apply_after_value_plan(quote! { &thing })), "&thing");
+    }
+
+    #[test]
+    fn argument_plan_external_inferred_generic_string_literal_stays_direct() {
+        let expr = IrExpr::new(IrExprKind::String("x".to_string()), IrType::String);
+        let target = IrType::Generic("E".to_string());
+        let plan = ArgumentPassingPlan::for_use_site(
+            &expr,
+            ValueUseSite::ExternalInferredGenericArg {
+                target_ty: Some(&target),
+            },
+        );
+
+        assert_eq!(render(plan.apply_full(quote! { "x" })), "\"x\"");
+    }
+
+    #[test]
+    fn argument_plan_external_inferred_generic_read_string_clones() {
+        let expr = IrExpr::new(
+            IrExprKind::Var {
+                name: "text".to_string(),
+                access: VarAccess::Read,
+                ref_kind: VarRefKind::Value,
+            },
+            IrType::String,
+        );
+        let target = IrType::Generic("E".to_string());
+        let plan = ArgumentPassingPlan::for_use_site(
+            &expr,
+            ValueUseSite::ExternalInferredGenericArg {
+                target_ty: Some(&target),
+            },
+        );
+
+        assert_eq!(render(plan.apply_full(quote! { text })), "text.clone()");
+    }
+
+    #[test]
+    fn argument_plan_external_inferred_generic_moved_string_stays_direct() {
+        let expr = IrExpr::new(
+            IrExprKind::Var {
+                name: "text".to_string(),
+                access: VarAccess::Move,
+                ref_kind: VarRefKind::Value,
+            },
+            IrType::String,
+        );
+        let target = IrType::Generic("E".to_string());
+        let plan = ArgumentPassingPlan::for_use_site(
+            &expr,
+            ValueUseSite::ExternalInferredGenericArg {
+                target_ty: Some(&target),
+            },
+        );
+
+        assert_eq!(render(plan.apply_full(quote! { text })), "text");
     }
 
     #[test]

--- a/src/backend/ir/trait_bound_inference.rs
+++ b/src/backend/ir/trait_bound_inference.rs
@@ -1620,6 +1620,7 @@ fn tuple_item_use_site<'a>(site: ValueUseSite<'a>, target_ty: Option<&'a IrType>
             in_return,
         },
         ValueUseSite::ExternalCallArg { .. } => ValueUseSite::ExternalCallArg { target_ty },
+        ValueUseSite::ExternalInferredGenericArg { .. } => ValueUseSite::ExternalInferredGenericArg { target_ty },
         ValueUseSite::StructField { .. } => ValueUseSite::StructField { target_ty },
         ValueUseSite::CollectionElement { .. } => ValueUseSite::CollectionElement { target_ty },
         ValueUseSite::Assignment { .. } => ValueUseSite::Assignment { target_ty },

--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -858,14 +858,14 @@ fn homebrew_formula_is_rendered_from_the_toolchain_manifest() -> Result<(), Box<
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let checksum = fs::read_to_string(dist.join("incan-v0.5.0-dev.1-x86_64-unknown-linux-gnu.tar.gz.sha256"))?
+    let checksum = fs::read_to_string(dist.join("incan-v0.5.0-dev.2-x86_64-unknown-linux-gnu.tar.gz.sha256"))?
         .trim()
         .to_string();
     let formula = fs::read_to_string(dist.join("incan.rb"))?;
-    assert!(formula.contains(r#"version "0.5.0-dev.1""#));
+    assert!(formula.contains(r#"version "0.5.0-dev.2""#));
     assert!(formula.contains("npm and Homebrew install prebuilt Incan commands"));
     assert!(formula.contains(
-        r#"url "https://github.com/encero-systems/incan/releases/download/v0.5.0-dev.1/incan-v0.5.0-dev.1-x86_64-unknown-linux-gnu.tar.gz""#
+        r#"url "https://github.com/encero-systems/incan/releases/download/v0.5.0-dev.2/incan-v0.5.0-dev.2-x86_64-unknown-linux-gnu.tar.gz""#
     ));
     assert!(formula.contains(&format!(r#"sha256 "{checksum}""#)));
     assert!(formula.contains("def staged_files"));


### PR DESCRIPTION
## Summary

Fixes Rust interop method-call emission for unresolved `Into`-bound method generics. When an imported Rust method has a parameter shaped like an unresolved generic `E`, string-like arguments now keep an inferable Rust shape instead of becoming ambiguous `.into()` calls, while explicit Incan call-site generics such as `encode[str](...)` remain target-driven.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `tokenizer.encode("hello world", false)`-style Rust interop calls no longer generate `"hello world".into()` when that would leave Rust unable to infer the method generic.
- **Internals**: adds `ValueUseSite::ExternalInferredGenericArg` for unresolved external generics and selects it only for string-like method arguments when the call has no explicit type args. Non-moved owned strings clone; moved strings and literals stay direct.
- **Risks**: This touches method-call argument planning for inspected Rust signatures. Metadata-free external method calls still preserve the existing `.into()` behavior, and explicit generic calls still emit a turbofish.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan external_inferred_generic --lib`
- `cargo test -p incan external_rust_method_ --lib`
- `cargo test -p incan backend::ir::emit::expressions::tests::external_nominal_method_call_keeps_external_string_conversion --lib`
- `cargo test -p incan backend::ir::codegen::tests::test_codegen_borrows_reqwest_json_payload_returned_from_registry_client --lib --features rust_inspect`
- `cargo test --test toolchain_installer_tests homebrew_formula_is_rendered_from_the_toolchain_manifest`
- `mkdocs build --strict`
- `make pre-commit`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_5.md`, `workspaces/docs-site/docs/release_notes/index.md`.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #804