### PR TITLE
bugfix - preserve Rust FnMut slice callback parameters (#835)

### DIFF
--- a/src/backend/ir/emit/decls/functions.rs
+++ b/src/backend/ir/emit/decls/functions.rs
@@ -363,6 +363,14 @@ impl<'a> IrEmitter<'a> {
         if !self.needs_borrowed_function_adapter(&func.name, indices) {
             return Ok(None);
         }
+        if indices.iter().all(|index| {
+            func.params.get(*index).is_some_and(|param| {
+                matches!(param.ty, IrType::Ref(_) | IrType::RefMut(_))
+                    || matches!(&param.ty, IrType::RustDisplay(display) if display.trim_start().starts_with('&'))
+            })
+        }) {
+            return Ok(None);
+        }
         let helper_name = Self::borrowed_function_adapter_name(&func.name, indices);
         let Some(helper) = Self::borrowed_function_clone(func, helper_name, indices) else {
             return Ok(None);

--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -42,8 +42,36 @@ impl<'a> IrEmitter<'a> {
         else {
             return None;
         };
-        if !matches!(arg.ty, IrType::Function { .. }) || !self.needs_borrowed_function_adapter(name, &borrowed_indices)
-        {
+        let IrType::Function {
+            params: source_params, ..
+        } = &arg.ty
+        else {
+            return None;
+        };
+        // A source callback that already spells the required borrow must be passed directly. The adapter is only for
+        // changing an owned source parameter into an immutable borrow; creating one for an existing borrow would
+        // either be redundant or leave a helper that cannot be emitted.
+        let function_param_is_borrowed = |ty: &IrType| {
+            matches!(ty, IrType::Ref(_) | IrType::RefMut(_))
+                || matches!(ty, IrType::RustDisplay(display) if display.trim_start().starts_with('&'))
+        };
+        let source_already_borrows = self
+            .function_registry
+            .get(name)
+            .map(|signature| {
+                borrowed_indices.iter().all(|index| {
+                    signature
+                        .params
+                        .get(*index)
+                        .is_some_and(|param| function_param_is_borrowed(&param.ty))
+                })
+            })
+            .unwrap_or_else(|| {
+                borrowed_indices
+                    .iter()
+                    .all(|index| source_params.get(*index).is_some_and(function_param_is_borrowed))
+            });
+        if source_already_borrows || !self.needs_borrowed_function_adapter(name, &borrowed_indices) {
             return None;
         }
         let helper_name = Self::borrowed_function_adapter_name(name, &borrowed_indices);

--- a/src/backend/ir/lower/decl/functions.rs
+++ b/src/backend/ir/lower/decl/functions.rs
@@ -357,6 +357,13 @@ impl AstLowering {
     ) -> Result<IrFunction, LoweringError> {
         self.push_scope();
 
+        let rust_callback_param_displays = self
+            .type_info
+            .as_ref()
+            .and_then(|info| info.rust.function_param_type_displays.get(&f.name))
+            .filter(|displays| displays.len() == f.params.len())
+            .cloned();
+
         let type_param_names: std::collections::HashSet<&str> =
             f.type_params.iter().map(|tp| tp.name.as_str()).collect();
         let mut hidden_type_params = Vec::new();
@@ -365,7 +372,8 @@ impl AstLowering {
         let mut params: Vec<FunctionParam> = f
             .params
             .iter()
-            .map(|p| {
+            .enumerate()
+            .map(|(index, p)| {
                 let base_ty = self.lower_callable_param_type(
                     &p.node.ty.node,
                     Some(&type_param_names),
@@ -386,7 +394,12 @@ impl AstLowering {
                 }
                 Ok(FunctionParam {
                     name: p.node.name.clone(),
-                    ty: param_ty, // Store the emitted parameter type (emit will add &mut for mutable params)
+                    ty: rust_callback_param_displays
+                        .as_ref()
+                        .and_then(|displays| displays.get(index))
+                        .map(|display| IrType::RustDisplay(display.clone()))
+                        .unwrap_or(param_ty), /* Store the emitted parameter type (emit will add &mut for mutable
+                                               * params) */
                     mutability: if p.node.is_mut {
                         Mutability::Mutable
                     } else {

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -27,6 +27,98 @@ struct RustCallArgBinding<'a> {
 }
 
 impl TypeChecker {
+    /// Remove an invalid namespace prefix from a Rust slice display.
+    ///
+    /// Some rust-analyzer callback-bound displays report `crate::[T]` (or its already-expanded
+    /// `dependency::[T]` form). Rust slices are never namespaced; retaining that prefix makes generated Rust invalid.
+    fn strip_invalid_rust_slice_namespace(display: &str) -> String {
+        let mut normalized = String::with_capacity(display.len());
+        let mut remaining = display;
+        while let Some(index) = remaining.find("::[") {
+            let before = &remaining[..index];
+            let prefix_start = before
+                .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == ':'))
+                .map_or(0, |index| index + 1);
+            normalized.push_str(&before[..prefix_start]);
+            normalized.push('[');
+            remaining = &remaining[index + "::[".len()..];
+        }
+        normalized.push_str(remaining);
+        normalized
+    }
+
+    /// Return the exact Rust input displays carried by a callable bound.
+    ///
+    /// The resolved Incan function type preserves ownership semantics for checking, but it cannot distinguish a
+    /// borrowed slice from a borrowed `Vec`. Emission needs the original Rust spelling for callback parameters.
+    fn rust_callable_param_displays_from_bound(&self, rust_ty: &str) -> Option<Vec<String>> {
+        let body = Self::rust_callable_bound_body(rust_ty)?;
+        let body = body
+            .strip_prefix("std::ops::")
+            .or_else(|| body.strip_prefix("core::ops::"))
+            .unwrap_or(body);
+        let after_name = ["FnOnce", "FnMut", "Fn"]
+            .into_iter()
+            .find_map(|name| body.strip_prefix(name))?
+            .trim_start();
+        let args_end = Self::rust_callable_args_end(after_name)?;
+        if !after_name.starts_with('(') {
+            return None;
+        }
+        Some(
+            Self::split_top_level_generic_args(&after_name[1..args_end])
+                .into_iter()
+                // Keep the token boundary after `mut`: `&mut[f32]` is not valid Rust even though it is useful for
+                // type-display comparisons. These strings are emitted as Rust parameter types.
+                .map(|display| {
+                    let display = Self::rust_display_without_lifetimes(display);
+                    Self::strip_invalid_rust_slice_namespace(display.trim())
+                })
+                .collect(),
+        )
+    }
+
+    /// Preserve exact callable parameter displays for an inline closure or a direct named source function.
+    fn record_rust_callable_parameter_displays(
+        &mut self,
+        rust_type_display: &str,
+        owner_path: &str,
+        arg_expr: &Spanned<Expr>,
+        arg_ty: &ResolvedType,
+    ) {
+        let display = self.rust_display_for_owner_path(rust_type_display, owner_path);
+        let Some(param_displays) = self.rust_callable_param_displays_from_bound(display.as_str()) else {
+            return;
+        };
+        let ResolvedType::Function(params, _) = arg_ty else {
+            return;
+        };
+        if params.len() != param_displays.len()
+            || !params.iter().zip(&param_displays).all(|(param, display)| {
+                self.types_compatible(&param.ty, &self.resolved_param_type_from_rust_display(display))
+            })
+        {
+            return;
+        }
+
+        match &arg_expr.node {
+            Expr::Closure(_, _) => {
+                self.type_info
+                    .rust
+                    .closure_param_type_displays
+                    .insert((arg_expr.span.start, arg_expr.span.end), param_displays);
+            }
+            Expr::Ident(name) => {
+                self.type_info
+                    .rust
+                    .function_param_type_displays
+                    .entry(name.clone())
+                    .or_insert(param_displays);
+            }
+            _ => {}
+        }
+    }
+
     /// Reuse already-prepared metadata for Rust path types returned by inspected Rust calls.
     ///
     /// Chained registry APIs often return helper types that users never import directly. When metadata for those types
@@ -416,6 +508,7 @@ impl TypeChecker {
         arg_ty: &ResolvedType,
         record_exact_builtin_coercion: bool,
     ) {
+        self.record_rust_callable_parameter_displays(rust_type_display, owner_path, arg_expr, arg_ty);
         let param_display = self.rust_display_for_owner_path(rust_type_display, owner_path);
         let normalized = param_display.replace(' ', "");
         let target_ty =

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -663,6 +663,9 @@ impl TypeChecker {
             let prev = rendered.chars().next_back();
             if prev.is_some_and(|ch| ch == '_' || ch.is_ascii_alphanumeric()) {
                 rendered.push_str("crate::");
+            } else if after["crate::".len()..].starts_with('[') {
+                // rust-analyzer can render a slice nested in a generic callback bound as `crate::[T]`. A slice is
+                // not a crate item, so preserve its Rust spelling instead of producing the invalid `dep::[T]`.
             } else {
                 rendered.push_str(replacement.as_str());
             }
@@ -974,7 +977,7 @@ impl TypeChecker {
     }
 
     /// Return the body of a Rust callable bound display such as `impl FnMut(A) -> B`.
-    fn rust_callable_bound_body(display: &str) -> Option<&str> {
+    pub(in crate::frontend::typechecker) fn rust_callable_bound_body(display: &str) -> Option<&str> {
         let trimmed = Self::trim_top_level_rust_bound_suffix(display.trim());
         for prefix in ["impl ", "dyn "] {
             if let Some(rest) = trimmed.strip_prefix(prefix)
@@ -998,7 +1001,7 @@ impl TypeChecker {
     }
 
     /// Return the byte index of the matching close paren for an opening paren at the start of `text`.
-    fn rust_callable_args_end(text: &str) -> Option<usize> {
+    pub(in crate::frontend::typechecker) fn rust_callable_args_end(text: &str) -> Option<usize> {
         let mut depth = 0usize;
         for (idx, ch) in text.char_indices() {
             match ch {

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3218,6 +3218,13 @@ fn test_rust_owner_path_expands_crate_relative_signature_displays() {
         ),
         ResolvedType::RustPath("demo_runtime::ScalarFunctionImplementation".to_string()),
     );
+    assert_eq!(
+        checker.rust_display_for_owner_path(
+            "impl FnMut(&mut crate::[f32], &crate::OutputCallbackInfo)",
+            "demo_runtime::run",
+        ),
+        "impl FnMut(&mut [f32], &demo_runtime::OutputCallbackInfo)",
+    );
 }
 
 #[test]

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -196,6 +196,12 @@ pub struct RustInteropArtifacts {
     /// whose parameter shape cannot be faithfully represented by ordinary Incan surface types, such as `&[T]`.
     /// Lowering/emission consumes the displays directly so generated closures keep Rust inference stable.
     pub closure_param_type_displays: HashMap<(usize, usize), Vec<String>>,
+    /// Exact Rust parameter displays for source functions passed directly to a Rust callable boundary.
+    ///
+    /// Source annotations intentionally use Incan collection vocabulary (`&mut list[f32]`), while Rust callback
+    /// bounds can require a slice (`&mut [f32]`). Lowering uses this fact only for the proven callback function so it
+    /// does not globally change how Incan lists are represented.
+    pub function_param_type_displays: HashMap<String, Vec<String>>,
     /// Rust async call expressions proven during call validation, keyed by the full call-expression span.
     ///
     /// Rust metadata is now loaded lazily at the call boundary rather than during import collection. `await` consumes

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -3378,6 +3378,75 @@ impl Expr {
 }
 
 #[test]
+fn run_rust_callback_slice_fnmut_parameters_issue835() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "cli_rust_callback_slice_fnmut",
+        r#"
+
+[rust-dependencies]
+audio_callback = { path = "rust/audio_callback" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::audio_callback import OutputCallbackInfo, run
+
+def write_silence(_data: &mut list[f32], _info: &OutputCallbackInfo) -> None:
+  pass
+
+def report_error(_error: str) -> None:
+  pass
+
+def main() -> None:
+  run(write_silence, report_error)
+  run((_data, _info) => println(""), report_error)
+  println("callbacks-built")
+"#,
+    )?;
+
+    let helper_src = tmp.path().join("rust").join("audio_callback").join("src");
+    fs::create_dir_all(&helper_src)?;
+    fs::write(
+        helper_src
+            .parent()
+            .ok_or("audio callback src has no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "audio_callback"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        helper_src.join("lib.rs"),
+        r#"pub struct OutputCallbackInfo;
+
+pub fn run<D, E>(mut data_callback: D, mut error_callback: E)
+where
+    D: FnMut(&mut [f32], &OutputCallbackInfo) + Send + 'static,
+    E: FnMut(String),
+{
+    let mut data = [0.0_f32; 2];
+    let info = OutputCallbackInfo;
+    data_callback(&mut data, &info);
+    error_callback("synthetic callback error".to_string());
+}
+"#,
+    )?;
+
+    let output = run_incan(tmp.path(), &["run"])?;
+    assert_success(&output, "Rust FnMut borrowed-slice callbacks");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "callbacks-built",
+        "unexpected borrowed-slice callback output"
+    );
+    Ok(())
+}
+
+#[test]
 fn run_types_rust_callback_closures_in_every_match_arm_issue733() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(


### PR DESCRIPTION
## Summary

This fixes Rust callback interop for APIs bounded by `FnMut(&mut [T], ...)`. Named Incan callbacks annotated with `&mut list[T]` now retain the proven Rust slice spelling at the call boundary, and inline closures receive the same contextual parameter types. The fix also prevents the borrowed-function adapter path from emitting dangling helpers for callbacks that already borrow their inputs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: callbacks for Rust APIs such as realtime audio output streams can use either a named `&mut list[f32]` function or an unannotated inline closure when Rust requires `FnMut(&mut [f32], &OutputCallbackInfo)`.
- **Internals**: type checking records the exact Rust callable parameter displays for proven callback boundaries; lowering uses those displays only for the matching named function or closure. Slice displays malformed as `crate::[T]` are normalized before Rust emission.
- **Risks**: this is restricted to callbacks whose checked Incan function shape exactly matches the Rust callable bound. Conflicting Rust callback spellings for the same named function remain intentionally outside this slice.

## Testing / verification

- [x] `make pre-commit`
- [ ] `make examples` (not separately applicable; covered by the full gate)
- [x] `incan fmt --check .`
- [x] Manual verification described below

Manual verification notes:

- Added `run_rust_callback_slice_fnmut_parameters_issue835`, a generated-Rust integration fixture covering both named and inline callback forms against a minimal `FnMut(&mut [f32], &OutputCallbackInfo)` Rust API.
- `cargo test --test cli_integration run_rust_callback_slice_fnmut_parameters_issue835 -- --nocapture`
- `cargo test --lib test_rust_owner_path_expands_crate_relative_signature_displays -- --nocapture`
- `make lint-fast-ci`
- `git diff --check`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #835
