### PR TITLE
bugfix - compile generic Index trait adoptions (#815)

### DIFF
--- a/src/backend/ir/lower/decl/methods.rs
+++ b/src/backend/ir/lower/decl/methods.rs
@@ -190,21 +190,94 @@ impl AstLowering {
     pub(in crate::backend::ir::lower) fn trait_impl_targets_for_adopted_trait_bound(
         &self,
         bound: &ast::TraitBound,
+        owner_type_name: &str,
         type_params: &[ast::TypeParam],
     ) -> Vec<(String, Vec<IrType>)> {
         if bound.type_args.is_empty() {
             return self.trait_impl_targets_for_adopted_trait(&bound.name, type_params);
         }
         let type_param_names: std::collections::HashSet<&str> = type_params.iter().map(|tp| tp.name.as_str()).collect();
+        let owner_type = Self::trait_impl_owner_type(owner_type_name, type_params);
         let direct_args = bound
             .type_args
             .iter()
-            .map(|arg| self.lower_type_with_type_params(&arg.node, Some(&type_param_names)))
+            .map(|arg| {
+                let lowered = self.lower_type_with_type_params(&arg.node, Some(&type_param_names));
+                Self::substitute_trait_impl_self_type(lowered, &owner_type)
+            })
             .collect::<Vec<_>>();
         let mut seen = HashSet::new();
         let mut out = Vec::new();
         self.collect_trait_impl_targets_recursive(&bound.name, &direct_args, &mut seen, &mut out);
         out
+    }
+
+    /// Build the fully-instantiated owner type used when an adopted trait bound names `Self`.
+    ///
+    /// Trait implementation headers are outside a Rust method or trait body, so a bare `Self` is not valid there.
+    /// The IR must instead carry the adopter's nominal type, including its declared generic parameters.
+    fn trait_impl_owner_type(type_name: &str, type_params: &[ast::TypeParam]) -> IrType {
+        if type_params.is_empty() {
+            IrType::Struct(type_name.to_string())
+        } else {
+            IrType::NamedGeneric(
+                type_name.to_string(),
+                type_params
+                    .iter()
+                    .map(|param| IrType::Generic(param.name.clone()))
+                    .collect(),
+            )
+        }
+    }
+
+    /// Replace `Self` in an adopted trait target with its concrete implementation owner.
+    ///
+    /// This substitution is intentionally performed at the trait-target boundary rather than by emission: `Self`
+    /// still has its ordinary meaning in trait method bodies, while an impl header requires a concrete type.
+    fn substitute_trait_impl_self_type(ty: IrType, owner_type: &IrType) -> IrType {
+        match ty {
+            IrType::SelfType => owner_type.clone(),
+            IrType::List(inner) => IrType::List(Box::new(Self::substitute_trait_impl_self_type(*inner, owner_type))),
+            IrType::Dict(key, value) => IrType::Dict(
+                Box::new(Self::substitute_trait_impl_self_type(*key, owner_type)),
+                Box::new(Self::substitute_trait_impl_self_type(*value, owner_type)),
+            ),
+            IrType::Set(inner) => IrType::Set(Box::new(Self::substitute_trait_impl_self_type(*inner, owner_type))),
+            IrType::Tuple(items) => IrType::Tuple(
+                items
+                    .into_iter()
+                    .map(|item| Self::substitute_trait_impl_self_type(item, owner_type))
+                    .collect(),
+            ),
+            IrType::Option(inner) => {
+                IrType::Option(Box::new(Self::substitute_trait_impl_self_type(*inner, owner_type)))
+            }
+            IrType::Result(ok, err) => IrType::Result(
+                Box::new(Self::substitute_trait_impl_self_type(*ok, owner_type)),
+                Box::new(Self::substitute_trait_impl_self_type(*err, owner_type)),
+            ),
+            IrType::NamedGeneric(name, args) => IrType::NamedGeneric(
+                name,
+                args.into_iter()
+                    .map(|arg| Self::substitute_trait_impl_self_type(arg, owner_type))
+                    .collect(),
+            ),
+            IrType::TypeToken(inner) => {
+                IrType::TypeToken(Box::new(Self::substitute_trait_impl_self_type(*inner, owner_type)))
+            }
+            IrType::Function { params, ret } => IrType::Function {
+                params: params
+                    .into_iter()
+                    .map(|param| Self::substitute_trait_impl_self_type(param, owner_type))
+                    .collect(),
+                ret: Box::new(Self::substitute_trait_impl_self_type(*ret, owner_type)),
+            },
+            IrType::Ref(inner) => IrType::Ref(Box::new(Self::substitute_trait_impl_self_type(*inner, owner_type))),
+            IrType::RefMut(inner) => {
+                IrType::RefMut(Box::new(Self::substitute_trait_impl_self_type(*inner, owner_type)))
+            }
+            other => other,
+        }
     }
 
     /// Return whether the typechecker proved a body-less rusttype Rust-trait adoption is satisfied by the backing type.
@@ -661,7 +734,57 @@ impl AstLowering {
         let trait_sig = self.lowered_method_signature_for_match(trait_method, &trait_param_names, &subst);
         let empty_subst = std::collections::HashMap::new();
         let candidate_sig = self.lowered_method_signature_for_match(candidate, owner_type_param_names, &empty_subst);
-        trait_sig == candidate_sig
+        trait_sig.0 == candidate_sig.0
+            && trait_sig.1 == candidate_sig.1
+            && Self::trait_impl_type_matches(&trait_sig.2, &candidate_sig.2)
+    }
+
+    /// Compare trait-implementation types after the trait target has replaced its `Self` argument with the adopter
+    /// type.
+    ///
+    /// Concrete implementation methods retain `Self` in their source signature because it remains valid inside the
+    /// generated impl body. At this matching boundary it denotes the same owner as the concrete trait target.
+    fn trait_impl_type_matches(expected: &IrType, actual: &IrType) -> bool {
+        match (expected, actual) {
+            (_, IrType::SelfType) => true,
+            (IrType::List(expected), IrType::List(actual))
+            | (IrType::Set(expected), IrType::Set(actual))
+            | (IrType::Option(expected), IrType::Option(actual))
+            | (IrType::TypeToken(expected), IrType::TypeToken(actual))
+            | (IrType::Ref(expected), IrType::Ref(actual))
+            | (IrType::RefMut(expected), IrType::RefMut(actual)) => Self::trait_impl_type_matches(expected, actual),
+            (IrType::Dict(expected_key, expected_value), IrType::Dict(actual_key, actual_value))
+            | (IrType::Result(expected_key, expected_value), IrType::Result(actual_key, actual_value)) => {
+                Self::trait_impl_type_matches(expected_key, actual_key)
+                    && Self::trait_impl_type_matches(expected_value, actual_value)
+            }
+            (IrType::Tuple(expected), IrType::Tuple(actual))
+            | (IrType::NamedGeneric(_, expected), IrType::NamedGeneric(_, actual)) => {
+                expected.len() == actual.len()
+                    && expected
+                        .iter()
+                        .zip(actual)
+                        .all(|(expected, actual)| Self::trait_impl_type_matches(expected, actual))
+            }
+            (
+                IrType::Function {
+                    params: expected_params,
+                    ret: expected_ret,
+                },
+                IrType::Function {
+                    params: actual_params,
+                    ret: actual_ret,
+                },
+            ) => {
+                expected_params.len() == actual_params.len()
+                    && expected_params
+                        .iter()
+                        .zip(actual_params)
+                        .all(|(expected, actual)| Self::trait_impl_type_matches(expected, actual))
+                    && Self::trait_impl_type_matches(expected_ret, actual_ret)
+            }
+            _ => expected == actual,
+        }
     }
 
     /// Return whether a source-level trait target names the current Rust impl target.
@@ -680,7 +803,11 @@ impl AstLowering {
             .iter()
             .map(|arg| self.lower_type_with_type_params(&arg.node, Some(owner_type_param_names)))
             .collect::<Vec<_>>();
-        lowered_args == trait_type_args
+        lowered_args.len() == trait_type_args.len()
+            && trait_type_args
+                .iter()
+                .zip(&lowered_args)
+                .all(|(expected, actual)| Self::trait_impl_type_matches(expected, actual))
     }
 
     /// Return source-level method names for compiler-known imported traits whose declaration may be unavailable in
@@ -758,9 +885,10 @@ impl AstLowering {
         owner_type_param_names: &std::collections::HashSet<&str>,
         adopted_traits: &[Spanned<ast::TraitBound>],
     ) -> bool {
+        let owner_type_name = self.current_impl_type.clone().unwrap_or_default();
         for trait_ref in adopted_traits {
             for (trait_name, trait_type_args) in
-                self.trait_impl_targets_for_adopted_trait_bound(&trait_ref.node, type_params)
+                self.trait_impl_targets_for_adopted_trait_bound(&trait_ref.node, &owner_type_name, type_params)
             {
                 let Some(trait_decl) = self.trait_decls.get(&trait_name).cloned() else {
                     continue;

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -1713,9 +1713,11 @@ impl AstLowering {
 
                             // Generate trait impls for each trait this model implements
                             for trait_ref in &m.traits {
-                                for (trait_name, trait_type_args) in
-                                    self.trait_impl_targets_for_adopted_trait_bound(&trait_ref.node, &m.type_params)
-                                {
+                                for (trait_name, trait_type_args) in self.trait_impl_targets_for_adopted_trait_bound(
+                                    &trait_ref.node,
+                                    &struct_ir.name,
+                                    &m.type_params,
+                                ) {
                                     match self.lower_trait_impl(TraitImplLoweringInput {
                                         type_name: &struct_ir.name,
                                         type_params: &m.type_params,
@@ -1800,9 +1802,11 @@ impl AstLowering {
 
                             // Generate trait impls for each trait this class implements
                             for trait_ref in &c.traits {
-                                for (trait_name, trait_type_args) in
-                                    self.trait_impl_targets_for_adopted_trait_bound(&trait_ref.node, &c.type_params)
-                                {
+                                for (trait_name, trait_type_args) in self.trait_impl_targets_for_adopted_trait_bound(
+                                    &trait_ref.node,
+                                    &struct_ir.name,
+                                    &c.type_params,
+                                ) {
                                     match self.lower_trait_impl(TraitImplLoweringInput {
                                         type_name: &struct_ir.name,
                                         type_params: &c.type_params,
@@ -1853,9 +1857,11 @@ impl AstLowering {
                             if self.rusttype_forwarding_satisfied_by_alias(&n.name, &trait_ref.node.name) {
                                 continue;
                             }
-                            for (trait_name, trait_type_args) in
-                                self.trait_impl_targets_for_adopted_trait_bound(&trait_ref.node, &n.type_params)
-                            {
+                            for (trait_name, trait_type_args) in self.trait_impl_targets_for_adopted_trait_bound(
+                                &trait_ref.node,
+                                &n.name,
+                                &n.type_params,
+                            ) {
                                 match self.lower_trait_impl(TraitImplLoweringInput {
                                     type_name: &n.name,
                                     type_params: &n.type_params,
@@ -1903,9 +1909,11 @@ impl AstLowering {
                                 }
                             }
                             for trait_ref in &n.traits {
-                                for (trait_name, trait_type_args) in
-                                    self.trait_impl_targets_for_adopted_trait_bound(&trait_ref.node, &n.type_params)
-                                {
+                                for (trait_name, trait_type_args) in self.trait_impl_targets_for_adopted_trait_bound(
+                                    &trait_ref.node,
+                                    &struct_ir.name,
+                                    &n.type_params,
+                                ) {
                                     match self.lower_trait_impl(TraitImplLoweringInput {
                                         type_name: &struct_ir.name,
                                         type_params: &n.type_params,
@@ -1948,9 +1956,11 @@ impl AstLowering {
                         }
 
                         for trait_ref in &e.traits {
-                            for (trait_name, trait_type_args) in
-                                self.trait_impl_targets_for_adopted_trait_bound(&trait_ref.node, &e.type_params)
-                            {
+                            for (trait_name, trait_type_args) in self.trait_impl_targets_for_adopted_trait_bound(
+                                &trait_ref.node,
+                                &enum_ir.name,
+                                &e.type_params,
+                            ) {
                                 match self.lower_trait_impl(TraitImplLoweringInput {
                                     type_name: &enum_ir.name,
                                     type_params: &e.type_params,

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -2130,6 +2130,29 @@ impl TypeChecker {
         }
     }
 
+    /// Substitute call-site `Self` references inside a backend trait-dispatch target.
+    ///
+    /// The selected trait instantiation is carried separately from the method signature. Both must receive the same
+    /// receiver substitution so a source target such as `Index[list[str], Self]` emits `Index<Vec<String>, Box>` at
+    /// the call site rather than an illegal bare Rust `Self`.
+    fn method_dispatch_substituting_call_site_self(
+        &self,
+        dispatch: crate::frontend::typechecker::ResolvedMethodDispatch,
+        receiver: &ResolvedType,
+    ) -> crate::frontend::typechecker::ResolvedMethodDispatch {
+        match dispatch {
+            crate::frontend::typechecker::ResolvedMethodDispatch::Trait { trait_path, type_args } => {
+                crate::frontend::typechecker::ResolvedMethodDispatch::Trait {
+                    trait_path,
+                    type_args: type_args
+                        .into_iter()
+                        .map(|ty| self.substitute_self_in_resolved_type(ty, receiver))
+                        .collect(),
+                }
+            }
+        }
+    }
+
     /// Build formal parameter types and return type for a method call, replacing [`ResolvedType::SelfType`] with the
     /// instantiated receiver.
     ///
@@ -2299,6 +2322,7 @@ impl TypeChecker {
         if viable.is_empty() {
             return candidates.first().map(|candidate| {
                 if let Some(dispatch) = candidate.dispatch.clone() {
+                    let dispatch = self.method_dispatch_substituting_call_site_self(dispatch, receiver_ty);
                     self.type_info
                         .record_resolved_method_call(call_site_span, method, dispatch);
                     let (params, _) = self.method_types_substituting_call_site_self(&candidate.info, receiver_ty);
@@ -2328,6 +2352,7 @@ impl TypeChecker {
         if best.len() == 1 {
             let candidate = best.remove(0);
             if let Some(dispatch) = candidate.dispatch.clone() {
+                let dispatch = self.method_dispatch_substituting_call_site_self(dispatch, receiver_ty);
                 self.type_info
                     .record_resolved_method_call(call_site_span, method, dispatch);
                 let (params, _) = self.method_types_substituting_call_site_self(&candidate.info, receiver_ty);
@@ -2814,7 +2839,16 @@ impl TypeChecker {
                     }
                     ResolvedType::Unknown
                 }
-                _ => ResolvedType::Unknown,
+                _ => {
+                    let receiver_ty = ResolvedType::Generic(name, args);
+                    if let Some(ret) = self.resolve_index_dunder(&receiver_ty, index, &index_ty, span) {
+                        ret
+                    } else {
+                        self.errors
+                            .push(errors::missing_method(&receiver_ty.to_string(), "__getitem__", span));
+                        ResolvedType::Unknown
+                    }
+                }
             },
             ty if matches!(ty, ResolvedType::Str) || is_frozen_str(&ty) => {
                 if !is_intlike_for_index(&index_ty) {

--- a/tests/codegen_snapshot_tests.rs
+++ b/tests/codegen_snapshot_tests.rs
@@ -3218,6 +3218,63 @@ pub def by_index(data: JsonValue) -> Option[JsonValue]:
     );
 }
 
+/// Issue #815: explicit `Index[K, V]` adoption on a generic carrier must produce a Rust trait impl.
+#[test]
+fn test_issue815_generic_index_adoption_emits_trait_impl() {
+    let source = r#"
+from std.traits.indexing import Index
+
+class GenericBox[T with Clone] with Index[str, str]:
+  pub label: str
+  pub witness: list[T]
+
+  def __getitem__(self, key: str) for Index[str, str] -> str:
+    return key
+
+pub def indexed_label[T with Clone](box: GenericBox[T]) -> str:
+  return box["amount"]
+"#;
+    let rust_code = generate_rust(source);
+    let compact = rust_code.chars().filter(|ch| !ch.is_whitespace()).collect::<String>();
+    assert!(
+        compact.contains("impl<T:Clone>Index<String,String>forGenericBox<T>"),
+        "generic Index adoption must emit a parameterized Rust trait impl; generated:\n{rust_code}"
+    );
+    assert!(
+        compact.contains(
+            "crate::__incan_std::traits::indexing::Index::<String,String,>::__getitem__(&r#box,\"amount\".to_string())"
+        ),
+        "generic index access must dispatch through the adopted Index implementation; generated:\n{rust_code}"
+    );
+}
+
+/// Issue #815: `Self` in an adopted Index output must become the concrete carrier in an impl header and call site.
+#[test]
+fn test_issue815_self_returning_index_adoption_uses_owner_type() {
+    let source = r#"
+from std.traits.indexing import Index
+
+class PlainBox with Index[list[str], Self]:
+  pub label: str
+
+  def __getitem__(self, key: list[str]) for Index[list[str], Self] -> Self:
+    return self
+
+pub def nested_box(box: PlainBox) -> PlainBox:
+  return box[["name"]]
+"#;
+    let rust_code = generate_rust(source);
+    let compact = rust_code.chars().filter(|ch| !ch.is_whitespace()).collect::<String>();
+    assert!(
+        compact.contains("implIndex<Vec<String>,PlainBox>forPlainBox"),
+        "Self in an adopted Index target must emit as the owner type; generated:\n{rust_code}"
+    );
+    assert!(
+        compact.contains("Index::<Vec<String>,PlainBox,>::__getitem__(&r#box,vec![\"name\".to_string()])"),
+        "Self-returning index access must use the concrete Index instantiation; generated:\n{rust_code}"
+    );
+}
+
 #[test]
 fn test_enum_multi_instantiation_trait_methods_codegen_trait_impls_only() {
     let source = r#"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7519,6 +7519,13 @@ class PlainBox with Index[list[str], Self]:
     def __getitem__(self, key: list[str]) for Index[list[str], Self] -> Self:
         return self
 
+class GenericSelfBox[T with Clone] with Index[list[str], Self]:
+    pub label: str
+    pub witness: list[T]
+
+    def __getitem__(self, key: list[str]) for Index[list[str], Self] -> Self:
+        return self
+
 def test_generic_index() -> None:
     box = GenericBox[int](label="orders", witness=[1])
     assert_eq(box["amount"], "amount")
@@ -7526,6 +7533,10 @@ def test_generic_index() -> None:
 def test_self_returning_index() -> None:
     box = PlainBox(label="nested")
     assert_eq(box[["name"]].label, "nested")
+
+def test_generic_self_returning_index() -> None:
+    box = GenericSelfBox[int](label="nested-generic", witness=[1])
+    assert_eq(box[["name"]].label, "nested-generic")
 "#,
         );
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7497,6 +7497,47 @@ mod test_runner_e2e {
 
     // ---- Passing test ----
 
+    /// Issue #815: generic and `Self`-returning Index adoptions must compile in the generated test package.
+    #[test]
+    fn e2e_issue815_generic_index_trait_adoptions_compile() {
+        let dir = write_test_project(
+            "test_issue815_generic_index.incn",
+            r#"
+from std.testing import assert_eq
+from std.traits.indexing import Index
+
+class GenericBox[T with Clone] with Index[str, str]:
+    pub label: str
+    pub witness: list[T]
+
+    def __getitem__(self, key: str) for Index[str, str] -> str:
+        return key
+
+class PlainBox with Index[list[str], Self]:
+    pub label: str
+
+    def __getitem__(self, key: list[str]) for Index[list[str], Self] -> Self:
+        return self
+
+def test_generic_index() -> None:
+    box = GenericBox[int](label="orders", witness=[1])
+    assert_eq(box["amount"], "amount")
+
+def test_self_returning_index() -> None:
+    box = PlainBox(label="nested")
+    assert_eq(box[["name"]].label, "nested")
+"#,
+        );
+
+        let output = run_incan_test(&dir);
+        assert!(
+            output.status.success(),
+            "expected issue #815 test package to compile and pass.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
     #[test]
     fn e2e_basic_reporting_decorator_filter_and_capture_share_one_project() {
         let dir = write_test_project(


### PR DESCRIPTION
## Summary

Fixes compiler lowering and trait dispatch for explicit generic `Index[K, V]` adoptions, including `Self` in an adopted trait target. Generic carriers now generate parameterized Rust trait implementations, and index expressions resolve and dispatch through those implementations in generated packages.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `Index[K, V]` can be adopted by generic types, and `Self` can be used as the adopted index output type.
- **Internals**: Lowers adopted trait targets with the concrete implementation owner, substitutes receiver `Self` into dispatch metadata, and resolves generic `__getitem__` access through the trait implementation.
- **Risks**: The matching changes affect adopted generic-trait method selection; regression coverage exercises emitted Rust and generated test-package compilation.

## Testing / verification

- [x] Focused `cargo test --test codegen_snapshot_tests issue815`
- [x] Focused `cargo test --test integration_tests e2e_issue815_generic_index_trait_adoptions_compile -- --nocapture`
- [x] `cargo fmt --check`
- [ ] Repository-wide `make pre-commit` final aggregate (local runner began nextest but did not return an aggregate result)
- [x] Manual verification described below

Manual verification notes:

- Verified parameterized Rust `Index` impl emission for a generic carrier.
- Verified `Self` becomes the concrete owner in the emitted trait target and generated package tests execute successfully.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #815