### PR TITLE
bugfix - preserve Into-bound string method inference (#804)

### DIFF
--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -119,6 +119,8 @@ impl RustItemMetadata {
 pub enum MetadataFreeMethodArgBorrowPolicy {
     Shared,
     Mutable,
+    /// Preserve string literals as `&str` and adapt owned Incan strings with `.as_str()`.
+    StringAsStr,
 }
 
 /// Receiver class used by metadata-free external method compatibility policy.
@@ -126,6 +128,7 @@ pub enum MetadataFreeMethodArgBorrowPolicy {
 pub enum MetadataFreeReceiverClass {
     IoValue,
     EncodingInstance,
+    TokenizerInstance,
     ExternalAssociated,
 }
 
@@ -212,6 +215,12 @@ pub const METADATA_FREE_METHOD_BORROW_RULES: &[MetadataFreeMethodBorrowRule] = &
         receiver: MetadataFreeReceiverClass::EncodingInstance,
         arg: MetadataFreeArgClass::Any,
         policy: MetadataFreeMethodArgBorrowPolicy::Shared,
+    },
+    MetadataFreeMethodBorrowRule {
+        methods: &["encode"],
+        receiver: MetadataFreeReceiverClass::TokenizerInstance,
+        arg: MetadataFreeArgClass::StringBuffer,
+        policy: MetadataFreeMethodArgBorrowPolicy::StringAsStr,
     },
     MetadataFreeMethodBorrowRule {
         methods: &["decode"],

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -468,6 +468,16 @@ impl<'a> IrEmitter<'a> {
                             quote! { &#emitted }
                         }
                         MetadataFreeMethodArgBorrowPolicy::Mutable => quote! { &mut #emitted },
+                        MetadataFreeMethodArgBorrowPolicy::StringAsStr
+                            if !matches!(
+                                arg.kind,
+                                IrExprKind::String(_)
+                                    | IrExprKind::Literal(super::super::super::expr::Literal::StaticStr(_))
+                            ) =>
+                        {
+                            quote! { (#emitted).as_str() }
+                        }
+                        MetadataFreeMethodArgBorrowPolicy::StringAsStr => emitted,
                         MetadataFreeMethodArgBorrowPolicy::Shared => emitted,
                     };
                 }
@@ -525,6 +535,9 @@ impl<'a> IrEmitter<'a> {
             MetadataFreeReceiverClass::IoValue => Self::receiver_allows_io_method_fallback(receiver),
             MetadataFreeReceiverClass::EncodingInstance => {
                 Self::receiver_type_matches_any(receiver, &["Encoding", "encoding_rs::Encoding"])
+            }
+            MetadataFreeReceiverClass::TokenizerInstance => {
+                Self::receiver_type_matches_any(receiver, &["Tokenizer", "tokenizers::Tokenizer"])
             }
             MetadataFreeReceiverClass::ExternalAssociated => Self::is_external_associated_receiver(receiver),
         }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -5419,6 +5419,85 @@ def main() -> None:
 }
 
 #[test]
+fn build_metadata_free_into_bound_tokenizer_encode_issue804() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let helper_dir = tmp.path().join("rust").join("tokenizers");
+    fs::create_dir_all(helper_dir.join("src"))?;
+    fs::write(
+        helper_dir.join("Cargo.toml"),
+        "[package]\nname = \"tokenizers\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(
+        helper_dir.join("src").join("lib.rs"),
+        r#"pub struct Tokenizer;
+
+pub struct EncodeInput<'a>(&'a str);
+
+impl<'a> From<&'a str> for EncodeInput<'a> {
+    fn from(value: &'a str) -> Self {
+        Self(value)
+    }
+}
+
+impl Tokenizer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn encode<'a, E>(&self, value: E, _add_special_tokens: bool) -> Result<(), ()>
+    where
+        E: Into<EncodeInput<'a>>,
+    {
+        let _ = value.into();
+        Ok(())
+    }
+}
+"#,
+    )?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "metadata_free_into_bound_tokenizer_encode_issue804",
+        r#"
+[rust-dependencies]
+tokenizers = { path = "rust/tokenizers" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::tokenizers import Tokenizer
+
+def main() -> None:
+    tokenizer = Tokenizer.new()
+    literal = tokenizer.encode("literal", False)
+    text = "variable"
+    variable = tokenizer.encode(text, False)
+"#,
+    )?;
+
+    let build_output = run_incan(
+        tmp.path(),
+        &["build", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(
+        &build_output,
+        "incan build for metadata-free Into-bound tokenizer encode issue804",
+    );
+    let generated = fs::read_to_string(
+        tmp.path()
+            .join("target/incan/metadata_free_into_bound_tokenizer_encode_issue804/src/main.rs"),
+    )?;
+    assert!(
+        generated.contains("tokenizer.encode(\"literal\", false)"),
+        "literal must preserve its direct &str shape, got:\n{generated}"
+    );
+    assert!(
+        generated.contains("tokenizer.encode((text).as_str(), false)"),
+        "owned Incan strings must become &str for the Into-bound method, got:\n{generated}"
+    );
+    Ok(())
+}
+
+#[test]
 fn build_public_alias_of_imported_item_reexports_original_path_issue617() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "public_alias_import_reexport", "")?;

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -15,8 +15,8 @@
     {
       "path": "crates/incan_core/src/interop/metadata.rs",
       "category": "registry-backed Rust collection metadata policy and shared Rust type-shape parsing",
-      "expected_count": 23,
-      "expected_fingerprint": "0xa552cf64d66c9211"
+      "expected_count": 24,
+      "expected_fingerprint": "0xac5e63fe6457433b"
     },
     {
       "path": "crates/rust_inspect/src/cache.rs",


### PR DESCRIPTION
## Summary

This fixes ambiguous Rust Into-bound method calls such as Tokenizer.encode when an Incan string is passed. The compiler now preserves the inference-friendly argument shape: literals remain direct string literals, while non-literal string values are borrowed as str.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates docs/RFCs/*)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Rust interop calls to supported Into-bound APIs now compile for both literal and variable Incan strings without an ambiguous .into conversion.
- **Internals**: Adds a narrow metadata-free tokenizer receiver rule and an argument-borrow policy that emits as_str for non-literal strings. The semantic-string audit records the intentional registry expansion.
- **Risks**: The rule is limited to tokenizers.Tokenizer.encode, so other Rust method calls retain their current conversion behavior.

## Testing / verification

- [x] make test / cargo test
- [x] make examples (covered by the full pre-commit smoke gate)
- [x] incan fmt --check .
- [x] Manual verification described below

Manual verification notes:

- Added the local tokenizers compatibility fixture for literal and variable string arguments.
- Reproduced the real tokenizers 0.23.1 signature before and after the fix.
- Ran cargo test --test cli_integration build_metadata_free_into_bound_tokenizer_encode_issue804.
- Ran make smoke-test and make pre-commit.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #804