### PR TITLE
bugfix - add generic field value reflection bounds (#819)

### DIFF
--- a/crates/incan_core/src/lang/trait_bounds.rs
+++ b/crates/incan_core/src/lang/trait_bounds.rs
@@ -142,6 +142,7 @@ pub mod rust {
     // Compiler-provided Incan reflection capabilities
     pub const INCAN_CLASS_NAME: &str = "incan_stdlib::reflection::HasClassName";
     pub const INCAN_FIELD_METADATA: &str = "incan_stdlib::reflection::HasFieldMetadata";
+    pub const INCAN_FIELD_VALUE_REFLECTION: &str = "incan_stdlib::reflection::HasFieldValueReflection";
     pub const INCAN_TYPE_CLASS_NAME: &str = "incan_stdlib::reflection::HasTypeClassName";
     pub const INCAN_TYPE_FIELD_METADATA: &str = "incan_stdlib::reflection::HasTypeFieldMetadata";
 }

--- a/crates/incan_stdlib/src/lib.rs
+++ b/crates/incan_stdlib/src/lib.rs
@@ -51,7 +51,10 @@ pub mod __private {
 pub mod web;
 
 // Re-export commonly used items
-pub use reflection::{FieldInfo, HasClassName, HasFieldInfo, HasFieldMetadata, HasTypeClassName, HasTypeFieldMetadata};
+pub use reflection::{
+    FieldInfo, HasClassName, HasFieldInfo, HasFieldMetadata, HasFieldValueReflection, HasTypeClassName,
+    HasTypeFieldMetadata,
+};
 
 #[cfg(feature = "json")]
 pub use json::{FromJson, ToJson};

--- a/crates/incan_stdlib/src/prelude.rs
+++ b/crates/incan_stdlib/src/prelude.rs
@@ -8,7 +8,8 @@
 
 // Re-export runtime traits and helpers
 pub use crate::reflection::{
-    FieldInfo, HasClassName, HasFieldInfo, HasFieldMetadata, HasTypeClassName, HasTypeFieldMetadata,
+    FieldInfo, HasClassName, HasFieldInfo, HasFieldMetadata, HasFieldValueReflection, HasTypeClassName,
+    HasTypeFieldMetadata,
 };
 // frozen runtime types for consts (RFC 008)
 pub use crate::frozen::{FrozenBytes, FrozenDict, FrozenList, FrozenSet, FrozenStr};

--- a/crates/incan_stdlib/src/reflection.rs
+++ b/crates/incan_stdlib/src/reflection.rs
@@ -45,12 +45,12 @@ pub trait HasFieldMetadata {
 ///
 /// Concrete model and class values keep their compiler-generated typed `__field_value__()` and `__field_items__()`
 /// inherent methods. This trait is the erased generic capability used when source calls those helpers through a type
-/// parameter such as `T`.
+/// parameter such as `T`, following the same generated field-overlay surface.
 pub trait HasFieldValueReflection {
-    /// Return a public field value by canonical field name or model alias.
+    /// Return a reflected field value by canonical field name or model alias.
     fn __field_value__(&self, name: &str) -> Option<String>;
 
-    /// Return public field name/value pairs in declaration order.
+    /// Return reflected field name/value pairs in declaration order.
     fn __field_items__(&self) -> Vec<(String, String)>;
 }
 

--- a/crates/incan_stdlib/src/reflection.rs
+++ b/crates/incan_stdlib/src/reflection.rs
@@ -41,6 +41,19 @@ pub trait HasFieldMetadata {
     fn __fields__(&self) -> FrozenList<FieldInfo>;
 }
 
+/// Provides value-level field reflection for generic Incan row helpers.
+///
+/// Concrete model and class values keep their compiler-generated typed `__field_value__()` and `__field_items__()`
+/// inherent methods. This trait is the erased generic capability used when source calls those helpers through a type
+/// parameter such as `T`.
+pub trait HasFieldValueReflection {
+    /// Return a public field value by canonical field name or model alias.
+    fn __field_value__(&self, name: &str) -> Option<String>;
+
+    /// Return public field name/value pairs in declaration order.
+    fn __field_items__(&self) -> Vec<(String, String)>;
+}
+
 /// Provides type-level field metadata for generated models and classes.
 ///
 /// The compiler uses this trait for generic schema helpers that reflect on an explicit type argument, for example

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -2310,7 +2310,7 @@ def main() -> None:
     }
 
     #[test]
-    fn normal_codegen_expects_only_unread_private_model_fields() {
+    fn normal_codegen_omits_dead_code_expect_for_generated_field_reflection_reads() {
         let code = generate(
             r#"
 model User:
@@ -2325,8 +2325,65 @@ def main() -> None:
 
         assert!(code.contains("name: String"), "{code}");
         assert!(
+            code.contains("impl incan_stdlib::reflection::HasFieldValueReflection for User"),
+            "{code}"
+        );
+        assert!(code.contains("\"age\" => Some(format!(\"{}\", self.age))"), "{code}");
+        assert!(
+            !code.contains("#[expect(dead_code"),
+            "fields read by generated value reflection should not carry dead-code expectations:\n{code}"
+        );
+        assert!(
+            !code.contains("#[allow(dead_code"),
+            "fields read by generated value reflection should not carry dead-code allows:\n{code}"
+        );
+        assert_no_generated_unused_lint_allows(&code);
+    }
+
+    #[test]
+    fn normal_codegen_expects_unread_private_fields_when_value_reflection_is_not_emitted() {
+        let code = generate(
+            r#"
+model Box[T]:
+  value: T
+
+def main() -> None:
+  let box = Box[int](value=42)
+  print("ok")
+"#,
+        );
+
+        assert!(
             code.contains(
-                "#[expect(dead_code, reason = \"retained for Incan private field semantics\")]\n    age: i64"
+                "#[expect(dead_code, reason = \"retained for Incan private field semantics\")]\n    value: T"
+            ),
+            "{code}"
+        );
+        assert!(!code.contains("HasFieldValueReflection for Box"), "{code}");
+        assert_no_generated_unused_lint_allows(&code);
+    }
+
+    #[test]
+    fn normal_codegen_skips_value_reflection_for_non_scalar_fields() {
+        let code = generate(
+            r#"
+model Batch:
+  values: list[int]
+
+def main() -> None:
+  let batch = Batch(values=[1, 2, 3])
+  _ = batch
+  print("ok")
+"#,
+        );
+
+        assert!(
+            !code.contains("impl incan_stdlib::reflection::HasFieldValueReflection for Batch"),
+            "{code}"
+        );
+        assert!(
+            code.contains(
+                "#[expect(dead_code, reason = \"retained for Incan private field semantics\")]\n    values: Vec<i64>"
             ),
             "{code}"
         );

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -2341,6 +2341,38 @@ def main() -> None:
     }
 
     #[test]
+    fn normal_codegen_emits_value_reflection_for_optional_scalar_fields() {
+        let code = generate(
+            r#"
+model ProbeRow:
+  label: str
+  optional_label: Option[str]
+
+def main() -> None:
+  row = ProbeRow(label="paid", optional_label=None)
+  _ = row
+  print("ok")
+"#,
+        );
+        let compact = code.chars().filter(|c| !c.is_whitespace()).collect::<String>();
+
+        assert!(
+            code.contains("impl incan_stdlib::reflection::HasFieldValueReflection for ProbeRow"),
+            "{code}"
+        );
+        assert!(
+            compact.contains("\"optional_label\"=>{Some(match&self.optional_label"),
+            "{code}"
+        );
+        assert!(
+            compact
+                .contains("match&self.optional_label{Some(value)=>format!(\"{}\",value),None=>\"None\".to_string(),}"),
+            "{code}"
+        );
+        assert_no_generated_unused_lint_allows(&code);
+    }
+
+    #[test]
     fn normal_codegen_expects_unread_private_fields_when_value_reflection_is_not_emitted() {
         let code = generate(
             r#"

--- a/src/backend/ir/emit/decls/impls.rs
+++ b/src/backend/ir/emit/decls/impls.rs
@@ -462,7 +462,7 @@ impl<'a> IrEmitter<'a> {
         }
 
         Ok(Some(quote! {
-            /// Return a public field value by canonical field name or model alias.
+            /// Return a reflected field value by canonical field name or model alias.
             pub fn __field_value__(&self, name: String) -> Option<#value_ty_tokens> {
                 match name.as_str() {
                     #(#arms,)*
@@ -498,7 +498,7 @@ impl<'a> IrEmitter<'a> {
         }
 
         Ok(Some(quote! {
-            /// Return public field name/value pairs in declaration order.
+            /// Return reflected field name/value pairs in declaration order.
             pub fn __field_items__(&self) -> Vec<(String, #value_ty_tokens)> {
                 vec![#(#items),*]
             }

--- a/src/backend/ir/emit/decls/structures.rs
+++ b/src/backend/ir/emit/decls/structures.rs
@@ -5,7 +5,10 @@ use quote::{format_ident, quote};
 
 use incan_core::lang::derives::{self, DeriveId};
 
-use super::super::super::decl::{IrEnum, IrEnumValue, IrEnumValueType, IrStruct, VariantFields};
+use super::super::super::decl::{
+    IrEnum, IrEnumValue, IrEnumValueType, IrStruct, IrTypeParam, StructField, VariantFields,
+};
+use super::super::super::types::IrType;
 use super::super::{EmitError, IrEmitter};
 
 const SERDE_SERIALIZE_DERIVE: &str = "serde::Serialize";
@@ -82,6 +85,7 @@ impl<'a> IrEmitter<'a> {
         let generics = self.emit_type_params(&s.type_params);
         let generics_bare = self.emit_type_params_bare(&s.type_params);
         let reflection_impls = self.emit_struct_reflection_trait_impls(s)?;
+        let field_value_reflection_reads_fields = Self::struct_emits_field_value_reflection(s);
 
         if is_tuple_struct {
             let tuple_fields: Vec<TokenStream> = s
@@ -90,7 +94,11 @@ impl<'a> IrEmitter<'a> {
                 .map(|f| {
                     let fty = self.emit_type(&f.ty);
                     let fvis = self.emit_visibility(&f.visibility);
-                    let dead_code_expect = self.private_field_dead_code_expect(&s.name, &f.name, &f.visibility);
+                    let dead_code_expect = if field_value_reflection_reads_fields {
+                        quote! {}
+                    } else {
+                        self.private_field_dead_code_expect(&s.name, &f.name, &f.visibility)
+                    };
                     quote! { #dead_code_expect #fvis #fty }
                 })
                 .collect();
@@ -120,7 +128,11 @@ impl<'a> IrEmitter<'a> {
                     let fname = format_ident!("{}", &f.name);
                     let fty = self.emit_type(&f.ty);
                     let fvis = self.emit_visibility(&f.visibility);
-                    let dead_code_expect = self.private_field_dead_code_expect(&s.name, &f.name, &f.visibility);
+                    let dead_code_expect = if field_value_reflection_reads_fields {
+                        quote! {}
+                    } else {
+                        self.private_field_dead_code_expect(&s.name, &f.name, &f.visibility)
+                    };
                     let serde_attr = if has_serde {
                         f.alias
                             .as_ref()
@@ -231,10 +243,127 @@ impl<'a> IrEmitter<'a> {
             quote! {}
         };
 
+        let field_value_reflection_impl = if Self::struct_emits_field_value_reflection(s) {
+            let mut value_arms = Vec::new();
+            let mut items = Vec::new();
+            for field in &s.fields {
+                let value = Self::field_reflection_string_expr(field);
+                let mut keys = vec![field.name.clone()];
+                if let Some(alias) = &field.alias
+                    && alias != &field.name
+                {
+                    keys.push(alias.clone());
+                }
+                for lookup_key in keys {
+                    value_arms.push(quote! { #lookup_key => Some(#value) });
+                }
+
+                let field_name = field.name.as_str();
+                items.push(quote! { (#field_name.to_string(), #value) });
+            }
+
+            quote! {
+                impl #generics incan_stdlib::reflection::HasFieldValueReflection for #name #generics_bare {
+                    fn __field_value__(&self, name: &str) -> Option<String> {
+                        match name {
+                            #(#value_arms,)*
+                            _ => None,
+                        }
+                    }
+
+                    fn __field_items__(&self) -> Vec<(String, String)> {
+                        vec![#(#items),*]
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         Ok(quote! {
             #class_name_impl
             #field_metadata_impl
+            #field_value_reflection_impl
         })
+    }
+
+    /// Return whether this struct can emit the generic value-level field reflection trait.
+    fn struct_emits_field_value_reflection(s: &IrStruct) -> bool {
+        let is_tuple_struct =
+            !s.fields.is_empty() && s.fields.iter().all(|f| f.name.chars().all(|c| c.is_ascii_digit()));
+        !is_tuple_struct
+            && s.derives.iter().any(|derive| derive == derives::FIELD_INFO_DERIVE_NAME)
+            && !s
+                .fields
+                .iter()
+                .any(|field| Self::field_type_mentions_type_param(&field.ty, &s.type_params))
+            && s.fields
+                .iter()
+                .all(|field| Self::field_type_supports_value_reflection(&field.ty))
+    }
+
+    /// Return whether a field type mentions one of the owning struct's type parameters.
+    fn field_type_mentions_type_param(ty: &IrType, type_params: &[IrTypeParam]) -> bool {
+        let is_type_param = |name: &str| type_params.iter().any(|param| param.name == name);
+        match ty {
+            IrType::Generic(name) | IrType::Struct(name) | IrType::Enum(name) | IrType::Trait(name) => {
+                is_type_param(name)
+            }
+            IrType::NamedGeneric(name, args) => {
+                is_type_param(name)
+                    || args
+                        .iter()
+                        .any(|arg| Self::field_type_mentions_type_param(arg, type_params))
+            }
+            IrType::List(inner)
+            | IrType::Set(inner)
+            | IrType::Option(inner)
+            | IrType::Ref(inner)
+            | IrType::RefMut(inner)
+            | IrType::TypeToken(inner) => Self::field_type_mentions_type_param(inner, type_params),
+            IrType::Dict(key, value) | IrType::Result(key, value) => {
+                Self::field_type_mentions_type_param(key, type_params)
+                    || Self::field_type_mentions_type_param(value, type_params)
+            }
+            IrType::Tuple(items) => items
+                .iter()
+                .any(|item| Self::field_type_mentions_type_param(item, type_params)),
+            IrType::Function { params, ret } => {
+                params
+                    .iter()
+                    .any(|param| Self::field_type_mentions_type_param(param, type_params))
+                    || Self::field_type_mentions_type_param(ret, type_params)
+            }
+            IrType::ExternalUnion { union, .. } => Self::field_type_mentions_type_param(union, type_params),
+            IrType::ImplTrait(bound) => bound
+                .type_args
+                .iter()
+                .chain(bound.assoc_types.iter().map(|(_, ty)| ty))
+                .any(|arg| Self::field_type_mentions_type_param(arg, type_params)),
+            _ => false,
+        }
+    }
+
+    /// Emit the string value used by generic field-value reflection for one concrete field.
+    fn field_reflection_string_expr(field: &StructField) -> TokenStream {
+        let field_ident = format_ident!("{}", field.name);
+        quote! { format!("{}", self.#field_ident) }
+    }
+
+    /// Return whether generic field-value reflection can stringify this type without extra Rust trait bounds.
+    fn field_type_supports_value_reflection(ty: &IrType) -> bool {
+        matches!(
+            ty,
+            IrType::Bool
+                | IrType::Int
+                | IrType::Float
+                | IrType::Numeric(_)
+                | IrType::Decimal { .. }
+                | IrType::String
+                | IrType::StaticStr
+                | IrType::FrozenStr
+                | IrType::StrRef
+        )
     }
 
     /// Emit a Rust enum definition plus shared and value-enum-specific helper implementations.

--- a/src/backend/ir/emit/decls/structures.rs
+++ b/src/backend/ir/emit/decls/structures.rs
@@ -4,6 +4,7 @@ use proc_macro2::{Ident, Literal, TokenStream};
 use quote::{format_ident, quote};
 
 use incan_core::lang::derives::{self, DeriveId};
+use incan_core::lang::surface::constructors::{self, ConstructorId};
 
 use super::super::super::decl::{
     IrEnum, IrEnumValue, IrEnumValueType, IrStruct, IrTypeParam, StructField, VariantFields,
@@ -347,11 +348,12 @@ impl<'a> IrEmitter<'a> {
     /// Emit the string value used by generic field-value reflection for one concrete field.
     fn field_reflection_string_expr(field: &StructField) -> TokenStream {
         let field_ident = format_ident!("{}", field.name);
+        let none = constructors::as_str(ConstructorId::None);
         match &field.ty {
             IrType::Option(inner) if Self::field_type_supports_scalar_value_reflection(inner) => quote! {
                 match &self.#field_ident {
                     Some(value) => format!("{}", value),
-                    None => "None".to_string(),
+                    None => #none.to_string(),
                 }
             },
             _ => quote! { format!("{}", self.#field_ident) },

--- a/src/backend/ir/emit/decls/structures.rs
+++ b/src/backend/ir/emit/decls/structures.rs
@@ -347,11 +347,28 @@ impl<'a> IrEmitter<'a> {
     /// Emit the string value used by generic field-value reflection for one concrete field.
     fn field_reflection_string_expr(field: &StructField) -> TokenStream {
         let field_ident = format_ident!("{}", field.name);
-        quote! { format!("{}", self.#field_ident) }
+        match &field.ty {
+            IrType::Option(inner) if Self::field_type_supports_scalar_value_reflection(inner) => quote! {
+                match &self.#field_ident {
+                    Some(value) => format!("{}", value),
+                    None => "None".to_string(),
+                }
+            },
+            _ => quote! { format!("{}", self.#field_ident) },
+        }
     }
 
     /// Return whether generic field-value reflection can stringify this type without extra Rust trait bounds.
     fn field_type_supports_value_reflection(ty: &IrType) -> bool {
+        if Self::field_type_supports_scalar_value_reflection(ty) {
+            return true;
+        }
+
+        matches!(ty, IrType::Option(inner) if Self::field_type_supports_scalar_value_reflection(inner))
+    }
+
+    /// Return whether a scalar field type can be reflected through Rust's built-in Display implementations.
+    fn field_type_supports_scalar_value_reflection(ty: &IrType) -> bool {
         matches!(
             ty,
             IrType::Bool

--- a/src/backend/ir/trait_bound_inference.rs
+++ b/src/backend/ir/trait_bound_inference.rs
@@ -1895,6 +1895,9 @@ fn reflection_magic_trait_bound(method: &str) -> Option<&'static str> {
     match magic_methods::from_str(method) {
         Some(magic_methods::MagicMethodId::ClassName) => Some(tb::INCAN_CLASS_NAME),
         Some(magic_methods::MagicMethodId::Fields) => Some(tb::INCAN_FIELD_METADATA),
+        Some(magic_methods::MagicMethodId::FieldValue | magic_methods::MagicMethodId::FieldItems) => {
+            Some(tb::INCAN_FIELD_VALUE_REFLECTION)
+        }
         _ => None,
     }
 }
@@ -3040,7 +3043,7 @@ fn propagate_transitive_bounds(
 mod tests {
     use super::*;
     use crate::backend::ir::decl::{FunctionParam, IrDecl, IrDeclKind, IrImpl, Visibility};
-    use crate::backend::ir::expr::{FormatStyle, IrCallArgKind, MethodCallArgPolicy, VarAccess};
+    use crate::backend::ir::expr::{FormatStyle, IrCallArgKind, Literal, MethodCallArgPolicy, VarAccess};
     use crate::backend::ir::{FunctionRegistry, FunctionSignature, Mutability, TypedExpr};
 
     fn function(name: &str, type_params: Vec<IrTypeParam>) -> IrFunction {
@@ -3144,6 +3147,76 @@ mod tests {
         assert!(
             impl_block.methods[0].type_params.is_empty(),
             "impl-owner generics must stay on the impl header, not the method signature"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn generic_value_field_reflection_methods_infer_field_value_bound() -> Result<(), Box<dyn std::error::Error>> {
+        let generic_receiver = || {
+            Box::new(TypedExpr::new(
+                IrExprKind::Var {
+                    name: "value".to_string(),
+                    access: VarAccess::Read,
+                    ref_kind: VarRefKind::Value,
+                },
+                IrType::Generic("T".to_string()),
+            ))
+        };
+        let mut func = function("reflect_values", vec![IrTypeParam::bare("T")]);
+        func.body = vec![
+            IrStmt::new(IrStmtKind::Expr(TypedExpr::new(
+                IrExprKind::MethodCall {
+                    receiver: generic_receiver(),
+                    method: "__field_value__".to_string(),
+                    dispatch: None,
+                    type_args: Vec::new(),
+                    args: vec![IrCallArg {
+                        name: None,
+                        kind: IrCallArgKind::Positional,
+                        expr: TypedExpr::new(
+                            IrExprKind::Literal(Literal::StaticStr("name".to_string())),
+                            IrType::StaticStr,
+                        ),
+                    }],
+                    callable_signature: None,
+                    arg_policy: MethodCallArgPolicy::Default,
+                },
+                IrType::Option(Box::new(IrType::String)),
+            ))),
+            IrStmt::new(IrStmtKind::Expr(TypedExpr::new(
+                IrExprKind::MethodCall {
+                    receiver: generic_receiver(),
+                    method: "__field_items__".to_string(),
+                    dispatch: None,
+                    type_args: Vec::new(),
+                    args: Vec::new(),
+                    callable_signature: None,
+                    arg_policy: MethodCallArgPolicy::Default,
+                },
+                IrType::List(Box::new(IrType::Tuple(vec![IrType::String, IrType::String]))),
+            ))),
+        ];
+        let mut program = program(vec![func]);
+
+        infer_trait_bounds(&mut program);
+
+        let decl = program
+            .declarations
+            .first()
+            .ok_or_else(|| std::io::Error::other("expected function declaration"))?;
+        let IrDecl {
+            kind: IrDeclKind::Function(func),
+            ..
+        } = decl
+        else {
+            return Err(std::io::Error::other("expected function declaration").into());
+        };
+        let bounds = &func.type_params[0].bounds;
+        assert_eq!(
+            bounds,
+            &[IrTraitBound::simple(tb::INCAN_FIELD_VALUE_REFLECTION)],
+            "generic field value reflection should infer only the field-value reflection bound, got {bounds:?}"
         );
         Ok(())
     }

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -1361,6 +1361,10 @@ impl TypeChecker {
             Some(magic_methods::MagicMethodId::Fields) => Some(ResolvedType::FrozenList(Box::new(
                 ResolvedType::Named(surface_types::as_str(SurfaceTypeId::FieldInfo).to_string()),
             ))),
+            Some(magic_methods::MagicMethodId::FieldValue) => Some(option_ty(ResolvedType::Str)),
+            Some(magic_methods::MagicMethodId::FieldItems) => {
+                Some(list_ty(ResolvedType::Tuple(vec![ResolvedType::Str, ResolvedType::Str])))
+            }
             _ => None,
         }
     }
@@ -3978,7 +3982,10 @@ impl TypeChecker {
         if let Some(id) = magic_methods::from_str(method)
             && !matches!(
                 id,
-                magic_methods::MagicMethodId::ClassName | magic_methods::MagicMethodId::Fields
+                magic_methods::MagicMethodId::ClassName
+                    | magic_methods::MagicMethodId::Fields
+                    | magic_methods::MagicMethodId::FieldValue
+                    | magic_methods::MagicMethodId::FieldItems
             )
         {
             return ResolvedType::Unknown;

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -5942,6 +5942,12 @@ def reflected_field_count[T](value: T) -> int:
 
 def reflected_class_name[T](value: T) -> str:
   return value.__class_name__()
+
+def reflected_field_value[T](value: T) -> Option[str]:
+  return value.__field_value__("name")
+
+def reflected_field_items[T](value: T) -> list[tuple[str, str]]:
+  return value.__field_items__()
 "#;
     let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
     let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
@@ -5967,6 +5973,34 @@ def reflected_class_name[T](value: T) -> str:
             )
         }),
         "expected generic __fields__() to resolve to FrozenList[FieldInfo], got {:?}",
+        info.expressions.expr_types
+    );
+    assert!(
+        info.expressions.expr_types.values().any(|ty| {
+            matches!(
+                ty,
+                ResolvedType::Generic(name, args)
+                    if collection_types::from_str(name.as_str()) == Some(CollectionTypeId::Option)
+                        && matches!(args.as_slice(), [ResolvedType::Str])
+            )
+        }),
+        "expected generic __field_value__() to resolve to Option[str], got {:?}",
+        info.expressions.expr_types
+    );
+    assert!(
+        info.expressions.expr_types.values().any(|ty| {
+            matches!(
+                ty,
+                ResolvedType::Generic(name, args)
+                    if collection_types::from_str(name.as_str()) == Some(CollectionTypeId::List)
+                        && matches!(
+                            args.as_slice(),
+                            [ResolvedType::Tuple(items)]
+                                if matches!(items.as_slice(), [ResolvedType::Str, ResolvedType::Str])
+                        )
+            )
+        }),
+        "expected generic __field_items__() to resolve to list[tuple[str, str]], got {:?}",
         info.expressions.expr_types
     );
     Ok(())

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -3995,6 +3995,73 @@ def main() -> None:
 }
 
 #[test]
+fn run_optional_scalar_generic_value_reflection_issue819() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "generic_value_field_reflection_optional_scalar_issue819",
+        "",
+    )?;
+    fs::write(
+        &main_path,
+        r#"model ProbeRow:
+    id: int
+    score: float
+    active: bool
+    label: str
+    optional_label: Option[str]
+
+
+def show_items[T](row: T) -> None:
+    for name, value in row.__field_items__():
+        println(f"{name}={value}")
+
+
+def main() -> None:
+    show_items[ProbeRow](ProbeRow(id=7, score=3.5, active=true, label="paid", optional_label=None))
+    show_items[ProbeRow](ProbeRow(id=8, score=4.25, active=false, label="late", optional_label=Some("x")))
+"#,
+    )?;
+
+    let check_output = run_incan(
+        tmp.path(),
+        &["--check", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(
+        &check_output,
+        "incan --check for optional generic value field reflection issue819",
+    );
+
+    let run_output = run_incan(
+        tmp.path(),
+        &["run", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(
+        &run_output,
+        "incan run for optional generic value field reflection issue819",
+    );
+    let stdout = String::from_utf8_lossy(&run_output.stdout);
+    let lines = stdout.lines().collect::<Vec<_>>();
+    assert_eq!(
+        lines,
+        vec![
+            "id=7",
+            "score=3.5",
+            "active=true",
+            "label=paid",
+            "optional_label=None",
+            "id=8",
+            "score=4.25",
+            "active=false",
+            "label=late",
+            "optional_label=x",
+        ],
+        "unexpected optional generic value reflection output:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn run_primitive_type_parameter_class_names_issue750() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "primitive_type_parameter_names_issue750", "")?;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -3930,6 +3930,71 @@ def main() -> None:
 }
 
 #[test]
+fn run_generic_value_field_reflection_calls_issue819() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "generic_value_field_reflection_issue819", "")?;
+    fs::write(
+        &main_path,
+        r#"model Row:
+    id: int
+    status: str
+    paid: bool
+
+
+def summarize_lookup[T](rows: list[T]) -> str:
+    mut parts: list[str] = []
+    if len(rows) == 0:
+        return ",".join(parts)
+    for field in T.__fields__():
+        match rows[0].__field_value__(str(field.wire_name)):
+            Some(value) =>
+                parts.append(f"{field.wire_name}={value}")
+            None =>
+                parts.append(f"{field.wire_name}=<missing>")
+    return "|".join(parts)
+
+
+def summarize_items[T](rows: list[T]) -> str:
+    mut parts: list[str] = []
+    if len(rows) == 0:
+        return ",".join(parts)
+    for name, value in rows[0].__field_items__():
+        parts.append(f"{name}={value}")
+    return "|".join(parts)
+
+
+def main() -> None:
+    rows = [Row(id=1, status="paid", paid=true)]
+    println(summarize_lookup[Row](rows))
+    println(summarize_items[Row](rows))
+"#,
+    )?;
+
+    let check_output = run_incan(
+        tmp.path(),
+        &["--check", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(
+        &check_output,
+        "incan --check for generic value field reflection issue819",
+    );
+
+    let run_output = run_incan(
+        tmp.path(),
+        &["run", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(&run_output, "incan run for generic value field reflection issue819");
+    let stdout = String::from_utf8_lossy(&run_output.stdout);
+    let lines = stdout.lines().collect::<Vec<_>>();
+    assert_eq!(
+        lines,
+        vec!["id=1|status=paid|paid=true", "id=1|status=paid|paid=true"],
+        "unexpected generic value reflection output:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn run_primitive_type_parameter_class_names_issue750() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "primitive_type_parameter_names_issue750", "")?;

--- a/tests/snapshots/codegen_snapshot_tests__classes.snap
+++ b/tests/snapshots/codegen_snapshot_tests__classes.snap
@@ -56,6 +56,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Point {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Point {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "x" => Some(format!("{}", self.x)),
+            "y" => Some(format!("{}", self.y)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("x".to_string(), format!("{}", self.x)), ("y".to_string(), format!("{}",
+            self.y))
+        ]
+    }
+}
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Rectangle {
     pub width: i64,
@@ -105,6 +120,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Rectangle {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Rectangle {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "width" => Some(format!("{}", self.width)),
+            "height" => Some(format!("{}", self.height)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("width".to_string(), format!("{}", self.width)), ("height".to_string(),
+            format!("{}", self.height))
+        ]
+    }
+}
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Circle {
     radius: f64,
@@ -142,6 +172,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Circle {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Circle {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "radius" => Some(format!("{}", self.radius)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("radius".to_string(), format!("{}", self.radius))]
     }
 }
 impl Circle {
@@ -189,6 +230,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Counter {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Counter {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "count" => Some(format!("{}", self.count)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("count".to_string(), format!("{}", self.count))]
     }
 }
 impl Counter {
@@ -257,7 +309,6 @@ impl Stack {
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Calculator {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     name: String,
 }
 impl incan_stdlib::reflection::HasClassName for Calculator {
@@ -295,6 +346,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Calculator {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Calculator {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("name".to_string(), format!("{}", self.name))]
+    }
+}
 impl Calculator {
     pub fn add(&self, a: i64, b: i64) -> i64 {
         return a + b;
@@ -303,7 +365,6 @@ impl Calculator {
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Person {
     name: String,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     age: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Person {
@@ -348,6 +409,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Person {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Person {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            "age" => Some(format!("{}", self.age)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("name".to_string(), format!("{}", self.name)), ("age".to_string(),
+            format!("{}", self.age))
+        ]
     }
 }
 impl Person {

--- a/tests/snapshots/codegen_snapshot_tests__constructor_field_defaults.snap
+++ b/tests/snapshots/codegen_snapshot_tests__constructor_field_defaults.snap
@@ -11,7 +11,6 @@ incan_stdlib::__incan_stdlib_version_check!("<INCAN_STDLIB_VERSION>");
 struct Settings {
     theme: String,
     font_size: i64,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     auto_save: bool,
 }
 impl incan_stdlib::reflection::HasClassName for Settings {
@@ -65,6 +64,23 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Settings {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Settings {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "theme" => Some(format!("{}", self.theme)),
+            "font_size" => Some(format!("{}", self.font_size)),
+            "auto_save" => Some(format!("{}", self.auto_save)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("theme".to_string(), format!("{}", self.theme)), ("font_size".to_string(),
+            format!("{}", self.font_size)), ("auto_save".to_string(), format!("{}", self
+            .auto_save))
+        ]
     }
 }
 fn main() {

--- a/tests/snapshots/codegen_snapshot_tests__explicit_call_site_generics.snap
+++ b/tests/snapshots/codegen_snapshot_tests__explicit_call_site_generics.snap
@@ -37,6 +37,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Boxed {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Boxed {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl Boxed {
     pub fn pick<T>(&self, value: T) -> T {
         return value;

--- a/tests/snapshots/codegen_snapshot_tests__fixed_call_unpack.snap
+++ b/tests/snapshots/codegen_snapshot_tests__fixed_call_unpack.snap
@@ -52,6 +52,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Counter {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Counter {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl Counter {
     pub fn add(&self, left: i64, right: i64) -> i64 {
         return left + right;

--- a/tests/snapshots/codegen_snapshot_tests__generic_methods.snap
+++ b/tests/snapshots/codegen_snapshot_tests__generic_methods.snap
@@ -34,6 +34,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Box {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Box {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl Box {
     pub fn get<T: Clone>(&self, value: T) -> T {
         return value;
@@ -114,6 +124,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Pair {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Pair {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl Pair {
     pub fn swap<T: Clone, U: Clone>(&self, _: T, right: U) -> U {
         return right;
@@ -121,7 +141,6 @@ impl Pair {
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct EchoBox {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     marker: i64,
 }
 impl incan_stdlib::reflection::HasClassName for EchoBox {
@@ -157,6 +176,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for EchoBox {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for EchoBox {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "marker" => Some(format!("{}", self.marker)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("marker".to_string(), format!("{}", self.marker))]
     }
 }
 impl Echo for EchoBox {

--- a/tests/snapshots/codegen_snapshot_tests__issue241_field_backed_method_arg_clone.snap
+++ b/tests/snapshots/codegen_snapshot_tests__issue241_field_backed_method_arg_clone.snap
@@ -34,6 +34,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Cursor {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Cursor {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl Cursor {
     pub fn join(&self, _: Self, _: bool) -> Self {
         return Cursor {};

--- a/tests/snapshots/codegen_snapshot_tests__issue246_class_field_visibility.snap
+++ b/tests/snapshots/codegen_snapshot_tests__issue246_class_field_visibility.snap
@@ -56,6 +56,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for LazyFrame {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for LazyFrame {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "_cursor" => Some(format!("{}", self._cursor)),
+            "schema" => Some(format!("{}", self.schema)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("_cursor".to_string(), format!("{}", self._cursor)), ("schema".to_string(),
+            format!("{}", self.schema))
+        ]
+    }
+}
 impl LazyFrame {
     pub fn cursor(&self) -> i64 {
         return self._cursor;

--- a/tests/snapshots/codegen_snapshot_tests__issue364_filtered_list_comp_borrow.snap
+++ b/tests/snapshots/codegen_snapshot_tests__issue364_filtered_list_comp_borrow.snap
@@ -56,6 +56,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for StoredNode {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for StoredNode {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "store_id_raw" => Some(format!("{}", self.store_id_raw)),
+            "node" => Some(format!("{}", self.node)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("store_id_raw".to_string(), format!("{}", self.store_id_raw)), ("node"
+            .to_string(), format!("{}", self.node))
+        ]
+    }
+}
 fn store_nodes(store_id: i64, stored_nodes: Vec<StoredNode>) -> Vec<String> {
     return (stored_nodes)
         .iter()

--- a/tests/snapshots/codegen_snapshot_tests__issue366_clone_self_string_field.snap
+++ b/tests/snapshots/codegen_snapshot_tests__issue366_clone_self_string_field.snap
@@ -56,6 +56,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for ActiveRegistration {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for ActiveRegistration {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "logical_name" => Some(format!("{}", self.logical_name)),
+            "rank" => Some(format!("{}", self.rank)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("logical_name".to_string(), format!("{}", self.logical_name)), ("rank"
+            .to_string(), format!("{}", self.rank))
+        ]
+    }
+}
 impl ActiveRegistration {
     pub fn clone(&self) -> Self {
         return ActiveRegistration {

--- a/tests/snapshots/codegen_snapshot_tests__issue389_for_tuple_unpack_enumerate.snap
+++ b/tests/snapshots/codegen_snapshot_tests__issue389_for_tuple_unpack_enumerate.snap
@@ -9,11 +9,8 @@ expression: rust_code
 incan_stdlib::__incan_stdlib_version_check!("<INCAN_STDLIB_VERSION>");
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Binding {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     name: String,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     output_index: i64,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     expr_index: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Binding {
@@ -67,6 +64,23 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Binding {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Binding {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            "output_index" => Some(format!("{}", self.output_index)),
+            "expr_index" => Some(format!("{}", self.expr_index)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("name".to_string(), format!("{}", self.name)), ("output_index".to_string(),
+            format!("{}", self.output_index)), ("expr_index".to_string(), format!("{}",
+            self.expr_index))
+        ]
     }
 }
 fn field_ref(index: i64) -> i64 {

--- a/tests/snapshots/codegen_snapshot_tests__issue483_list_comp_tuple_unpack_enumerate.snap
+++ b/tests/snapshots/codegen_snapshot_tests__issue483_list_comp_tuple_unpack_enumerate.snap
@@ -9,11 +9,8 @@ expression: rust_code
 incan_stdlib::__incan_stdlib_version_check!("<INCAN_STDLIB_VERSION>");
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Binding {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     name: String,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     output_index: i64,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     expr_index: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Binding {
@@ -67,6 +64,23 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Binding {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Binding {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            "output_index" => Some(format!("{}", self.output_index)),
+            "expr_index" => Some(format!("{}", self.expr_index)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("name".to_string(), format!("{}", self.name)), ("output_index".to_string(),
+            format!("{}", self.output_index)), ("expr_index".to_string(), format!("{}",
+            self.expr_index))
+        ]
     }
 }
 fn field_ref(index: i64) -> i64 {

--- a/tests/snapshots/codegen_snapshot_tests__list_clone_model.snap
+++ b/tests/snapshots/codegen_snapshot_tests__list_clone_model.snap
@@ -9,7 +9,6 @@ expression: rust_code
 incan_stdlib::__incan_stdlib_version_check!("<INCAN_STDLIB_VERSION>");
 #[derive(Clone, Debug, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Node {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     id: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Node {
@@ -45,6 +44,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Node {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Node {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "id" => Some(format!("{}", self.id)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("id".to_string(), format!("{}", self.id))]
     }
 }
 fn clone_nodes(nodes: Vec<Node>) -> Vec<Node> {

--- a/tests/snapshots/codegen_snapshot_tests__list_pop_clone_only_model.snap
+++ b/tests/snapshots/codegen_snapshot_tests__list_pop_clone_only_model.snap
@@ -46,6 +46,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for PopRegressItem {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for PopRegressItem {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "id" => Some(format!("{}", self.id)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("id".to_string(), format!("{}", self.id))]
+    }
+}
 fn drain_items() {
     let mut xs: Vec<PopRegressItem> = vec![PopRegressItem { id : 1 }];
     while ::std::convert::identity(xs.len() as i64) > 0 {

--- a/tests/snapshots/codegen_snapshot_tests__model_struct.snap
+++ b/tests/snapshots/codegen_snapshot_tests__model_struct.snap
@@ -10,7 +10,6 @@ incan_stdlib::__incan_stdlib_version_check!("<INCAN_STDLIB_VERSION>");
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct User {
     name: String,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     age: i64,
 }
 impl incan_stdlib::reflection::HasClassName for User {
@@ -55,6 +54,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for User {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for User {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            "age" => Some(format!("{}", self.age)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("name".to_string(), format!("{}", self.name)), ("age".to_string(),
+            format!("{}", self.age))
+        ]
     }
 }
 fn main() {

--- a/tests/snapshots/codegen_snapshot_tests__models.snap
+++ b/tests/snapshots/codegen_snapshot_tests__models.snap
@@ -12,7 +12,6 @@ pub use crate::__incan_std::serde::json;
 struct User {
     name: String,
     age: i64,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     email: String,
 }
 impl incan_stdlib::reflection::HasClassName for User {
@@ -68,12 +67,26 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for User {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for User {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            "age" => Some(format!("{}", self.age)),
+            "email" => Some(format!("{}", self.email)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("name".to_string(), format!("{}", self.name)), ("age".to_string(),
+            format!("{}", self.age)), ("email".to_string(), format!("{}", self.email))
+        ]
+    }
+}
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Product {
     id: i64,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     name: String,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     price: f64,
 }
 impl incan_stdlib::reflection::HasClassName for Product {
@@ -129,12 +142,26 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Product {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Product {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "id" => Some(format!("{}", self.id)),
+            "name" => Some(format!("{}", self.name)),
+            "price" => Some(format!("{}", self.price)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("id".to_string(), format!("{}", self.id)), ("name".to_string(),
+            format!("{}", self.name)), ("price".to_string(), format!("{}", self.price))
+        ]
+    }
+}
 #[derive(Clone, Debug, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Config {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     host: String,
     port: i64,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     timeout: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Config {
@@ -188,6 +215,23 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Config {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Config {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "host" => Some(format!("{}", self.host)),
+            "port" => Some(format!("{}", self.port)),
+            "timeout" => Some(format!("{}", self.timeout)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("host".to_string(), format!("{}", self.host)), ("port".to_string(),
+            format!("{}", self.port)), ("timeout".to_string(), format!("{}", self
+            .timeout))
+        ]
     }
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
@@ -315,10 +359,8 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for StudentData {
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Address {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     street: String,
     city: String,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     zipcode: String,
 }
 impl incan_stdlib::reflection::HasClassName for Address {
@@ -372,6 +414,23 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Address {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Address {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "street" => Some(format!("{}", self.street)),
+            "city" => Some(format!("{}", self.city)),
+            "zipcode" => Some(format!("{}", self.zipcode)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("street".to_string(), format!("{}", self.street)), ("city".to_string(),
+            format!("{}", self.city)), ("zipcode".to_string(), format!("{}", self
+            .zipcode))
+        ]
     }
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
@@ -481,6 +540,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Coordinate {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Coordinate {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "latitude" => Some(format!("{}", self.latitude)),
+            "longitude" => Some(format!("{}", self.longitude)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("latitude".to_string(), format!("{}", self.latitude)), ("longitude"
+            .to_string(), format!("{}", self.longitude))
+        ]
     }
 }
 fn create_coordinate(lat: f64, lon: f64) -> Coordinate {

--- a/tests/snapshots/codegen_snapshot_tests__models.snap
+++ b/tests/snapshots/codegen_snapshot_tests__models.snap
@@ -236,11 +236,8 @@ impl incan_stdlib::reflection::HasFieldValueReflection for Config {
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct OptionalData {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     required: String,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     optional: Option<String>,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     maybe_number: Option<i64>,
 }
 impl incan_stdlib::reflection::HasClassName for OptionalData {
@@ -294,6 +291,39 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for OptionalData {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for OptionalData {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "required" => Some(format!("{}", self.required)),
+            "optional" => {
+                Some(
+                    match &self.optional {
+                        Some(value) => format!("{}", value),
+                        None => "None".to_string(),
+                    },
+                )
+            }
+            "maybe_number" => {
+                Some(
+                    match &self.maybe_number {
+                        Some(value) => format!("{}", value),
+                        None => "None".to_string(),
+                    },
+                )
+            }
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("required".to_string(), format!("{}", self.required)), ("optional"
+            .to_string(), match & self.optional { Some(value) => format!("{}", value),
+            None => "None".to_string(), }), ("maybe_number".to_string(), match & self
+            .maybe_number { Some(value) => format!("{}", value), None => "None"
+            .to_string(), })
+        ]
     }
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]

--- a/tests/snapshots/codegen_snapshot_tests__rfc024_module_derive_json.snap
+++ b/tests/snapshots/codegen_snapshot_tests__rfc024_module_derive_json.snap
@@ -18,7 +18,6 @@ pub use crate::__incan_std::serde::json;
     incan_derive::IncanClass
 )]
 struct Payload {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     value: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Payload {
@@ -54,6 +53,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Payload {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Payload {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 impl json::Serialize for Payload {

--- a/tests/snapshots/codegen_snapshot_tests__rfc024_partial_alias_derive.snap
+++ b/tests/snapshots/codegen_snapshot_tests__rfc024_partial_alias_derive.snap
@@ -16,7 +16,6 @@ pub use crate::__incan_std::serde::json::Serialize as JsonSerialize;
     incan_derive::IncanClass
 )]
 struct Payload {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     value: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Payload {
@@ -52,6 +51,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Payload {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Payload {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 impl JsonSerialize for Payload {

--- a/tests/snapshots/codegen_snapshot_tests__rfc043_rust_derive_passthrough.snap
+++ b/tests/snapshots/codegen_snapshot_tests__rfc043_rust_derive_passthrough.snap
@@ -56,6 +56,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for PayloadKey {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for PayloadKey {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
+    }
+}
 impl PayloadKey {
     /// Returns field metadata for this type.
     pub fn __fields__(

--- a/tests/snapshots/codegen_snapshot_tests__rfc046_computed_properties.snap
+++ b/tests/snapshots/codegen_snapshot_tests__rfc046_computed_properties.snap
@@ -49,6 +49,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Money {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Money {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "cents" => Some(format!("{}", self.cents)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("cents".to_string(), format!("{}", self.cents))]
+    }
+}
 impl Money {
     pub fn dollars(&self) -> i64 {
         return self.cents + 1;

--- a/tests/snapshots/codegen_snapshot_tests__rust_allow.snap
+++ b/tests/snapshots/codegen_snapshot_tests__rust_allow.snap
@@ -47,6 +47,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for AllowModel {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for AllowModel {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
+    }
+}
 impl AllowModel {
     #[allow(unused_variables)]
     pub fn model_method(&self, _: i64) -> i64 {
@@ -91,6 +102,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for allow_class {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for allow_class {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 impl allow_class {

--- a/tests/snapshots/codegen_snapshot_tests__std_async_channel_compiled.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_async_channel_compiled.snap
@@ -143,6 +143,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for RecvError {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for RecvError {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl RecvError {
     pub fn message(&self) -> String {
         return "channel closed: no more messages".to_string();

--- a/tests/snapshots/codegen_snapshot_tests__std_async_sync_compiled.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_async_sync_compiled.snap
@@ -64,6 +64,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for SemaphoreAcquireError {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for SemaphoreAcquireError {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl SemaphoreAcquireError {
     pub fn message(&self) -> String {
         return "failed to acquire semaphore permit: semaphore closed".to_string();

--- a/tests/snapshots/codegen_snapshot_tests__std_async_time_compiled.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_async_time_compiled.snap
@@ -51,6 +51,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for TimeoutError {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for TimeoutError {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl TimeoutError {
     pub fn message(&self) -> String {
         return "operation timed out".to_string();
@@ -125,6 +135,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Duration {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Duration {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "secs" => Some(format!("{}", self.secs)),
+            "nanos" => Some(format!("{}", self.nanos)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("secs".to_string(), format!("{}", self.secs)), ("nanos".to_string(),
+            format!("{}", self.nanos))
+        ]
     }
 }
 impl Duration {

--- a/tests/snapshots/codegen_snapshot_tests__std_graph_compiled.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_graph_compiled.snap
@@ -102,6 +102,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for GraphError {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for GraphError {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "detail" => Some(format!("{}", self.detail)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("detail".to_string(), format!("{}", self.detail))]
+    }
+}
 impl GraphError {
     pub fn message(&self) -> String {
         return self.detail.clone();

--- a/tests/snapshots/codegen_snapshot_tests__std_serde_json_import.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_serde_json_import.snap
@@ -18,11 +18,8 @@ pub use crate::__incan_std::serde::json;
     incan_derive::IncanClass
 )]
 struct Config {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     host: String,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     port: i64,
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     debug: bool,
 }
 impl incan_stdlib::reflection::HasClassName for Config {
@@ -76,6 +73,22 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Config {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Config {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "host" => Some(format!("{}", self.host)),
+            "port" => Some(format!("{}", self.port)),
+            "debug" => Some(format!("{}", self.debug)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("host".to_string(), format!("{}", self.host)), ("port".to_string(),
+            format!("{}", self.port)), ("debug".to_string(), format!("{}", self.debug))
+        ]
     }
 }
 impl json::Serialize for Config {

--- a/tests/snapshots/codegen_snapshot_tests__std_serde_with_serialize_trait.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_serde_with_serialize_trait.snap
@@ -16,7 +16,6 @@ pub use crate::__incan_std::serde::json::Serialize;
     incan_derive::IncanClass
 )]
 struct Payload {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     value: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Payload {
@@ -52,6 +51,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Payload {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Payload {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 impl Serialize for Payload {

--- a/tests/snapshots/codegen_snapshot_tests__std_traits_convert_usage.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_traits_convert_usage.snap
@@ -48,6 +48,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for UserId {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for UserId {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
+    }
+}
 impl UserId {
     pub fn from(value: i64) -> Self {
         return UserId { value: value };
@@ -98,6 +109,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for PositiveInt {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for PositiveInt {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 impl PositiveInt {

--- a/tests/snapshots/codegen_snapshot_tests__std_uuid_compiled.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_uuid_compiled.snap
@@ -184,6 +184,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for UuidError {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for UuidError {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "kind" => Some(format!("{}", self.kind)),
+            "detail" => Some(format!("{}", self.detail)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("kind".to_string(), format!("{}", self.kind)), ("detail".to_string(),
+            format!("{}", self.detail))
+        ]
+    }
+}
 impl UuidError {
     /// Return the human-readable error detail.
     ///
@@ -628,6 +643,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for _UuidText {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for _UuidText {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "text" => Some(format!("{}", self.text)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("text".to_string(), format!("{}", self.text))]
     }
 }
 impl _UuidText {

--- a/tests/snapshots/codegen_snapshot_tests__trait_supertrait_assignability.snap
+++ b/tests/snapshots/codegen_snapshot_tests__trait_supertrait_assignability.snap
@@ -61,6 +61,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Thing {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Thing {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "x" => Some(format!("{}", self.x)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("x".to_string(), format!("{}", self.x))]
+    }
+}
 impl Mid for Thing {
     fn mid_id(&self) -> i64 {
         return self.x + 1;
@@ -108,6 +119,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Row {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Row {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "id" => Some(format!("{}", self.id)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("id".to_string(), format!("{}", self.id))]
     }
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]

--- a/tests/snapshots/codegen_snapshot_tests__traits.snap
+++ b/tests/snapshots/codegen_snapshot_tests__traits.snap
@@ -54,6 +54,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Dog {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Dog {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("name".to_string(), format!("{}", self.name))]
+    }
+}
 impl Named for Dog {}
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Rectangle {
@@ -102,6 +113,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Rectangle {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Rectangle {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "width" => Some(format!("{}", self.width)),
+            "height" => Some(format!("{}", self.height)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("width".to_string(), format!("{}", self.width)), ("height".to_string(),
+            format!("{}", self.height))
+        ]
     }
 }
 impl Rectangle {
@@ -159,6 +185,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Circle {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Circle {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "radius" => Some(format!("{}", self.radius)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("radius".to_string(), format!("{}", self.radius))]
+    }
+}
 impl Circle {
     pub fn draw(&self) -> String {
         return {
@@ -214,6 +251,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Square {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Square {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "side" => Some(format!("{}", self.side)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("side".to_string(), format!("{}", self.side))]
     }
 }
 impl Square {
@@ -307,6 +355,22 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Carton {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Carton {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "width" => Some(format!("{}", self.width)),
+            "height" => Some(format!("{}", self.height)),
+            "depth" => Some(format!("{}", self.depth)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("width".to_string(), format!("{}", self.width)), ("height".to_string(),
+            format!("{}", self.height)), ("depth".to_string(), format!("{}", self.depth))
+        ]
+    }
+}
 impl Carton {
     pub fn resize(&self, factor: f64) {
         self.width = self.width * factor;
@@ -377,6 +441,21 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Document {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Document {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "title" => Some(format!("{}", self.title)),
+            "content" => Some(format!("{}", self.content)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("title".to_string(), format!("{}", self.title)), ("content".to_string(),
+            format!("{}", self.content))
+        ]
     }
 }
 impl Document {

--- a/tests/snapshots/codegen_snapshot_tests__uppercase_var_field_access.snap
+++ b/tests/snapshots/codegen_snapshot_tests__uppercase_var_field_access.snap
@@ -46,6 +46,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Person {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Person {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("name".to_string(), format!("{}", self.name))]
+    }
+}
 fn main() {
     std::panic::set_hook(
         std::boxed::Box::new(|panic_info| {

--- a/tests/snapshots/codegen_snapshot_tests__user_defined_method_decorators.snap
+++ b/tests/snapshots/codegen_snapshot_tests__user_defined_method_decorators.snap
@@ -32,7 +32,6 @@ pub(crate) fn __incan_init_module_statics() {
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Box {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     value: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Box {
@@ -68,6 +67,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Box {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Box {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 static __INCAN_DECORATED_BOX_LABEL: std::sync::LazyLock<

--- a/tests/snapshots/codegen_snapshot_tests__user_defined_mutable_method_decorators.snap
+++ b/tests/snapshots/codegen_snapshot_tests__user_defined_mutable_method_decorators.snap
@@ -32,7 +32,6 @@ pub(crate) fn __incan_init_module_statics() {
 }
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Counter {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     value: i64,
 }
 impl incan_stdlib::reflection::HasClassName for Counter {
@@ -68,6 +67,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Counter {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Counter {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 static __INCAN_DECORATED_COUNTER_BUMP: std::sync::LazyLock<

--- a/tests/snapshots/codegen_snapshot_tests__user_defined_operators.snap
+++ b/tests/snapshots/codegen_snapshot_tests__user_defined_operators.snap
@@ -46,6 +46,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Money {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Money {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "cents" => Some(format!("{}", self.cents)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("cents".to_string(), format!("{}", self.cents))]
+    }
+}
 impl Money {
     pub fn __add__(&self, other: Money) -> Money {
         return Money {
@@ -95,6 +106,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for User {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for User {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "id" => Some(format!("{}", self.id)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("id".to_string(), format!("{}", self.id))]
+    }
+}
 impl PartialEq for User {
     fn eq(&self, other: &Self) -> bool {
         return self.id == other.id;
@@ -137,6 +159,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Row {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Row {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 impl Row {
@@ -184,6 +217,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for OpBox {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for OpBox {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "value" => Some(format!("{}", self.value)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("value".to_string(), format!("{}", self.value))]
     }
 }
 impl OpBox {

--- a/tests/snapshots/codegen_snapshot_tests__variadic_calls.snap
+++ b/tests/snapshots/codegen_snapshot_tests__variadic_calls.snap
@@ -66,6 +66,16 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Collector {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for Collector {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
 impl Collector {
     pub fn collect(
         &self,

--- a/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_io_source.snap
+++ b/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_io_source.snap
@@ -111,6 +111,34 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for IoError {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for IoError {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "kind" => Some(format!("{}", self.kind)),
+            "detail" => Some(format!("{}", self.detail)),
+            "operation" => Some(format!("{}", self.operation)),
+            "position" => Some(format!("{}", self.position)),
+            "path" => {
+                Some(
+                    match &self.path {
+                        Some(value) => format!("{}", value),
+                        None => "None".to_string(),
+                    },
+                )
+            }
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("kind".to_string(), format!("{}", self.kind)), ("detail".to_string(),
+            format!("{}", self.detail)), ("operation".to_string(), format!("{}", self
+            .operation)), ("position".to_string(), format!("{}", self.position)), ("path"
+            .to_string(), match & self.path { Some(value) => format!("{}", value), None
+            => "None".to_string(), })
+        ]
+    }
+}
 impl IoError {
     /// Return the human-readable error detail.
     ///

--- a/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_telemetry_core_source.snap
+++ b/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_telemetry_core_source.snap
@@ -795,6 +795,55 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for InstrumentationScope {
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
     }
 }
+impl incan_stdlib::reflection::HasFieldValueReflection for InstrumentationScope {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "name" => Some(format!("{}", self.name)),
+            "Name" => Some(format!("{}", self.name)),
+            "version" => {
+                Some(
+                    match &self.version {
+                        Some(value) => format!("{}", value),
+                        None => "None".to_string(),
+                    },
+                )
+            }
+            "Version" => {
+                Some(
+                    match &self.version {
+                        Some(value) => format!("{}", value),
+                        None => "None".to_string(),
+                    },
+                )
+            }
+            "schema_url" => {
+                Some(
+                    match &self.schema_url {
+                        Some(value) => format!("{}", value),
+                        None => "None".to_string(),
+                    },
+                )
+            }
+            "SchemaUrl" => {
+                Some(
+                    match &self.schema_url {
+                        Some(value) => format!("{}", value),
+                        None => "None".to_string(),
+                    },
+                )
+            }
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![
+            ("name".to_string(), format!("{}", self.name)), ("version".to_string(), match
+            & self.version { Some(value) => format!("{}", value), None => "None"
+            .to_string(), }), ("schema_url".to_string(), match & self.schema_url {
+            Some(value) => format!("{}", value), None => "None".to_string(), })
+        ]
+    }
+}
 impl InstrumentationScope {
     /// Returns field metadata for this type.
     pub fn __fields__(

--- a/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_web_prelude_import.snap
+++ b/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_web_prelude_import.snap
@@ -18,7 +18,6 @@ pub use crate::__incan_std::web::route;
 pub use crate::__incan_std::web::GET;
 #[derive(Debug, Clone, incan_derive::FieldInfo, incan_derive::IncanClass)]
 struct Search {
-    #[expect(dead_code, reason = "retained for Incan private field semantics")]
     q: String,
 }
 impl incan_stdlib::reflection::HasClassName for Search {
@@ -54,6 +53,17 @@ impl incan_stdlib::reflection::HasTypeFieldMetadata for Search {
             },
         ];
         incan_stdlib::frozen::FrozenList::new(&__INCAN_FIELDS)
+    }
+}
+impl incan_stdlib::reflection::HasFieldValueReflection for Search {
+    fn __field_value__(&self, name: &str) -> Option<String> {
+        match name {
+            "q" => Some(format!("{}", self.q)),
+            _ => None,
+        }
+    }
+    fn __field_items__(&self) -> Vec<(String, String)> {
+        vec![("q".to_string(), format!("{}", self.q))]
     }
 }
 #[incan_web_macros::route("/snapshot/{id}", method = "GET")]


### PR DESCRIPTION
## Summary

This PR fixes generic value-level field reflection for scalar model/class rows. Generic helpers can now call `value.__field_value__(name)` and `value.__field_items__()` through `T`, with the backend inferring the required runtime capability bound and generated scalar row types implementing that capability.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Generic scalar row helpers can inspect field values with `Option[str]` lookup results and `list[tuple[str, str]]` item results. Concrete typed reflection remains unchanged.
- **Internals**: Added `HasFieldValueReflection`, taught generic magic-method typing and trait-bound inference about value reflection, and emits scalar-only generated impls for reflected non-tuple structs whose fields are stringifiable without extra Rust trait bounds.
- **Risks**: This is intentionally a scalar string bridge for v0.5 row reflection, not a full typed field-value enum or arbitrary nested value reflection design. Non-scalar/generic-field structs do not receive the generated impl, so Rust will reject generic value reflection for those shapes rather than emitting unsafe `Debug` requirements.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test --test cli_integration run_generic_value_field_reflection_calls_issue819 -- --nocapture`
- `cargo test generic_value_field_reflection_methods_infer_field_value_bound -- --nocapture`
- `cargo test test_generic_reflection_magic_methods_record_surface_types -- --nocapture`
- `cargo test normal_codegen_omits_dead_code_expect_for_generated_field_reflection_reads -- --nocapture`
- `cargo test normal_codegen_expects_unread_private_fields_when_value_reflection_is_not_emitted -- --nocapture`
- `cargo test normal_codegen_skips_value_reflection_for_non_scalar_fields -- --nocapture`
- `cargo test --test cli_integration test_runner_prefers_project_sibling_import_over_unimported_stdlib_stub_type -- --nocapture`
- `cargo test --test integration_tests codegen_tests::test_imported_value_enum_ordinal_map_compile_and_run -- --nocapture`
- `INSTA_UPDATE=always cargo test --test codegen_snapshot_tests -- --nocapture`
- `INSTA_UPDATE=always cargo test --test stdlib_generated_rust_snapshot_tests -- --nocapture`
- `cargo run -p incan_core --bin generate_lang_reference` (no tracked docs diff)
- `make fmt`
- `git diff --check`
- `make pre-commit` (passed including smoke-test-fast)

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): n/a

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #819