### PR TITLE
bugfix - preserve declaration-owned vocab clauses (#813)

### DIFF
--- a/crates/incan_syntax/src/ast/stmts.rs
+++ b/crates/incan_syntax/src/ast/stmts.rs
@@ -226,6 +226,11 @@ pub struct SurfaceStmt {
 /// Parser metadata describing how a raw vocab block keyword was resolved.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VocabKeywordBinding {
+    /// Whether the rich imported DSL metadata declares this nested block as a clause owned by its parent declaration.
+    ///
+    /// Low-level keyword surface kinds only select parser entrypoints. The public vocab AST must preserve this richer
+    /// ownership fact so desugaring does not confuse compatibility registrations with nested declarations.
+    pub is_declaration_owned_clause: bool,
     pub dependency_key: String,
     pub activation_namespace: String,
     pub surface_kind: incan_vocab::KeywordSurfaceKind,

--- a/crates/incan_syntax/src/parser/core.rs
+++ b/crates/incan_syntax/src/parser/core.rs
@@ -30,6 +30,7 @@ struct ActiveImportedKeywordSpec {
     surface_kind: incan_vocab::KeywordSurfaceKind,
     placement: incan_vocab::KeywordPlacement,
     desugar_target: incan_vocab::DesugarTarget,
+    is_declaration_owned_clause: bool,
     clause_body_kind: Option<incan_vocab::ClauseBodyKind>,
     expression_item_modifiers: Vec<incan_vocab::ExpressionItemModifierSurface>,
 }
@@ -358,8 +359,9 @@ impl<'a> Parser<'a> {
                 let desugar_target = declaration_surface
                     .map(|declaration| declaration.desugars_to)
                     .unwrap_or(incan_vocab::DesugarTarget::Statements);
-                let (clause_body_kind, expression_item_modifiers) = self
-                    .active_clause_surface_for_keyword(library, keyword)
+                let clause_surface = self.active_clause_surface_for_keyword(library, keyword);
+                let is_declaration_owned_clause = clause_surface.is_some();
+                let (clause_body_kind, expression_item_modifiers) = clause_surface
                     .map(|clause| (Some(clause.body_kind), clause.expression_item_modifiers.clone()))
                     .unwrap_or((None, Vec::new()));
                 let specs = self
@@ -378,6 +380,7 @@ impl<'a> Parser<'a> {
                     surface_kind: keyword.surface_kind,
                     placement: keyword.placement.clone(),
                     desugar_target,
+                    is_declaration_owned_clause,
                     clause_body_kind,
                     expression_item_modifiers,
                 });

--- a/crates/incan_syntax/src/parser/expr.rs
+++ b/crates/incan_syntax/src/parser/expr.rs
@@ -921,6 +921,7 @@ impl<'a> Parser<'a> {
         Ok(VocabBlockStmt {
             keyword: keyword_name,
             keyword_binding: VocabKeywordBinding {
+                is_declaration_owned_clause: spec.is_declaration_owned_clause,
                 dependency_key: spec.dependency_key,
                 activation_namespace: spec.activation_namespace,
                 surface_kind: spec.surface_kind,
@@ -1067,6 +1068,7 @@ impl<'a> Parser<'a> {
         Ok(VocabBlockStmt {
             keyword: keyword_name,
             keyword_binding: VocabKeywordBinding {
+                is_declaration_owned_clause: spec.is_declaration_owned_clause,
                 dependency_key: spec.dependency_key,
                 activation_namespace: spec.activation_namespace,
                 surface_kind: spec.surface_kind,

--- a/crates/incan_syntax/src/parser/stmts.rs
+++ b/crates/incan_syntax/src/parser/stmts.rs
@@ -182,6 +182,7 @@ impl<'a> Parser<'a> {
         let spec_placement = spec.placement.clone();
         let spec_valid_decorators = spec.valid_decorators.clone();
         let spec_clause_body_kind = spec.clause_body_kind;
+        let spec_is_declaration_owned_clause = spec.is_declaration_owned_clause;
         let spec_expression_item_modifiers = spec.expression_item_modifiers.clone();
 
         // Avoid committing to vocab-block parsing unless a top-level header-delimiting `:` is visible ahead. This
@@ -265,6 +266,7 @@ impl<'a> Parser<'a> {
         Ok(Some(Statement::VocabBlock(VocabBlockStmt {
             keyword: keyword_name,
             keyword_binding: VocabKeywordBinding {
+                is_declaration_owned_clause: spec_is_declaration_owned_clause,
                 dependency_key: spec_dependency_key,
                 activation_namespace: spec_activation_namespace,
                 surface_kind: spec_surface_kind,

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -2769,6 +2769,7 @@ def add(a: int, b: int) -> int:
         let raw_vocab_default = spanned(ast::Expr::VocabBlock(Box::new(ast::VocabBlockStmt {
             keyword: "query".to_string(),
             keyword_binding: ast::VocabKeywordBinding {
+                is_declaration_owned_clause: false,
                 dependency_key: "fixture".to_string(),
                 activation_namespace: "fixture".to_string(),
                 surface_kind: incan_vocab::KeywordSurfaceKind::BlockDeclaration,

--- a/src/frontend/vocab_ast_bridge.rs
+++ b/src/frontend/vocab_ast_bridge.rs
@@ -144,9 +144,12 @@ pub fn internal_vocab_block_to_public(
 
 /// Classify one internal statement as a public vocab body item.
 ///
-/// Nested `VocabBlock` nodes do not all mean the same thing. Block-context keywords and sub-block keywords become
-/// `VocabBodyItem::Clause`, while declaration-shaped nested blocks remain full nested declarations. Ordinary
-/// statements are bridged through the public statement model instead.
+/// Nested `VocabBlock` nodes do not all mean the same thing. Blocks owned by a rich declaration's `ClauseSurface`
+/// become `VocabBodyItem::Clause`, while other nested blocks remain full nested declarations. The ownership bit is
+/// carried by parser metadata because low-level keyword surface kinds do not faithfully describe public AST ownership
+/// for compatibility registrations; the historical context/sub-block interpretation remains as a fallback for raw
+/// registrations that do not provide a rich surface. Ordinary statements are bridged through the public statement
+/// model instead.
 ///
 /// # Errors
 ///
@@ -156,10 +159,11 @@ fn internal_statement_to_body_item(
 ) -> Result<incan_vocab::VocabBodyItem, VocabAstBridgeError> {
     match &statement.node {
         ast::Statement::VocabBlock(nested)
-            if matches!(
-                nested.keyword_binding.surface_kind,
-                incan_vocab::KeywordSurfaceKind::BlockContextKeyword | incan_vocab::KeywordSurfaceKind::SubBlock
-            ) =>
+            if nested.keyword_binding.is_declaration_owned_clause
+                || matches!(
+                    nested.keyword_binding.surface_kind,
+                    incan_vocab::KeywordSurfaceKind::BlockContextKeyword | incan_vocab::KeywordSurfaceKind::SubBlock
+                ) =>
         {
             Ok(incan_vocab::VocabBodyItem::Clause(internal_vocab_clause_to_public(
                 nested,
@@ -177,8 +181,9 @@ fn internal_statement_to_body_item(
 
 /// Convert one nested internal vocab block into a public clause.
 ///
-/// Clauses reuse the same parsed `VocabBlockStmt` carrier as declarations on the internal side. The surface kind on
-/// the keyword binding decides that this block should be interpreted as clause syntax instead of a nested declaration.
+/// Clauses reuse the same parsed `VocabBlockStmt` carrier as declarations on the internal side. Rich declaration
+/// ownership metadata decides that this block should be interpreted as clause syntax instead of a nested declaration;
+/// legacy block-context and sub-block registrations retain their existing clause interpretation.
 ///
 /// # Errors
 ///
@@ -1197,6 +1202,7 @@ mod tests {
 
     fn default_keyword_binding(surface_kind: incan_vocab::KeywordSurfaceKind) -> ast::VocabKeywordBinding {
         ast::VocabKeywordBinding {
+            is_declaration_owned_clause: false,
             dependency_key: "demo".to_string(),
             activation_namespace: "demo.dsl".to_string(),
             surface_kind,
@@ -1208,6 +1214,7 @@ mod tests {
 
     fn expression_list_clause_binding() -> ast::VocabKeywordBinding {
         ast::VocabKeywordBinding {
+            is_declaration_owned_clause: true,
             surface_kind: incan_vocab::KeywordSurfaceKind::BlockContextKeyword,
             placement: incan_vocab::KeywordPlacement::in_block(["query"]),
             clause_body_kind: Some(incan_vocab::ClauseBodyKind::ExpressionList),
@@ -1251,6 +1258,76 @@ mod tests {
                 return Err(format!("expected clause body item, got {other:?}").into());
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn bridges_owned_clause_even_when_compatibility_metadata_uses_block_declaration()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let clause_block = ast::VocabBlockStmt {
+            keyword: "FROM".to_string(),
+            keyword_binding: ast::VocabKeywordBinding {
+                is_declaration_owned_clause: true,
+                placement: incan_vocab::KeywordPlacement::in_block(["query"]),
+                ..default_keyword_binding(incan_vocab::KeywordSurfaceKind::BlockDeclaration)
+            },
+            decorators: Vec::new(),
+            header_args: Vec::new(),
+            body: vec![ast::Spanned::new(
+                ast::Statement::Expr(ast::Spanned::new(
+                    ast::Expr::Ident("orders".to_string()),
+                    ast::Span::default(),
+                )),
+                ast::Span::default(),
+            )],
+            body_item_trailing_commas: vec![false],
+        };
+        let window_clause_block = ast::VocabBlockStmt {
+            keyword: "WINDOW".to_string(),
+            keyword_binding: ast::VocabKeywordBinding {
+                is_declaration_owned_clause: true,
+                placement: incan_vocab::KeywordPlacement::in_block(["query"]),
+                ..default_keyword_binding(incan_vocab::KeywordSurfaceKind::BlockDeclaration)
+            },
+            decorators: Vec::new(),
+            header_args: Vec::new(),
+            body: Vec::new(),
+            body_item_trailing_commas: Vec::new(),
+        };
+        let declaration_block = ast::VocabBlockStmt {
+            keyword: "query".to_string(),
+            keyword_binding: default_keyword_binding(incan_vocab::KeywordSurfaceKind::BlockDeclaration),
+            decorators: Vec::new(),
+            header_args: Vec::new(),
+            body: vec![
+                ast::Spanned::new(ast::Statement::VocabBlock(clause_block), ast::Span::default()),
+                ast::Spanned::new(
+                    ast::Statement::Expr(ast::Spanned::new(
+                        ast::Expr::Ident("retained".to_string()),
+                        ast::Span::default(),
+                    )),
+                    ast::Span::default(),
+                ),
+                ast::Spanned::new(ast::Statement::VocabBlock(window_clause_block), ast::Span::default()),
+            ],
+            body_item_trailing_commas: vec![false, false, false],
+        };
+
+        let bridged = internal_vocab_block_to_public(&declaration_block, ast::Span::default())?;
+        let [
+            incan_vocab::VocabBodyItem::Clause(clause),
+            incan_vocab::VocabBodyItem::Statement(_),
+            incan_vocab::VocabBodyItem::Clause(window),
+        ] = bridged.body.as_slice()
+        else {
+            return Err(format!("expected an owned clause, got {:?}", bridged.body).into());
+        };
+        assert_eq!(clause.keyword, "FROM");
+        assert_eq!(
+            clause.body,
+            incan_vocab::VocabClauseBody::Expression(incan_vocab::IncanExpr::Name("orders".to_string()))
+        );
+        assert_eq!(window.keyword, "WINDOW");
         Ok(())
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -12044,6 +12044,65 @@ pub def display[T](data: DataSet[T]) -> None:
         Ok(())
     }
 
+    /// Write a package whose rich clause ownership disagrees with legacy low-level keyword surface kinds.
+    ///
+    /// This preserves the compatibility shape used by existing vocab packages: parser activation still receives raw
+    /// keyword registrations, while the richer `DslSurface` is the authority on which nested blocks are clauses.
+    fn write_pub_library_with_mixed_expression_clause_desugarer(
+        root: &Path,
+        desugarer_bytes: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let artifact_root = root.join("deps").join("querykit").join("target").join("lib");
+        std::fs::create_dir_all(artifact_root.join("desugarers"))?;
+        write_minimal_library_crate(&artifact_root, "querykit_core")?;
+        let desugarer_path = artifact_root.join("desugarers").join("querykit_desugarer.wasm");
+        std::fs::write(&desugarer_path, desugarer_bytes)?;
+
+        let metadata = incan_vocab::VocabRegistration::new()
+            .with_keyword_registration(incan_vocab::KeywordRegistration {
+                activation: incan_vocab::KeywordActivation::OnImport {
+                    namespace: "querykit.query".to_string(),
+                },
+                keywords: vec![
+                    incan_vocab::KeywordSpec::block("query"),
+                    incan_vocab::KeywordSpec::block("FROM").in_block("query"),
+                    incan_vocab::KeywordSpec::block("WINDOW").in_block("query"),
+                ],
+                valid_decorators: Vec::new(),
+            })
+            .with_surface(
+                incan_vocab::DslSurface::on_import("querykit.query").with_declaration(
+                    incan_vocab::DeclarationSurface::named("query")
+                        .with_mixed_body()
+                        .desugars_to_expression()
+                        .with_clauses([
+                            incan_vocab::ClauseSurface::expr("FROM").required(),
+                            incan_vocab::ClauseSurface::nested_items("WINDOW").optional(),
+                        ]),
+                ),
+            )
+            .metadata();
+        let mut manifest = LibraryManifest::new("querykit_core", "0.1.0");
+        manifest.vocab = Some(incan::library_manifest::VocabExports {
+            crate_path: "vocab_companion".to_string(),
+            package_name: "vocab_companion".to_string(),
+            keyword_registrations: metadata.keyword_registrations,
+            dsl_surfaces: metadata.dsl_surfaces,
+            provider_manifest: incan_vocab::LibraryManifest::default(),
+            desugarer_artifact: Some(incan::library_manifest::VocabDesugarerArtifact {
+                artifact_kind: incan_vocab::DesugarerArtifactKind::WasmModule,
+                abi_version: incan_vocab::WASM_DESUGAR_ABI_VERSION,
+                relative_path: "desugarers/querykit_desugarer.wasm".to_string(),
+                target: "wasm32-wasip1".to_string(),
+                profile: "release".to_string(),
+                entrypoint: "desugar_block".to_string(),
+                sha256: hex::encode(Sha256::digest(desugarer_bytes)),
+            }),
+        });
+        manifest.write_to_path(&artifact_root.join("querykit_core.incnlib"))?;
+        Ok(())
+    }
+
     fn write_pub_library_with_vocab_desugarer_and_filter_helper(
         root: &Path,
         dependency_key: &str,
@@ -14604,6 +14663,85 @@ def test_dependency_vocab_query_block() -> None:
         assert!(
             test_output.status.success(),
             "expected incan test to parse and run dependency-activated vocab in a test file.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&test_output.stdout),
+            String::from_utf8_lossy(&test_output.stderr)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn consumer_build_and_test_desugars_mixed_expression_vocab_clauses_issue813()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let response = incan_vocab::DesugarResponse::expression(incan_vocab::IncanExpr::Int(7));
+        let output_payload = serde_json::to_string(&response)?;
+        let wasm = compile_desugarer_wasm_requiring_request_substring(
+            &output_payload,
+            "mixed expression vocab body did not expose FROM as a clause",
+            r#""body":[{"Clause":{"keyword":"FROM""#,
+        )?;
+        write_pub_library_with_mixed_expression_clause_desugarer(tmp.path(), &wasm)?;
+
+        let main_path = write_project_files(
+            tmp.path(),
+            "[project]\nname = \"consumer\"\n\n[dependencies]\nquerykit = { path = \"deps/querykit\" }\n",
+            r#"import pub::querykit
+
+def main() -> None:
+  selected: int = query:
+    FROM:
+      42
+    let retained = 1
+    WINDOW:
+      marker = retained
+  assert selected == 7
+"#,
+        )?;
+        let tests_dir = tmp.path().join("tests");
+        std::fs::create_dir_all(&tests_dir)?;
+        let test_path = tests_dir.join("test_mixed_query.incn");
+        std::fs::write(
+            &test_path,
+            r#"import pub::querykit
+
+def test_mixed_expression_vocab_result() -> None:
+  selected: int = query:
+    FROM:
+      42
+    let retained = 1
+    WINDOW:
+      marker = retained
+  assert selected == 7
+"#,
+        )?;
+
+        let check_output = run_check(&main_path)?;
+        assert!(
+            check_output.status.success(),
+            "expected mixed expression vocab declaration to typecheck.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&check_output.stdout),
+            String::from_utf8_lossy(&check_output.stderr)
+        );
+
+        let out_dir = tmp.path().join("out");
+        let build_output = run_build(&main_path, &out_dir)?;
+        let generated_main = std::fs::read_to_string(out_dir.join("src/main.rs"))?;
+        assert!(
+            build_output.status.success(),
+            "expected generated Rust build for the mixed expression vocab declaration to succeed.\ngenerated main.rs:\n{}\nstdout:\n{}\nstderr:\n{}",
+            generated_main,
+            String::from_utf8_lossy(&build_output.stdout),
+            String::from_utf8_lossy(&build_output.stderr)
+        );
+        assert!(
+            generated_main.contains("selected"),
+            "expected generated Rust to retain the desugared typed assignment.\ngenerated main.rs:\n{generated_main}"
+        );
+
+        let test_output = run_test(&test_path)?;
+        assert!(
+            test_output.status.success(),
+            "expected incan test to execute a typed result from the mixed expression vocab declaration.\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&test_output.stdout),
             String::from_utf8_lossy(&test_output.stderr)
         );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -12044,11 +12044,11 @@ pub def display[T](data: DataSet[T]) -> None:
         Ok(())
     }
 
-    /// Write a package whose rich clause ownership disagrees with legacy low-level keyword surface kinds.
+    /// Write a package whose rich quality-clause ownership disagrees with legacy low-level keyword surface kinds.
     ///
     /// This preserves the compatibility shape used by existing vocab packages: parser activation still receives raw
     /// keyword registrations, while the richer `DslSurface` is the authority on which nested blocks are clauses.
-    fn write_pub_library_with_mixed_expression_clause_desugarer(
+    fn write_pub_library_with_mixed_quality_clause_desugarer(
         root: &Path,
         desugarer_bytes: &[u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -12064,22 +12064,40 @@ pub def display[T](data: DataSet[T]) -> None:
                     namespace: "querykit.query".to_string(),
                 },
                 keywords: vec![
-                    incan_vocab::KeywordSpec::block("query"),
-                    incan_vocab::KeywordSpec::block("FROM").in_block("query"),
-                    incan_vocab::KeywordSpec::block("WINDOW").in_block("query"),
+                    incan_vocab::KeywordSpec::block("quality"),
+                    incan_vocab::KeywordSpec::block("FROM").in_block("quality"),
+                    incan_vocab::KeywordSpec::block("REQUIRE").in_block("quality"),
+                    incan_vocab::KeywordSpec::block("GROUP")
+                        .with_compound_tokens(["BY"])
+                        .in_block("quality"),
+                    incan_vocab::KeywordSpec::block("EXPECT").in_block("quality"),
                 ],
                 valid_decorators: Vec::new(),
             })
             .with_surface(
-                incan_vocab::DslSurface::on_import("querykit.query").with_declaration(
-                    incan_vocab::DeclarationSurface::named("query")
-                        .with_mixed_body()
-                        .desugars_to_expression()
-                        .with_clauses([
-                            incan_vocab::ClauseSurface::expr("FROM").required(),
-                            incan_vocab::ClauseSurface::nested_items("WINDOW").optional(),
-                        ]),
-                ),
+                incan_vocab::DslSurface::on_import("querykit.query")
+                    .with_declaration(
+                        incan_vocab::DeclarationSurface::named("quality")
+                            .with_mixed_body()
+                            .desugars_to_expression()
+                            .with_clauses([
+                                incan_vocab::ClauseSurface::expr("FROM").optional(),
+                                incan_vocab::ClauseSurface::expr_list("GROUP BY")
+                                    .repeating()
+                                    .after("FROM"),
+                                incan_vocab::ClauseSurface::expr_list("EXPECT")
+                                    .repeating()
+                                    .after("FROM"),
+                                incan_vocab::ClauseSurface::expr_list("REQUIRE")
+                                    .repeating()
+                                    .after("FROM"),
+                            ]),
+                    )
+                    .with_scoped_surface(
+                        incan_vocab::ScopedSurfaceDescriptor::leading_dot_path("quality.group.field")
+                            .in_clause_body("quality", "GROUP")
+                            .with_receiver(incan_vocab::ScopedSurfaceReceiver::clause("FROM")),
+                    ),
             )
             .metadata();
         let mut manifest = LibraryManifest::new("querykit_core", "0.1.0");
@@ -14670,17 +14688,17 @@ def test_dependency_vocab_query_block() -> None:
     }
 
     #[test]
-    fn consumer_build_and_test_desugars_mixed_expression_vocab_clauses_issue813()
+    fn consumer_build_and_test_desugars_quality_expression_vocab_clauses_issue813()
     -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;
         let response = incan_vocab::DesugarResponse::expression(incan_vocab::IncanExpr::Int(7));
         let output_payload = serde_json::to_string(&response)?;
         let wasm = compile_desugarer_wasm_requiring_request_substring(
             &output_payload,
-            "mixed expression vocab body did not expose FROM as a clause",
-            r#""body":[{"Clause":{"keyword":"FROM""#,
+            "quality expression vocab body did not expose EXPECT as a clause",
+            r#""keyword":"EXPECT""#,
         )?;
-        write_pub_library_with_mixed_expression_clause_desugarer(tmp.path(), &wasm)?;
+        write_pub_library_with_mixed_quality_clause_desugarer(tmp.path(), &wasm)?;
 
         let main_path = write_project_files(
             tmp.path(),
@@ -14688,37 +14706,37 @@ def test_dependency_vocab_query_block() -> None:
             r#"import pub::querykit
 
 def main() -> None:
-  selected: int = query:
-    FROM:
-      42
-    let retained = 1
-    WINDOW:
-      marker = retained
-  assert selected == 7
+    checks: int = quality {
+        FROM orders
+        REQUIRE row_count() >= 1 as non_empty_orders
+        GROUP BY .customer_id
+        EXPECT count() >= 1 as customer_groups_present
+    }
+    assert checks == 7
 "#,
         )?;
         let tests_dir = tmp.path().join("tests");
         std::fs::create_dir_all(&tests_dir)?;
-        let test_path = tests_dir.join("test_mixed_query.incn");
+        let test_path = tests_dir.join("test_quality.incn");
         std::fs::write(
             &test_path,
             r#"import pub::querykit
 
-def test_mixed_expression_vocab_result() -> None:
-  selected: int = query:
-    FROM:
-      42
-    let retained = 1
-    WINDOW:
-      marker = retained
-  assert selected == 7
+def test_quality_expression_vocab_result() -> None:
+    checks: int = quality {
+        FROM orders
+        REQUIRE row_count() >= 1 as non_empty_orders
+        GROUP BY .customer_id
+        EXPECT count() >= 1 as customer_groups_present
+    }
+    assert checks == 7
 "#,
         )?;
 
         let check_output = run_check(&main_path)?;
         assert!(
             check_output.status.success(),
-            "expected mixed expression vocab declaration to typecheck.\nstdout:\n{}\nstderr:\n{}",
+            "expected quality expression vocab declaration to typecheck.\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&check_output.stdout),
             String::from_utf8_lossy(&check_output.stderr)
         );
@@ -14728,23 +14746,68 @@ def test_mixed_expression_vocab_result() -> None:
         let generated_main = std::fs::read_to_string(out_dir.join("src/main.rs"))?;
         assert!(
             build_output.status.success(),
-            "expected generated Rust build for the mixed expression vocab declaration to succeed.\ngenerated main.rs:\n{}\nstdout:\n{}\nstderr:\n{}",
+            "expected generated Rust build for the quality expression vocab declaration to succeed.\ngenerated main.rs:\n{}\nstdout:\n{}\nstderr:\n{}",
             generated_main,
             String::from_utf8_lossy(&build_output.stdout),
             String::from_utf8_lossy(&build_output.stderr)
         );
         assert!(
-            generated_main.contains("selected"),
+            generated_main.contains("checks"),
             "expected generated Rust to retain the desugared typed assignment.\ngenerated main.rs:\n{generated_main}"
         );
 
         let test_output = run_test(&test_path)?;
         assert!(
             test_output.status.success(),
-            "expected incan test to execute a typed result from the mixed expression vocab declaration.\nstdout:\n{}\nstderr:\n{}",
+            "expected incan test to execute a typed result from the quality expression vocab declaration.\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&test_output.stdout),
             String::from_utf8_lossy(&test_output.stderr)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn consumer_check_desugars_each_quality_clause_issue813() -> Result<(), Box<dyn std::error::Error>> {
+        for (clause, request_fragment) in [
+            ("FROM", r#""keyword":"FROM""#),
+            ("REQUIRE", r#""keyword":"REQUIRE""#),
+            ("GROUP BY", r#""keyword":"GROUP","compound_tokens":["BY"]"#),
+            ("EXPECT", r#""keyword":"EXPECT""#),
+        ] {
+            let tmp = tempfile::tempdir()?;
+            let response = incan_vocab::DesugarResponse::expression(incan_vocab::IncanExpr::Int(7));
+            let output_payload = serde_json::to_string(&response)?;
+            let wasm = compile_desugarer_wasm_requiring_request_substring(
+                &output_payload,
+                &format!("quality expression vocab body did not expose {clause} as a clause"),
+                request_fragment,
+            )?;
+            write_pub_library_with_mixed_quality_clause_desugarer(tmp.path(), &wasm)?;
+
+            let main_path = write_project_files(
+                tmp.path(),
+                "[project]\nname = \"consumer\"\n\n[dependencies]\nquerykit = { path = \"deps/querykit\" }\n",
+                r#"import pub::querykit
+
+def main() -> None:
+    checks: int = quality {
+        FROM orders
+        REQUIRE row_count() >= 1 as non_empty_orders
+        GROUP BY .customer_id
+        EXPECT count() >= 1 as customer_groups_present
+    }
+    assert checks == 7
+"#,
+            )?;
+
+            let check_output = run_check(&main_path)?;
+            assert!(
+                check_output.status.success(),
+                "expected quality expression vocab declaration to expose {clause} to the desugarer.\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&check_output.stdout),
+                String::from_utf8_lossy(&check_output.stderr)
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Fixes vocabulary desugaring when compatibility keyword registrations describe nested blocks as declarations but the imported rich DSL surface declares them as clauses. The parser carries declaration-owned clause metadata into the public vocabulary AST, so desugarers receive the intended clause structure.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates docs/RFCs/*)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Imported vocabulary packages can use compatibility registrations without losing rich declaration-clause routing during desugaring.
- **Internals**: Adds a parser-owned is_declaration_owned_clause bit and uses it as the public AST bridge authority, retaining the legacy surface-kind fallback for raw registrations.
- **Risks**: Imported DSL parsing and desugarer inputs change only where rich clause metadata explicitly applies. The regression mirrors the InQL quality vocabulary shape, including the declared GROUP BY leading-dot field surface.

## Testing / verification

- [x] cargo fmt --check
- [x] cargo test vocab_ast_bridge
- [x] cargo test --test integration_tests issue813 -- --nocapture
- [x] make pre-commit

Manual verification notes:

- The regression builds a consumer package, typechecks it, builds generated Rust, and executes an Incan test using the InQL quality form: quality with FROM, REQUIRE, GROUP BY .customer_id, and EXPECT.
- The public WASM vocabulary desugarer independently rejects a request missing each of FROM, REQUIRE, GROUP BY, or EXPECT, proving all four arrive as clause items.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #813