### PR TITLE
bugfix - reject borrowed FnMut callback mismatches (#805)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "blake2",
  "blake3",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1525,14 +1525,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1541,14 +1541,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "axum",
  "incan_core",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -645,6 +645,355 @@ pub fn split_top_level_rust_args(text: &str) -> Vec<&str> {
     args
 }
 
+/// Return whether `display` is a Rust callable bound display such as `impl FnMut(&mut T)`.
+#[must_use]
+pub fn rust_display_is_callable_bound(display: &str) -> bool {
+    let mut display = display.trim();
+    if let Some(rest) = display.strip_prefix("impl")
+        && rust_source_keyword_boundary(display, "impl".len())
+    {
+        display = rest.trim_start();
+    } else if let Some(rest) = display.strip_prefix("dyn")
+        && rust_source_keyword_boundary(display, "dyn".len())
+    {
+        display = rest.trim_start();
+    }
+    split_top_level_rust_bounds(display)
+        .into_iter()
+        .any(rust_callable_bound_has_signature)
+}
+
+/// Return a source function's callable `Fn*` bound for a generic parameter, if one is declared.
+#[must_use]
+pub fn rust_source_callable_bound_for_type_param<F>(
+    function_source: &str,
+    type_param: &str,
+    mut normalize_type: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let type_param = rust_simple_type_param_name(type_param)?;
+    let header = rust_source_function_header(function_source)?;
+    if let Some(generic_params) = header.generic_params {
+        for generic in split_top_level_rust_args(generic_params) {
+            let Some((name, bounds)) = generic.split_once(':') else {
+                continue;
+            };
+            if name.trim() == type_param {
+                for bound in split_top_level_rust_bounds(bounds) {
+                    if let Some(display) = rust_source_callable_bound_display(bound, &mut normalize_type) {
+                        return Some(display);
+                    }
+                }
+            }
+        }
+    }
+
+    let where_idx = find_top_level_rust_keyword(header.tail, "where")?;
+    for predicate in split_top_level_rust_args(&header.tail[where_idx + "where".len()..]) {
+        let Some((name, bounds)) = predicate.split_once(':') else {
+            continue;
+        };
+        if name.trim() == type_param {
+            for bound in split_top_level_rust_bounds(bounds) {
+                if let Some(display) = rust_source_callable_bound_display(bound, &mut normalize_type) {
+                    return Some(display);
+                }
+            }
+        }
+    }
+    None
+}
+
+struct RustSourceFunctionHeader<'a> {
+    generic_params: Option<&'a str>,
+    tail: &'a str,
+}
+
+/// Recover the generic parameter list and post-parameter header tail from a Rust function item source string.
+fn rust_source_function_header(function_source: &str) -> Option<RustSourceFunctionHeader<'_>> {
+    for (fn_idx, _) in function_source.match_indices("fn") {
+        if !rust_source_keyword_at(function_source, fn_idx, "fn") {
+            continue;
+        }
+        let mut idx = skip_rust_source_whitespace(function_source, fn_idx + "fn".len());
+        if let Some(rest) = function_source.get(idx..).and_then(|rest| rest.strip_prefix("r#")) {
+            idx = function_source.len() - rest.len();
+        }
+        let Some(after_name) = skip_rust_source_ident(function_source, idx) else {
+            continue;
+        };
+        idx = after_name;
+        idx = skip_rust_source_whitespace(function_source, idx);
+        let Some(rest) = function_source.get(idx..) else {
+            continue;
+        };
+        let generic_params = if rest.starts_with('<') {
+            let Some(generic_end) = matching_rust_angle_end(function_source, idx) else {
+                continue;
+            };
+            let params = &function_source[idx + 1..generic_end];
+            idx = skip_rust_source_whitespace(function_source, generic_end + 1);
+            Some(params)
+        } else {
+            None
+        };
+        let Some(rest) = function_source.get(idx..) else {
+            continue;
+        };
+        if !rest.starts_with('(') {
+            continue;
+        }
+        let Some(params_end) = matching_rust_paren_end(function_source, idx) else {
+            continue;
+        };
+        let tail_start = params_end + 1;
+        let Some(tail) = function_source.get(tail_start..) else {
+            continue;
+        };
+        let tail_end = find_top_level_rust_header_end(tail).unwrap_or(tail.len());
+        return Some(RustSourceFunctionHeader {
+            generic_params,
+            tail: &tail[..tail_end],
+        });
+    }
+    None
+}
+
+/// Return a single uppercase generic type-parameter identifier when `text` has no path or compound type syntax.
+fn rust_simple_type_param_name(text: &str) -> Option<&str> {
+    let trimmed = text.trim();
+    (!trimmed.is_empty()
+        && !trimmed.contains("::")
+        && !trimmed.contains(['<', '>', '(', ')', '[', ']', '&', ' '])
+        && trimmed.chars().all(rust_source_ident_char)
+        && trimmed.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()))
+    .then_some(trimmed)
+}
+
+/// Return whether one top-level bound starts with a callable trait and a parenthesized argument list.
+fn rust_callable_bound_has_signature(bound: &str) -> bool {
+    let Some((_, after_name)) = rust_callable_bound_name_and_tail(bound) else {
+        return false;
+    };
+    after_name.starts_with('(') && matching_rust_paren_end(after_name, 0).is_some()
+}
+
+/// Normalize one source `Fn*` bound into the stable `impl Fn*(...)` display form used by Rust metadata.
+fn rust_source_callable_bound_display<F>(bound: &str, mut normalize_type: F) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let (name, after_name) = rust_callable_bound_name_and_tail(bound)?;
+    if !after_name.starts_with('(') {
+        return None;
+    }
+    let args_end = matching_rust_paren_end(after_name, 0)?;
+    let args_inner = &after_name[1..args_end];
+    let mut args = Vec::new();
+    for arg in split_top_level_rust_args(args_inner) {
+        args.push(normalize_type(arg)?);
+    }
+    let after_args = after_name[args_end + 1..].trim_start();
+    let ret = if let Some(ret) = after_args.strip_prefix("->") {
+        Some(normalize_type(
+            split_top_level_rust_bounds(ret).first().copied().unwrap_or(ret),
+        )?)
+    } else {
+        None
+    };
+    Some(match ret {
+        Some(ret) => format!("impl {name}({}) -> {ret}", args.join(", ")),
+        None => format!("impl {name}({})", args.join(", ")),
+    })
+}
+
+/// Split a Rust callable bound into its unqualified callable trait name and the remaining signature text.
+fn rust_callable_bound_name_and_tail(bound: &str) -> Option<(&'static str, &str)> {
+    let bound = bound.trim();
+    for name in ["FnOnce", "FnMut", "Fn"] {
+        if let Some(rest) = bound.strip_prefix(name) {
+            return Some((name, rest.trim_start()));
+        }
+        for prefix in ["std::ops::", "core::ops::"] {
+            if let Some(rest) = bound.strip_prefix(prefix).and_then(|rest| rest.strip_prefix(name)) {
+                return Some((name, rest.trim_start()));
+            }
+        }
+    }
+    None
+}
+
+/// Split Rust trait bounds joined with top-level `+` without splitting inside generic or function syntax.
+fn split_top_level_rust_bounds(text: &str) -> Vec<&str> {
+    let mut bounds = Vec::new();
+    let mut start = 0usize;
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '<' => angle += 1,
+            '>' => angle = angle.saturating_sub(1),
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            '+' if angle == 0 && paren == 0 && bracket == 0 => {
+                let bound = text[start..idx].trim();
+                if !bound.is_empty() {
+                    bounds.push(bound);
+                }
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    let tail = text[start..].trim();
+    if !tail.is_empty() {
+        bounds.push(tail);
+    }
+    bounds
+}
+
+/// Return the matching `>` for a generic parameter list, ignoring arrows inside callable return types.
+fn matching_rust_angle_end(text: &str, open_idx: usize) -> Option<usize> {
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text[open_idx..].char_indices() {
+        match ch {
+            '<' if paren == 0 && bracket == 0 => angle += 1,
+            '>' if paren == 0 && bracket == 0 && previous_rust_source_char(text, open_idx + idx) != Some('-') => {
+                angle = angle.checked_sub(1)?;
+                if angle == 0 {
+                    return Some(open_idx + idx);
+                }
+            }
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Return the matching `)` for a parenthesized Rust source region.
+fn matching_rust_paren_end(text: &str, open_idx: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (idx, ch) in text[open_idx..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(open_idx + idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Find the top-level `{` or `;` that ends a Rust function header.
+fn find_top_level_rust_header_end(text: &str) -> Option<usize> {
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '<' => angle += 1,
+            '>' => angle = angle.saturating_sub(1),
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            '{' | ';' if angle == 0 && paren == 0 && bracket == 0 => return Some(idx),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Find a keyword token outside nested generic, function, and slice delimiters.
+fn find_top_level_rust_keyword(text: &str, keyword: &str) -> Option<usize> {
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '<' => angle += 1,
+            '>' => angle = angle.saturating_sub(1),
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            _ if angle == 0
+                && paren == 0
+                && bracket == 0
+                && text[idx..].starts_with(keyword)
+                && rust_source_keyword_at(text, idx, keyword) =>
+            {
+                return Some(idx);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Skip Rust source whitespace starting at `idx`.
+fn skip_rust_source_whitespace(text: &str, mut idx: usize) -> usize {
+    while let Some(ch) = text.get(idx..).and_then(|rest| rest.chars().next()) {
+        if !ch.is_whitespace() {
+            break;
+        }
+        idx += ch.len_utf8();
+    }
+    idx
+}
+
+/// Skip a simple Rust identifier starting at `idx`.
+fn skip_rust_source_ident(text: &str, mut idx: usize) -> Option<usize> {
+    let mut saw_ident = false;
+    while let Some(ch) = text.get(idx..).and_then(|rest| rest.chars().next()) {
+        if !rust_source_ident_char(ch) {
+            break;
+        }
+        saw_ident = true;
+        idx += ch.len_utf8();
+    }
+    saw_ident.then_some(idx)
+}
+
+/// Return whether `keyword` starts at `idx` with identifier-token boundaries on both sides.
+fn rust_source_keyword_at(text: &str, idx: usize, keyword: &str) -> bool {
+    text.get(idx..).is_some_and(|rest| rest.starts_with(keyword))
+        && previous_rust_source_char(text, idx).is_none_or(|ch| !rust_source_ident_char(ch))
+        && rust_source_keyword_boundary(text, idx + keyword.len())
+}
+
+/// Return whether `idx` is at an identifier boundary in Rust source text.
+fn rust_source_keyword_boundary(text: &str, idx: usize) -> bool {
+    text.get(idx..)
+        .and_then(|rest| rest.chars().next())
+        .is_none_or(|ch| !rust_source_ident_char(ch))
+}
+
+/// Return whether `ch` belongs to the simple ASCII identifier vocabulary this source scanner accepts.
+fn rust_source_ident_char(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
+
+/// Return the source character immediately before `idx`.
+fn previous_rust_source_char(text: &str, idx: usize) -> Option<char> {
+    text.get(..idx).and_then(|prefix| prefix.chars().next_back())
+}
+
 /// A public field surfaced on a Rust struct/union-like type.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RustFieldInfo {
@@ -859,6 +1208,96 @@ mod tests {
             parse_rust_type_shape_text("T", |_| None, RustTypeShapePathFallback::RustPath),
             RustTypeShape::TypeParam("T".to_string()),
         );
+    }
+
+    fn normalize_probe_type(text: &str) -> Option<String> {
+        let normalized = text.trim().replace(' ', "");
+        if let Some(inner) = normalized.strip_prefix("&mut") {
+            return normalize_probe_type(inner).map(|inner| format!("&mut {inner}"));
+        }
+        if let Some(inner) = normalized.strip_prefix('&') {
+            return normalize_probe_type(inner).map(|inner| format!("&{inner}"));
+        }
+        Some(match normalized.as_str() {
+            "Data" => "source_dep::audio::Data".to_string(),
+            "OutputCallbackInfo" => "source_dep::audio::OutputCallbackInfo".to_string(),
+            other => other.to_string(),
+        })
+    }
+
+    #[test]
+    fn rust_source_callable_bound_for_type_param_reads_inline_generic_bounds() {
+        let source = r#"
+pub fn run_inline<D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>(callback: D) {
+    let _ = callback;
+}
+"#;
+
+        assert_eq!(
+            rust_source_callable_bound_for_type_param(source, "D", normalize_probe_type).as_deref(),
+            Some("impl FnMut(&mut source_dep::audio::Data, &source_dep::audio::OutputCallbackInfo)")
+        );
+    }
+
+    #[test]
+    fn rust_source_callable_bound_for_type_param_reads_where_bounds() {
+        let source = r#"
+pub fn run_where<D, E>(callback: D, error: E)
+where
+    D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    E: FnMut(String),
+{
+    let _ = callback;
+    let _ = error;
+}
+"#;
+
+        assert_eq!(
+            rust_source_callable_bound_for_type_param(source, "D", normalize_probe_type).as_deref(),
+            Some("impl FnMut(&mut source_dep::audio::Data, &source_dep::audio::OutputCallbackInfo)")
+        );
+        assert_eq!(
+            rust_source_callable_bound_for_type_param(source, "E", normalize_probe_type).as_deref(),
+            Some("impl FnMut(String)")
+        );
+    }
+
+    #[test]
+    fn rust_source_callable_bound_for_type_param_accepts_qualified_fn_traits() {
+        let source = r#"
+pub fn run_qualified<D: std::ops::FnOnce(Data) -> OutputCallbackInfo>(callback: D);
+"#;
+
+        assert_eq!(
+            rust_source_callable_bound_for_type_param(source, "D", normalize_probe_type).as_deref(),
+            Some("impl FnOnce(source_dep::audio::Data) -> source_dep::audio::OutputCallbackInfo")
+        );
+    }
+
+    #[test]
+    fn rust_source_callable_bound_for_type_param_skips_incidental_fn_tokens() {
+        let source = r#"
+const SAMPLE: &str = "fn ";
+
+pub fn run_inline<D: FnMut(&mut Data, &OutputCallbackInfo)>(callback: D) {
+    let _ = callback;
+}
+"#;
+
+        assert_eq!(
+            rust_source_callable_bound_for_type_param(source, "D", normalize_probe_type).as_deref(),
+            Some("impl FnMut(&mut source_dep::audio::Data, &source_dep::audio::OutputCallbackInfo)")
+        );
+    }
+
+    #[test]
+    fn rust_display_is_callable_bound_detects_only_callable_bound_displays() {
+        assert!(rust_display_is_callable_bound(
+            "impl FnMut(&mut demo::Data, &demo::Info) + Send"
+        ));
+        assert!(rust_display_is_callable_bound("dyn std::ops::Fn(String)"));
+        assert!(!rust_display_is_callable_bound("impl Buf"));
+        assert!(!rust_display_is_callable_bound("implBuf"));
     }
 
     #[test]

--- a/crates/incan_core/src/interop/mod.rs
+++ b/crates/incan_core/src/interop/mod.rs
@@ -21,5 +21,6 @@ pub use metadata::{
     RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo, RustTypeMetadataCompleteness,
     RustTypeShape, RustTypeShapePathFallback, RustVariantInfo, RustVisibility, metadata_free_function_signature,
     metadata_free_method_signature, parse_rust_type_shape_text, render_rust_type_shape, render_rust_type_shape_path,
-    split_top_level_rust_args, strip_rust_borrow_lifetimes,
+    rust_display_is_callable_bound, rust_source_callable_bound_for_type_param, split_top_level_rust_args,
+    strip_rust_borrow_lifetimes,
 };

--- a/crates/rust_inspect/src/cache.rs
+++ b/crates/rust_inspect/src/cache.rs
@@ -16,7 +16,8 @@ use std::time::Instant;
 use incan_core::interop::{
     RustFieldInfo, RustFunctionSig, RustItemKind, RustItemMetadata, RustMethodSig, RustParam, RustTraitAssoc,
     RustTraitInfo, RustTypeInfo, RustTypeMetadataCompleteness, RustTypeShape, RustTypeShapePathFallback,
-    RustVariantInfo, RustVisibility, parse_rust_type_shape_text, split_top_level_rust_args,
+    RustVariantInfo, RustVisibility, parse_rust_type_shape_text, rust_source_callable_bound_for_type_param,
+    split_top_level_rust_args,
 };
 use incan_core::lang::types::collections::{self, CollectionTypeId};
 use ra_ap_syntax::{
@@ -1753,169 +1754,6 @@ fn rust_callable_bound_marker(ident: &str) -> bool {
     )
 }
 
-/// Return a simple Rust type-parameter identifier from source text.
-fn simple_type_param_name(text: &str) -> Option<&str> {
-    let trimmed = text.trim();
-    (!trimmed.is_empty()
-        && trimmed.chars().all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-        && trimmed.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()))
-    .then_some(trimmed)
-}
-
-/// Return the matching `>` for a source generic list whose opening `<` is at `open_idx`.
-fn matching_angle_end(text: &str, open_idx: usize) -> Option<usize> {
-    let mut angle = 0usize;
-    let mut paren = 0usize;
-    let mut bracket = 0usize;
-    for (idx, ch) in text[open_idx..].char_indices() {
-        match ch {
-            '<' if paren == 0 && bracket == 0 => angle += 1,
-            '>' if paren == 0 && bracket == 0 => {
-                angle = angle.checked_sub(1)?;
-                if angle == 0 {
-                    return Some(open_idx + idx);
-                }
-            }
-            '(' => paren += 1,
-            ')' => paren = paren.saturating_sub(1),
-            '[' => bracket += 1,
-            ']' => bracket = bracket.saturating_sub(1),
-            _ => {}
-        }
-    }
-    None
-}
-
-/// Return the matching `)` for a source paren whose opening `(` is at `open_idx`.
-fn matching_paren_end(text: &str, open_idx: usize) -> Option<usize> {
-    let mut depth = 0usize;
-    for (idx, ch) in text[open_idx..].char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' => {
-                depth = depth.checked_sub(1)?;
-                if depth == 0 {
-                    return Some(open_idx + idx);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
-/// Split top-level Rust trait bounds joined with `+`.
-fn split_top_level_rust_bounds(text: &str) -> Vec<&str> {
-    let mut bounds = Vec::new();
-    let mut start = 0usize;
-    let mut angle = 0usize;
-    let mut paren = 0usize;
-    let mut bracket = 0usize;
-    for (idx, ch) in text.char_indices() {
-        match ch {
-            '<' => angle += 1,
-            '>' => angle = angle.saturating_sub(1),
-            '(' => paren += 1,
-            ')' => paren = paren.saturating_sub(1),
-            '[' => bracket += 1,
-            ']' => bracket = bracket.saturating_sub(1),
-            '+' if angle == 0 && paren == 0 && bracket == 0 => {
-                let bound = text[start..idx].trim();
-                if !bound.is_empty() {
-                    bounds.push(bound);
-                }
-                start = idx + ch.len_utf8();
-            }
-            _ => {}
-        }
-    }
-    let tail = text[start..].trim();
-    if !tail.is_empty() {
-        bounds.push(tail);
-    }
-    bounds
-}
-
-/// Normalize one `Fn*` bound while preserving Rust callable-bound syntax for downstream consumers.
-fn source_callable_bound_display<F>(bound: &str, mut normalize_type: F) -> Option<String>
-where
-    F: FnMut(&str) -> String,
-{
-    let bound = bound.trim();
-    let (name, after_name) = ["FnOnce", "FnMut", "Fn"]
-        .into_iter()
-        .find_map(|name| bound.strip_prefix(name).map(|rest| (name, rest.trim_start())))?;
-    if !after_name.starts_with('(') {
-        return None;
-    }
-    let args_end = matching_paren_end(after_name, 0)?;
-    let args_inner = &after_name[1..args_end];
-    let args = split_top_level_rust_args(args_inner)
-        .into_iter()
-        .map(&mut normalize_type)
-        .collect::<Vec<_>>();
-    let after_args = after_name[args_end + 1..].trim_start();
-    let ret = after_args
-        .strip_prefix("->")
-        .map(|ret| normalize_type(split_top_level_rust_bounds(ret).first().copied().unwrap_or(ret)));
-    Some(match ret {
-        Some(ret) => format!("impl {name}({}) -> {ret}", args.join(", ")),
-        None => format!("impl {name}({})", args.join(", ")),
-    })
-}
-
-/// Return a source function's callable `Fn*` bound for a generic parameter, if one is declared.
-fn source_callable_bound_for_type_param<F>(
-    function_source: &str,
-    type_param: &str,
-    mut normalize_type: F,
-) -> Option<String>
-where
-    F: FnMut(&str) -> String,
-{
-    let type_param = simple_type_param_name(type_param)?;
-    let params_start = function_source.find('(').unwrap_or(function_source.len());
-    let before_params = &function_source[..params_start];
-    if let Some(generic_start) = before_params.find('<')
-        && let Some(generic_end) = matching_angle_end(before_params, generic_start)
-    {
-        for generic in split_top_level_rust_args(&before_params[generic_start + 1..generic_end]) {
-            let Some((name, bounds)) = generic.split_once(':') else {
-                continue;
-            };
-            if name.trim() == type_param {
-                for bound in split_top_level_rust_bounds(bounds) {
-                    if let Some(display) = source_callable_bound_display(bound, &mut normalize_type) {
-                        return Some(display);
-                    }
-                }
-            }
-        }
-    }
-
-    let params_end = function_source
-        .find('(')
-        .and_then(|idx| matching_paren_end(function_source, idx))
-        .unwrap_or(params_start);
-    let header_tail = &function_source[params_end + 1..];
-    let header_end = header_tail.find(['{', ';']).unwrap_or(header_tail.len());
-    let header_tail = &header_tail[..header_end];
-    let where_idx = header_tail.find("where")?;
-    for predicate in split_top_level_rust_args(&header_tail[where_idx + "where".len()..]) {
-        let Some((name, bounds)) = predicate.split_once(':') else {
-            continue;
-        };
-        if name.trim() == type_param {
-            for bound in split_top_level_rust_bounds(bounds) {
-                if let Some(display) = source_callable_bound_display(bound, &mut normalize_type) {
-                    return Some(display);
-                }
-            }
-        }
-    }
-    None
-}
-
 /// Normalize one identifier token inside a source alias target while preserving valid Rust `dyn Fn` syntax.
 fn source_alias_target_ident_display(
     ident: &str,
@@ -2030,8 +1868,8 @@ fn source_function_metadata(
                         .map(|pat| pat.syntax().text().to_string().trim().to_string());
                     let raw_ty = ty.syntax().text().to_string();
                     let type_display =
-                        source_callable_bound_for_type_param(function_source.as_str(), raw_ty.as_str(), |inner| {
-                            ctx.type_display(inner)
+                        rust_source_callable_bound_for_type_param(function_source.as_str(), raw_ty.as_str(), |inner| {
+                            Some(ctx.type_display(inner))
                         })
                         .unwrap_or_else(|| ctx.type_display(raw_ty.as_str()));
                     Some(RustParam { name, type_display })
@@ -2080,8 +1918,8 @@ fn source_function_signature(
                         .map(|pat| pat.syntax().text().to_string().trim().to_string());
                     let raw_ty = ty.syntax().text().to_string();
                     let type_display =
-                        source_callable_bound_for_type_param(function_source.as_str(), raw_ty.as_str(), |inner| {
-                            ctx.type_display(inner)
+                        rust_source_callable_bound_for_type_param(function_source.as_str(), raw_ty.as_str(), |inner| {
+                            Some(ctx.type_display(inner))
                         })
                         .unwrap_or_else(|| ctx.type_display(raw_ty.as_str()));
                     Some(RustParam { name, type_display })

--- a/crates/rust_inspect/src/cache.rs
+++ b/crates/rust_inspect/src/cache.rs
@@ -1753,6 +1753,169 @@ fn rust_callable_bound_marker(ident: &str) -> bool {
     )
 }
 
+/// Return a simple Rust type-parameter identifier from source text.
+fn simple_type_param_name(text: &str) -> Option<&str> {
+    let trimmed = text.trim();
+    (!trimmed.is_empty()
+        && trimmed.chars().all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        && trimmed.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()))
+    .then_some(trimmed)
+}
+
+/// Return the matching `>` for a source generic list whose opening `<` is at `open_idx`.
+fn matching_angle_end(text: &str, open_idx: usize) -> Option<usize> {
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text[open_idx..].char_indices() {
+        match ch {
+            '<' if paren == 0 && bracket == 0 => angle += 1,
+            '>' if paren == 0 && bracket == 0 => {
+                angle = angle.checked_sub(1)?;
+                if angle == 0 {
+                    return Some(open_idx + idx);
+                }
+            }
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Return the matching `)` for a source paren whose opening `(` is at `open_idx`.
+fn matching_paren_end(text: &str, open_idx: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (idx, ch) in text[open_idx..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(open_idx + idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Split top-level Rust trait bounds joined with `+`.
+fn split_top_level_rust_bounds(text: &str) -> Vec<&str> {
+    let mut bounds = Vec::new();
+    let mut start = 0usize;
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '<' => angle += 1,
+            '>' => angle = angle.saturating_sub(1),
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            '+' if angle == 0 && paren == 0 && bracket == 0 => {
+                let bound = text[start..idx].trim();
+                if !bound.is_empty() {
+                    bounds.push(bound);
+                }
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    let tail = text[start..].trim();
+    if !tail.is_empty() {
+        bounds.push(tail);
+    }
+    bounds
+}
+
+/// Normalize one `Fn*` bound while preserving Rust callable-bound syntax for downstream consumers.
+fn source_callable_bound_display<F>(bound: &str, mut normalize_type: F) -> Option<String>
+where
+    F: FnMut(&str) -> String,
+{
+    let bound = bound.trim();
+    let (name, after_name) = ["FnOnce", "FnMut", "Fn"]
+        .into_iter()
+        .find_map(|name| bound.strip_prefix(name).map(|rest| (name, rest.trim_start())))?;
+    if !after_name.starts_with('(') {
+        return None;
+    }
+    let args_end = matching_paren_end(after_name, 0)?;
+    let args_inner = &after_name[1..args_end];
+    let args = split_top_level_rust_args(args_inner)
+        .into_iter()
+        .map(&mut normalize_type)
+        .collect::<Vec<_>>();
+    let after_args = after_name[args_end + 1..].trim_start();
+    let ret = after_args
+        .strip_prefix("->")
+        .map(|ret| normalize_type(split_top_level_rust_bounds(ret).first().copied().unwrap_or(ret)));
+    Some(match ret {
+        Some(ret) => format!("impl {name}({}) -> {ret}", args.join(", ")),
+        None => format!("impl {name}({})", args.join(", ")),
+    })
+}
+
+/// Return a source function's callable `Fn*` bound for a generic parameter, if one is declared.
+fn source_callable_bound_for_type_param<F>(
+    function_source: &str,
+    type_param: &str,
+    mut normalize_type: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> String,
+{
+    let type_param = simple_type_param_name(type_param)?;
+    let params_start = function_source.find('(').unwrap_or(function_source.len());
+    let before_params = &function_source[..params_start];
+    if let Some(generic_start) = before_params.find('<')
+        && let Some(generic_end) = matching_angle_end(before_params, generic_start)
+    {
+        for generic in split_top_level_rust_args(&before_params[generic_start + 1..generic_end]) {
+            let Some((name, bounds)) = generic.split_once(':') else {
+                continue;
+            };
+            if name.trim() == type_param {
+                for bound in split_top_level_rust_bounds(bounds) {
+                    if let Some(display) = source_callable_bound_display(bound, &mut normalize_type) {
+                        return Some(display);
+                    }
+                }
+            }
+        }
+    }
+
+    let params_end = function_source
+        .find('(')
+        .and_then(|idx| matching_paren_end(function_source, idx))
+        .unwrap_or(params_start);
+    let header_tail = &function_source[params_end + 1..];
+    let header_end = header_tail.find(['{', ';']).unwrap_or(header_tail.len());
+    let header_tail = &header_tail[..header_end];
+    let where_idx = header_tail.find("where")?;
+    for predicate in split_top_level_rust_args(&header_tail[where_idx + "where".len()..]) {
+        let Some((name, bounds)) = predicate.split_once(':') else {
+            continue;
+        };
+        if name.trim() == type_param {
+            for bound in split_top_level_rust_bounds(bounds) {
+                if let Some(display) = source_callable_bound_display(bound, &mut normalize_type) {
+                    return Some(display);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Normalize one identifier token inside a source alias target while preserving valid Rust `dyn Fn` syntax.
 fn source_alias_target_ident_display(
     ident: &str,
@@ -1854,6 +2017,7 @@ fn source_function_metadata(
     }
     let name = generated_source_name(function.name()?.to_string().as_str());
     let definition = ctx.definition_path(name.as_str());
+    let function_source = function.syntax().text().to_string();
     let params = function
         .param_list()
         .map(|param_list| {
@@ -1864,10 +2028,13 @@ fn source_function_metadata(
                     let name = param
                         .pat()
                         .map(|pat| pat.syntax().text().to_string().trim().to_string());
-                    Some(RustParam {
-                        name,
-                        type_display: ctx.type_display(ty.syntax().text().to_string().as_str()),
-                    })
+                    let raw_ty = ty.syntax().text().to_string();
+                    let type_display =
+                        source_callable_bound_for_type_param(function_source.as_str(), raw_ty.as_str(), |inner| {
+                            ctx.type_display(inner)
+                        })
+                        .unwrap_or_else(|| ctx.type_display(raw_ty.as_str()));
+                    Some(RustParam { name, type_display })
                 })
                 .collect::<Vec<_>>()
         })
@@ -1896,6 +2063,7 @@ fn source_function_signature(
     ctx: &SourceMetadataContext<'_>,
     receiver_type: Option<&str>,
 ) -> RustFunctionSig {
+    let function_source = function.syntax().text().to_string();
     let params = function
         .param_list()
         .map(|param_list| {
@@ -1910,10 +2078,13 @@ fn source_function_signature(
                     let name = param
                         .pat()
                         .map(|pat| pat.syntax().text().to_string().trim().to_string());
-                    Some(RustParam {
-                        name,
-                        type_display: ctx.type_display(ty.syntax().text().to_string().as_str()),
-                    })
+                    let raw_ty = ty.syntax().text().to_string();
+                    let type_display =
+                        source_callable_bound_for_type_param(function_source.as_str(), raw_ty.as_str(), |inner| {
+                            ctx.type_display(inner)
+                        })
+                        .unwrap_or_else(|| ctx.type_display(raw_ty.as_str()));
+                    Some(RustParam { name, type_display })
                 }))
                 .collect::<Vec<_>>()
         })

--- a/crates/rust_inspect/src/cache_tests.rs
+++ b/crates/rust_inspect/src/cache_tests.rs
@@ -510,7 +510,7 @@ fn dependency_source_metadata_resolves_public_reexported_functions_and_aliases_w
     )?;
     fs::write(
         dep.join("src").join("lib.rs"),
-        "pub use function::ScalarFunctionImplementation;\npub use udf::create_udf;\npub mod async_api;\npub mod catalog;\npub mod datasource;\npub mod execution;\npub mod expr_fn { pub use super::math::expr_fn::*; }\npub mod frame;\npub mod frame_ext;\npub mod function;\npub mod math;\npub mod table;\npub mod types;\npub mod udf;\n",
+        "pub use function::ScalarFunctionImplementation;\npub use udf::create_udf;\npub mod async_api;\npub mod audio;\npub mod catalog;\npub mod datasource;\npub mod execution;\npub mod expr_fn { pub use super::math::expr_fn::*; }\npub mod frame;\npub mod frame_ext;\npub mod function;\npub mod math;\npub mod table;\npub mod types;\npub mod udf;\n",
     )?;
     fs::write(
         dep.join("src").join("catalog.rs"),
@@ -579,6 +579,31 @@ pub mod expr_fn {
     fs::write(
         dep.join("src").join("async_api").join("plan.rs"),
         "use datafusion_expr::Expr;\n\npub async fn load_plan() -> Result<Expr, String> { todo!() }\n",
+    )?;
+    fs::write(
+        dep.join("src").join("audio.rs"),
+        r#"
+pub struct Data;
+pub struct OutputCallbackInfo;
+pub struct Device;
+
+impl Device {
+    /// Build an output stream from generic Rust callback bounds.
+    pub fn build_output_stream_raw<D, E>(
+        &self,
+        mut data_callback: D,
+        mut error_callback: E,
+    ) where
+        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        E: FnMut(String),
+    {
+        let mut data = Data;
+        let info = OutputCallbackInfo;
+        data_callback(&mut data, &info);
+        error_callback("boom".to_string());
+    }
+}
+"#,
     )?;
     fs::write(
         dep.join("src").join("function.rs"),
@@ -721,6 +746,24 @@ impl NestedFrame {
     assert_eq!(
         sig.return_type,
         "Result<public_api::logical_expr::Expr, String>"
+    );
+
+    let device = cache.get_or_extract(&root, "source_dep::audio::Device", &|_| ())?;
+    let RustItemKind::Type(type_info) = &device.kind else {
+        return Err("expected source dependency Device metadata".into());
+    };
+    let build_output = type_info
+        .methods
+        .iter()
+        .find(|method| method.name == "build_output_stream_raw")
+        .ok_or("expected build_output_stream_raw method metadata")?;
+    assert_eq!(
+        build_output.signature.params[1].type_display,
+        "impl FnMut(&mut source_dep::audio::Data, &source_dep::audio::OutputCallbackInfo)"
+    );
+    assert_eq!(
+        build_output.signature.params[2].type_display,
+        "impl FnMut(String)"
     );
 
     let alias = cache.get_or_extract(&root, "source_dep::ScalarFunctionImplementation", &|_| ())?;

--- a/crates/rust_inspect/src/cache_tests.rs
+++ b/crates/rust_inspect/src/cache_tests.rs
@@ -602,6 +602,21 @@ impl Device {
         data_callback(&mut data, &info);
         error_callback("boom".to_string());
     }
+
+    /// Build an output stream from inline generic Rust callback bounds.
+    pub fn build_output_stream_inline<
+        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        E: FnMut(String),
+    >(
+        &self,
+        mut data_callback: D,
+        mut error_callback: E,
+    ) {
+        let mut data = Data;
+        let info = OutputCallbackInfo;
+        data_callback(&mut data, &info);
+        error_callback("boom".to_string());
+    }
 }
 "#,
     )?;
@@ -763,6 +778,19 @@ impl NestedFrame {
     );
     assert_eq!(
         build_output.signature.params[2].type_display,
+        "impl FnMut(String)"
+    );
+    let build_output_inline = type_info
+        .methods
+        .iter()
+        .find(|method| method.name == "build_output_stream_inline")
+        .ok_or("expected build_output_stream_inline method metadata")?;
+    assert_eq!(
+        build_output_inline.signature.params[1].type_display,
+        "impl FnMut(&mut source_dep::audio::Data, &source_dep::audio::OutputCallbackInfo)"
+    );
+    assert_eq!(
+        build_output_inline.signature.params[2].type_display,
         "impl FnMut(String)"
     );
 

--- a/crates/rust_inspect/src/extractor.rs
+++ b/crates/rust_inspect/src/extractor.rs
@@ -6,7 +6,8 @@ use incan_core::interop::{
     RustFieldInfo, RustFunctionSig, RustImplementedTrait, RustItemKind, RustItemMetadata, RustMethodSig,
     RustModuleChild, RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo,
     RustTypeShape, RustTypeShapePathFallback, RustVariantInfo, RustVisibility, parse_rust_type_shape_text,
-    render_rust_type_shape, split_top_level_rust_args, strip_rust_borrow_lifetimes,
+    render_rust_type_shape, rust_display_is_callable_bound, rust_source_callable_bound_for_type_param,
+    strip_rust_borrow_lifetimes,
 };
 use ra_ap_hir::{
     Adt, AssocItem, Crate, DisplayTarget, Enum, FieldSource, Function, HasSource, HasVisibility, HirDisplay, Impl,
@@ -49,13 +50,6 @@ fn display_looks_like_type_param(display: &str) -> bool {
         && !display.contains("::")
         && !display.contains(['<', '>', '(', ')', '[', ']', '&', ' '])
         && display.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-}
-
-/// Return a simple generic type-parameter identifier written in source.
-fn simple_type_param_name(text: &str) -> Option<&str> {
-    let trimmed = text.trim();
-    (display_looks_like_type_param(trimmed) && trimmed.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()))
-        .then_some(trimmed)
 }
 
 fn module_path_segments(module: Module, db: &RootDatabase) -> Vec<String> {
@@ -585,164 +579,6 @@ fn type_shape_contains_unknown(shape: &RustTypeShape) -> bool {
     }
 }
 
-/// Return the matching `>` for a source generic list whose opening `<` is at `open_idx`.
-fn matching_angle_end(text: &str, open_idx: usize) -> Option<usize> {
-    let mut angle = 0usize;
-    let mut paren = 0usize;
-    let mut bracket = 0usize;
-    for (idx, ch) in text[open_idx..].char_indices() {
-        match ch {
-            '<' if paren == 0 && bracket == 0 => angle += 1,
-            '>' if paren == 0 && bracket == 0 => {
-                angle = angle.checked_sub(1)?;
-                if angle == 0 {
-                    return Some(open_idx + idx);
-                }
-            }
-            '(' => paren += 1,
-            ')' => paren = paren.saturating_sub(1),
-            '[' => bracket += 1,
-            ']' => bracket = bracket.saturating_sub(1),
-            _ => {}
-        }
-    }
-    None
-}
-
-/// Return the matching `)` for a source paren whose opening `(` is at `open_idx`.
-fn matching_paren_end(text: &str, open_idx: usize) -> Option<usize> {
-    let mut depth = 0usize;
-    for (idx, ch) in text[open_idx..].char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' => {
-                depth = depth.checked_sub(1)?;
-                if depth == 0 {
-                    return Some(open_idx + idx);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
-/// Split top-level Rust trait bounds joined with `+`.
-fn split_top_level_rust_bounds(text: &str) -> Vec<&str> {
-    let mut bounds = Vec::new();
-    let mut start = 0usize;
-    let mut angle = 0usize;
-    let mut paren = 0usize;
-    let mut bracket = 0usize;
-    for (idx, ch) in text.char_indices() {
-        match ch {
-            '<' => angle += 1,
-            '>' => angle = angle.saturating_sub(1),
-            '(' => paren += 1,
-            ')' => paren = paren.saturating_sub(1),
-            '[' => bracket += 1,
-            ']' => bracket = bracket.saturating_sub(1),
-            '+' if angle == 0 && paren == 0 && bracket == 0 => {
-                let bound = text[start..idx].trim();
-                if !bound.is_empty() {
-                    bounds.push(bound);
-                }
-                start = idx + ch.len_utf8();
-            }
-            _ => {}
-        }
-    }
-    let tail = text[start..].trim();
-    if !tail.is_empty() {
-        bounds.push(tail);
-    }
-    bounds
-}
-
-/// Normalize one `Fn*` bound while preserving Rust callable-bound syntax for downstream consumers.
-fn source_callable_bound_display<F>(bound: &str, mut normalize_type: F) -> Option<String>
-where
-    F: FnMut(&str) -> Option<String>,
-{
-    let bound = bound.trim();
-    let (name, after_name) = ["FnOnce", "FnMut", "Fn"]
-        .into_iter()
-        .find_map(|name| bound.strip_prefix(name).map(|rest| (name, rest.trim_start())))?;
-    if !after_name.starts_with('(') {
-        return None;
-    }
-    let args_end = matching_paren_end(after_name, 0)?;
-    let args_inner = &after_name[1..args_end];
-    let mut args = Vec::new();
-    for arg in split_top_level_rust_args(args_inner) {
-        args.push(normalize_type(arg)?);
-    }
-    let after_args = after_name[args_end + 1..].trim_start();
-    let ret = if let Some(ret) = after_args.strip_prefix("->") {
-        Some(normalize_type(
-            split_top_level_rust_bounds(ret).first().copied().unwrap_or(ret),
-        )?)
-    } else {
-        None
-    };
-    Some(match ret {
-        Some(ret) => format!("impl {name}({}) -> {ret}", args.join(", ")),
-        None => format!("impl {name}({})", args.join(", ")),
-    })
-}
-
-/// Return a source function's callable `Fn*` bound for a generic parameter, if one is declared.
-fn source_callable_bound_for_type_param<F>(
-    function_source: &str,
-    type_param: &str,
-    mut normalize_type: F,
-) -> Option<String>
-where
-    F: FnMut(&str) -> Option<String>,
-{
-    let type_param = simple_type_param_name(type_param)?;
-    let params_start = function_source.find('(').unwrap_or(function_source.len());
-    let before_params = &function_source[..params_start];
-    if let Some(generic_start) = before_params.find('<')
-        && let Some(generic_end) = matching_angle_end(before_params, generic_start)
-    {
-        for generic in split_top_level_rust_args(&before_params[generic_start + 1..generic_end]) {
-            let Some((name, bounds)) = generic.split_once(':') else {
-                continue;
-            };
-            if name.trim() == type_param {
-                for bound in split_top_level_rust_bounds(bounds) {
-                    if let Some(display) = source_callable_bound_display(bound, &mut normalize_type) {
-                        return Some(display);
-                    }
-                }
-            }
-        }
-    }
-
-    let params_end = function_source
-        .find('(')
-        .and_then(|idx| matching_paren_end(function_source, idx))
-        .unwrap_or(params_start);
-    let header_tail = &function_source[params_end + 1..];
-    let header_end = header_tail.find(['{', ';']).unwrap_or(header_tail.len());
-    let header_tail = &header_tail[..header_end];
-    let where_idx = header_tail.find("where")?;
-    for predicate in split_top_level_rust_args(&header_tail[where_idx + "where".len()..]) {
-        let Some((name, bounds)) = predicate.split_once(':') else {
-            continue;
-        };
-        if name.trim() == type_param {
-            for bound in split_top_level_rust_bounds(bounds) {
-                if let Some(display) = source_callable_bound_display(bound, &mut normalize_type) {
-                    return Some(display);
-                }
-            }
-        }
-    }
-    None
-}
-
 /// Resolve a function parameter's declared source annotation into a canonical display string.
 ///
 /// rust-analyzer sometimes degrades borrowed parameter displays to `&?` even when the written source still carries a
@@ -763,11 +599,11 @@ fn source_function_param_type_text(f: Function, param: &ra_ap_hir::Param<'_>, db
 fn source_function_param_type_display(f: Function, param: &ra_ap_hir::Param<'_>, db: &RootDatabase) -> Option<String> {
     let text = source_function_param_type_text(f, param, db)?;
     let source = f.source(db)?;
-    if let Some(display) =
-        source_callable_bound_for_type_param(source.value.syntax().text().to_string().as_str(), text.as_str(), |ty| {
-            source_function_type_display(f, ty, db)
-        })
-    {
+    if let Some(display) = rust_source_callable_bound_for_type_param(
+        source.value.syntax().text().to_string().as_str(),
+        text.as_str(),
+        |ty| source_function_type_display(f, ty, db),
+    ) {
         return Some(display);
     }
     source_function_type_display(f, text.as_str(), db)
@@ -781,15 +617,16 @@ fn extract_function_sig(f: Function, db: &RootDatabase, dt: DisplayTarget) -> Ru
         .map(|p| {
             let shape = rust_type_shape(p.ty(), db, dt);
             let mut type_display = function_sig_type_display(p.ty(), db, dt);
-            if (type_shape_contains_unknown(&shape)
-                || p.ty().contains_unknown()
-                || type_display.contains('?')
-                || source_function_param_type_display(f, &p, db).is_some_and(|source_type_display| {
-                    source_type_display.starts_with('&') && !type_display.starts_with('&')
-                }))
-                && let Some(source_type_display) = source_function_param_type_display(f, &p, db)
-            {
-                type_display = source_type_display;
+            if let Some(source_type_display) = source_function_param_type_display(f, &p, db) {
+                let source_is_callable_bound = rust_display_is_callable_bound(source_type_display.as_str());
+                if source_is_callable_bound
+                    || type_shape_contains_unknown(&shape)
+                    || p.ty().contains_unknown()
+                    || type_display.contains('?')
+                    || (source_type_display.starts_with('&') && !type_display.starts_with('&'))
+                {
+                    type_display = source_type_display;
+                }
             }
             RustParam {
                 name: p.name(db).map(|n| n.as_str().to_owned()),
@@ -1358,6 +1195,41 @@ impl Codec {
             .find(|method| method.name == "decode")
             .ok_or_else(|| std::io::Error::other("expected decode metadata"))?;
         assert_eq!(decode.signature.params[1].type_display, "&[u8]");
+        Ok(())
+    }
+
+    #[test]
+    fn function_metadata_applies_inline_source_callable_bound_display() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        fs::create_dir_all(tmp.path().join("src"))?;
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            r#"[package]
+name = "demo_callback_probe"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )?;
+        fs::write(
+            tmp.path().join("src/lib.rs"),
+            r#"pub struct Data;
+pub struct OutputCallbackInfo;
+
+pub fn run_inline<D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>(callback: D) {
+    let _ = callback;
+}
+"#,
+        )?;
+
+        let workspace = RustWorkspace::load(tmp.path(), &|_| ())?;
+        let metadata = extract_rust_item(&workspace, "demo_callback_probe::run_inline")?;
+        let RustItemKind::Function(sig) = metadata.kind else {
+            return Err(std::io::Error::other("expected function metadata").into());
+        };
+        assert_eq!(
+            sig.params[0].type_display,
+            "impl FnMut(&mut demo_callback_probe::Data, &demo_callback_probe::OutputCallbackInfo)"
+        );
         Ok(())
     }
 }

--- a/crates/rust_inspect/src/extractor.rs
+++ b/crates/rust_inspect/src/extractor.rs
@@ -6,7 +6,7 @@ use incan_core::interop::{
     RustFieldInfo, RustFunctionSig, RustImplementedTrait, RustItemKind, RustItemMetadata, RustMethodSig,
     RustModuleChild, RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo,
     RustTypeShape, RustTypeShapePathFallback, RustVariantInfo, RustVisibility, parse_rust_type_shape_text,
-    render_rust_type_shape, strip_rust_borrow_lifetimes,
+    render_rust_type_shape, split_top_level_rust_args, strip_rust_borrow_lifetimes,
 };
 use ra_ap_hir::{
     Adt, AssocItem, Crate, DisplayTarget, Enum, FieldSource, Function, HasSource, HasVisibility, HirDisplay, Impl,
@@ -49,6 +49,13 @@ fn display_looks_like_type_param(display: &str) -> bool {
         && !display.contains("::")
         && !display.contains(['<', '>', '(', ')', '[', ']', '&', ' '])
         && display.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Return a simple generic type-parameter identifier written in source.
+fn simple_type_param_name(text: &str) -> Option<&str> {
+    let trimmed = text.trim();
+    (display_looks_like_type_param(trimmed) && trimmed.chars().next().is_some_and(|ch| ch.is_ascii_uppercase()))
+        .then_some(trimmed)
 }
 
 fn module_path_segments(module: Module, db: &RootDatabase) -> Vec<String> {
@@ -242,6 +249,26 @@ fn source_type_shape(text: &str, crate_name: &str, module: Module, db: &RootData
     )
 }
 
+/// Detect a source-level borrow annotation and return whether it is mutable plus the inner type text.
+fn source_borrow_kind(text: &str) -> Option<(bool, &str)> {
+    let after_amp = text.trim().strip_prefix('&')?.trim_start();
+    let after_lifetime = if let Some(rest) = after_amp.strip_prefix('\'') {
+        let end = rest
+            .char_indices()
+            .find_map(|(idx, ch)| (!(ch == '_' || ch.is_ascii_alphanumeric())).then_some(idx))
+            .unwrap_or(rest.len());
+        rest[end..].trim_start()
+    } else {
+        after_amp
+    };
+    if let Some(rest) = after_lifetime.strip_prefix("mut")
+        && rest.chars().next().is_none_or(char::is_whitespace)
+    {
+        return Some((true, rest.trim_start()));
+    }
+    Some((false, after_lifetime))
+}
+
 fn source_field_type_shape(field: &ra_ap_hir::Field, db: &RootDatabase, crate_name: &str) -> Option<RustTypeShape> {
     let source = field.source(db)?;
     let text = match source.value {
@@ -404,6 +431,48 @@ fn source_function_return_type_display(f: Function, db: &RootDatabase) -> Option
     })
 }
 
+/// Render source type text in the same canonical display form used by extracted function metadata.
+fn source_function_type_display(f: Function, text: &str, db: &RootDatabase) -> Option<String> {
+    if let Some(display) = borrowed_builtin_source_display(text) {
+        return Some(display);
+    }
+    if let Some((is_mut, inner)) = source_borrow_kind(text) {
+        let inner = source_function_type_display(f, inner, db)?;
+        return Some(if is_mut {
+            format!("&mut {inner}")
+        } else {
+            format!("&{inner}")
+        });
+    }
+    if let Some(imported_display) = canonicalize_imported_single_segment_type_display(text, f, db) {
+        return Some(imported_display);
+    }
+    let module = f.module(db);
+    let crate_name = module
+        .krate(db)
+        .display_name(db)
+        .map(|name| name.canonical_name().as_str().to_owned())?;
+    let shape = source_type_shape(text, crate_name.as_str(), module, db);
+    if let Some(display) = exact_numeric_boundary_display(text) {
+        return Some(display);
+    }
+    if matches!(shape, RustTypeShape::TypeParam(_))
+        && let Some(imported_display) = canonicalize_imported_single_segment_type_display(text, f, db)
+    {
+        return Some(imported_display);
+    }
+    let rendered = match shape {
+        RustTypeShape::Unknown => normalize_display_path(text),
+        other => render_rust_type_shape(&other),
+    };
+    if rendered.contains('?')
+        && let Some(imported_display) = canonicalize_imported_single_segment_type_display(text, f, db)
+    {
+        return Some(imported_display);
+    }
+    Some(rendered)
+}
+
 /// Return the written RHS of a Rust `type` alias when available.
 ///
 /// HIR type displays may erase callable trait-object arguments inside aliases to `_`. The source RHS is the
@@ -516,12 +585,170 @@ fn type_shape_contains_unknown(shape: &RustTypeShape) -> bool {
     }
 }
 
+/// Return the matching `>` for a source generic list whose opening `<` is at `open_idx`.
+fn matching_angle_end(text: &str, open_idx: usize) -> Option<usize> {
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text[open_idx..].char_indices() {
+        match ch {
+            '<' if paren == 0 && bracket == 0 => angle += 1,
+            '>' if paren == 0 && bracket == 0 => {
+                angle = angle.checked_sub(1)?;
+                if angle == 0 {
+                    return Some(open_idx + idx);
+                }
+            }
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Return the matching `)` for a source paren whose opening `(` is at `open_idx`.
+fn matching_paren_end(text: &str, open_idx: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (idx, ch) in text[open_idx..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(open_idx + idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Split top-level Rust trait bounds joined with `+`.
+fn split_top_level_rust_bounds(text: &str) -> Vec<&str> {
+    let mut bounds = Vec::new();
+    let mut start = 0usize;
+    let mut angle = 0usize;
+    let mut paren = 0usize;
+    let mut bracket = 0usize;
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '<' => angle += 1,
+            '>' => angle = angle.saturating_sub(1),
+            '(' => paren += 1,
+            ')' => paren = paren.saturating_sub(1),
+            '[' => bracket += 1,
+            ']' => bracket = bracket.saturating_sub(1),
+            '+' if angle == 0 && paren == 0 && bracket == 0 => {
+                let bound = text[start..idx].trim();
+                if !bound.is_empty() {
+                    bounds.push(bound);
+                }
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    let tail = text[start..].trim();
+    if !tail.is_empty() {
+        bounds.push(tail);
+    }
+    bounds
+}
+
+/// Normalize one `Fn*` bound while preserving Rust callable-bound syntax for downstream consumers.
+fn source_callable_bound_display<F>(bound: &str, mut normalize_type: F) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let bound = bound.trim();
+    let (name, after_name) = ["FnOnce", "FnMut", "Fn"]
+        .into_iter()
+        .find_map(|name| bound.strip_prefix(name).map(|rest| (name, rest.trim_start())))?;
+    if !after_name.starts_with('(') {
+        return None;
+    }
+    let args_end = matching_paren_end(after_name, 0)?;
+    let args_inner = &after_name[1..args_end];
+    let mut args = Vec::new();
+    for arg in split_top_level_rust_args(args_inner) {
+        args.push(normalize_type(arg)?);
+    }
+    let after_args = after_name[args_end + 1..].trim_start();
+    let ret = if let Some(ret) = after_args.strip_prefix("->") {
+        Some(normalize_type(
+            split_top_level_rust_bounds(ret).first().copied().unwrap_or(ret),
+        )?)
+    } else {
+        None
+    };
+    Some(match ret {
+        Some(ret) => format!("impl {name}({}) -> {ret}", args.join(", ")),
+        None => format!("impl {name}({})", args.join(", ")),
+    })
+}
+
+/// Return a source function's callable `Fn*` bound for a generic parameter, if one is declared.
+fn source_callable_bound_for_type_param<F>(
+    function_source: &str,
+    type_param: &str,
+    mut normalize_type: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let type_param = simple_type_param_name(type_param)?;
+    let params_start = function_source.find('(').unwrap_or(function_source.len());
+    let before_params = &function_source[..params_start];
+    if let Some(generic_start) = before_params.find('<')
+        && let Some(generic_end) = matching_angle_end(before_params, generic_start)
+    {
+        for generic in split_top_level_rust_args(&before_params[generic_start + 1..generic_end]) {
+            let Some((name, bounds)) = generic.split_once(':') else {
+                continue;
+            };
+            if name.trim() == type_param {
+                for bound in split_top_level_rust_bounds(bounds) {
+                    if let Some(display) = source_callable_bound_display(bound, &mut normalize_type) {
+                        return Some(display);
+                    }
+                }
+            }
+        }
+    }
+
+    let params_end = function_source
+        .find('(')
+        .and_then(|idx| matching_paren_end(function_source, idx))
+        .unwrap_or(params_start);
+    let header_tail = &function_source[params_end + 1..];
+    let header_end = header_tail.find(['{', ';']).unwrap_or(header_tail.len());
+    let header_tail = &header_tail[..header_end];
+    let where_idx = header_tail.find("where")?;
+    for predicate in split_top_level_rust_args(&header_tail[where_idx + "where".len()..]) {
+        let Some((name, bounds)) = predicate.split_once(':') else {
+            continue;
+        };
+        if name.trim() == type_param {
+            for bound in split_top_level_rust_bounds(bounds) {
+                if let Some(display) = source_callable_bound_display(bound, &mut normalize_type) {
+                    return Some(display);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Resolve a function parameter's declared source annotation into a canonical display string.
 ///
 /// rust-analyzer sometimes degrades borrowed parameter displays to `&?` even when the written source still carries a
 /// concrete imported or local pointee type. When that happens, the source annotation is the more faithful contract and
 /// should drive metadata so downstream typechecking/codegen can keep the concrete borrow boundary.
-fn source_function_param_type_display(f: Function, param: &ra_ap_hir::Param<'_>, db: &RootDatabase) -> Option<String> {
+fn source_function_param_type_text(f: Function, param: &ra_ap_hir::Param<'_>, db: &RootDatabase) -> Option<String> {
     let source = f.source(db)?;
     let param_list = source.value.param_list()?;
     let self_offset = usize::from(param_list.self_param().is_some());
@@ -529,37 +756,21 @@ fn source_function_param_type_display(f: Function, param: &ra_ap_hir::Param<'_>,
         return None;
     }
     let source_param = param_list.params().nth(param.index() - self_offset)?;
-    let text = source_param.ty()?.to_string();
-    if let Some(display) = borrowed_builtin_source_display(text.as_str()) {
+    source_param.ty().map(|ty| ty.to_string())
+}
+
+/// Resolve a function parameter's source annotation or callable generic bound into a canonical display string.
+fn source_function_param_type_display(f: Function, param: &ra_ap_hir::Param<'_>, db: &RootDatabase) -> Option<String> {
+    let text = source_function_param_type_text(f, param, db)?;
+    let source = f.source(db)?;
+    if let Some(display) =
+        source_callable_bound_for_type_param(source.value.syntax().text().to_string().as_str(), text.as_str(), |ty| {
+            source_function_type_display(f, ty, db)
+        })
+    {
         return Some(display);
     }
-    if let Some(imported_display) = canonicalize_imported_single_segment_type_display(text.as_str(), f, db) {
-        return Some(imported_display);
-    }
-    let module = f.module(db);
-    let crate_name = module
-        .krate(db)
-        .display_name(db)
-        .map(|name| name.canonical_name().as_str().to_owned())?;
-    let shape = source_type_shape(text.as_str(), crate_name.as_str(), module, db);
-    if let Some(display) = exact_numeric_boundary_display(text.as_str()) {
-        return Some(display);
-    }
-    if matches!(shape, RustTypeShape::TypeParam(_))
-        && let Some(imported_display) = canonicalize_imported_single_segment_type_display(text.as_str(), f, db)
-    {
-        return Some(imported_display);
-    }
-    let rendered = match shape {
-        RustTypeShape::Unknown => normalize_display_path(text.as_str()),
-        other => render_rust_type_shape(&other),
-    };
-    if rendered.contains('?')
-        && let Some(imported_display) = canonicalize_imported_single_segment_type_display(text.as_str(), f, db)
-    {
-        return Some(imported_display);
-    }
-    Some(rendered)
+    source_function_type_display(f, text.as_str(), db)
 }
 
 /// Extract a Rust function signature from inspection metadata.

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -338,6 +338,13 @@ impl TypeChecker {
     fn rust_arg_boundary_match(&self, arg_ty: &ResolvedType, rust_param_ty: &str) -> RustArgBoundaryMatch {
         let display = Self::rust_display_without_lifetimes(rust_param_ty);
         let normalized = display.replace(' ', "");
+        if let Some(target_ty) = self.resolved_function_type_from_rust_callable_bound_display(display.as_str()) {
+            return if self.types_compatible(arg_ty, &target_ty) {
+                RustArgBoundaryMatch::Exact
+            } else {
+                RustArgBoundaryMatch::NoMatch
+            };
+        }
         if Self::rust_display_type_var_name(normalized.as_str()).is_some() {
             return RustArgBoundaryMatch::Exact;
         }
@@ -780,7 +787,9 @@ impl TypeChecker {
 mod validate_rust_function_call_tests {
     use super::TypeChecker;
     use crate::frontend::ast::{CallArg, Expr, IntLiteral, Literal, Span, Spanned};
-    use crate::frontend::symbols::{NewtypeInfo, ResolvedType, Symbol, SymbolKind, TypeInfo, VariableInfo};
+    use crate::frontend::symbols::{
+        CallableParam, NewtypeInfo, ResolvedType, ScopeKind, Symbol, SymbolKind, TypeInfo, VariableInfo,
+    };
     use incan_core::interop::{RustFunctionSig, RustParam};
     use incan_core::lang::types::numerics::NumericTypeId;
     use std::collections::HashMap;
@@ -846,6 +855,134 @@ mod validate_rust_function_call_tests {
                     && e.message.contains("got 1")
             }),
             "expected builtin_arity for 0-param Rust call with 1 arg, errors={:?}",
+            checker.errors
+        );
+    }
+
+    #[test]
+    fn rust_callable_bound_rejects_by_value_function_for_borrowed_fnmut() {
+        let mut checker = TypeChecker::new();
+        let span = Span::new(10, 22);
+        let data = ResolvedType::RustPath("demo::Data".to_string());
+        let info = ResolvedType::RustPath("demo::OutputCallbackInfo".to_string());
+        checker.symbols.define(Symbol {
+            name: "write_output".to_string(),
+            kind: SymbolKind::Variable(VariableInfo {
+                ty: ResolvedType::Function(
+                    vec![CallableParam::positional(data), CallableParam::positional(info)],
+                    Box::new(ResolvedType::Unit),
+                ),
+                is_mutable: false,
+                is_used: false,
+            }),
+            span,
+            scope: 0,
+        });
+        let arg_expr = Spanned::new(Expr::Ident("write_output".to_string()), span);
+        let args = [CallArg::Positional(arg_expr)];
+        let sig = RustFunctionSig {
+            params: vec![RustParam {
+                name: Some("callback".to_string()),
+                type_display: "impl FnMut(&mut demo::Data, &demo::OutputCallbackInfo)".to_string(),
+            }],
+            return_type: "()".to_string(),
+            is_async: false,
+            is_unsafe: false,
+        };
+
+        let _ = checker.validate_rust_function_call("rust::demo::use_callback", &sig, &args, span);
+
+        assert!(
+            checker.errors.iter().any(|error| {
+                error.message.contains("FnMut")
+                    || (error.message.contains("&mut demo::Data") && error.message.contains("demo::OutputCallbackInfo"))
+            }),
+            "expected a borrowed callback diagnostic before codegen, got {:?}",
+            checker.errors
+        );
+    }
+
+    #[test]
+    fn rust_callable_bound_accepts_exact_borrowed_fnmut_function() {
+        let mut checker = TypeChecker::new();
+        let span = Span::new(10, 22);
+        let data = ResolvedType::RustPath("demo::Data".to_string());
+        let info = ResolvedType::RustPath("demo::OutputCallbackInfo".to_string());
+        checker.symbols.define(Symbol {
+            name: "write_output".to_string(),
+            kind: SymbolKind::Variable(VariableInfo {
+                ty: ResolvedType::Function(
+                    vec![
+                        CallableParam::positional(ResolvedType::RefMut(Box::new(data))),
+                        CallableParam::positional(ResolvedType::Ref(Box::new(info))),
+                    ],
+                    Box::new(ResolvedType::Unit),
+                ),
+                is_mutable: false,
+                is_used: false,
+            }),
+            span,
+            scope: 0,
+        });
+        let arg_expr = Spanned::new(Expr::Ident("write_output".to_string()), span);
+        let args = [CallArg::Positional(arg_expr)];
+        let sig = RustFunctionSig {
+            params: vec![RustParam {
+                name: Some("callback".to_string()),
+                type_display: "impl FnMut(&mut demo::Data, &demo::OutputCallbackInfo)".to_string(),
+            }],
+            return_type: "()".to_string(),
+            is_async: false,
+            is_unsafe: false,
+        };
+
+        let _ = checker.validate_rust_function_call("rust::demo::use_callback", &sig, &args, span);
+
+        assert!(
+            checker.errors.is_empty(),
+            "exact borrowed Rust callback should typecheck, got {:?}",
+            checker.errors
+        );
+    }
+
+    #[test]
+    fn rust_callable_bound_accepts_generic_placeholder_callback_arg() {
+        let mut checker = TypeChecker::new();
+        let span = Span::new(10, 22);
+        checker.symbols.enter_scope(ScopeKind::Function);
+        checker.symbols.define(Symbol {
+            name: "TaskFn".to_string(),
+            kind: SymbolKind::Type(TypeInfo::Builtin),
+            span,
+            scope: 1,
+        });
+        checker.symbols.define(Symbol {
+            name: "task".to_string(),
+            kind: SymbolKind::Variable(VariableInfo {
+                ty: ResolvedType::Named("TaskFn".to_string()),
+                is_mutable: false,
+                is_used: false,
+            }),
+            span,
+            scope: 1,
+        });
+        let arg_expr = Spanned::new(Expr::Ident("task".to_string()), span);
+        let args = [CallArg::Positional(arg_expr)];
+        let sig = RustFunctionSig {
+            params: vec![RustParam {
+                name: Some("task".to_string()),
+                type_display: "impl FnOnce() -> T".to_string(),
+            }],
+            return_type: "()".to_string(),
+            is_async: false,
+            is_unsafe: false,
+        };
+
+        let _ = checker.validate_rust_function_call("rust::demo::spawn_blocking", &sig, &args, span);
+
+        assert!(
+            checker.errors.is_empty(),
+            "generic placeholder callbacks should keep satisfying generic Rust callable bounds, got {:?}",
             checker.errors
         );
     }

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -952,6 +952,103 @@ impl TypeChecker {
         Some((false, after_amp))
     }
 
+    /// Remove trailing callable marker bounds such as `+ Send + Sync` from a Rust callable-bound display.
+    fn trim_top_level_rust_bound_suffix(text: &str) -> &str {
+        let mut angle = 0usize;
+        let mut paren = 0usize;
+        let mut bracket = 0usize;
+        for (idx, ch) in text.char_indices() {
+            match ch {
+                '<' => angle += 1,
+                '>' => angle = angle.saturating_sub(1),
+                '(' => paren += 1,
+                ')' => paren = paren.saturating_sub(1),
+                '[' => bracket += 1,
+                ']' => bracket = bracket.saturating_sub(1),
+                '+' if angle == 0 && paren == 0 && bracket == 0 => return text[..idx].trim(),
+                _ => {}
+            }
+        }
+        text.trim()
+    }
+
+    /// Return the body of a Rust callable bound display such as `impl FnMut(A) -> B`.
+    fn rust_callable_bound_body(display: &str) -> Option<&str> {
+        let trimmed = Self::trim_top_level_rust_bound_suffix(display.trim());
+        for prefix in ["impl ", "dyn "] {
+            if let Some(rest) = trimmed.strip_prefix(prefix)
+                && matches!(rest, r if r.starts_with("Fn") || r.starts_with("std::ops::Fn") || r.starts_with("core::ops::Fn"))
+            {
+                return Some(rest.trim());
+            }
+        }
+        for compact_prefix in ["impl", "dyn"] {
+            if let Some(rest) = trimmed.strip_prefix(compact_prefix)
+                && matches!(rest, r if r.starts_with("Fn") || r.starts_with("std::ops::Fn") || r.starts_with("core::ops::Fn"))
+            {
+                return Some(rest.trim());
+            }
+        }
+        if trimmed.starts_with("Fn") || trimmed.starts_with("std::ops::Fn") || trimmed.starts_with("core::ops::Fn") {
+            Some(trimmed)
+        } else {
+            None
+        }
+    }
+
+    /// Return the byte index of the matching close paren for an opening paren at the start of `text`.
+    fn rust_callable_args_end(text: &str) -> Option<usize> {
+        let mut depth = 0usize;
+        for (idx, ch) in text.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth = depth.checked_sub(1)?;
+                    if depth == 0 {
+                        return Some(idx);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// Resolve a Rust callable bound display into an Incan function type.
+    ///
+    /// Rust generic callback parameters often surface as `impl FnMut(&mut T, &U)` or through a generic bound that is
+    /// normalized to that display. Treating those as ordinary type variables lets by-value Incan function values reach
+    /// rustc and fail there. This resolver preserves the callback input borrow shape so the frontend can reject
+    /// incompatible named callbacks before emission.
+    fn resolved_function_type_from_rust_callable_bound_display(&self, rust_ty: &str) -> Option<ResolvedType> {
+        let body = Self::rust_callable_bound_body(rust_ty)?;
+        let body = body
+            .strip_prefix("std::ops::")
+            .or_else(|| body.strip_prefix("core::ops::"))
+            .unwrap_or(body);
+        let after_name = ["FnOnce", "FnMut", "Fn"]
+            .into_iter()
+            .find_map(|name| body.strip_prefix(name))?
+            .trim_start();
+        if !after_name.starts_with('(') {
+            return None;
+        }
+        let args_end = Self::rust_callable_args_end(after_name)?;
+        let args_inner = &after_name[1..args_end];
+        let params = Self::split_top_level_generic_args(args_inner)
+            .into_iter()
+            .map(|arg| CallableParam::positional(self.resolved_param_type_from_rust_display(arg)))
+            .collect::<Vec<_>>();
+        let after_args = after_name[args_end + 1..].trim_start();
+        let ret = if let Some(ret_display) = after_args.strip_prefix("->") {
+            let ret_display = Self::trim_top_level_rust_bound_suffix(ret_display);
+            self.resolved_type_from_rust_display(ret_display)
+        } else {
+            ResolvedType::Unit
+        };
+        Some(ResolvedType::Function(params, Box::new(ret)))
+    }
+
     /// Remove Rust lifetime labels that decorate borrowed display types.
     ///
     /// rust-analyzer commonly prints borrowed method parameters as `&'h str` or `&'a [u8]`. The typechecker only needs
@@ -1135,6 +1232,9 @@ impl TypeChecker {
         let trimmed = rust_ty.trim();
         let display = Self::rust_display_without_lifetimes(trimmed);
         let normalized = display.replace(' ', "");
+        if let Some(callable) = self.resolved_function_type_from_rust_callable_bound_display(display.as_str()) {
+            return callable;
+        }
         if let Some(Symbol {
             kind: SymbolKind::RustItem(info),
             ..
@@ -1261,6 +1361,9 @@ impl TypeChecker {
         let trimmed = rust_ty.trim();
         let display = Self::rust_display_without_lifetimes(trimmed);
         let normalized = display.replace(' ', "");
+        if let Some(callable) = self.resolved_function_type_from_rust_callable_bound_display(display.as_str()) {
+            return callable;
+        }
         if let Some(name) = Self::rust_display_type_var_name(normalized.as_str()) {
             return ResolvedType::TypeVar(name.to_string());
         }
@@ -1312,6 +1415,9 @@ impl TypeChecker {
         let trimmed = rust_ty.trim();
         let display = Self::rust_display_without_lifetimes(trimmed);
         let normalized = display.replace(' ', "");
+        if let Some(callable) = self.resolved_function_type_from_rust_callable_bound_display(display.as_str()) {
+            return callable;
+        }
         if let Some((is_mut, inner)) = Self::rust_display_borrow_kind(display.as_str()) {
             let inner_normalized = Self::compact_rust_display(inner);
             let inner_ty = match inner {
@@ -4471,6 +4577,8 @@ impl TypeChecker {
         match (actual, expected) {
             (ResolvedType::Unknown, _) | (_, ResolvedType::Unknown) => true,
             (ResolvedType::TypeVar(_), _) | (_, ResolvedType::TypeVar(_)) => true,
+            (actual, _) if self.is_generic_placeholder_type(actual) => true,
+            (_, expected) if self.is_generic_placeholder_type(expected) => true,
             (ResolvedType::CallSiteInfer, _) | (_, ResolvedType::CallSiteInfer) => true,
             (ResolvedType::TypeToken(actual_inner), ResolvedType::TypeToken(expected_inner)) => {
                 self.types_compatible(actual_inner, expected_inner)
@@ -4800,7 +4908,7 @@ impl TypeChecker {
                     && p1
                         .iter()
                         .zip(p2.iter())
-                        .all(|(t1, t2)| t1.kind == t2.kind && self.types_compatible(&t1.ty, &t2.ty))
+                        .all(|(t1, t2)| t1.kind == t2.kind && self.callable_param_types_compatible(&t1.ty, &t2.ty))
                     && self.types_compatible(r1, r2)
             }
             (ResolvedType::Tuple(e1), ResolvedType::Tuple(e2)) => {
@@ -4811,6 +4919,23 @@ impl TypeChecker {
             // Incan/Rust-typed expressions stay checkable (RFC 005/041 permissive model).
             (ResolvedType::RustPath(_), _) | (_, ResolvedType::RustPath(_)) => true,
             _ => false,
+        }
+    }
+
+    /// Function parameters must preserve borrow shape exactly.
+    ///
+    /// Ordinary value compatibility is intentionally permissive at Rust boundaries, but callback signatures are called
+    /// by Rust with a fixed argument ABI. A function that takes `T` or `&T` is not a valid substitute for one that Rust
+    /// will call as `FnMut(&mut T)`.
+    fn callable_param_types_compatible(&self, actual: &ResolvedType, expected: &ResolvedType) -> bool {
+        match (actual, expected) {
+            (ResolvedType::Ref(actual_inner), ResolvedType::Ref(expected_inner))
+            | (ResolvedType::RefMut(actual_inner), ResolvedType::RefMut(expected_inner)) => {
+                self.types_compatible(actual_inner, expected_inner)
+            }
+            (ResolvedType::Ref(_) | ResolvedType::RefMut(_), _)
+            | (_, ResolvedType::Ref(_) | ResolvedType::RefMut(_)) => false,
+            _ => self.types_compatible(actual, expected),
         }
     }
 }

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3181,6 +3181,27 @@ fn test_resolved_param_type_from_builtin_borrowed_displays_preserves_ref_payload
 }
 
 #[test]
+fn test_resolved_param_type_from_rust_callable_bound_preserves_callback_borrows() {
+    let checker = TypeChecker::new();
+    assert_eq!(
+        checker.resolved_param_type_from_rust_display(
+            "impl FnMut(&mut demo::Data, &demo::OutputCallbackInfo) -> () + Send + 'static",
+        ),
+        ResolvedType::Function(
+            vec![
+                CallableParam::positional(ResolvedType::RefMut(Box::new(ResolvedType::RustPath(
+                    "demo::Data".to_string()
+                )))),
+                CallableParam::positional(ResolvedType::Ref(Box::new(ResolvedType::RustPath(
+                    "demo::OutputCallbackInfo".to_string()
+                )))),
+            ],
+            Box::new(ResolvedType::Unit),
+        )
+    );
+}
+
+#[test]
 fn test_rust_owner_path_expands_crate_relative_signature_displays() {
     let checker = TypeChecker::new();
     assert_eq!(
@@ -3260,6 +3281,36 @@ fn test_types_compatible_refmut_is_assignable_to_ref_but_not_reverse() {
     assert!(
         !checker.types_compatible(&immutable, &mutable),
         "immutable borrow must not satisfy mutable borrow expectations"
+    );
+}
+
+#[test]
+fn test_types_compatible_function_params_require_exact_borrow_shape() {
+    let checker = TypeChecker::new();
+    let data = ResolvedType::RustPath("demo::Data".to_string());
+    let info = ResolvedType::RustPath("demo::OutputCallbackInfo".to_string());
+    let by_value_callback = ResolvedType::Function(
+        vec![
+            CallableParam::positional(data.clone()),
+            CallableParam::positional(info.clone()),
+        ],
+        Box::new(ResolvedType::Unit),
+    );
+    let borrowed_callback = ResolvedType::Function(
+        vec![
+            CallableParam::positional(ResolvedType::RefMut(Box::new(data))),
+            CallableParam::positional(ResolvedType::Ref(Box::new(info))),
+        ],
+        Box::new(ResolvedType::Unit),
+    );
+
+    assert!(
+        !checker.types_compatible(&by_value_callback, &borrowed_callback),
+        "by-value function parameters must not satisfy borrowed Rust callback parameters"
+    );
+    assert!(
+        checker.types_compatible(&borrowed_callback, &borrowed_callback),
+        "exact borrowed callback parameter shape should remain compatible"
     );
 }
 

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -27,8 +27,8 @@
     {
       "path": "crates/rust_inspect/src/cache_tests.rs",
       "category": "rust-inspect generated enum metadata regression assertions",
-      "expected_count": 14,
-      "expected_fingerprint": "0x2136b9af70108159"
+      "expected_count": 15,
+      "expected_fingerprint": "0xad65689ca46c8b68"
     },
     {
       "path": "crates/rust_inspect/src/cache_timing.rs",
@@ -333,8 +333,8 @@
     {
       "path": "src/frontend/typechecker/mod.rs",
       "category": "Rust display type parsing and stdlib derive compatibility",
-      "expected_count": 34,
-      "expected_fingerprint": "0xa66345b30dd9c215"
+      "expected_count": 36,
+      "expected_fingerprint": "0x83c71e98845e3793"
     },
     {
       "path": "src/frontend/typechecker/stdlib_loader.rs",

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -27,8 +27,8 @@
     {
       "path": "crates/rust_inspect/src/cache_tests.rs",
       "category": "rust-inspect generated enum metadata regression assertions",
-      "expected_count": 15,
-      "expected_fingerprint": "0xad65689ca46c8b68"
+      "expected_count": 16,
+      "expected_fingerprint": "0x6868ad0500373ab2"
     },
     {
       "path": "crates/rust_inspect/src/cache_timing.rs",

--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -858,14 +858,14 @@ fn homebrew_formula_is_rendered_from_the_toolchain_manifest() -> Result<(), Box<
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let checksum = fs::read_to_string(dist.join("incan-v0.5.0-dev.2-x86_64-unknown-linux-gnu.tar.gz.sha256"))?
+    let checksum = fs::read_to_string(dist.join("incan-v0.5.0-dev.3-x86_64-unknown-linux-gnu.tar.gz.sha256"))?
         .trim()
         .to_string();
     let formula = fs::read_to_string(dist.join("incan.rb"))?;
-    assert!(formula.contains(r#"version "0.5.0-dev.2""#));
+    assert!(formula.contains(r#"version "0.5.0-dev.3""#));
     assert!(formula.contains("npm and Homebrew install prebuilt Incan commands"));
     assert!(formula.contains(
-        r#"url "https://github.com/encero-systems/incan/releases/download/v0.5.0-dev.2/incan-v0.5.0-dev.2-x86_64-unknown-linux-gnu.tar.gz""#
+        r#"url "https://github.com/encero-systems/incan/releases/download/v0.5.0-dev.3/incan-v0.5.0-dev.3-x86_64-unknown-linux-gnu.tar.gz""#
     ));
     assert!(formula.contains(&format!(r#"sha256 "{checksum}""#)));
     assert!(formula.contains("def staged_files"));


### PR DESCRIPTION
## Summary

This PR fixes Rust interop validation for generic callback parameters whose Rust bounds are callable traits such as `FnMut(&mut T, &U)`. The frontend now sees those bounds as callable signatures with preserved borrow shape, so invalid by-value Incan callbacks are rejected during typechecking instead of being emitted and rejected by rustc.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Rust interop calls now diagnose by-value callbacks passed to borrowed Rust callback contracts such as `FnMut(&mut T, &U)` at typecheck time.
- **Internals**: `rust_inspect` substitutes simple generic `Fn`/`FnMut`/`FnOnce` bounds into inspected parameter displays, and the typechecker resolves Rust callable-bound displays into function types before generic type-var fallback. Function parameter compatibility now preserves ref/refmut shape exactly while scoped generic placeholders still satisfy generic callable bounds such as `impl FnOnce() -> T`.
- **Risks**: This touches Rust signature display parsing and callable compatibility. The main compatibility risk is over-rejecting generic callable wrappers, covered by the added `TaskFn` regression and the async integration tests.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan rust_callable_bound_ --lib`
- `cargo test -p incan rust_boundary --lib`
- `cargo test -p rust_inspect --lib cache::tests::dependency_source_metadata -- --nocapture`
- `cargo test -p rust_inspect type_metadata_preserves_borrowed_slice_params_and_borrowed_option_returns --lib`
- `cargo test -p incan external_inferred_generic --lib`
- `cargo test -p incan homebrew_formula_is_rendered_from_the_toolchain_manifest --test toolchain_installer_tests`
- `cargo test -p incan semantic_string_checks_are_classified --test vocab_guardrails`
- `cargo test -p incan test_build_async_await_try_ordering_emits_await_before_try --test integration_tests`
- `cargo test -p incan test_check_web_route_uses_proc_macro_passthrough --test integration_tests`
- `cargo clippy -p rust_inspect --all-targets --all-features -- -D warnings`
- `mkdocs build --strict` from `workspaces/docs-site`
- `make pre-commit`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_5.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #805