### PR TITLE
chore - document Hees SDK validation path (#552)

### DIFF
--- a/workspaces/docs-site/docs/contributing/index.md
+++ b/workspaces/docs-site/docs/contributing/index.md
@@ -31,6 +31,7 @@ If you’re new, start with:
 - [Layering rules](explanation/layering.md) — dependency boundaries and guardrails
 - [Generated Rust stdlib coverage](reference/generated_rust_stdlib_coverage.md) — generated-Rust coverage inventory for stdlib modules
 - [Hees.ai v0.5 dependency inventory](reference/hees_ai_v05_dependency_inventory.md) — proof-lane dependency map and scope guardrails
+- [Hees.ai v0.5 installed-SDK validation](reference/hees_ai_v05_sdk_validation.md) — command contract and blocker routing for #552
 - [Rust-source backend deprecation policy](reference/rust_source_backend_deprecation.md) — compatibility rules while semantic authority moves out of generated Rust
 
 ## Design (RFCs and roadmap)

--- a/workspaces/docs-site/docs/contributing/reference/hees_ai_v05_dependency_inventory.md
+++ b/workspaces/docs-site/docs/contributing/reference/hees_ai_v05_dependency_inventory.md
@@ -2,7 +2,7 @@
 
 This inventory seeds issue [#651](https://github.com/encero-systems/incan/issues/651). It keeps the Hees.ai proof lane constrained: Hees.ai may validate Incan compiler, stdlib, runtime, and tooling direction, but it must not quietly turn the 0.5 milestone into broad product scope.
 
-Status: seed inventory. It maps known proof-lane needs from [#549](https://github.com/encero-systems/incan/issues/549) and [#552](https://github.com/encero-systems/incan/issues/552) to provider lanes and guardrails.
+Status: seed inventory. It maps known proof-lane needs from [#549](https://github.com/encero-systems/incan/issues/549) and [#552](https://github.com/encero-systems/incan/issues/552) to provider lanes and guardrails. The concrete installed-SDK command contract for #552 lives in [Hees.ai v0.5 installed-SDK validation](hees_ai_v05_sdk_validation.md).
 
 ## Categories
 
@@ -43,7 +43,7 @@ Use these anchors before creating new proof-only machinery:
 
 | Hees.ai need | Classification | Provider issue or source | Notes |
 | --- | --- | --- | --- |
-| Installed-command validation path. | Existing 0.4 tooling / Hees.ai validation. | [#552](https://github.com/encero-systems/incan/issues/552). | The proof should prefer installed `incan` commands and report local-only assumptions as blockers. |
+| Installed-command validation path. | Existing 0.4 tooling / Hees.ai validation. | [#552](https://github.com/encero-systems/incan/issues/552), [installed-SDK validation](hees_ai_v05_sdk_validation.md). | The proof should prefer installed `incan` commands and report local-only assumptions as blockers. |
 | Governed workbench demo scenario. | Hees.ai-only product behavior with Incan validation hooks. | [#549](https://github.com/encero-systems/incan/issues/549). | Keep scenario copy, policy content, and product UX outside Incan compiler scope. |
 | Stable compiler-owned identities for evidence. | 0.5 backend foundation. | [#648](https://github.com/encero-systems/incan/issues/648), [#650](https://github.com/encero-systems/incan/issues/650). | Needed if proof artifacts cite source declarations/calls beyond text spans. |
 | Backend-neutral type/runtime facts. | 0.5 backend foundation. | [#649](https://github.com/encero-systems/incan/issues/649). | Needed if proof artifacts explain type or runtime obligations in Incan terms. |
@@ -79,6 +79,6 @@ These belong outside Incan 0.5 unless separately approved:
 ## Next inventory actions
 
 1. Freeze the #549 scenario transcript/artifact list before implementing dependencies.
-2. Run the #552 installed-SDK path and record exact blockers.
+2. Run the #552 [installed-SDK validation path](hees_ai_v05_sdk_validation.md) and record exact blockers.
 3. For every blocker, decide whether it is existing 0.4 tooling, 0.5 backend foundation, 0.5 stdlib/runtime, temporary shim, or Hees.ai-only.
 4. Reject any product need that cannot explain how it validates Incan itself.

--- a/workspaces/docs-site/docs/contributing/reference/hees_ai_v05_sdk_validation.md
+++ b/workspaces/docs-site/docs/contributing/reference/hees_ai_v05_sdk_validation.md
@@ -1,0 +1,72 @@
+# Hees.ai v0.5 installed-SDK validation
+
+This validation contract defines how the constrained Hees.ai proof lane for issue [#552](https://github.com/encero-systems/incan/issues/552) proves that it can run from an installed Incan SDK instead of a repo-local compiler checkout.
+
+Status: Incan-side validation contract. Closing #552 still requires a recorded run from the Hees.ai revision that carries the governed-workbench proof; this reference defines the commands and evidence that run must provide.
+
+## North star
+
+A maintainer with the staged v0.5 SDK installed should be able to enter the Hees.ai project, run one documented command sequence, and capture evidence that the proof path uses the installed `incan` command. The SDK does not need to be publicly released first: an installed artifact produced by the release pipeline is valid when its version and artifact identity are recorded. Public proof docs must not require `/Users/.../incan/target/debug/incan`, a sibling Incan checkout, or generated Rust paths from a compiler repo.
+
+The validation should prove Incan surfaces, not Hees.ai product polish:
+
+- stable installed command discovery;
+- project locking, checking, testing, building, and reporting through public CLI commands;
+- workbench wrapper behavior that honors the installed SDK path;
+- trace/report/decision artifacts that demonstrate governed behavior;
+- explicit blocker routing for missing compiler, stdlib, runtime, package, or tooling surfaces.
+
+## Command levels
+
+Use levels so the proof can keep moving without pretending that every environment has local models, ample disk, or network.
+
+| Level | Purpose | Commands | Required evidence |
+| --- | --- | --- | --- |
+| SDK discovery | Prove the caller is not using a repo-local compiler binary. | `INCAN_BIN="$(command -v incan)"`; `"$INCAN_BIN" --version`; `INCAN_BIN="$INCAN_BIN" bin/hees-workbench --print-incan-bin`. | The printed path resolves to the installed staged SDK command or explicitly supplied installed SDK binary, not `../incan/target/debug/incan`. Record the v0.5 version and release-artifact identity. An earlier stable SDK may test wrapper discovery, but it does not satisfy v0.5 release evidence. |
+| Static project check | Prove the project can be checked from the installed SDK without running the workbench. | `"$INCAN_BIN" check src/hees_workbench.incn --format json`; optionally `"$INCAN_BIN" check src/main.incn --format json`. | JSON diagnostics are empty or contain linked blockers with issue numbers. The command should not require a sibling compiler checkout. |
+| Lock and contract tests | Prove package resolution and ordinary test surfaces. | `"$INCAN_BIN" lock`; `"$INCAN_BIN" test`. | Fresh lock state, test result, compiler version, and any dependency-resolution blockers. This level may create target output and should be skipped during disk-pressure incidents unless the caller accepts that cost. |
+| Workbench build-only | Prove the wrapper can build the selected workbench target with the installed SDK. | `INCAN_BIN="$INCAN_BIN" HEES_WORKBENCH_BUILD_ONLY=1 bin/hees-workbench digital_wellness`. | Wrapper-resolved compiler path, exit status, build/report artifact paths, and disk impact. This level may rebuild Cargo output. |
+| Live governed proof | Prove the flagship #549 behavior when local model/runtime prerequisites are present. | `INCAN_BIN="$INCAN_BIN" bin/hees-workbench digital_wellness`. | Stable progress lines plus `target/hees-workbench/latest_trace.json`, `latest_report.md`, `latest_candidates.json`, `latest_decisions.json`, and policy artifact paths. If Ollama or model prerequisites are absent, record that as an environment blocker rather than an Incan failure. |
+
+## Public documentation rules
+
+Public Hees.ai proof docs should show `incan` or an explicit `INCAN_BIN="$(command -v incan)"` setup. They must not instruct users to run `/Users/danny/Development/encero/incan/target/debug/incan` or any other compiler-repo `target/debug/incan` path.
+
+Repo-local compiler paths are acceptable only in private spike notes or failure forensics, and only when the note also explains the installed-SDK blocker that forced the local path.
+
+Wrappers should resolve compilers in this order:
+
+1. honor an explicit `INCAN_BIN`;
+2. use `command -v incan` when available;
+3. fail with a message that asks the operator to install Incan or set `INCAN_BIN`.
+
+They should not silently prefer a sibling checkout's `target/debug/incan` in the default public proof path. A local-debug escape hatch may exist, but it must be opt-in and should not be the first resolution path.
+
+## Blocker categories
+
+Every failed validation step should be classified before opening or updating issues.
+
+| Category | Route |
+| --- | --- |
+| Installed SDK discovery or release layout failure | #552 or the installer/release-manifest owner. |
+| Project lock, package, or dependency resolution failure | Link the exact compiler/tooling issue; do not hide it as a Hees-only quirk. |
+| Missing stdlib/runtime surface such as environment, process, HTTP, web lifecycle, time, or byte streams | Link the owning stdlib/runtime issue, such as #557, #341, #440, #526, #579, or #544. |
+| Missing backend-neutral source identity, semantic facts, HIR, or type facts | Link #634, #648, #649, #650, #282, or #224. |
+| Product scenario, domain copy, UI polish, corpus content, or local model availability | Track in Hees.ai, not in the Incan milestone. |
+
+## Handoff and evidence ownership
+
+This reference deliberately does not describe one mutable Hees.ai checkout as the current implementation. The Hees.ai revision selected for the proof owns its wrapper and public-documentation changes. Issue #552 must link that exact revision and record the command output, SDK version, installed binary path, and produced artifacts.
+
+If the selected consumer revision lacks `bin/hees-workbench --print-incan-bin` or the installed-command resolution order above, fix that consumer boundary before recording release evidence. Do not substitute edits in a dirty checkout or a compiler-repository binary and call the proof complete.
+
+## Done criteria for #552
+
+#552 is done when:
+
+- the Hees.ai proof docs expose an installed-SDK command sequence;
+- the workbench wrapper path prints and uses the installed SDK command by default;
+- any remaining local-only assumptions are recorded as linked blockers;
+- at least the SDK discovery and static project check levels have been run with the installed v0.5 artifact selected for release, with its exact version and artifact identity recorded;
+- any skipped build/test/live levels state the reason, such as disk pressure, missing model service, or an open compiler/runtime blocker;
+- IncQL and Pallay validation remain out of scope.

--- a/workspaces/docs-site/docs/roadmap.md
+++ b/workspaces/docs-site/docs/roadmap.md
@@ -116,6 +116,7 @@ Core tracking issues:
 - [#282](https://github.com/encero-systems/incan/issues/282): backend orchestration migration scaffolding.
 - [#224](https://github.com/encero-systems/incan/issues/224): `CompilationSession` semantic database transition.
 - [#549](https://github.com/encero-systems/incan/issues/549): Hees.ai governed workbench demo.
+- [#552](https://github.com/encero-systems/incan/issues/552): Hees.ai installed-SDK validation path.
 - [#651](https://github.com/encero-systems/incan/issues/651): Hees.ai dependency inventory and guardrails.
 - [#405](https://github.com/encero-systems/incan/issues/405): RFC 077 workspace and multi-package project foundations.
 - [#829](https://github.com/encero-systems/incan/issues/829): crash-safe local publication and file coordination ([RFC 112](RFCs/closed/implemented/112_crash_safe_publication_and_file_coordination.md), implemented in [#833](https://github.com/encero-systems/incan/pull/833)).
@@ -125,6 +126,7 @@ Phase-0 references:
 - [Backend behavior inventory](contributing/reference/backend_behavior_inventory.md) seeds #646 with behavior categories, evidence lanes, hosted-runtime assumptions, and the current Rust interop bug cluster.
 - [Rust-source backend deprecation policy](contributing/reference/rust_source_backend_deprecation.md) seeds #647 with rules for compatibility fixes while semantic authority moves toward backend-neutral facts.
 - [Hees.ai v0.5 dependency inventory](contributing/reference/hees_ai_v05_dependency_inventory.md) seeds #651 with proof-lane dependencies, shim rules, and product-scope guardrails.
+- [Hees.ai v0.5 installed-SDK validation](contributing/reference/hees_ai_v05_sdk_validation.md) seeds #552 with the command contract, blocker categories, and public-doc rules for the constrained proof path.
 
 Allowed stdlib work includes `std.http`, `std.ci`, CLI framework, `std.archive`, `std.process`, `std.web` lifecycle, `std.environ`, package-level timezones, fallible reader chunk streams, and selected stdlib compilation/source-authored behavior work.
 

--- a/workspaces/docs-site/mkdocs.yml
+++ b/workspaces/docs-site/mkdocs.yml
@@ -301,6 +301,7 @@ nav:
           - Backend behavior inventory: contributing/reference/backend_behavior_inventory.md
           - Generated Rust stdlib coverage: contributing/reference/generated_rust_stdlib_coverage.md
           - Hees.ai v0.5 dependency inventory: contributing/reference/hees_ai_v05_dependency_inventory.md
+          - Hees.ai v0.5 installed-SDK validation: contributing/reference/hees_ai_v05_sdk_validation.md
           - Rust-source backend deprecation policy: contributing/reference/rust_source_backend_deprecation.md
       - RFCs: RFCs/index.md
   - Release notes:


### PR DESCRIPTION
## Summary

Defines the complete Incan-side installed-SDK validation contract for the constrained Hees.ai v0.5 proof lane. The reference specifies staged-SDK discovery, command levels, evidence ownership, blocker routing, and public-documentation rules without depending on a mutable Hees.ai checkout or requiring v0.5 to be published before release validation can run.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: no language or CLI behavior changes. Contributors get one canonical contract for proving that Hees.ai uses an installed staged v0.5 SDK rather than a compiler-checkout binary.
- **Internals**: links the contract from the dependency inventory, contributing index, roadmap, and MkDocs navigation. Evidence belongs to the exact Hees.ai consumer revision selected for the proof instead of being inferred from mutable checkout state.
- **Risks**: this PR defines the Incan-side contract; issue #552 remains open until the consumer run records its SDK version, installed binary path, command output, and produced proof artifacts.

## Testing / verification

- [ ] `make test` / `cargo test` (not applicable to this documentation-only change)
- [ ] `make examples` (not applicable)
- [ ] `incan fmt --check .` (not applicable)
- [x] Manual verification described below

Manual verification:

- `make docs-build`
- `git diff --check origin/main...HEAD`
- verified the GitHub diff is limited to the five intended documentation/navigation files after rebasing onto current `main`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The new page is a contributing reference. It defines the validation contract and evidence fields; product-specific Hees.ai implementation and proof artifacts remain in the consumer repository.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions, or documented why tests are not applicable

Refs #552.
