### PR TITLE
feature - deliver v0.5 workspace foundation (#405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "clap",
  "crc32fast",
  "flate2",
+ "globset",
  "hex",
  "incan_codegraph",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10.9"
 hex = "0.4.3"
 semver = "1.0.27"
+globset = "0.4"
 rust_inspect = { path = "crates/rust_inspect", optional = true }
 # WASM runtime for desugarer packaging
 wasmtime = { version = "45.0.3", default-features = false, features = ["cranelift", "runtime", "std"] }

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -29,6 +29,7 @@ use crate::library_manifest::LibraryManifest;
 use crate::library_manifest::LibraryRustAbi;
 use crate::lockfile::CargoFeatureSelection;
 use crate::manifest::ProjectManifest;
+use crate::workspace::WorkspaceGraph;
 
 use super::build_report::{
     BuildReportDraft, BuildReportMode, BuildReportOptions, BuildReportProject, RustInspectionFormat, SourceFileReport,
@@ -759,7 +760,8 @@ fn prepare_project_with_options(
     };
     let path = normalized_file_path.as_path();
     let inferred_project_root = resolve_project_root(path);
-    let manifest = ProjectManifest::discover(&inferred_project_root).map_err(|e| CliError::failure(e.to_string()))?;
+    let manifest = WorkspaceGraph::discover_effective_project_manifest(&inferred_project_root)
+        .map_err(|e| CliError::failure(e.to_string()))?;
     if let Some(manifest) = manifest.as_ref() {
         enforce_project_toolchain_constraint(manifest)?;
     }
@@ -1063,7 +1065,9 @@ fn prepare_library_project(
     let mut timings_ms = BTreeMap::new();
     let source_load_start = Instant::now();
     let project_root = resolve_library_project_root(file_path)?;
-    let Some(manifest) = ProjectManifest::discover(&project_root).map_err(|e| CliError::failure(e.to_string()))? else {
+    let Some(manifest) = WorkspaceGraph::discover_effective_project_manifest(&project_root)
+        .map_err(|e| CliError::failure(e.to_string()))?
+    else {
         return Err(CliError::failure(
             "No incan.toml found for `incan build --lib` (run `incan init` first)",
         ));

--- a/src/cli/commands/build_report.rs
+++ b/src/cli/commands/build_report.rs
@@ -6,6 +6,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use clap::ValueEnum;
 use serde::Serialize;
@@ -31,12 +32,32 @@ pub enum BuildReportFormat {
 pub struct BuildReportOptions {
     pub format: Option<BuildReportFormat>,
     pub output_path: Option<PathBuf>,
+    /// Compiler-owned collector for a workspace command that emits one aggregate report after all member builds.
+    captured_reports: Option<Arc<Mutex<Vec<BuildReport>>>>,
 }
 
 impl BuildReportOptions {
+    /// Construct CLI report options without exposing compiler-internal capture state.
+    pub fn new(format: Option<BuildReportFormat>, output_path: Option<PathBuf>) -> Self {
+        Self {
+            format,
+            output_path,
+            captured_reports: None,
+        }
+    }
+
     /// Return whether the caller requested any build report output.
     pub(crate) fn enabled(&self) -> bool {
         self.format.is_some()
+    }
+
+    /// Preserve normal report formatting semantics while collecting a completed member report instead of emitting it.
+    pub(crate) fn with_capture(&self, captured_reports: Arc<Mutex<Vec<BuildReport>>>) -> Self {
+        Self {
+            format: self.format,
+            output_path: self.output_path.clone(),
+            captured_reports: Some(captured_reports),
+        }
     }
 }
 
@@ -228,6 +249,13 @@ pub struct RustFileReport {
 
 /// Write or print a build report according to CLI options.
 pub(crate) fn emit_build_report(report: &BuildReport, options: &BuildReportOptions) -> CliResult<()> {
+    if let Some(captured_reports) = &options.captured_reports {
+        captured_reports
+            .lock()
+            .map_err(|_| CliError::failure("failed to lock captured workspace build reports"))?
+            .push(report.clone());
+        return Ok(());
+    }
     let Some(format) = options.format else {
         return Ok(());
     };

--- a/src/cli/commands/diagnostics.rs
+++ b/src/cli/commands/diagnostics.rs
@@ -68,6 +68,7 @@ pub fn check_path_report(path: &Path) -> CliResult<DiagnosticReport> {
     Ok(check_path_outcome(path)?.report)
 }
 
+/// Run collection, project resolution, and typechecking while retaining either a stable report or its source failure.
 fn check_path_outcome(path: &Path) -> CliResult<CheckOutcome> {
     let modules = match collect_modules_detailed(&path.to_string_lossy()) {
         Ok(modules) => modules,
@@ -201,6 +202,7 @@ fn render_check_failure(failure: CliDiagnosticFailure, format: DiagnosticOutputF
     }
 }
 
+/// Construct the canonical empty diagnostic report for a successful check.
 fn successful_check_report() -> DiagnosticReport {
     DiagnosticReport {
         schema_version: DIAGNOSTIC_SCHEMA_VERSION,
@@ -209,6 +211,7 @@ fn successful_check_report() -> DiagnosticReport {
     }
 }
 
+/// Convert a compiler or tooling failure into the shared structured check outcome.
 fn failed_check_outcome(failure: CliDiagnosticFailure) -> CheckOutcome {
     let diagnostics = failure
         .diagnostics

--- a/src/cli/commands/diagnostics.rs
+++ b/src/cli/commands/diagnostics.rs
@@ -31,11 +31,17 @@ pub enum DiagnosticOutputFormat {
     Json,
 }
 
-#[derive(Debug, Serialize)]
-struct DiagnosticReport {
-    schema_version: u32,
-    ok: bool,
-    diagnostics: Vec<StableDiagnostic>,
+#[derive(Debug, Clone, Serialize)]
+pub struct DiagnosticReport {
+    pub schema_version: u32,
+    pub ok: bool,
+    pub diagnostics: Vec<StableDiagnostic>,
+}
+
+/// One completed check, retaining the human diagnostic source needed by the text renderer.
+struct CheckOutcome {
+    report: DiagnosticReport,
+    failure: Option<CliDiagnosticFailure>,
 }
 
 #[derive(Debug, Serialize)]
@@ -47,9 +53,25 @@ struct ExplainReport {
 
 /// Run the canonical check pipeline for a file or project entrypoint.
 pub fn check_path(path: &Path, format: DiagnosticOutputFormat) -> CliResult<ExitCode> {
+    let outcome = check_path_outcome(path)?;
+    match outcome.failure {
+        Some(failure) => render_check_failure(failure, format),
+        None => render_check_success(format),
+    }
+}
+
+/// Check a path and retain the stable report for a workspace-level machine-readable envelope.
+///
+/// This deliberately performs the same compiler pipeline as [`check_path`]. The plain command owns text rendering,
+/// while the workspace command can aggregate these completed reports without rerunning or parsing CLI output.
+pub fn check_path_report(path: &Path) -> CliResult<DiagnosticReport> {
+    Ok(check_path_outcome(path)?.report)
+}
+
+fn check_path_outcome(path: &Path) -> CliResult<CheckOutcome> {
     let modules = match collect_modules_detailed(&path.to_string_lossy()) {
         Ok(modules) => modules,
-        Err(failure) => return render_check_failure(failure, format),
+        Err(failure) => return Ok(failed_check_outcome(failure)),
     };
     let normalized_path = normalize_input_path(path)?;
     let project_root = resolve_project_root(&normalized_path);
@@ -62,7 +84,7 @@ pub fn check_path(path: &Path, format: DiagnosticOutputFormat) -> CliResult<Exit
                 diagnostics::CompileError::new(error.to_string(), crate::frontend::ast::Span::default()),
                 diagnostics::DiagnosticPhase::Tooling,
             );
-            return render_check_failure(failure, format);
+            return Ok(failed_check_outcome(failure));
         }
     };
     let library_manifest_index = manifest
@@ -105,8 +127,11 @@ pub fn check_path(path: &Path, format: DiagnosticOutputFormat) -> CliResult<Exit
         #[cfg(feature = "rust_inspect")]
         rust_inspect_manifest_dir.as_deref(),
     ) {
-        Ok(()) => render_check_success(format),
-        Err(failure) => render_check_failure(failure, format),
+        Ok(()) => Ok(CheckOutcome {
+            report: successful_check_report(),
+            failure: None,
+        }),
+        Err(failure) => Ok(failed_check_outcome(failure)),
     }
 }
 
@@ -157,11 +182,7 @@ fn render_check_success(format: DiagnosticOutputFormat) -> CliResult<ExitCode> {
             Ok(ExitCode::SUCCESS)
         }
         DiagnosticOutputFormat::Json => {
-            let report = DiagnosticReport {
-                schema_version: DIAGNOSTIC_SCHEMA_VERSION,
-                ok: true,
-                diagnostics: Vec::new(),
-            };
+            let report = successful_check_report();
             print_json(&report)?;
             Ok(ExitCode::SUCCESS)
         }
@@ -173,26 +194,41 @@ fn render_check_failure(failure: CliDiagnosticFailure, format: DiagnosticOutputF
     match format {
         DiagnosticOutputFormat::Text => Err(CliError::failure(failure.render_human())),
         DiagnosticOutputFormat::Json => {
-            let diagnostics = failure
-                .diagnostics
-                .iter()
-                .map(|diagnostic| {
-                    diagnostics::stable_diagnostic(
-                        &diagnostic.file_path,
-                        &diagnostic.source,
-                        &diagnostic.error,
-                        diagnostic.phase,
-                    )
-                })
-                .collect();
-            let report = DiagnosticReport {
-                schema_version: DIAGNOSTIC_SCHEMA_VERSION,
-                ok: false,
-                diagnostics,
-            };
+            let report = failed_check_outcome(failure).report;
             print_json(&report)?;
             Err(CliError::new("", ExitCode::FAILURE))
         }
+    }
+}
+
+fn successful_check_report() -> DiagnosticReport {
+    DiagnosticReport {
+        schema_version: DIAGNOSTIC_SCHEMA_VERSION,
+        ok: true,
+        diagnostics: Vec::new(),
+    }
+}
+
+fn failed_check_outcome(failure: CliDiagnosticFailure) -> CheckOutcome {
+    let diagnostics = failure
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            diagnostics::stable_diagnostic(
+                &diagnostic.file_path,
+                &diagnostic.source,
+                &diagnostic.error,
+                diagnostic.phase,
+            )
+        })
+        .collect();
+    CheckOutcome {
+        report: DiagnosticReport {
+            schema_version: DIAGNOSTIC_SCHEMA_VERSION,
+            ok: false,
+            diagnostics,
+        },
+        failure: Some(failure),
     }
 }
 

--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -22,6 +22,7 @@ use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::{diagnostics, lexer, parser};
 use crate::lockfile::{CargoFeatureSelection, IncanLock, compute_deps_fingerprint};
 use crate::manifest::ProjectManifest;
+use crate::workspace::WorkspaceGraph;
 
 use super::common::{
     CargoPolicy, ProjectRequirements, build_source_map, cargo_command_flags, cargo_lockfile_flags, collect_modules,
@@ -72,6 +73,16 @@ pub fn lock_project(
     let start_dir = entry_file
         .and_then(|p| p.parent().map(|p| p.to_path_buf()))
         .unwrap_or_else(|| PathBuf::from("."));
+    if let Some(workspace) =
+        WorkspaceGraph::discover(&start_dir).map_err(|error| CliError::failure(error.to_string()))?
+    {
+        return lock_workspace(
+            &workspace,
+            cargo_features,
+            cargo_no_default_features,
+            cargo_all_features,
+        );
+    }
     let manifest = ProjectManifest::discover(&start_dir)
         .map_err(|e| CliError::failure(e.to_string()))?
         .ok_or_else(|| CliError::failure("No incan.toml found (run `incan init`)"))?;
@@ -115,6 +126,38 @@ pub fn lock_project(
         &context.rust_inspect_query_paths,
     )?;
 
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Resolve every member into one root-owned workspace lockfile.
+///
+/// RFC 077 makes lock scope independent of the caller's current member: an invocation from any contained member must
+/// produce the same root `incan.lock`, including dependency requirements discovered from every selected project.
+fn lock_workspace(
+    workspace: &WorkspaceGraph,
+    cargo_features: Vec<String>,
+    cargo_no_default_features: bool,
+    cargo_all_features: bool,
+) -> CliResult<ExitCode> {
+    let cargo_features = CargoFeatureSelection {
+        cargo_features,
+        cargo_no_default_features,
+        cargo_all_features,
+    }
+    .normalized();
+    let context = collect_workspace_lock_context(workspace, &cargo_features)?;
+    let cargo_policy = CargoPolicy::explicit(false, false, false, Vec::new());
+    generate_lockfile(
+        workspace.root(),
+        "incan_workspace",
+        context.rust_edition,
+        &context.resolved,
+        &context.project_requirements,
+        &cargo_features,
+        &cargo_policy,
+        #[cfg(feature = "rust_inspect")]
+        &context.rust_inspect_query_paths,
+    )?;
     Ok(ExitCode::SUCCESS)
 }
 
@@ -270,6 +313,37 @@ pub(crate) fn resolve_lock_payload(request: LockResolutionRequest<'_>) -> CliRes
         return Ok(None);
     }
 
+    // A workspace lock is root-owned even when a build starts from one of its members. Resolve
+    // every member here as `incan lock` does, so ordinary build/test commands neither create nor
+    // consult a member-local lockfile.
+    if let Some(workspace) =
+        WorkspaceGraph::discover(project_root).map_err(|error| CliError::failure(error.to_string()))?
+    {
+        let context = collect_workspace_lock_context(&workspace, cargo_features)?;
+        let mut resolved = merge_resolved_dependencies(resolved, &context.resolved)?;
+        let project_requirements = merge_project_requirements(project_requirements, &context.project_requirements)?;
+        merge_project_requirement_dependencies(&mut resolved, &project_requirements)?;
+        #[cfg(feature = "rust_inspect")]
+        let rust_inspect_query_paths = {
+            let mut query_paths = BTreeSet::new();
+            query_paths.extend(rust_inspect_query_paths.iter().cloned());
+            query_paths.extend(context.rust_inspect_query_paths);
+            query_paths.into_iter().collect::<Vec<_>>()
+        };
+        return resolve_lock_for_inputs(
+            workspace.root(),
+            "incan_workspace",
+            context.rust_edition,
+            &resolved,
+            &project_requirements,
+            cargo_features,
+            cargo_policy,
+            #[cfg(feature = "rust_inspect")]
+            &rust_inspect_query_paths,
+        )
+        .map(|lock| Some(lock.cargo_lock_payload));
+    }
+
     let project_context = if let Some(manifest) = manifest {
         collect_project_lock_context(manifest, None, cargo_features)?
     } else {
@@ -293,19 +367,49 @@ pub(crate) fn resolve_lock_payload(request: LockResolutionRequest<'_>) -> CliRes
         .map(|context| context.rust_inspect_query_paths.as_slice())
         .unwrap_or(rust_inspect_query_paths);
 
-    let lock_path = project_root.join("incan.lock");
     let rust_edition = manifest.and_then(|m| m.build.as_ref().and_then(|b| b.rust_edition.clone()));
     let mut resolved_with_requirements = resolved.clone();
     merge_project_requirement_dependencies(&mut resolved_with_requirements, project_requirements)?;
-    let fingerprint = compute_deps_fingerprint(
-        &resolved_with_requirements.dependencies,
-        &resolved_with_requirements.dev_dependencies,
+    resolve_lock_for_inputs(
+        project_root,
+        project_name,
+        rust_edition,
+        &resolved_with_requirements,
+        project_requirements,
         cargo_features,
-        Some(project_root),
+        cargo_policy,
+        #[cfg(feature = "rust_inspect")]
+        rust_inspect_query_paths,
+    )
+    .map(|lock| Some(lock.cargo_lock_payload))
+}
+
+/// Load or create one lockfile after its complete dependency surface has been assembled.
+///
+/// Callers merge project requirements into `resolved` first. Keeping that rule outside this helper
+/// lets a single project and an aggregate workspace use the same freshness and strict-mode
+/// behavior while retaining their different collection scopes.
+#[allow(clippy::too_many_arguments)]
+fn resolve_lock_for_inputs(
+    lock_root: &Path,
+    project_name: &str,
+    rust_edition: Option<String>,
+    resolved: &ResolvedDependencies,
+    project_requirements: &ProjectRequirements,
+    cargo_features: &CargoFeatureSelection,
+    cargo_policy: &CargoPolicy,
+    #[cfg(feature = "rust_inspect")] rust_inspect_query_paths: &[String],
+) -> CliResult<IncanLock> {
+    let lock_path = lock_root.join("incan.lock");
+    let fingerprint = compute_deps_fingerprint(
+        &resolved.dependencies,
+        &resolved.dev_dependencies,
+        cargo_features,
+        Some(lock_root),
     );
 
     let strict = cargo_policy.locked || cargo_policy.frozen;
-    if strict && let Some(message) = strict_git_source_error(&resolved_with_requirements) {
+    if strict && let Some(message) = strict_git_source_error(resolved) {
         return Err(CliError::failure(message));
     }
     if lock_path.exists() {
@@ -332,9 +436,9 @@ pub(crate) fn resolve_lock_payload(request: LockResolutionRequest<'_>) -> CliRes
                 "warning: incan.lock is out of date; using the existing lock payload without rewriting it. \
                  Run `incan lock` to refresh it."
             );
-            return Ok(Some(lock.cargo_lock_payload));
+            return Ok(lock);
         }
-        return Ok(Some(lock.cargo_lock_payload));
+        return Ok(lock);
     }
 
     if strict {
@@ -342,17 +446,17 @@ pub(crate) fn resolve_lock_payload(request: LockResolutionRequest<'_>) -> CliRes
     }
 
     let lock = generate_lockfile(
-        project_root,
+        lock_root,
         project_name,
         rust_edition,
-        &resolved_with_requirements,
+        resolved,
         project_requirements,
         cargo_features,
         cargo_policy,
         #[cfg(feature = "rust_inspect")]
         rust_inspect_query_paths,
     )?;
-    Ok(Some(lock.cargo_lock_payload))
+    Ok(lock)
 }
 
 /// Fully collected dependency inputs that define a manifest project's lock freshness surface.
@@ -360,6 +464,15 @@ struct ProjectLockContext {
     modules: Vec<ParsedModule>,
     resolved: ResolvedDependencies,
     project_requirements: ProjectRequirements,
+    #[cfg(feature = "rust_inspect")]
+    rust_inspect_query_paths: Vec<String>,
+}
+
+/// Fully merged lock inputs for every member of one validated workspace.
+struct WorkspaceLockContext {
+    resolved: ResolvedDependencies,
+    project_requirements: ProjectRequirements,
+    rust_edition: Option<String>,
     #[cfg(feature = "rust_inspect")]
     rust_inspect_query_paths: Vec<String>,
 }
@@ -381,7 +494,68 @@ fn project_lock_entry_paths(manifest: &ProjectManifest, explicit_entry_file: Opt
     if let Some(file) = explicit_entry_file {
         paths.insert(file.to_path_buf());
     }
+    if paths.is_empty() {
+        let library_root = manifest.project_root().join("src").join("lib.incn");
+        let application_root = manifest.project_root().join("src").join("main.incn");
+        if library_root.is_file() {
+            paths.insert(library_root);
+        } else if application_root.is_file() {
+            paths.insert(application_root);
+        }
+    }
     paths.into_iter().collect()
+}
+
+/// Collect and validate the complete dependency context represented by a workspace root lock.
+///
+/// Each member is loaded through [`WorkspaceGraph::effective_manifest_for`] so explicit workspace inheritance reaches
+/// ordinary dependency and library-manifest resolution. The resulting context is deterministic in member order and
+/// rejects incompatible crate identities rather than allowing one member to overwrite another in the root lock.
+fn collect_workspace_lock_context(
+    workspace: &WorkspaceGraph,
+    cargo_features: &CargoFeatureSelection,
+) -> CliResult<WorkspaceLockContext> {
+    let mut resolved = ResolvedDependencies {
+        dependencies: Vec::new(),
+        dev_dependencies: Vec::new(),
+    };
+    let mut project_requirements = ProjectRequirements::default();
+    let mut rust_edition = None;
+    #[cfg(feature = "rust_inspect")]
+    let mut rust_inspect_query_paths = BTreeSet::new();
+
+    for member in workspace.members() {
+        let manifest = workspace
+            .effective_manifest_for(member)
+            .map_err(|error| CliError::failure(error.to_string()))?;
+        enforce_project_toolchain_constraint(&manifest)?;
+        let Some(context) = collect_project_lock_context(&manifest, None, cargo_features)? else {
+            continue;
+        };
+        resolved = merge_resolved_dependencies(&resolved, &context.resolved)?;
+        project_requirements = merge_project_requirements(&project_requirements, &context.project_requirements)?;
+        let member_edition = manifest.build.as_ref().and_then(|build| build.rust_edition.clone());
+        if let (Some(expected), Some(actual)) = (&rust_edition, &member_edition)
+            && expected != actual
+        {
+            return Err(CliError::failure(format!(
+                "workspace members require conflicting Rust editions: {expected} and {actual}; align [build].rust-edition before generating one workspace lock"
+            )));
+        }
+        if rust_edition.is_none() {
+            rust_edition = member_edition;
+        }
+        #[cfg(feature = "rust_inspect")]
+        rust_inspect_query_paths.extend(context.rust_inspect_query_paths);
+    }
+
+    Ok(WorkspaceLockContext {
+        resolved,
+        project_requirements,
+        rust_edition,
+        #[cfg(feature = "rust_inspect")]
+        rust_inspect_query_paths: rust_inspect_query_paths.into_iter().collect(),
+    })
 }
 
 /// Collect the project-wide script and test dependency inputs used for both lock generation and freshness checks.
@@ -1116,6 +1290,63 @@ mod tests {
             optional: false,
             package: None,
         }
+    }
+
+    fn write_workspace_member(
+        root: &Path,
+        name: &str,
+        rust_edition: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let member_root = root.join("packages").join(name);
+        fs::create_dir_all(member_root.join("src"))?;
+        let edition = rust_edition
+            .map(|edition| format!("\n[build]\nrust-edition = \"{edition}\"\n"))
+            .unwrap_or_default();
+        fs::write(
+            member_root.join("incan.toml"),
+            format!("[project]\nname = \"{name}\"\n[project.scripts]\nmain = \"src/main.incn\"{edition}"),
+        )?;
+        fs::write(member_root.join("src/main.incn"), "def main() -> None:\n    return\n")?;
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_lock_context_collects_every_member_and_uses_one_edition() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join("incan.toml"),
+            "[workspace]\nmembers = [\"packages/*\"]\n",
+        )?;
+        write_workspace_member(temp.path(), "alpha", Some("2024"))?;
+        write_workspace_member(temp.path(), "beta", Some("2024"))?;
+
+        let graph = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        let context = collect_workspace_lock_context(&graph, &CargoFeatureSelection::default())?;
+
+        assert!(context.resolved.dependencies.is_empty());
+        assert!(context.resolved.dev_dependencies.is_empty());
+        assert!(context.project_requirements.dependencies.is_empty());
+        assert_eq!(context.rust_edition.as_deref(), Some("2024"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_lock_context_rejects_conflicting_member_editions() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join("incan.toml"),
+            "[workspace]\nmembers = [\"packages/*\"]\n",
+        )?;
+        write_workspace_member(temp.path(), "alpha", Some("2021"))?;
+        write_workspace_member(temp.path(), "beta", Some("2024"))?;
+
+        let graph = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        let error = collect_workspace_lock_context(&graph, &CargoFeatureSelection::default())
+            .err()
+            .ok_or("conflicting workspace Rust editions must fail")?;
+
+        assert!(error.message.contains("conflicting Rust editions"));
+        Ok(())
     }
 
     #[test]

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -28,6 +28,7 @@ pub mod lock;
 pub mod stdlib_loader;
 pub mod tools;
 pub(crate) mod vocab_extraction;
+pub mod workspace;
 
 // Re-export public API so callers can use `commands::build_file()` etc.
 pub use build::{build_file, build_library, inspect_rust, run_file, run_inline_source};
@@ -43,6 +44,7 @@ pub use tools::{
     ToolsDoctorFormat, ToolsMetadataFormat, ToolsModelMetadataFormat, tools_doctor, tools_metadata_api,
     tools_metadata_model,
 };
+pub use workspace::inspect_workspace;
 
 // Crate-internal API (used by test_runner and other CLI modules)
 pub(crate) use lock::{LockResolutionRequest, resolve_lock_payload};

--- a/src/cli/commands/workspace.rs
+++ b/src/cli/commands/workspace.rs
@@ -1,0 +1,108 @@
+//! RFC 077 machine-readable workspace topology inspection.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::cli::{CliError, CliResult, ExitCode};
+use crate::workspace::{WORKSPACE_INSPECT_SCHEMA_VERSION, WorkspaceGraph};
+
+/// Emit the validated workspace topology and current implicit command scope as JSON.
+pub fn inspect_workspace(path: &Path, workspace: bool, members: &[String]) -> CliResult<ExitCode> {
+    let graph = WorkspaceGraph::discover(path)
+        .map_err(|error| CliError::failure(error.to_string()))?
+        .ok_or_else(|| CliError::failure(format!("no workspace found for {}", path.display())))?;
+    let selected = graph
+        .select_members(path, workspace, members)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    let report = WorkspaceInspectionReport {
+        schema_version: WORKSPACE_INSPECT_SCHEMA_VERSION,
+        root: graph.root(),
+        manifest_path: graph.manifest_path(),
+        members: graph
+            .members()
+            .iter()
+            .map(|member| WorkspaceMemberReport {
+                name: &member.name,
+                path: &member.path,
+                manifest_path: &member.manifest_path,
+                root_member: member.root_member,
+                effective_library_dependencies: graph
+                    .effective_library_dependencies_for(member)
+                    .unwrap_or(&EMPTY_LIBRARY_DEPENDENCIES),
+                effective_rust_dependencies: graph
+                    .effective_rust_dependencies_for(member)
+                    .unwrap_or(&EMPTY_DEPENDENCIES),
+                effective_rust_dev_dependencies: graph
+                    .effective_rust_dev_dependencies_for(member)
+                    .unwrap_or(&EMPTY_DEPENDENCIES),
+            })
+            .collect(),
+        default_members: graph.default_members(),
+        exclusions: graph.exclusions(),
+        shared: graph.shared(),
+        lock: graph.lock(),
+        selected_members: selected.into_iter().map(|member| member.name.as_str()).collect(),
+        warnings: graph.warnings(),
+    };
+    let output = serde_json::to_string_pretty(&report)
+        .map_err(|error| CliError::failure(format!("failed to serialize workspace inspection: {error}")))?;
+    println!("{output}");
+    Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Serialize)]
+struct WorkspaceInspectionReport<'a> {
+    schema_version: u32,
+    root: &'a Path,
+    manifest_path: &'a Path,
+    members: Vec<WorkspaceMemberReport<'a>>,
+    default_members: &'a [String],
+    exclusions: &'a [String],
+    shared: &'a crate::workspace::WorkspaceSharedConfiguration,
+    lock: &'a crate::workspace::WorkspaceLockState,
+    selected_members: Vec<&'a str>,
+    warnings: &'a [String],
+}
+
+#[derive(Serialize)]
+struct WorkspaceMemberReport<'a> {
+    name: &'a str,
+    path: &'a Path,
+    manifest_path: &'a Path,
+    root_member: bool,
+    effective_library_dependencies: &'a std::collections::BTreeMap<String, crate::manifest::LibraryDependencySpec>,
+    effective_rust_dependencies: &'a std::collections::BTreeMap<String, crate::manifest::DependencySpec>,
+    effective_rust_dev_dependencies: &'a std::collections::BTreeMap<String, crate::manifest::DependencySpec>,
+}
+
+static EMPTY_DEPENDENCIES: std::sync::LazyLock<std::collections::BTreeMap<String, crate::manifest::DependencySpec>> =
+    std::sync::LazyLock::new(std::collections::BTreeMap::new);
+
+static EMPTY_LIBRARY_DEPENDENCIES: std::sync::LazyLock<
+    std::collections::BTreeMap<String, crate::manifest::LibraryDependencySpec>,
+> = std::sync::LazyLock::new(std::collections::BTreeMap::new);
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn inspect_workspace_accepts_a_rooted_workspace() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join("incan.toml"),
+            "[project]\nname = 'root'\n[workspace]\nmembers = ['packages/*']\n",
+        )?;
+        fs::create_dir_all(temp.path().join("packages/member"))?;
+        fs::write(
+            temp.path().join("packages/member/incan.toml"),
+            "[project]\nname = 'member'\n",
+        )?;
+
+        assert_eq!(inspect_workspace(temp.path(), false, &[])?, ExitCode::SUCCESS);
+        Ok(())
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -54,6 +54,7 @@ use commands::common::{CargoPolicy, CargoPolicyCliFlags};
 use commands::diagnostics::DiagnosticOutputFormat;
 use commands::lifecycle::{EnvOutputFormat, VersionBumpArg};
 use commands::tools::{ToolsDoctorFormat, ToolsMetadataFormat, ToolsModelMetadataFormat};
+use serde::Serialize;
 
 // ============================================================================
 // CLI Error handling
@@ -240,6 +241,12 @@ pub enum Command {
         /// File or project entrypoint to check
         #[arg(value_name = "PATH")]
         path: PathBuf,
+        /// Select every workspace member instead of the implicit current scope.
+        #[arg(long, conflicts_with = "member")]
+        workspace: bool,
+        /// Select one workspace member by name or workspace-relative path. May be repeated.
+        #[arg(long = "member", value_name = "NAME_OR_PATH")]
+        member: Vec<String>,
         /// Output format
         #[arg(long = "format", value_enum, default_value = "text")]
         format: DiagnosticOutputFormat,
@@ -568,6 +575,57 @@ struct TestCommandOptions {
     cargo_all_features: bool,
 }
 
+#[derive(Serialize)]
+struct WorkspaceCheckReport {
+    schema_version: u32,
+    ok: bool,
+    workspace: WorkspaceCheckScope,
+    members: Vec<WorkspaceMemberCheckReport>,
+}
+
+#[derive(Serialize)]
+struct WorkspaceCheckScope {
+    root: PathBuf,
+    selected_members: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct WorkspaceMemberCheckReport {
+    member: String,
+    report: commands::diagnostics::DiagnosticReport,
+}
+
+/// Resolve the source entrypoint used by a workspace-level check for one member.
+///
+/// The single-project `check` command deliberately accepts a file. Workspace selection names projects instead, so
+/// it first honors the member's declared main script and then uses the conventional source entrypoints for libraries
+/// and small projects that have not declared a script yet.
+fn workspace_member_check_entry(
+    workspace: &WorkspaceGraph,
+    member: &crate::workspace::WorkspaceMember,
+) -> CliResult<PathBuf> {
+    let manifest = workspace
+        .effective_manifest_for(member)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    if let Some(main) = manifest
+        .project
+        .as_ref()
+        .and_then(|project| project.scripts.get("main"))
+    {
+        return Ok(member.path.join(main));
+    }
+    for candidate in ["src/main.incn", "src/lib.incn"] {
+        let path = member.path.join(candidate);
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+    Err(CliError::failure(format!(
+        "workspace member {} has no [project.scripts].main, src/main.incn, or src/lib.incn entrypoint",
+        member.name
+    )))
+}
+
 #[derive(Subcommand, Debug)]
 pub enum InspectCommand {
     /// Generate and inspect current Rust backend output
@@ -783,6 +841,90 @@ fn execute_format(path: &PathBuf, workspace: bool, members: &[String], check: bo
     first_failure.map_or(Ok(ExitCode::SUCCESS), Err)
 }
 
+/// Resolve RFC 077 scope before typechecking and retain one coherent JSON document for a workspace check.
+fn execute_check(
+    path: &PathBuf,
+    workspace: bool,
+    members: &[String],
+    format: DiagnosticOutputFormat,
+) -> CliResult<ExitCode> {
+    // A missing file is a valid `incan check` input: the diagnostics pipeline owns its stable tooling error. Discover
+    // workspace scope from the containing directory instead of canonicalizing that missing file first.
+    let discovery_path = if path.exists() {
+        path.clone()
+    } else {
+        path.parent().map(PathBuf::from).unwrap_or_else(|| path.clone())
+    };
+    let Some(graph) =
+        WorkspaceGraph::discover(&discovery_path).map_err(|error| CliError::failure(error.to_string()))?
+    else {
+        if workspace || !members.is_empty() {
+            return Err(CliError::failure(format!(
+                "workspace selection requires a validated workspace containing {}",
+                path.display()
+            )));
+        }
+        return commands::check_path(path, format);
+    };
+    let selected = graph
+        .select_members(&discovery_path, workspace, members)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    let selected_members = selected.iter().map(|member| member.name.clone()).collect::<Vec<_>>();
+
+    if format == DiagnosticOutputFormat::Json {
+        let mut member_reports = Vec::with_capacity(selected.len());
+        for member in selected {
+            let target = if !workspace && members.is_empty() && selected_members.len() == 1 && path.is_file() {
+                path.clone()
+            } else {
+                workspace_member_check_entry(&graph, member)?
+            };
+            let report = commands::diagnostics::check_path_report(&target)?;
+            member_reports.push(WorkspaceMemberCheckReport {
+                member: member.name.clone(),
+                report,
+            });
+        }
+        let ok = member_reports.iter().all(|member| member.report.ok);
+        let report = WorkspaceCheckReport {
+            schema_version: crate::frontend::diagnostics::DIAGNOSTIC_SCHEMA_VERSION,
+            ok,
+            workspace: WorkspaceCheckScope {
+                root: graph.root().to_path_buf(),
+                selected_members,
+            },
+            members: member_reports,
+        };
+        let json = serde_json::to_string_pretty(&report)
+            .map_err(|error| CliError::failure(format!("failed to serialize workspace check report: {error}")))?;
+        println!("{json}");
+        return if ok {
+            Ok(ExitCode::SUCCESS)
+        } else {
+            Err(CliError::new("", ExitCode::FAILURE))
+        };
+    }
+
+    let mut first_failure = None;
+    for member in selected {
+        println!("== workspace {} / member {} ==", graph.root().display(), member.name);
+        let target = if !workspace && members.is_empty() && selected_members.len() == 1 && path.is_file() {
+            path.clone()
+        } else {
+            workspace_member_check_entry(&graph, member)?
+        };
+        if let Err(error) = commands::check_path(&target, format) {
+            if !error.message.is_empty() {
+                eprintln!("{}", error.message);
+            }
+            if first_failure.is_none() {
+                first_failure = Some(CliError::new("", error.exit_code));
+            }
+        }
+    }
+    first_failure.map_or(Ok(ExitCode::SUCCESS), Err)
+}
+
 /// Resolve RFC 077 scope before test discovery or execution, then run each selected member in workspace order.
 ///
 /// The runner deliberately remains member-oriented: it already owns test discovery, generated batch compilation,
@@ -965,7 +1107,12 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
                 commands::build_file(&file.to_string_lossy(), out.as_ref(), build_options, report_options)
             }
         }
-        Some(Command::Check { path, format }) => commands::check_path(&path, format),
+        Some(Command::Check {
+            path,
+            workspace,
+            member,
+            format,
+        }) => execute_check(&path, workspace, &member, format),
         Some(Command::Explain { code, format }) => commands::explain_diagnostic(&code, format),
         Some(Command::Inspect { command }) => match command {
             InspectCommand::Rust { path, lib_mode, format } => commands::inspect_rust(&path, lib_mode, format),
@@ -1639,6 +1786,24 @@ mod tests {
         };
         assert!(workspace);
         assert!(member.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_workspace_check_selection() -> Result<(), clap::Error> {
+        let cli = parse_cli(["incan", "check", ".", "--member", "alpha", "--format", "json"])?;
+        let Some(Command::Check {
+            workspace,
+            member,
+            format,
+            ..
+        }) = cli.command
+        else {
+            return Err(expected_command("check"));
+        };
+        assert!(!workspace);
+        assert_eq!(member, vec!["alpha"]);
+        assert_eq!(format, DiagnosticOutputFormat::Json);
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -182,6 +182,12 @@ pub enum Command {
         /// Source file to compile (optional in `--lib` mode)
         #[arg(value_name = "FILE")]
         file: Option<PathBuf>,
+        /// Select every workspace member instead of the implicit current scope.
+        #[arg(long, conflicts_with = "member")]
+        workspace: bool,
+        /// Select one workspace member by name or workspace-relative path. May be repeated.
+        #[arg(long = "member", value_name = "NAME_OR_PATH")]
+        member: Vec<String>,
         /// Enable library mode precondition checks (`src/lib.incn` required)
         #[arg(long = "lib")]
         lib_mode: bool,
@@ -626,6 +632,42 @@ fn workspace_member_check_entry(
     )))
 }
 
+/// Resolve the executable or library source that a selected workspace member owns.
+fn workspace_member_build_entry(
+    workspace: &WorkspaceGraph,
+    member: &crate::workspace::WorkspaceMember,
+    lib_mode: bool,
+) -> CliResult<PathBuf> {
+    if lib_mode {
+        let library = member.path.join("src/lib.incn");
+        if library.is_file() {
+            return Ok(library);
+        }
+        return Err(CliError::failure(format!(
+            "workspace member {} has no src/lib.incn required by --lib",
+            member.name
+        )));
+    }
+    let manifest = workspace
+        .effective_manifest_for(member)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    if let Some(main) = manifest
+        .project
+        .as_ref()
+        .and_then(|project| project.scripts.get("main"))
+    {
+        return Ok(member.path.join(main));
+    }
+    let conventional_main = member.path.join("src/main.incn");
+    if conventional_main.is_file() {
+        return Ok(conventional_main);
+    }
+    Err(CliError::failure(format!(
+        "workspace member {} has no [project.scripts].main or src/main.incn entrypoint",
+        member.name
+    )))
+}
+
 #[derive(Subcommand, Debug)]
 pub enum InspectCommand {
     /// Generate and inspect current Rust backend output
@@ -838,6 +880,94 @@ fn execute_format(path: &PathBuf, workspace: bool, members: &[String], check: bo
         }
     }
 
+    first_failure.map_or(Ok(ExitCode::SUCCESS), Err)
+}
+
+/// Build one resolved executable or library entrypoint without reinterpreting workspace scope.
+fn execute_single_build(
+    file: Option<PathBuf>,
+    lib_mode: bool,
+    output_dir: Option<&String>,
+    build_options: commands::build::BuildCommandOptions,
+    report_options: BuildReportOptions,
+) -> CliResult<ExitCode> {
+    if lib_mode {
+        let file_arg = file.as_ref().map(|path| path.to_string_lossy().to_string());
+        commands::build_library(file_arg.as_deref(), output_dir, build_options, report_options)
+    } else {
+        let file = resolve_build_entry_file(file)?;
+        commands::build_file(&file.to_string_lossy(), output_dir, build_options, report_options)
+    }
+}
+
+/// Resolve RFC 077 scope before executing build work for each selected member in stable workspace order.
+fn execute_build(
+    file: Option<PathBuf>,
+    workspace: bool,
+    members: &[String],
+    lib_mode: bool,
+    output_dir: Option<String>,
+    build_options: commands::build::BuildCommandOptions,
+    report_options: BuildReportOptions,
+) -> CliResult<ExitCode> {
+    if file.is_some() && (workspace || !members.is_empty()) {
+        return Err(CliError::failure(
+            "a source FILE identifies one build target; omit FILE when selecting workspace members",
+        ));
+    }
+    let scope_start = match file.as_ref() {
+        Some(file) => file.clone(),
+        None => env::current_dir()
+            .map_err(|error| CliError::failure(format!("failed to read current directory: {error}")))?,
+    };
+    let Some(graph) = WorkspaceGraph::discover(&scope_start).map_err(|error| CliError::failure(error.to_string()))?
+    else {
+        if workspace || !members.is_empty() {
+            return Err(CliError::failure(format!(
+                "workspace selection requires a validated workspace containing {}",
+                scope_start.display()
+            )));
+        }
+        return execute_single_build(file, lib_mode, output_dir.as_ref(), build_options, report_options);
+    };
+
+    // An explicit source file remains the single-project command contract unless the caller has selected members.
+    if file.is_some() {
+        return execute_single_build(file, lib_mode, output_dir.as_ref(), build_options, report_options);
+    }
+    let selected = graph
+        .select_members(&scope_start, workspace, members)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    if selected.len() > 1 && output_dir.is_some() {
+        return Err(CliError::failure(
+            "an explicit OUTPUT_DIR cannot be shared by multiple workspace members; select one member or omit OUTPUT_DIR",
+        ));
+    }
+    if selected.len() > 1 && report_options.enabled() {
+        return Err(CliError::failure(
+            "multi-member build reports are not available yet; select one member or omit --report",
+        ));
+    }
+
+    let mut first_failure = None;
+    for member in selected {
+        println!("== workspace {} / member {} ==", graph.root().display(), member.name);
+        let entry = workspace_member_build_entry(&graph, member, lib_mode)?;
+        if let Err(error) = execute_single_build(
+            Some(entry),
+            lib_mode,
+            output_dir.as_ref(),
+            build_options.clone(),
+            report_options.clone(),
+        ) {
+            if !error.message.is_empty() {
+                eprintln!("{}", error.message);
+            }
+            if first_failure.is_none() {
+                first_failure = Some(CliError::new("", error.exit_code));
+            }
+        }
+    }
     first_failure.map_or(Ok(ExitCode::SUCCESS), Err)
 }
 
@@ -1057,6 +1187,8 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
     match cli.command {
         Some(Command::Build {
             file,
+            workspace,
+            member,
             lib_mode,
             output_dir,
             locked,
@@ -1099,13 +1231,7 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
                 cargo_all_features,
                 generated_cargo_target_dir,
             };
-            if lib_mode {
-                let file_arg = file.as_ref().map(|p| p.to_string_lossy().to_string());
-                commands::build_library(file_arg.as_deref(), out.as_ref(), build_options, report_options)
-            } else {
-                let file = resolve_build_entry_file(file)?;
-                commands::build_file(&file.to_string_lossy(), out.as_ref(), build_options, report_options)
-            }
+            execute_build(file, workspace, &member, lib_mode, out, build_options, report_options)
         }
         Some(Command::Check {
             path,
@@ -1804,6 +1930,17 @@ mod tests {
         assert!(!workspace);
         assert_eq!(member, vec!["alpha"]);
         assert_eq!(format, DiagnosticOutputFormat::Json);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_workspace_build_selection() -> Result<(), clap::Error> {
+        let cli = parse_cli(["incan", "build", "--workspace"])?;
+        let Some(Command::Build { workspace, member, .. }) = cli.command else {
+            return Err(expected_command("build"));
+        };
+        assert!(workspace);
+        assert!(member.is_empty());
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -345,6 +345,12 @@ pub enum Command {
         /// Version bump to apply
         #[arg(value_enum)]
         bump: Option<VersionBumpArg>,
+        /// Select every workspace member. `incan version` requires this to resolve to exactly one member.
+        #[arg(long, conflicts_with_all = ["member", "project"])]
+        workspace: bool,
+        /// Select one workspace member by name or workspace-relative path.
+        #[arg(long = "member", value_name = "NAME_OR_PATH", conflicts_with = "project")]
+        member: Vec<String>,
         /// Explicit SemVer version to set
         #[arg(long = "set", value_name = "VERSION")]
         set: Option<String>,
@@ -1462,17 +1468,23 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
         ),
         Some(Command::Version {
             bump,
+            workspace,
+            member,
             set,
             dry_run,
             keep_prerelease,
             project,
-        }) => commands::version_project(commands::lifecycle::VersionCommandOptions {
-            bump,
-            set,
-            dry_run,
-            keep_prerelease,
-            project,
-        }),
+        }) => execute_workspace_version(
+            commands::lifecycle::VersionCommandOptions {
+                bump,
+                set,
+                dry_run,
+                keep_prerelease,
+                project,
+            },
+            workspace,
+            &member,
+        ),
         Some(Command::Env { command }) => match command {
             EnvCommand::List { format, project } => commands::env_list(format, project.as_deref()),
             EnvCommand::Show { env, format, project } => commands::env_show(env.as_deref(), format, project.as_deref()),
@@ -1663,6 +1675,39 @@ fn execute_workspace_run(
         },
         options,
     )
+}
+
+/// Resolve a version request to exactly one RFC 077 workspace member before it mutates a manifest.
+fn execute_workspace_version(
+    mut options: commands::lifecycle::VersionCommandOptions,
+    workspace: bool,
+    members: &[String],
+) -> CliResult<ExitCode> {
+    if options.project.is_some() {
+        return commands::version_project(options);
+    }
+    let cwd =
+        env::current_dir().map_err(|error| CliError::failure(format!("failed to read current directory: {error}")))?;
+    let Some(graph) = WorkspaceGraph::discover(&cwd).map_err(|error| CliError::failure(error.to_string()))? else {
+        if workspace || !members.is_empty() {
+            return Err(CliError::failure(format!(
+                "workspace selection requires a validated workspace containing {}",
+                cwd.display()
+            )));
+        }
+        return commands::version_project(options);
+    };
+    let selected = graph
+        .select_members(&cwd, workspace, members)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    let [member] = selected.as_slice() else {
+        return Err(CliError::failure(
+            "incan version requires exactly one workspace member; pass one --member selector",
+        ));
+    };
+    println!("== workspace {} / member {} ==", graph.root().display(), member.name);
+    options.project = Some(member.path.clone());
+    commands::version_project(options)
 }
 
 /// Handle the `run` subcommand with its various forms.
@@ -2139,6 +2184,17 @@ mod tests {
         };
         assert_eq!(bump, Some(VersionBumpArg::Patch));
         assert!(dry_run);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_workspace_version_selection() -> Result<(), clap::Error> {
+        let cli = parse_cli(["incan", "version", "patch", "--member", "beta", "--dry-run"])?;
+        let Some(Command::Version { workspace, member, .. }) = cli.command else {
+            return Err(expected_command("version"));
+        };
+        assert!(!workspace);
+        assert_eq!(member, vec!["beta"]);
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -306,6 +306,12 @@ pub enum Command {
         /// File or directory to format
         #[arg(value_name = "PATH", default_value = ".")]
         path: PathBuf,
+        /// Select every workspace member instead of the implicit current scope.
+        #[arg(long, conflicts_with = "member")]
+        workspace: bool,
+        /// Select one workspace member by name or workspace-relative path. May be repeated.
+        #[arg(long = "member", value_name = "NAME_OR_PATH")]
+        member: Vec<String>,
         /// Check formatting without modifying files
         #[arg(long)]
         check: bool,
@@ -736,6 +742,47 @@ pub fn run() {
     }
 }
 
+/// Resolve RFC 077 scope before formatting each selected member in stable workspace order.
+///
+/// Formatting normally writes source files. A virtual workspace root can imply several members, so that mutation
+/// requires an explicit `--workspace` or `--member` selection; `--check` remains safe to fan out over the inferred
+/// read-only scope.
+fn execute_format(path: &PathBuf, workspace: bool, members: &[String], check: bool, diff: bool) -> CliResult<ExitCode> {
+    let Some(graph) = WorkspaceGraph::discover(path).map_err(|error| CliError::failure(error.to_string()))? else {
+        if workspace || !members.is_empty() {
+            return Err(CliError::failure(format!(
+                "workspace selection requires a validated workspace containing {}",
+                path.display()
+            )));
+        }
+        return commands::format_files(&path.to_string_lossy(), check, diff);
+    };
+
+    let selected = graph
+        .select_members(path, workspace, members)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    if selected.len() > 1 && !check && !workspace && members.is_empty() {
+        return Err(CliError::failure(
+            "formatting this workspace would modify multiple members; pass --workspace or one or more --member selectors",
+        ));
+    }
+
+    let mut first_failure = None;
+    for member in selected {
+        println!("== workspace {} / member {} ==", graph.root().display(), member.name);
+        if let Err(error) = commands::format_files(&member.path.to_string_lossy(), check, diff) {
+            if !error.message.is_empty() {
+                eprintln!("{}", error.message);
+            }
+            if first_failure.is_none() {
+                first_failure = Some(CliError::new("", error.exit_code));
+            }
+        }
+    }
+
+    first_failure.map_or(Ok(ExitCode::SUCCESS), Err)
+}
+
 /// Resolve RFC 077 scope before test discovery or execution, then run each selected member in workspace order.
 ///
 /// The runner deliberately remains member-oriented: it already owns test discovery, generated batch compilation,
@@ -972,7 +1019,13 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
                 release,
             },
         ),
-        Some(Command::Fmt { path, check, diff }) => commands::format_files(&path.to_string_lossy(), check, diff),
+        Some(Command::Fmt {
+            path,
+            workspace,
+            member,
+            check,
+            diff,
+        }) => execute_format(&path, workspace, &member, check, diff),
         Some(Command::Test {
             path,
             workspace,
@@ -1575,6 +1628,17 @@ mod tests {
             return Err(expected_command("fmt"));
         };
         assert!(check);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_workspace_format_selection() -> Result<(), clap::Error> {
+        let cli = parse_cli(["incan", "fmt", "--workspace", "--check"])?;
+        let Some(Command::Fmt { workspace, member, .. }) = cli.command else {
+            return Err(expected_command("fmt"));
+        };
+        assert!(workspace);
+        assert!(member.is_empty());
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -274,6 +274,12 @@ pub enum Command {
         /// Source file to run
         #[arg(value_name = "FILE", conflicts_with = "command")]
         file: Option<PathBuf>,
+        /// Select every workspace member. `incan run` requires this to resolve to exactly one member.
+        #[arg(long, conflicts_with = "member")]
+        workspace: bool,
+        /// Select one workspace member by name or workspace-relative path.
+        #[arg(long = "member", value_name = "NAME_OR_PATH")]
+        member: Vec<String>,
         /// Run inline source code
         #[arg(short = 'c', long = "command", value_name = "CODE")]
         command: Option<String>,
@@ -1335,6 +1341,8 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
         },
         Some(Command::Run {
             file,
+            workspace,
+            member,
             command,
             locked,
             offline,
@@ -1348,7 +1356,7 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
             cargo_all_features,
             release,
             cargo_passthrough,
-        }) => execute_run(
+        }) => execute_workspace_run(
             RunInput { file, code: command },
             RunOptions {
                 cargo_policy: CargoPolicy::from_cli_and_env(
@@ -1368,6 +1376,8 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
                 cargo_all_features,
                 release,
             },
+            workspace,
+            &member,
         ),
         Some(Command::Fmt {
             path,
@@ -1604,6 +1614,55 @@ fn resolve_build_entry_file(file: Option<PathBuf>) -> CliResult<PathBuf> {
 /// Resolve the run target for `incan run`, falling back to project metadata when available.
 fn resolve_run_entry_file(file: Option<PathBuf>) -> CliResult<PathBuf> {
     resolve_main_script_entry_file(file, "run", "a file path, -c/--command")
+}
+
+/// Resolve a run request to exactly one RFC 077 workspace member before program execution.
+///
+/// Scope is written to stderr because stdout belongs to the program being run. An inline command or explicit source
+/// file already identifies its target and cannot be multiplied across members implicitly.
+fn execute_workspace_run(
+    input: RunInput,
+    options: RunOptions,
+    workspace: bool,
+    members: &[String],
+) -> CliResult<ExitCode> {
+    if (input.file.is_some() || input.code.is_some()) && (workspace || !members.is_empty()) {
+        return Err(CliError::failure(
+            "a source FILE or -c/--command identifies one run target; omit it when selecting a workspace member",
+        ));
+    }
+    if input.file.is_some() || input.code.is_some() {
+        return execute_run(input, options);
+    }
+
+    let cwd =
+        env::current_dir().map_err(|error| CliError::failure(format!("failed to read current directory: {error}")))?;
+    let Some(graph) = WorkspaceGraph::discover(&cwd).map_err(|error| CliError::failure(error.to_string()))? else {
+        if workspace || !members.is_empty() {
+            return Err(CliError::failure(format!(
+                "workspace selection requires a validated workspace containing {}",
+                cwd.display()
+            )));
+        }
+        return execute_run(input, options);
+    };
+    let selected = graph
+        .select_members(&cwd, workspace, members)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    let [member] = selected.as_slice() else {
+        return Err(CliError::failure(
+            "incan run requires exactly one workspace member; pass one --member selector",
+        ));
+    };
+    eprintln!("== workspace {} / member {} ==", graph.root().display(), member.name);
+    let entry = workspace_member_build_entry(&graph, member, false)?;
+    execute_run(
+        RunInput {
+            file: Some(entry),
+            code: None,
+        },
+        options,
+    )
 }
 
 /// Handle the `run` subcommand with its various forms.
@@ -1884,6 +1943,17 @@ mod tests {
             return Err(expected_command("run"));
         };
         assert!(!release, "run should default to debug profile");
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_workspace_run_selection() -> Result<(), clap::Error> {
+        let cli = parse_cli(["incan", "run", "--member", "alpha"])?;
+        let Some(Command::Run { workspace, member, .. }) = cli.command else {
+            return Err(expected_command("run"));
+        };
+        assert!(!workspace);
+        assert_eq!(member, vec!["alpha"]);
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -350,6 +350,12 @@ pub enum Command {
         command: InspectCommand,
     },
 
+    /// Inspect validated RFC 077 workspace topology
+    Workspace {
+        #[command(subcommand)]
+        command: WorkspaceCommand,
+    },
+
     /// Run tests (pytest-style)
     Test {
         /// Path to test file or directory
@@ -543,6 +549,30 @@ pub enum InspectCommand {
         #[arg(long = "allow-errors")]
         allow_errors: bool,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum WorkspaceCommand {
+    /// Emit the validated workspace topology and current implicit member scope
+    Inspect {
+        /// File or directory used to discover the active workspace
+        #[arg(value_name = "PATH", default_value = ".")]
+        path: PathBuf,
+        /// Output format. RFC 077 starts with the machine-readable contract only.
+        #[arg(long = "format", value_enum, default_value = "json")]
+        format: WorkspaceInspectionFormat,
+        /// Select every workspace member instead of the implicit current scope.
+        #[arg(long, conflicts_with = "member")]
+        workspace: bool,
+        /// Select one member by name or workspace-relative path. May be repeated.
+        #[arg(long = "member", value_name = "NAME_OR_PATH")]
+        member: Vec<String>,
+    },
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceInspectionFormat {
+    Json,
 }
 
 #[derive(Subcommand, Debug)]
@@ -747,6 +777,14 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
                 format,
                 allow_errors,
             } => commands::inspect_codegraph(&path, format, allow_errors),
+        },
+        Some(Command::Workspace { command }) => match command {
+            WorkspaceCommand::Inspect {
+                path,
+                format: WorkspaceInspectionFormat::Json,
+                workspace,
+                member,
+            } => commands::inspect_workspace(&path, workspace, &member),
         },
         Some(Command::Run {
             file,
@@ -1156,6 +1194,44 @@ mod tests {
         };
         assert!(file.is_none());
         assert!(lib_mode);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_workspace_inspect_json() -> Result<(), clap::Error> {
+        let cli = parse_cli(["incan", "workspace", "inspect", "packages/storage", "--format", "json"])?;
+        let Some(Command::Workspace {
+            command:
+                WorkspaceCommand::Inspect {
+                    path,
+                    format: WorkspaceInspectionFormat::Json,
+                    workspace,
+                    member,
+                },
+        }) = cli.command
+        else {
+            return Err(expected_command("workspace inspect"));
+        };
+        assert_eq!(path, PathBuf::from("packages/storage"));
+        assert!(!workspace);
+        assert!(member.is_empty());
+
+        let cli = parse_cli([
+            "incan",
+            "workspace",
+            "inspect",
+            "--member",
+            "storage",
+            "--member",
+            "examples/demo",
+        ])?;
+        let Some(Command::Workspace {
+            command: WorkspaceCommand::Inspect { member, .. },
+        }) = cli.command
+        else {
+            return Err(expected_command("workspace inspect member selection"));
+        };
+        assert_eq!(member, ["storage", "examples/demo"]);
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -46,6 +46,7 @@ use std::path::PathBuf;
 use std::process;
 
 use crate::manifest::ProjectManifest;
+use crate::workspace::WorkspaceGraph;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use commands::build_report::{BuildReportFormat, BuildReportOptions, RustInspectionFormat};
 use commands::codegraph::CodegraphInspectionFormat;
@@ -361,6 +362,12 @@ pub enum Command {
         /// Path to test file or directory
         #[arg(value_name = "PATH", default_value = ".")]
         path: PathBuf,
+        /// Select every workspace member instead of the implicit current scope.
+        #[arg(long, conflicts_with = "member")]
+        workspace: bool,
+        /// Select one workspace member by name or workspace-relative path. May be repeated.
+        #[arg(long = "member", value_name = "NAME_OR_PATH")]
+        member: Vec<String>,
         /// Verbose output
         #[arg(short, long)]
         verbose: bool,
@@ -521,6 +528,38 @@ pub enum Command {
         #[arg(long = "cargo-all-features")]
         cargo_all_features: bool,
     },
+}
+
+/// Owned CLI inputs for the test command before RFC 077 scope resolution.
+///
+/// `TestRunConfig` intentionally borrows a single path and filter while it executes one member. This wrapper keeps
+/// the parsed CLI inputs intact while a workspace command expands to a deterministic sequence of member runs.
+struct TestCommandOptions {
+    path: PathBuf,
+    workspace: bool,
+    members: Vec<String>,
+    verbose: bool,
+    stop_on_fail: bool,
+    include_slow: bool,
+    filter: Option<String>,
+    marker_expr: Option<String>,
+    strict_markers: bool,
+    jobs: usize,
+    test_features: Vec<String>,
+    timeout: Option<String>,
+    no_capture: bool,
+    fail_on_empty: bool,
+    list_only: bool,
+    report_format: test_runner::TestOutputFormat,
+    junit_path: Option<PathBuf>,
+    durations: Option<usize>,
+    shuffle: bool,
+    seed: Option<u64>,
+    run_xfail: bool,
+    cargo_policy: CargoPolicy,
+    cargo_features: Vec<String>,
+    cargo_no_default_features: bool,
+    cargo_all_features: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -697,6 +736,117 @@ pub fn run() {
     }
 }
 
+/// Resolve RFC 077 scope before test discovery or execution, then run each selected member in workspace order.
+///
+/// The runner deliberately remains member-oriented: it already owns test discovery, generated batch compilation,
+/// and JSONL emission. This command layer supplies the validated workspace context so each emitted result is
+/// attributable without inventing a second test-result protocol.
+fn execute_tests(options: TestCommandOptions, use_color: bool) -> CliResult<ExitCode> {
+    let Some(workspace) =
+        WorkspaceGraph::discover(&options.path).map_err(|error| CliError::failure(error.to_string()))?
+    else {
+        if options.workspace || !options.members.is_empty() {
+            return Err(CliError::failure(format!(
+                "workspace selection requires a validated workspace containing {}",
+                options.path.display()
+            )));
+        }
+        return test_runner::run_tests(test_runner::TestRunConfig {
+            path: &options.path.to_string_lossy(),
+            verbose: options.verbose,
+            stop_on_fail: options.stop_on_fail,
+            include_slow: options.include_slow,
+            filter: options.filter.as_deref(),
+            marker_expr: options.marker_expr.as_deref(),
+            strict_markers: options.strict_markers,
+            jobs: options.jobs,
+            test_features: options.test_features,
+            timeout: options.timeout.as_deref(),
+            no_capture: options.no_capture,
+            use_color,
+            fail_on_empty: options.fail_on_empty,
+            list_only: options.list_only,
+            report_format: options.report_format,
+            junit_path: options.junit_path,
+            durations: options.durations,
+            shuffle: options.shuffle,
+            seed: options.seed,
+            run_xfail: options.run_xfail,
+            cargo_policy: options.cargo_policy,
+            cargo_features: options.cargo_features,
+            cargo_no_default_features: options.cargo_no_default_features,
+            cargo_all_features: options.cargo_all_features,
+            workspace_context: None,
+        });
+    };
+
+    let selected = workspace
+        .select_members(&options.path, options.workspace, &options.members)
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    if selected.len() > 1 && options.junit_path.is_some() {
+        return Err(CliError::failure(
+            "--junit accepts one member at a time; select one workspace member to avoid overwriting its report",
+        ));
+    }
+
+    let selected_members = selected.iter().map(|member| member.name.clone()).collect::<Vec<_>>();
+    let mut first_failure = None;
+    for member in selected {
+        if options.report_format == test_runner::TestOutputFormat::Console {
+            println!(
+                "== workspace {} / member {} ==",
+                workspace.root().display(),
+                member.name
+            );
+        }
+        let member_path = member.path.to_string_lossy().into_owned();
+        let result = test_runner::run_tests(test_runner::TestRunConfig {
+            path: &member_path,
+            verbose: options.verbose,
+            stop_on_fail: options.stop_on_fail,
+            include_slow: options.include_slow,
+            filter: options.filter.as_deref(),
+            marker_expr: options.marker_expr.as_deref(),
+            strict_markers: options.strict_markers,
+            jobs: options.jobs,
+            test_features: options.test_features.clone(),
+            timeout: options.timeout.as_deref(),
+            no_capture: options.no_capture,
+            use_color,
+            fail_on_empty: options.fail_on_empty,
+            list_only: options.list_only,
+            report_format: options.report_format,
+            junit_path: options.junit_path.clone(),
+            durations: options.durations,
+            shuffle: options.shuffle,
+            seed: options.seed,
+            run_xfail: options.run_xfail,
+            cargo_policy: options.cargo_policy.clone(),
+            cargo_features: options.cargo_features.clone(),
+            cargo_no_default_features: options.cargo_no_default_features,
+            cargo_all_features: options.cargo_all_features,
+            workspace_context: Some(test_runner::TestWorkspaceContext {
+                root: workspace.root().to_path_buf(),
+                selected_members: selected_members.clone(),
+                member: member.name.clone(),
+            }),
+        });
+        if let Err(error) = result {
+            if !error.message.is_empty() {
+                eprintln!("{}", error.message);
+            }
+            if first_failure.is_none() {
+                first_failure = Some(CliError::new("", error.exit_code));
+            }
+            if options.stop_on_fail {
+                break;
+            }
+        }
+    }
+
+    first_failure.map_or(Ok(ExitCode::SUCCESS), Err)
+}
+
 /// Execute the CLI command and return result.
 /// Execute one already-parsed CLI request without terminating the process.
 fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
@@ -825,6 +975,8 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
         Some(Command::Fmt { path, check, diff }) => commands::format_files(&path.to_string_lossy(), check, diff),
         Some(Command::Test {
             path,
+            workspace,
+            member,
             verbose,
             stop_on_fail,
             slow,
@@ -854,44 +1006,47 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
             cargo_no_default_features,
             cargo_all_features,
             cargo_passthrough,
-        }) => test_runner::run_tests(test_runner::TestRunConfig {
-            path: &path.to_string_lossy(),
-            verbose,
-            stop_on_fail,
-            include_slow: slow,
-            filter: filter.as_deref(),
-            marker_expr: marker_expr.as_deref(),
-            strict_markers,
-            jobs,
-            test_features,
-            timeout: timeout.as_deref(),
-            no_capture,
+        }) => execute_tests(
+            TestCommandOptions {
+                path,
+                workspace,
+                members: member,
+                verbose,
+                stop_on_fail,
+                include_slow: slow,
+                filter,
+                marker_expr,
+                strict_markers,
+                jobs,
+                test_features,
+                timeout,
+                no_capture,
+                fail_on_empty,
+                list_only,
+                report_format,
+                junit_path,
+                durations,
+                shuffle,
+                seed,
+                run_xfail,
+                cargo_policy: CargoPolicy::from_cli_and_env(
+                    CargoPolicyCliFlags {
+                        offline,
+                        no_offline,
+                        locked,
+                        no_locked,
+                        frozen,
+                        no_frozen,
+                    },
+                    cargo_args,
+                    cargo_passthrough,
+                ),
+                cargo_features,
+                cargo_no_default_features,
+                cargo_all_features,
+            },
             use_color,
-            fail_on_empty,
-            list_only,
-            report_format,
-            junit_path,
-            durations,
-            shuffle,
-            seed,
-            run_xfail,
-            cargo_policy: CargoPolicy::from_cli_and_env(
-                CargoPolicyCliFlags {
-                    offline,
-                    no_offline,
-                    locked,
-                    no_locked,
-                    frozen,
-                    no_frozen,
-                },
-                cargo_args,
-                cargo_passthrough,
-            ),
-            cargo_features,
-            cargo_no_default_features,
-            cargo_all_features,
-            workspace_context: None,
-        }),
+        ),
         Some(Command::Version {
             bump,
             set,
@@ -1438,6 +1593,17 @@ mod tests {
         assert!(verbose);
         assert!(stop_on_fail);
         assert_eq!(filter.as_deref(), Some("unit"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_parse_workspace_test_selection() -> Result<(), clap::Error> {
+        let cli = parse_cli(["incan", "test", "--member", "alpha", "--member", "packages/beta"])?;
+        let Some(Command::Test { workspace, member, .. }) = cli.command else {
+            return Err(expected_command("test"));
+        };
+        assert!(!workspace);
+        assert_eq!(member, vec!["alpha", "packages/beta"]);
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -42,7 +42,7 @@ pub mod test_runner;
 use std::env;
 use std::fmt;
 use std::io::{self, IsTerminal};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::{Arc, Mutex};
 
@@ -878,7 +878,7 @@ pub fn run() {
 /// Formatting normally writes source files. A virtual workspace root can imply several members, so that mutation
 /// requires an explicit `--workspace` or `--member` selection; `--check` remains safe to fan out over the inferred
 /// read-only scope.
-fn execute_format(path: &PathBuf, workspace: bool, members: &[String], check: bool, diff: bool) -> CliResult<ExitCode> {
+fn execute_format(path: &Path, workspace: bool, members: &[String], check: bool, diff: bool) -> CliResult<ExitCode> {
     let Some(graph) = WorkspaceGraph::discover(path).map_err(|error| CliError::failure(error.to_string()))? else {
         if workspace || !members.is_empty() {
             return Err(CliError::failure(format!(
@@ -1065,7 +1065,7 @@ fn execute_build(
 
 /// Resolve RFC 077 scope before typechecking and retain one coherent JSON document for a workspace check.
 fn execute_check(
-    path: &PathBuf,
+    path: &Path,
     workspace: bool,
     members: &[String],
     format: DiagnosticOutputFormat,
@@ -1073,9 +1073,9 @@ fn execute_check(
     // A missing file is a valid `incan check` input: the diagnostics pipeline owns its stable tooling error. Discover
     // workspace scope from the containing directory instead of canonicalizing that missing file first.
     let discovery_path = if path.exists() {
-        path.clone()
+        path.to_path_buf()
     } else {
-        path.parent().map(PathBuf::from).unwrap_or_else(|| path.clone())
+        path.parent().map(PathBuf::from).unwrap_or_else(|| path.to_path_buf())
     };
     let Some(graph) =
         WorkspaceGraph::discover(&discovery_path).map_err(|error| CliError::failure(error.to_string()))?
@@ -1097,7 +1097,7 @@ fn execute_check(
         let mut member_reports = Vec::with_capacity(selected.len());
         for member in selected {
             let target = if !workspace && members.is_empty() && selected_members.len() == 1 && path.is_file() {
-                path.clone()
+                path.to_path_buf()
             } else {
                 workspace_member_check_entry(&graph, member)?
             };
@@ -1131,7 +1131,7 @@ fn execute_check(
     for member in selected {
         println!("== workspace {} / member {} ==", graph.root().display(), member.name);
         let target = if !workspace && members.is_empty() && selected_members.len() == 1 && path.is_file() {
-            path.clone()
+            path.to_path_buf()
         } else {
             workspace_member_check_entry(&graph, member)?
         };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -890,6 +890,7 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
             cargo_features,
             cargo_no_default_features,
             cargo_all_features,
+            workspace_context: None,
         }),
         Some(Command::Version {
             bump,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,6 +44,7 @@ use std::fmt;
 use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 use std::process;
+use std::sync::{Arc, Mutex};
 
 use crate::manifest::ProjectManifest;
 use crate::workspace::WorkspaceGraph;
@@ -601,6 +602,24 @@ struct WorkspaceMemberCheckReport {
     report: commands::diagnostics::DiagnosticReport,
 }
 
+#[derive(Serialize)]
+struct WorkspaceBuildReport {
+    schema_version: u32,
+    ok: bool,
+    workspace: WorkspaceCheckScope,
+    members: Vec<WorkspaceMemberBuildReport>,
+}
+
+#[derive(Serialize)]
+struct WorkspaceMemberBuildReport {
+    member: String,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    report: Option<commands::build_report::BuildReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
 /// Resolve the source entrypoint used by a workspace-level check for one member.
 ///
 /// The single-project `check` command deliberately accepts a file. Workspace selection names projects instead, so
@@ -900,6 +919,23 @@ fn execute_single_build(
     }
 }
 
+/// Emit one workspace-scoped build report after all member reports have been captured.
+fn emit_workspace_build_report(report: &WorkspaceBuildReport, options: &BuildReportOptions) -> CliResult<()> {
+    let json = serde_json::to_string_pretty(report)
+        .map_err(|error| CliError::failure(format!("failed to serialize workspace build report: {error}")))?;
+    if let Some(path) = &options.output_path {
+        std::fs::write(path, json).map_err(|error| {
+            CliError::failure(format!(
+                "failed to write workspace build report {}: {error}",
+                path.display()
+            ))
+        })?;
+    } else {
+        println!("{json}");
+    }
+    Ok(())
+}
+
 /// Resolve RFC 077 scope before executing build work for each selected member in stable workspace order.
 fn execute_build(
     file: Option<PathBuf>,
@@ -943,30 +979,74 @@ fn execute_build(
             "an explicit OUTPUT_DIR cannot be shared by multiple workspace members; select one member or omit OUTPUT_DIR",
         ));
     }
-    if selected.len() > 1 && report_options.enabled() {
-        return Err(CliError::failure(
-            "multi-member build reports are not available yet; select one member or omit --report",
-        ));
-    }
-
+    let selected_members = selected.iter().map(|member| member.name.clone()).collect::<Vec<_>>();
     let mut first_failure = None;
+    let mut member_reports = Vec::with_capacity(selected.len());
     for member in selected {
-        println!("== workspace {} / member {} ==", graph.root().display(), member.name);
+        if report_options.enabled() {
+            eprintln!("== workspace {} / member {} ==", graph.root().display(), member.name);
+        } else {
+            println!("== workspace {} / member {} ==", graph.root().display(), member.name);
+        }
         let entry = workspace_member_build_entry(&graph, member, lib_mode)?;
-        if let Err(error) = execute_single_build(
+        let captured_reports = Arc::new(Mutex::new(Vec::new()));
+        let member_report_options = if report_options.enabled() {
+            report_options.with_capture(Arc::clone(&captured_reports))
+        } else {
+            report_options.clone()
+        };
+        let result = execute_single_build(
             Some(entry),
             lib_mode,
             output_dir.as_ref(),
             build_options.clone(),
-            report_options.clone(),
-        ) {
-            if !error.message.is_empty() {
-                eprintln!("{}", error.message);
-            }
-            if first_failure.is_none() {
-                first_failure = Some(CliError::new("", error.exit_code));
+            member_report_options,
+        );
+        let captured_report = if report_options.enabled() {
+            captured_reports
+                .lock()
+                .map_err(|_| CliError::failure("failed to lock captured workspace build report"))?
+                .pop()
+        } else {
+            None
+        };
+        match result {
+            Ok(_) => member_reports.push(WorkspaceMemberBuildReport {
+                member: member.name.clone(),
+                ok: true,
+                report: captured_report,
+                error: None,
+            }),
+            Err(error) => {
+                let message = error.message.clone();
+                member_reports.push(WorkspaceMemberBuildReport {
+                    member: member.name.clone(),
+                    ok: false,
+                    report: captured_report,
+                    error: (!message.is_empty()).then_some(message),
+                });
+                if !error.message.is_empty() {
+                    eprintln!("{}", error.message);
+                }
+                if first_failure.is_none() {
+                    first_failure = Some(CliError::new("", error.exit_code));
+                }
             }
         }
+    }
+    if report_options.enabled() {
+        emit_workspace_build_report(
+            &WorkspaceBuildReport {
+                schema_version: commands::build_report::BUILD_REPORT_SCHEMA_VERSION,
+                ok: first_failure.is_none(),
+                workspace: WorkspaceCheckScope {
+                    root: graph.root().to_path_buf(),
+                    selected_members,
+                },
+                members: member_reports,
+            },
+            &report_options,
+        )?;
     }
     first_failure.map_or(Ok(ExitCode::SUCCESS), Err)
 }
@@ -1208,10 +1288,7 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
             cargo_passthrough,
         }) => {
             let out = output_dir.map(|p| p.to_string_lossy().to_string());
-            let report_options = BuildReportOptions {
-                format: report,
-                output_path: report_output,
-            };
+            let report_options = BuildReportOptions::new(report, report_output);
             let cargo_policy = CargoPolicy::from_cli_and_env(
                 CargoPolicyCliFlags {
                     offline,

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -29,6 +29,7 @@ use crate::frontend::vocab_desugar_pass;
 use crate::frontend::{lexer, parser};
 use crate::lockfile::CargoFeatureSelection;
 use crate::manifest::ProjectManifest;
+use crate::workspace::WorkspaceGraph;
 use sha2::{Digest, Sha256};
 
 use super::module_graph::collect_source_modules_for_test;
@@ -2884,7 +2885,9 @@ pub(super) fn run_file_tests_batch(
     }
     let source = source_parts.join("\n");
 
-    let manifest = match ProjectManifest::discover(first.file_path.parent().unwrap_or_else(|| Path::new("."))) {
+    let manifest = match WorkspaceGraph::discover_effective_project_manifest(
+        first.file_path.parent().unwrap_or_else(|| Path::new(".")),
+    ) {
         Ok(manifest) => manifest,
         Err(err) => {
             return tests

--- a/src/cli/test_runner/mod.rs
+++ b/src/cli/test_runner/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use module_graph::collect_source_modules_for_test;
 pub use reporter::{ConsoleReporter, TestReporter};
 pub use types::{
     DiscoveryResult, FixtureInfo, FixtureScope, ParametrizeCall, ParametrizeCase, TestInfo, TestMarker,
-    TestOutputFormat, TestResult, TestRunConfig, TestSummary,
+    TestOutputFormat, TestResult, TestRunConfig, TestSummary, TestWorkspaceContext,
 };
 
 use discovery::{
@@ -309,7 +309,7 @@ fn marker_names(test: &TestInfo) -> BTreeSet<String> {
 }
 
 /// Emit one JSON Lines result record for a test case.
-fn emit_json_result(test: &TestInfo, result: &TestResult, root: &Path) {
+fn emit_json_result(test: &TestInfo, result: &TestResult, root: &Path, workspace: Option<&TestWorkspaceContext>) {
     let mut record = serde_json::json!({
         "schema_version": "incan.test.v1",
         "test_id": stable_test_id(test, root),
@@ -333,6 +333,16 @@ fn emit_json_result(test: &TestInfo, result: &TestResult, root: &Path) {
                 obj.insert("reason".to_string(), serde_json::Value::String(reason.clone()));
             }
             TestResult::Passed(_) | TestResult::XPassed(_) => {}
+        }
+        if let Some(workspace) = workspace {
+            obj.insert(
+                "workspace".to_string(),
+                serde_json::json!({
+                    "root": workspace.root,
+                    "selected_members": workspace.selected_members,
+                    "member": workspace.member,
+                }),
+            );
         }
     }
     println!("{record}");
@@ -1057,6 +1067,7 @@ pub fn run_tests(config: TestRunConfig<'_>) -> CliResult<ExitCode> {
         cargo_features,
         cargo_no_default_features,
         cargo_all_features,
+        workspace_context,
     } = config;
 
     let start_time = Instant::now();
@@ -1363,7 +1374,7 @@ pub fn run_tests(config: TestRunConfig<'_>) -> CliResult<ExitCode> {
         if report_format == TestOutputFormat::Console {
             print_test_result(&test, &result, verbose, use_color);
         } else {
-            emit_json_result(&test, &result, &stable_id_root);
+            emit_json_result(&test, &result, &stable_id_root, workspace_context.as_ref());
         }
         results.push((test, result));
     }
@@ -1443,7 +1454,12 @@ pub fn run_tests(config: TestRunConfig<'_>) -> CliResult<ExitCode> {
                     "xpassed": xpassed,
                     "duration_ms": total_time.as_millis(),
                     "shuffle_seed": shuffle_seed,
-                }
+                },
+                "workspace": workspace_context.as_ref().map(|workspace| serde_json::json!({
+                    "root": workspace.root,
+                    "selected_members": workspace.selected_members,
+                    "member": workspace.member,
+                })),
             })
         );
     }

--- a/src/cli/test_runner/mod.rs
+++ b/src/cli/test_runner/mod.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::cli::commands::common::CargoPolicy;
 use crate::cli::{CliError, CliResult, ExitCode};
-use crate::manifest::ProjectManifest;
+use crate::workspace::WorkspaceGraph;
 
 mod discovery;
 mod execution;
@@ -203,7 +203,9 @@ fn enforce_test_path_toolchain_constraint(path: &Path) -> CliResult<()> {
     } else {
         path
     };
-    if let Some(manifest) = ProjectManifest::discover(start).map_err(|error| CliError::failure(error.to_string()))? {
+    if let Some(manifest) = WorkspaceGraph::discover_effective_project_manifest(start)
+        .map_err(|error| CliError::failure(error.to_string()))?
+    {
         crate::cli::commands::common::enforce_project_toolchain_constraint(&manifest)?;
     }
     Ok(())

--- a/src/cli/test_runner/types.rs
+++ b/src/cli/test_runner/types.rs
@@ -169,4 +169,14 @@ pub struct TestRunConfig<'a> {
     pub cargo_features: Vec<String>,
     pub cargo_no_default_features: bool,
     pub cargo_all_features: bool,
+    /// RFC 077 workspace identity included in every machine-readable record for a member-scoped run.
+    pub workspace_context: Option<TestWorkspaceContext>,
+}
+
+/// Stable workspace identity for one member test invocation.
+#[derive(Debug, Clone)]
+pub struct TestWorkspaceContext {
+    pub root: PathBuf,
+    pub selected_members: Vec<String>,
+    pub member: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod rust_inspect;
 pub(crate) mod semantics_registry;
 pub(crate) mod toolchain_layout;
 pub mod version;
+pub mod workspace;
 
 pub use frontend::ast;
 pub use frontend::diagnostics;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1908,8 +1908,7 @@ pretty_assertions = { workspace = true }
 serde = { workspace = true, version = "1" }
 "#;
         let error = ProjectManifest::from_str(content, Path::new("incan.toml"))
-            .err()
-            .expect("workspace identity refinement must fail");
+            .expect_err("workspace identity refinement must fail");
         assert!(error.to_string().contains("may refine only"));
     }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -627,6 +627,7 @@ pub fn parse_workspace_rust_dev_dependency_declarations(
     parse_workspace_rust_dependency_table(&workspace.rust_dev_dependencies, "rust-dev-dependencies", manifest_path)
 }
 
+/// Parse one workspace Rust dependency table and reject member-style inheritance or workspace-level optionality.
 fn parse_workspace_rust_dependency_table(
     entries: &HashMap<String, toml::Value>,
     section: &str,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -517,6 +517,27 @@ impl ProjectManifest {
         self.workspace.as_ref()
     }
 
+    /// Return a copy whose dependency tables have been resolved by a validated workspace graph.
+    ///
+    /// Dependency inheritance is intentionally resolved outside this parser because it needs the workspace root and
+    /// every member manifest. Consumers that need one member's effective build or lock inputs must use this view,
+    /// rather than treating `{ workspace = true }` as an empty local declaration.
+    pub fn with_effective_workspace_dependencies(
+        &self,
+        library_dependencies: BTreeMap<String, LibraryDependencySpec>,
+        rust_dependencies: BTreeMap<String, DependencySpec>,
+        rust_dev_dependencies: BTreeMap<String, DependencySpec>,
+    ) -> Self {
+        let mut resolved = self.clone();
+        resolved.library_dependencies = library_dependencies.into_iter().collect();
+        resolved.rust_dependencies = rust_dependencies.into_iter().collect();
+        resolved.rust_dev_dependencies = rust_dev_dependencies.into_iter().collect();
+        resolved.workspace_library_dependencies.clear();
+        resolved.workspace_rust_dependencies.clear();
+        resolved.workspace_rust_dev_dependencies.clear();
+        resolved
+    }
+
     /// RFC 048 model bundle JSON paths declared under `[tool.incan.metadata]`.
     pub fn contract_model_bundle_paths(&self) -> Vec<String> {
         self.incan_tool()

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -85,21 +85,21 @@ impl std::fmt::Display for ManifestLocationDisplay {
 // Dependency specification types
 // ============================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum DependencySource {
     Registry,
     Git { url: String, reference: GitReference },
     Path { path: PathBuf },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum GitReference {
     Branch(String),
     Tag(String),
     Rev(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DependencySpec {
     pub crate_name: String,
     pub version: Option<String>,
@@ -119,10 +119,28 @@ impl DependencySpec {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LibraryDependencySpec {
     pub library_name: String,
     pub path: PathBuf,
+}
+
+/// A member-local opt-in to a workspace-owned Incan library dependency declaration.
+///
+/// RFC 077 deliberately permits no member-level refinements for Incan library dependencies: the workspace owns the
+/// complete declaration and the member either opts in or declares an independent dependency.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceLibraryDependencyRef;
+
+/// A member-local opt-in to a workspace-owned Rust dependency declaration.
+///
+/// The workspace owns source, version, package identity, and default-feature policy. A member may add features and
+/// choose whether its use is optional; resolution of the effective dependency happens only after the workspace graph
+/// has been validated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceRustDependencyRef {
+    pub features: Vec<String>,
+    pub optional: bool,
 }
 
 // ============================================================================
@@ -208,6 +226,48 @@ pub struct BuildSection {
     /// is used by convention when it exists; otherwise the project root itself is used.
     #[serde(rename = "source-root", skip_serializing_if = "Option::is_none")]
     pub source_root: Option<String>,
+}
+
+/// `[workspace]` coordination metadata from an Incan workspace root manifest.
+///
+/// RFC 077 deliberately keeps membership separate from dependency inheritance: this section declares the topology,
+/// while member manifests opt into any shared declaration explicitly. The graph builder owns filesystem expansion and
+/// cross-manifest validation because those checks cannot be performed from one TOML document alone.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceSection {
+    /// Explicit root-relative paths or glob patterns for non-root members.
+    #[serde(default)]
+    pub members: Vec<String>,
+    /// Members selected from the workspace root when no selector is provided.
+    #[serde(rename = "default-members", default)]
+    pub default_members: Vec<String>,
+    /// Root-relative paths or globs removed after member expansion.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    /// Shared Incan dependency declarations. Resolution is implemented after topology validation.
+    #[serde(default)]
+    pub dependencies: HashMap<String, toml::Value>,
+    /// Shared Rust dependency declarations. Resolution is implemented after topology validation.
+    #[serde(rename = "rust-dependencies", default)]
+    pub rust_dependencies: HashMap<String, toml::Value>,
+    /// Shared Rust development dependency declarations. Resolution is implemented after topology validation.
+    #[serde(rename = "rust-dev-dependencies", default)]
+    pub rust_dev_dependencies: HashMap<String, toml::Value>,
+    /// Reserved workspace-owned environment declarations.
+    #[serde(default)]
+    pub envs: HashMap<String, toml::Value>,
+    /// Reserved workspace policy configuration, retained for validation and inspection before policy evaluation lands.
+    #[serde(default)]
+    pub policy: Option<toml::Value>,
+    /// Reserved workspace source/catalog configuration, retained for validation and inspection before resolution
+    /// lands.
+    #[serde(default)]
+    pub sources: Option<toml::Value>,
+    /// Reserved workspace capability configuration. Capability mutation remains member-local until RFC 077 is
+    /// complete.
+    #[serde(default)]
+    pub capabilities: Option<toml::Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -338,12 +398,22 @@ pub struct ProjectManifest {
     pub vocab: Option<VocabSection>,
     /// `[tool]` configuration (optional).
     pub tool: Option<ToolSection>,
+    /// `[workspace]` configuration when this manifest is a workspace root.
+    pub workspace: Option<WorkspaceSection>,
     /// `[dependencies]` (Incan library dependencies).
     library_dependencies: HashMap<String, LibraryDependencySpec>,
+    /// Incan library dependency entries that explicitly inherit their full declaration from
+    /// `[workspace.dependencies]`.
+    workspace_library_dependencies: HashMap<String, WorkspaceLibraryDependencyRef>,
     /// `[rust-dependencies]` (Rust crate dependencies).
     rust_dependencies: HashMap<String, DependencySpec>,
     /// `[rust-dev-dependencies]` (dev-only Rust crates).
     rust_dev_dependencies: HashMap<String, DependencySpec>,
+    /// Rust dependency entries that explicitly inherit their identity from `[workspace.rust-dependencies]`.
+    workspace_rust_dependencies: HashMap<String, WorkspaceRustDependencyRef>,
+    /// Dev-only Rust dependency entries that explicitly inherit their identity from
+    /// `[workspace.rust-dev-dependencies]`.
+    workspace_rust_dev_dependencies: HashMap<String, WorkspaceRustDependencyRef>,
 }
 
 impl ProjectManifest {
@@ -392,6 +462,11 @@ impl ProjectManifest {
         &self.library_dependencies
     }
 
+    /// Explicit member opt-ins to workspace-owned Incan library dependencies.
+    pub fn workspace_library_dependencies(&self) -> &HashMap<String, WorkspaceLibraryDependencyRef> {
+        &self.workspace_library_dependencies
+    }
+
     /// Normal Rust dependencies from the manifest.
     pub fn rust_dependencies(&self) -> &HashMap<String, DependencySpec> {
         &self.rust_dependencies
@@ -400,6 +475,16 @@ impl ProjectManifest {
     /// Dev-only Rust dependencies from the manifest.
     pub fn rust_dev_dependencies(&self) -> &HashMap<String, DependencySpec> {
         &self.rust_dev_dependencies
+    }
+
+    /// Explicit member opt-ins to workspace-owned Rust dependencies.
+    pub fn workspace_rust_dependencies(&self) -> &HashMap<String, WorkspaceRustDependencyRef> {
+        &self.workspace_rust_dependencies
+    }
+
+    /// Explicit member opt-ins to workspace-owned Rust dev dependencies.
+    pub fn workspace_rust_dev_dependencies(&self) -> &HashMap<String, WorkspaceRustDependencyRef> {
+        &self.workspace_rust_dev_dependencies
     }
 
     /// Path to the `incan.toml` file.
@@ -425,6 +510,11 @@ impl ProjectManifest {
     /// Optional Incan-owned tool configuration.
     pub fn incan_tool(&self) -> Option<&IncanToolSection> {
         self.tool.as_ref().and_then(|tool| tool.incan.as_ref())
+    }
+
+    /// Workspace configuration when this manifest declares a workspace root.
+    pub fn workspace(&self) -> Option<&WorkspaceSection> {
+        self.workspace.as_ref()
     }
 
     /// RFC 048 model bundle JSON paths declared under `[tool.incan.metadata]`.
@@ -462,6 +552,98 @@ impl ProjectManifest {
             .map(|(name, spec)| (name.clone(), dependency_spec_to_toml_value(spec)))
             .collect()
     }
+}
+
+/// Parse `[workspace.rust-dependencies]` declarations into the same canonical dependency representation used by
+/// project manifests. Paths resolve relative to the workspace root manifest.
+pub fn parse_workspace_rust_dependency_declarations(
+    workspace: &WorkspaceSection,
+    manifest_path: &Path,
+) -> Result<BTreeMap<String, DependencySpec>, ManifestError> {
+    parse_workspace_rust_dependency_table(&workspace.rust_dependencies, "rust-dependencies", manifest_path)
+}
+
+/// Parse `[workspace.dependencies]` declarations into the canonical Incan library dependency representation.
+///
+/// Paths resolve relative to the workspace root manifest. Unlike Rust dependencies, library members cannot refine a
+/// shared declaration; they opt in with exactly `{ workspace = true }`.
+pub fn parse_workspace_library_dependency_declarations(
+    workspace: &WorkspaceSection,
+    manifest_path: &Path,
+) -> Result<BTreeMap<String, LibraryDependencySpec>, ManifestError> {
+    let mut dependencies = BTreeMap::new();
+    for (name, value) in &workspace.dependencies {
+        let entry = DependencyEntry::deserialize(value.clone()).map_err(|error| {
+            manifest_invalid(
+                manifest_path,
+                None,
+                format!("invalid [workspace.dependencies] entry `{name}`: {error}"),
+            )
+        })?;
+        if matches!(&entry, DependencyEntry::Table(table) if table.workspace.is_some()) {
+            return Err(manifest_invalid(
+                manifest_path,
+                None,
+                format!("workspace library dependency `{name}` must declare its own path and cannot use `workspace`"),
+            ));
+        }
+        dependencies.insert(
+            name.clone(),
+            library_dependency_from_entry(name, &entry, manifest_path, None)?,
+        );
+    }
+    Ok(dependencies)
+}
+
+/// Parse `[workspace.rust-dev-dependencies]` declarations into the canonical dependency representation.
+///
+/// Dev dependencies obey the same inheritance constraints as normal Rust dependencies. They remain a distinct map
+/// so workspace inspection and later shared-lock resolution preserve Cargo's normal-versus-dev boundary.
+pub fn parse_workspace_rust_dev_dependency_declarations(
+    workspace: &WorkspaceSection,
+    manifest_path: &Path,
+) -> Result<BTreeMap<String, DependencySpec>, ManifestError> {
+    parse_workspace_rust_dependency_table(&workspace.rust_dev_dependencies, "rust-dev-dependencies", manifest_path)
+}
+
+fn parse_workspace_rust_dependency_table(
+    entries: &HashMap<String, toml::Value>,
+    section: &str,
+    manifest_path: &Path,
+) -> Result<BTreeMap<String, DependencySpec>, ManifestError> {
+    let mut dependencies = BTreeMap::new();
+    for (name, value) in entries {
+        let entry = DependencyEntry::deserialize(value.clone()).map_err(|error| {
+            manifest_invalid(
+                manifest_path,
+                None,
+                format!("invalid [workspace.{section}] entry `{name}`: {error}"),
+            )
+        })?;
+        if matches!(&entry, DependencyEntry::Table(table) if table.workspace.is_some()) {
+            return Err(manifest_invalid(
+                manifest_path,
+                None,
+                format!(
+                    "workspace {section} dependency `{name}` must declare its own identity and cannot use `workspace`"
+                ),
+            ));
+        }
+        let mut spec = dependency_from_entry(name, &entry, false, manifest_path, None)?;
+        if spec.optional {
+            return Err(manifest_invalid(
+                manifest_path,
+                None,
+                format!(
+                    "workspace {section} dependency `{name}` must not set `optional`; optionality belongs to each member"
+                ),
+            ));
+        }
+        spec.features.sort();
+        spec.features.dedup();
+        dependencies.insert(name.clone(), spec);
+    }
+    Ok(dependencies)
 }
 
 /// Walk upward from `start_dir` to find an `incan.toml` file.
@@ -536,6 +718,8 @@ struct RawManifest {
     #[serde(default)]
     tool: Option<ToolSection>,
     #[serde(default)]
+    workspace: Option<WorkspaceSection>,
+    #[serde(default)]
     dependencies: Option<DependencyTable>,
     #[serde(rename = "rust-dependencies", default)]
     rust_dependencies: Option<DependencyTable>,
@@ -585,6 +769,7 @@ struct DependencyEntryTable {
     package: Option<String>,
     #[serde(rename = "default-features")]
     default_features: Option<bool>,
+    workspace: Option<bool>,
 }
 
 struct ManifestSpans<'a> {
@@ -782,15 +967,23 @@ fn parse_manifest_content(content: &str, path: &Path) -> Result<ProjectManifest,
         }
     }
 
+    let workspace_library_dependencies = library_dependencies.workspace_refs;
+    let workspace_rust_dependencies = rust_dependencies.workspace_refs;
+    let workspace_rust_dev_dependencies = rust_dev_dependencies.workspace_refs;
+
     Ok(ProjectManifest {
         path: path.to_path_buf(),
         project: raw.project,
         build: raw.build,
         vocab: raw.vocab,
         tool: raw.tool,
-        library_dependencies,
+        workspace: raw.workspace,
+        library_dependencies: library_dependencies.specs,
+        workspace_library_dependencies,
         rust_dependencies: rust_dependencies.specs,
         rust_dev_dependencies: rust_dev_dependencies.specs,
+        workspace_rust_dependencies,
+        workspace_rust_dev_dependencies,
     })
 }
 
@@ -1000,6 +1193,7 @@ const DEPENDENCY_ENTRY_KEYS: &[&str] = &[
     "optional",
     "package",
     "default-features",
+    "workspace",
 ];
 
 /// Validate the raw TOML shapes of all dependency tables before serde decoding proceeds.
@@ -1087,7 +1281,7 @@ fn validate_dependency_entry_item(
                     format!("dependency `{entry_name}` field `{key}` must be a string"),
                 ));
             }
-            "optional" | "default-features" if !value.is_bool() => {
+            "optional" | "default-features" | "workspace" if !value.is_bool() => {
                 return Err(manifest_invalid(
                     path,
                     location,
@@ -1169,7 +1363,7 @@ fn parse_library_dependency_table(
     table: &DependencyTable,
     spans: &ManifestSpans<'_>,
     path: &Path,
-) -> Result<HashMap<String, LibraryDependencySpec>, ManifestError> {
+) -> Result<ParsedLibraryDependencyTable, ManifestError> {
     if !table.optional.is_empty() {
         return Err(manifest_invalid(
             path,
@@ -1178,13 +1372,61 @@ fn parse_library_dependency_table(
         ));
     }
 
-    let mut result = HashMap::new();
+    let mut result = ParsedLibraryDependencyTable::default();
     for (name, entry) in &table.entries {
         let location = spans.entry_location(&["dependencies"], name);
+        if workspace_library_dependency_ref_from_entry(name, entry, path, location)? {
+            result
+                .workspace_refs
+                .insert(name.clone(), WorkspaceLibraryDependencyRef);
+            continue;
+        }
         let spec = library_dependency_from_entry(name, entry, path, location)?;
-        result.insert(name.clone(), spec);
+        result.specs.insert(name.clone(), spec);
     }
     Ok(result)
+}
+
+/// Parse a `{ workspace = true }` Incan library opt-in without assigning any member-local path or identity.
+fn workspace_library_dependency_ref_from_entry(
+    name: &str,
+    entry: &DependencyEntry,
+    path: &Path,
+    location: Option<ManifestLocation>,
+) -> Result<bool, ManifestError> {
+    let DependencyEntry::Table(table) = entry else {
+        return Ok(false);
+    };
+    let Some(workspace) = table.workspace else {
+        return Ok(false);
+    };
+    if !workspace {
+        return Err(manifest_invalid(
+            path,
+            location,
+            format!("library dependency `{name}` sets `workspace = false`; omit the key for a member-local dependency"),
+        ));
+    }
+    if table.version.is_some()
+        || table.features.is_some()
+        || table.git.is_some()
+        || table.branch.is_some()
+        || table.tag.is_some()
+        || table.rev.is_some()
+        || table.path.is_some()
+        || table.optional.is_some()
+        || table.package.is_some()
+        || table.default_features.is_some()
+    {
+        return Err(manifest_invalid(
+            path,
+            location,
+            format!(
+                "workspace library dependency `{name}` may only set `workspace = true`; its complete declaration belongs to [workspace.dependencies]"
+            ),
+        ));
+    }
+    Ok(true)
 }
 
 /// Parse one library dependency entry from `[dependencies]`.
@@ -1284,6 +1526,10 @@ fn parse_dependency_table(
             ));
         }
         let location = spans.entry_location(table_path, name);
+        if let Some(workspace_ref) = workspace_dependency_ref_from_entry(name, entry, false, path, location)? {
+            result.workspace_refs.insert(name.clone(), workspace_ref);
+            continue;
+        }
         let spec = dependency_from_entry(name, entry, false, path, location)?;
         result.specs.insert(name.clone(), spec);
         if let Some(location) = location {
@@ -1293,6 +1539,10 @@ fn parse_dependency_table(
 
     for (name, entry) in &table.optional {
         let location = spans.entry_location(table_path, name);
+        if let Some(workspace_ref) = workspace_dependency_ref_from_entry(name, entry, true, path, location)? {
+            result.workspace_refs.insert(name.clone(), workspace_ref);
+            continue;
+        }
         let spec = dependency_from_entry(name, entry, true, path, location)?;
         result.specs.insert(name.clone(), spec);
         if let Some(location) = location {
@@ -1301,6 +1551,53 @@ fn parse_dependency_table(
     }
 
     Ok(result)
+}
+
+/// Parse a `{ workspace = true }` dependency opt-in without assigning a member-local source identity.
+fn workspace_dependency_ref_from_entry(
+    name: &str,
+    entry: &DependencyEntry,
+    optional_override: bool,
+    path: &Path,
+    location: Option<ManifestLocation>,
+) -> Result<Option<WorkspaceRustDependencyRef>, ManifestError> {
+    let DependencyEntry::Table(table) = entry else {
+        return Ok(None);
+    };
+    let Some(workspace) = table.workspace else {
+        return Ok(None);
+    };
+    if !workspace {
+        return Err(manifest_invalid(
+            path,
+            location,
+            format!("dependency `{name}` sets `workspace = false`; omit the key for a member-local dependency"),
+        ));
+    }
+    if table.version.is_some()
+        || table.git.is_some()
+        || table.branch.is_some()
+        || table.tag.is_some()
+        || table.rev.is_some()
+        || table.path.is_some()
+        || table.package.is_some()
+        || table.default_features.is_some()
+    {
+        return Err(manifest_invalid(
+            path,
+            location,
+            format!(
+                "workspace dependency `{name}` may refine only `features` and `optional`; source, version, package, and default-feature policy belong to the workspace"
+            ),
+        ));
+    }
+    let mut features = table.features.clone().unwrap_or_default();
+    features.sort();
+    features.dedup();
+    Ok(Some(WorkspaceRustDependencyRef {
+        features,
+        optional: optional_override || table.optional.unwrap_or(false),
+    }))
 }
 
 /// Parse one Rust dependency entry into the canonical dependency model.
@@ -1481,9 +1778,16 @@ fn validate_package_collisions(
 }
 
 #[derive(Debug, Default)]
+struct ParsedLibraryDependencyTable {
+    specs: HashMap<String, LibraryDependencySpec>,
+    workspace_refs: HashMap<String, WorkspaceLibraryDependencyRef>,
+}
+
+#[derive(Debug, Default)]
 struct ParsedDependencyTable {
     specs: HashMap<String, DependencySpec>,
     locations: HashMap<String, ManifestLocation>,
+    workspace_refs: HashMap<String, WorkspaceRustDependencyRef>,
 }
 
 /// Return a stable identity key for one dependency source.
@@ -1545,6 +1849,47 @@ pretty_assertions = "1.4"
         assert!(manifest.rust_dependencies().contains_key("serde"));
         assert!(manifest.rust_dev_dependencies().contains_key("pretty_assertions"));
         Ok(())
+    }
+
+    #[test]
+    fn parses_workspace_rust_dependency_refs_without_assigning_member_local_identity() -> Result<(), ManifestError> {
+        let content = r#"
+[rust-dependencies]
+serde = { workspace = true, features = ["derive"], optional = true }
+
+[rust-dev-dependencies]
+pretty_assertions = { workspace = true }
+"#;
+        let manifest = ProjectManifest::from_str(content, Path::new("incan.toml"))?;
+        assert!(manifest.rust_dependencies().is_empty());
+        assert!(manifest.rust_dev_dependencies().is_empty());
+        assert_eq!(
+            manifest.workspace_rust_dependencies().get("serde"),
+            Some(&WorkspaceRustDependencyRef {
+                features: vec!["derive".to_string()],
+                optional: true,
+            })
+        );
+        assert_eq!(
+            manifest.workspace_rust_dev_dependencies().get("pretty_assertions"),
+            Some(&WorkspaceRustDependencyRef {
+                features: Vec::new(),
+                optional: false,
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_workspace_rust_dependency_identity_refinements() {
+        let content = r#"
+[rust-dependencies]
+serde = { workspace = true, version = "1" }
+"#;
+        let error = ProjectManifest::from_str(content, Path::new("incan.toml"))
+            .err()
+            .expect("workspace identity refinement must fail");
+        assert!(error.to_string().contains("may refine only"));
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -390,6 +390,22 @@ impl WorkspaceGraph {
         ))
     }
 
+    /// Discover the manifest that compilation should consume for one path.
+    ///
+    /// A selected workspace member receives its explicit shared-dependency opt-ins before callers construct library
+    /// indexes, resolve Rust crates, or generate a lock payload. A workspace root that selects multiple members does
+    /// not silently choose one: command fan-out owns that later RFC 077 decision, so this method falls back to the
+    /// ordinary manifest discovery contract there.
+    pub fn discover_effective_project_manifest(start: &Path) -> Result<Option<ProjectManifest>, WorkspaceError> {
+        if let Some(workspace) = Self::discover(start)? {
+            let selected = workspace.selected_members_for(start)?;
+            if let [member] = selected.as_slice() {
+                return workspace.effective_manifest_for(member).map(Some);
+            }
+        }
+        Ok(ProjectManifest::discover(start)?)
+    }
+
     /// Resolve the member scope implied by `start` before any command execution.
     pub fn selected_members_for(&self, start: &Path) -> Result<Vec<&WorkspaceMember>, WorkspaceError> {
         let start = canonical_start_path(start)?;
@@ -844,6 +860,8 @@ fn resolve_effective_rust_dev_dependencies(
 mod tests {
     use std::fs;
 
+    use crate::manifest::DependencySource;
+
     use super::*;
 
     fn write_manifest(root: &Path, relative: &str, content: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -949,6 +967,34 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["first", "second"]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn effective_manifest_discovery_applies_member_workspace_rust_dependencies()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write_manifest(
+            temp.path(),
+            "incan.toml",
+            "[workspace]\nmembers = ['members/*']\n[workspace.rust-dependencies]\ntiny_workspace = { path = 'shared/tiny_workspace' }\n",
+        )?;
+        write_manifest(
+            temp.path(),
+            "members/app/incan.toml",
+            "[project]\nname = 'app'\n[rust-dependencies]\ntiny_workspace = { workspace = true }\n",
+        )?;
+
+        let manifest = WorkspaceGraph::discover_effective_project_manifest(&temp.path().join("members/app"))?
+            .ok_or("member manifest should be discovered")?;
+        let dependency = manifest
+            .rust_dependencies()
+            .get("tiny_workspace")
+            .ok_or("effective shared dependency should be available to compilation")?;
+        let DependencySource::Path { path } = &dependency.source else {
+            return Err("effective shared dependency should retain its path source".into());
+        };
+        assert_eq!(path, &temp.path().canonicalize()?.join("shared/tiny_workspace"));
         Ok(())
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -486,11 +486,13 @@ impl WorkspaceGraph {
             .collect())
     }
 
+    /// Return whether a canonical start path is the workspace root or lies within a declared member.
     fn contains_path(&self, path: &Path) -> bool {
         path == self.root || self.members.iter().any(|member| path.starts_with(&member.path))
     }
 }
 
+/// Canonicalize a workspace-discovery start path, treating an empty relative parent as the current directory.
 fn canonical_start_path(path: &Path) -> Result<PathBuf, WorkspaceError> {
     // `Path::parent()` is an empty path for a bare relative filename. Test and compiler callers use that parent as
     // their discovery start, where it means the current directory rather than a path that should be handed to the
@@ -503,6 +505,7 @@ fn canonical_start_path(path: &Path) -> Result<PathBuf, WorkspaceError> {
     canonical_path(path)
 }
 
+/// Canonicalize a filesystem path while retaining its path context in workspace diagnostics.
 fn canonical_path(path: &Path) -> Result<PathBuf, WorkspaceError> {
     fs::canonicalize(path).map_err(|source| WorkspaceError::Io {
         path: path.to_path_buf(),
@@ -510,6 +513,7 @@ fn canonical_path(path: &Path) -> Result<PathBuf, WorkspaceError> {
     })
 }
 
+/// Load and validate one manifest used to construct a workspace graph.
 fn read_manifest(path: &Path) -> Result<ProjectManifest, WorkspaceError> {
     let content = fs::read_to_string(path).map_err(|source| WorkspaceError::Io {
         path: path.to_path_buf(),
@@ -518,6 +522,7 @@ fn read_manifest(path: &Path) -> Result<ProjectManifest, WorkspaceError> {
     ProjectManifest::from_str(&content, path).map_err(Into::into)
 }
 
+/// Inspect the canonical root lock and report any non-authoritative member-local locks without mutating them.
 fn inspect_root_lock(root: &Path, members: &[WorkspaceMember]) -> WorkspaceLockState {
     let path = root.join("incan.lock");
     let stale_member_lockfiles = members
@@ -559,6 +564,7 @@ fn inspect_root_lock(root: &Path, members: &[WorkspaceMember]) -> WorkspaceLockS
     }
 }
 
+/// Validate and normalize the project name required for a workspace member.
 fn required_project_name(name: Option<&str>, manifest: &Path) -> Result<String, WorkspaceError> {
     let Some(name) = name.map(str::trim).filter(|name| !name.is_empty()) else {
         return Err(invalid(
@@ -569,6 +575,7 @@ fn required_project_name(name: Option<&str>, manifest: &Path) -> Result<String, 
     Ok(name.to_string())
 }
 
+/// Construct a workspace-validation error attributed to its owning manifest.
 fn invalid(manifest: &Path, message: impl Into<String>) -> WorkspaceError {
     WorkspaceError::Invalid {
         manifest: manifest.to_path_buf(),
@@ -576,6 +583,7 @@ fn invalid(manifest: &Path, message: impl Into<String>) -> WorkspaceError {
     }
 }
 
+/// Expand member or exclusion patterns into canonical workspace-relative directories in deterministic order.
 fn expand_patterns(
     root: &Path,
     patterns: &[String],
@@ -646,6 +654,7 @@ fn expand_patterns(
     Ok(expanded.into_iter().collect())
 }
 
+/// Return whether a member or exclusion pattern denotes the workspace root itself.
 fn pattern_is_root(pattern: &str) -> Result<bool, WorkspaceError> {
     if contains_glob(pattern) {
         return Glob::new(pattern)
@@ -660,12 +669,14 @@ fn pattern_is_root(pattern: &str) -> Result<bool, WorkspaceError> {
         .all(|component| matches!(component, std::path::Component::CurDir)))
 }
 
+/// Detect glob metacharacters accepted by the workspace member-pattern grammar.
 fn contains_glob(pattern: &str) -> bool {
     pattern
         .bytes()
         .any(|byte| matches!(byte, b'*' | b'?' | b'[' | b'{' | b'!'))
 }
 
+/// Recursively enumerate canonical directories beneath a workspace root for deterministic glob expansion.
 fn discover_directories(root: &Path) -> Result<Vec<PathBuf>, WorkspaceError> {
     let mut directories = vec![root.to_path_buf()];
     let mut index = 0;
@@ -699,6 +710,7 @@ fn discover_directories(root: &Path) -> Result<Vec<PathBuf>, WorkspaceError> {
     Ok(directories)
 }
 
+/// Reject a workspace graph whose declared members do not have unique project names.
 fn validate_unique_member_names(members: &[WorkspaceMember], manifest: &Path) -> Result<(), WorkspaceError> {
     let mut paths_by_name = BTreeMap::new();
     for member in members {
@@ -717,6 +729,7 @@ fn validate_unique_member_names(members: &[WorkspaceMember], manifest: &Path) ->
     Ok(())
 }
 
+/// Resolve configured default member selectors to unique member names in declaration order.
 fn resolve_default_members(
     members: &[WorkspaceMember],
     root: &Path,
@@ -823,6 +836,7 @@ fn resolve_effective_rust_dependencies(
     Ok(effective_by_member)
 }
 
+/// Build effective Rust dev dependencies for every member from explicit workspace opt-ins and local refinements.
 fn resolve_effective_rust_dev_dependencies(
     members: &[WorkspaceMember],
     manifests: &BTreeMap<PathBuf, ProjectManifest>,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,1112 @@
+//! RFC 077 workspace discovery and topology validation.
+//!
+//! This module deliberately stops at the validated graph boundary. Locking, dependency inheritance, and command
+//! fan-out consume this graph in later RFC 077 stages; they must not rediscover membership independently.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use globset::Glob;
+use serde::Serialize;
+
+use crate::lockfile::IncanLock;
+use crate::manifest::{
+    DependencySpec, LibraryDependencySpec, MANIFEST_FILENAME, ManifestError, ProjectManifest, WorkspaceSection,
+    parse_workspace_library_dependency_declarations, parse_workspace_rust_dependency_declarations,
+    parse_workspace_rust_dev_dependency_declarations,
+};
+
+/// Stable schema version for the machine-readable workspace topology view.
+pub const WORKSPACE_INSPECT_SCHEMA_VERSION: u32 = 1;
+
+/// A validated workspace member in deterministic workspace order.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorkspaceMember {
+    /// Project identity from `[project].name`.
+    pub name: String,
+    /// Canonical absolute member directory.
+    pub path: PathBuf,
+    /// Canonical absolute member manifest path.
+    pub manifest_path: PathBuf,
+    /// Whether this is the implicit root project member.
+    pub root_member: bool,
+}
+
+/// Workspace-owned declarations that later inheritance, policy, and lock stages consume from the validated graph.
+///
+/// Maps are ordered here—not merely in their TOML representation—so JSON inspection and subsequent fingerprints are
+/// deterministic regardless of TOML deserialization order.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct WorkspaceSharedConfiguration {
+    pub dependencies: BTreeMap<String, toml::Value>,
+    pub rust_dependencies: BTreeMap<String, toml::Value>,
+    pub rust_dev_dependencies: BTreeMap<String, toml::Value>,
+    pub envs: BTreeMap<String, toml::Value>,
+    pub policy: Option<toml::Value>,
+    pub sources: Option<toml::Value>,
+    pub capabilities: Option<toml::Value>,
+}
+
+/// The root-owned lockfile location and its parse state.
+///
+/// Workspace topology remains inspectable when a lockfile is missing or malformed. Commands that require a current
+/// lock make their own strict decision later; inspection exposes enough evidence for users and tooling to explain
+/// that decision before attempting a build or mutation.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorkspaceLockState {
+    /// Absolute canonical workspace-root lockfile location. The path is retained even when no file exists yet.
+    pub path: PathBuf,
+    /// Whether the root lockfile is absent, valid, or present but unparsable.
+    pub status: WorkspaceLockStatus,
+    /// Parsed lockfile format when the lockfile is valid.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<u32>,
+    /// Compiler version recorded by a valid lockfile.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub incan_version: Option<String>,
+    /// Dependency-resolution fingerprint recorded by a valid lockfile.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deps_fingerprint: Option<String>,
+    /// A non-fatal parse/read error for an invalid lockfile.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Non-authoritative member-local lockfiles that should be migrated through an explicit reviewed change.
+    ///
+    /// Workspace inspection reports these paths but deliberately does not remove them. The workspace root lock is
+    /// the only authoritative lock once `[workspace]` is declared.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub stale_member_lockfiles: Vec<PathBuf>,
+}
+
+/// Stable machine-readable classification for a root lockfile.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceLockStatus {
+    /// No root `incan.lock` has been published.
+    Missing,
+    /// The root `incan.lock` parsed successfully.
+    Valid,
+    /// A root `incan.lock` exists but cannot be read or parsed.
+    Invalid,
+}
+
+/// Validated RFC 077 topology, shared by all future workspace-aware command paths.
+#[derive(Debug, Clone)]
+pub struct WorkspaceGraph {
+    root: PathBuf,
+    manifest_path: PathBuf,
+    members: Vec<WorkspaceMember>,
+    default_members: Vec<String>,
+    exclusions: Vec<String>,
+    warnings: Vec<String>,
+    shared: WorkspaceSharedConfiguration,
+    lock: WorkspaceLockState,
+    effective_library_dependencies: BTreeMap<PathBuf, BTreeMap<String, LibraryDependencySpec>>,
+    effective_rust_dependencies: BTreeMap<PathBuf, BTreeMap<String, DependencySpec>>,
+    effective_rust_dev_dependencies: BTreeMap<PathBuf, BTreeMap<String, DependencySpec>>,
+}
+
+/// Errors while discovering or validating one workspace graph.
+#[derive(Debug, thiserror::Error)]
+pub enum WorkspaceError {
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error("invalid workspace {manifest}: {message}")]
+    Invalid { manifest: PathBuf, message: String },
+    #[error("failed to inspect workspace path {path}: {source}")]
+    Io { path: PathBuf, source: std::io::Error },
+}
+
+impl WorkspaceGraph {
+    /// Discover the nearest workspace whose validated member graph contains `start`.
+    ///
+    /// A virtual workspace root is a valid context at its root even though it has no root member. Ancestor manifests
+    /// that do not contain the start path have no authority over it, matching RFC 077's project-discovery rule.
+    pub fn discover(start: &Path) -> Result<Option<Self>, WorkspaceError> {
+        let start = canonical_start_path(start)?;
+        let mut candidate = if start.is_dir() {
+            start.clone()
+        } else {
+            start.parent().map(Path::to_path_buf).unwrap_or_else(|| start.clone())
+        };
+
+        loop {
+            let manifest_path = candidate.join(MANIFEST_FILENAME);
+            if manifest_path.is_file() {
+                let manifest = read_manifest(&manifest_path)?;
+                if manifest.workspace().is_some() {
+                    let graph = Self::from_root_manifest(manifest)?;
+                    if graph.contains_path(&start) || graph.root == start {
+                        return Ok(Some(graph));
+                    }
+                }
+            }
+            if !candidate.pop() {
+                return Ok(None);
+            }
+        }
+    }
+
+    /// Build and validate a graph from a manifest known to contain `[workspace]`.
+    pub fn from_root_manifest(root_manifest: ProjectManifest) -> Result<Self, WorkspaceError> {
+        let manifest_path = canonical_path(root_manifest.path())?;
+        let root = manifest_path
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| WorkspaceError::Invalid {
+                manifest: manifest_path.clone(),
+                message: "workspace manifest has no parent directory".to_string(),
+            })?;
+        let workspace = root_manifest.workspace().ok_or_else(|| WorkspaceError::Invalid {
+            manifest: manifest_path.clone(),
+            message: "manifest does not declare [workspace]".to_string(),
+        })?;
+
+        let mut members = Vec::new();
+        let mut member_manifests = BTreeMap::new();
+        if let Some(project) = root_manifest.project.as_ref() {
+            let name = required_project_name(project.name.as_deref(), &manifest_path)?;
+            members.push(WorkspaceMember {
+                name,
+                path: root.clone(),
+                manifest_path: manifest_path.clone(),
+                root_member: true,
+            });
+            member_manifests.insert(root.clone(), root_manifest.clone());
+        }
+
+        let mut warnings = Vec::new();
+        let excluded = expand_patterns(&root, &workspace.exclude, "exclude", &manifest_path, &mut warnings)?;
+        let expanded = expand_patterns(&root, &workspace.members, "members", &manifest_path, &mut warnings)?;
+        let excluded: BTreeSet<PathBuf> = excluded.into_iter().collect();
+        let mut non_root = BTreeMap::new();
+
+        for path in expanded {
+            if excluded.contains(&path) {
+                continue;
+            }
+            if path == root {
+                return Err(invalid(
+                    &manifest_path,
+                    "[workspace].members must not include the workspace root; [project] makes it the implicit root member",
+                ));
+            }
+            let member_manifest_path = path.join(MANIFEST_FILENAME);
+            if !member_manifest_path.is_file() {
+                return Err(invalid(
+                    &manifest_path,
+                    format!(
+                        "workspace member {} does not contain {MANIFEST_FILENAME}",
+                        path.display()
+                    ),
+                ));
+            }
+            let member_manifest = read_manifest(&member_manifest_path)?;
+            if member_manifest.workspace().is_some() {
+                return Err(invalid(
+                    &manifest_path,
+                    format!("workspace member {} declares a nested [workspace]", path.display()),
+                ));
+            }
+            let name = required_project_name(
+                member_manifest
+                    .project
+                    .as_ref()
+                    .and_then(|project| project.name.as_deref()),
+                &member_manifest_path,
+            )?;
+            non_root.insert(
+                path.clone(),
+                WorkspaceMember {
+                    name,
+                    path: path.clone(),
+                    manifest_path: canonical_path(&member_manifest_path)?,
+                    root_member: false,
+                },
+            );
+            member_manifests.insert(path, member_manifest);
+        }
+        members.extend(non_root.into_values());
+
+        if members.is_empty() {
+            return Err(invalid(
+                &manifest_path,
+                "a virtual workspace must expand at least one member",
+            ));
+        }
+        validate_unique_member_names(&members, &manifest_path)?;
+        let default_members = resolve_default_members(&members, &root, workspace, &manifest_path)?;
+        let shared = WorkspaceSharedConfiguration {
+            dependencies: workspace
+                .dependencies
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect(),
+            rust_dependencies: workspace
+                .rust_dependencies
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect(),
+            rust_dev_dependencies: workspace
+                .rust_dev_dependencies
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect(),
+            envs: workspace
+                .envs
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect(),
+            policy: workspace.policy.clone(),
+            sources: workspace.sources.clone(),
+            capabilities: workspace.capabilities.clone(),
+        };
+        let shared_library_dependencies = parse_workspace_library_dependency_declarations(workspace, &manifest_path)?;
+        let shared_rust_dependencies = parse_workspace_rust_dependency_declarations(workspace, &manifest_path)?;
+        let shared_rust_dev_dependencies = parse_workspace_rust_dev_dependency_declarations(workspace, &manifest_path)?;
+        let effective_library_dependencies = resolve_effective_library_dependencies(
+            &members,
+            &member_manifests,
+            &shared_library_dependencies,
+            &manifest_path,
+        )?;
+        let effective_rust_dependencies = resolve_effective_rust_dependencies(
+            &members,
+            &member_manifests,
+            &shared_rust_dependencies,
+            &manifest_path,
+        )?;
+        let effective_rust_dev_dependencies = resolve_effective_rust_dev_dependencies(
+            &members,
+            &member_manifests,
+            &shared_rust_dev_dependencies,
+            &manifest_path,
+        )?;
+        let lock = inspect_root_lock(&root, &members);
+        warnings.extend(lock.stale_member_lockfiles.iter().map(|path| {
+            format!(
+                "member-local lockfile {} is non-authoritative; use the workspace root incan.lock",
+                path.display()
+            )
+        }));
+
+        Ok(Self {
+            root,
+            manifest_path,
+            members,
+            default_members,
+            exclusions: workspace.exclude.clone(),
+            warnings,
+            shared,
+            lock,
+            effective_library_dependencies,
+            effective_rust_dependencies,
+            effective_rust_dev_dependencies,
+        })
+    }
+
+    /// Canonical workspace root directory.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Canonical workspace root manifest path.
+    pub fn manifest_path(&self) -> &Path {
+        &self.manifest_path
+    }
+
+    /// Members in RFC 077 deterministic workspace order.
+    pub fn members(&self) -> &[WorkspaceMember] {
+        &self.members
+    }
+
+    /// Resolved member names selected from the workspace root by default.
+    pub fn default_members(&self) -> &[String] {
+        &self.default_members
+    }
+
+    /// Original exclusion patterns for machine-readable inspection.
+    pub fn exclusions(&self) -> &[String] {
+        &self.exclusions
+    }
+
+    /// Non-fatal topology warnings, including unmatched member/exclusion globs.
+    pub fn warnings(&self) -> &[String] {
+        &self.warnings
+    }
+
+    /// Deterministic workspace-owned declarations retained from the root manifest.
+    pub fn shared(&self) -> &WorkspaceSharedConfiguration {
+        &self.shared
+    }
+
+    /// Root-owned lockfile state for machine-readable inspection and workspace-aware command planning.
+    pub fn lock(&self) -> &WorkspaceLockState {
+        &self.lock
+    }
+
+    /// Effective Incan library dependency graph for one member after explicit workspace inheritance.
+    pub fn effective_library_dependencies_for(
+        &self,
+        member: &WorkspaceMember,
+    ) -> Option<&BTreeMap<String, LibraryDependencySpec>> {
+        self.effective_library_dependencies.get(&member.path)
+    }
+
+    /// Effective Rust dependency graph for one member after workspace inheritance and additive refinements.
+    pub fn effective_rust_dependencies_for(
+        &self,
+        member: &WorkspaceMember,
+    ) -> Option<&BTreeMap<String, DependencySpec>> {
+        self.effective_rust_dependencies.get(&member.path)
+    }
+
+    /// Effective Rust dev-dependency graph for one member after workspace inheritance and additive refinements.
+    pub fn effective_rust_dev_dependencies_for(
+        &self,
+        member: &WorkspaceMember,
+    ) -> Option<&BTreeMap<String, DependencySpec>> {
+        self.effective_rust_dev_dependencies.get(&member.path)
+    }
+
+    /// Resolve the member scope implied by `start` before any command execution.
+    pub fn selected_members_for(&self, start: &Path) -> Result<Vec<&WorkspaceMember>, WorkspaceError> {
+        let start = canonical_start_path(start)?;
+        if start == self.root {
+            if !self.default_members.is_empty() {
+                return Ok(self
+                    .members
+                    .iter()
+                    .filter(|member| self.default_members.contains(&member.name))
+                    .collect());
+            }
+            if let Some(root_member) = self.members.iter().find(|member| member.root_member) {
+                return Ok(vec![root_member]);
+            }
+            return Ok(self.members.iter().collect());
+        }
+
+        let mut containing = self
+            .members
+            .iter()
+            .filter(|member| start.starts_with(&member.path))
+            .collect::<Vec<_>>();
+        containing.sort_by_key(|member| std::cmp::Reverse(member.path.components().count()));
+        containing.into_iter().next().map_or_else(
+            || {
+                Err(invalid(
+                    &self.manifest_path,
+                    format!("{} is not contained by this workspace", start.display()),
+                ))
+            },
+            |member| Ok(vec![member]),
+        )
+    }
+
+    /// Resolve an explicit RFC 077 workspace selector, or infer the current member scope when no selector is given.
+    ///
+    /// Callers must invoke this before they compile, execute, lock, or mutate any member state. The graph owns name
+    /// and root-relative path interpretation so individual commands cannot disagree about a selected package.
+    pub fn select_members<'a>(
+        &'a self,
+        start: &Path,
+        workspace: bool,
+        selectors: &[String],
+    ) -> Result<Vec<&'a WorkspaceMember>, WorkspaceError> {
+        if workspace {
+            return Ok(self.members.iter().collect());
+        }
+        if selectors.is_empty() {
+            return self.selected_members_for(start);
+        }
+
+        let mut selected = BTreeSet::new();
+        for selector in selectors {
+            let selector = selector.trim();
+            if selector.is_empty() {
+                return Err(invalid(
+                    &self.manifest_path,
+                    "workspace member selector cannot be empty",
+                ));
+            }
+            let by_name = self.members.iter().find(|member| member.name == selector);
+            let by_path = canonical_path(&self.root.join(selector))
+                .ok()
+                .and_then(|path| self.members.iter().find(|member| member.path == path));
+            let Some(member) = by_name.or(by_path) else {
+                return Err(invalid(
+                    &self.manifest_path,
+                    format!("workspace member selector `{selector}` does not resolve to a member"),
+                ));
+            };
+            selected.insert(member.path.clone());
+        }
+
+        Ok(self
+            .members
+            .iter()
+            .filter(|member| selected.contains(&member.path))
+            .collect())
+    }
+
+    fn contains_path(&self, path: &Path) -> bool {
+        path == self.root || self.members.iter().any(|member| path.starts_with(&member.path))
+    }
+}
+
+fn canonical_start_path(path: &Path) -> Result<PathBuf, WorkspaceError> {
+    canonical_path(path)
+}
+
+fn canonical_path(path: &Path) -> Result<PathBuf, WorkspaceError> {
+    fs::canonicalize(path).map_err(|source| WorkspaceError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn read_manifest(path: &Path) -> Result<ProjectManifest, WorkspaceError> {
+    let content = fs::read_to_string(path).map_err(|source| WorkspaceError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    ProjectManifest::from_str(&content, path).map_err(Into::into)
+}
+
+fn inspect_root_lock(root: &Path, members: &[WorkspaceMember]) -> WorkspaceLockState {
+    let path = root.join("incan.lock");
+    let stale_member_lockfiles = members
+        .iter()
+        .filter(|member| member.path != root)
+        .map(|member| member.path.join("incan.lock"))
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    if !path.exists() {
+        return WorkspaceLockState {
+            path,
+            status: WorkspaceLockStatus::Missing,
+            format: None,
+            incan_version: None,
+            deps_fingerprint: None,
+            error: None,
+            stale_member_lockfiles,
+        };
+    }
+    match IncanLock::load(&path) {
+        Ok(lock) => WorkspaceLockState {
+            path,
+            status: WorkspaceLockStatus::Valid,
+            format: Some(lock.format),
+            incan_version: Some(lock.incan_version),
+            deps_fingerprint: Some(lock.deps_fingerprint),
+            error: None,
+            stale_member_lockfiles,
+        },
+        Err(error) => WorkspaceLockState {
+            path,
+            status: WorkspaceLockStatus::Invalid,
+            format: None,
+            incan_version: None,
+            deps_fingerprint: None,
+            error: Some(error.to_string()),
+            stale_member_lockfiles,
+        },
+    }
+}
+
+fn required_project_name(name: Option<&str>, manifest: &Path) -> Result<String, WorkspaceError> {
+    let Some(name) = name.map(str::trim).filter(|name| !name.is_empty()) else {
+        return Err(invalid(
+            manifest,
+            "workspace members require a non-empty [project].name",
+        ));
+    };
+    Ok(name.to_string())
+}
+
+fn invalid(manifest: &Path, message: impl Into<String>) -> WorkspaceError {
+    WorkspaceError::Invalid {
+        manifest: manifest.to_path_buf(),
+        message: message.into(),
+    }
+}
+
+fn expand_patterns(
+    root: &Path,
+    patterns: &[String],
+    field: &str,
+    manifest: &Path,
+    warnings: &mut Vec<String>,
+) -> Result<Vec<PathBuf>, WorkspaceError> {
+    let all_directories = discover_directories(root)?;
+    let mut expanded = BTreeSet::new();
+    for pattern in patterns {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return Err(invalid(
+                manifest,
+                format!("[workspace].{field} cannot contain an empty path"),
+            ));
+        }
+        if pattern_is_root(pattern)? {
+            return Err(invalid(
+                manifest,
+                format!(
+                    "[workspace].{field} must not include the workspace root; use the implicit root member instead"
+                ),
+            ));
+        }
+        if contains_glob(pattern) {
+            let glob = Glob::new(pattern)
+                .map_err(|error| {
+                    invalid(
+                        manifest,
+                        format!("invalid [workspace].{field} glob `{pattern}`: {error}"),
+                    )
+                })?
+                .compile_matcher();
+            let matches = all_directories
+                .iter()
+                .filter(|directory| {
+                    directory
+                        .strip_prefix(root)
+                        .ok()
+                        .is_some_and(|relative| glob.is_match(relative))
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if matches.is_empty() {
+                warnings.push(format!("[workspace].{field} glob `{pattern}` matched no directories"));
+            }
+            expanded.extend(matches);
+        } else {
+            let path = canonical_path(&root.join(pattern))?;
+            if !path.starts_with(root) {
+                return Err(invalid(
+                    manifest,
+                    format!("[workspace].{field} path `{pattern}` resolves outside the workspace root"),
+                ));
+            }
+            if !path.is_dir() {
+                return Err(invalid(
+                    manifest,
+                    format!("[workspace].{field} path `{pattern}` is not a directory"),
+                ));
+            }
+            expanded.insert(path);
+        }
+    }
+    Ok(expanded.into_iter().collect())
+}
+
+fn pattern_is_root(pattern: &str) -> Result<bool, WorkspaceError> {
+    if contains_glob(pattern) {
+        return Glob::new(pattern)
+            .map(|glob| glob.compile_matcher().is_match(""))
+            .map_err(|error| WorkspaceError::Invalid {
+                manifest: PathBuf::from(MANIFEST_FILENAME),
+                message: format!("invalid workspace glob `{pattern}`: {error}"),
+            });
+    }
+    Ok(Path::new(pattern)
+        .components()
+        .all(|component| matches!(component, std::path::Component::CurDir)))
+}
+
+fn contains_glob(pattern: &str) -> bool {
+    pattern
+        .bytes()
+        .any(|byte| matches!(byte, b'*' | b'?' | b'[' | b'{' | b'!'))
+}
+
+fn discover_directories(root: &Path) -> Result<Vec<PathBuf>, WorkspaceError> {
+    let mut directories = vec![root.to_path_buf()];
+    let mut index = 0;
+    while let Some(directory) = directories.get(index).cloned() {
+        index += 1;
+        for entry in fs::read_dir(&directory).map_err(|source| WorkspaceError::Io {
+            path: directory.clone(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| WorkspaceError::Io {
+                path: directory.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            if entry
+                .file_type()
+                .map_err(|source| WorkspaceError::Io {
+                    path: path.clone(),
+                    source,
+                })?
+                .is_dir()
+            {
+                let canonical = canonical_path(&path)?;
+                if canonical.starts_with(root) && !directories.contains(&canonical) {
+                    directories.push(canonical);
+                }
+            }
+        }
+    }
+    directories.sort();
+    Ok(directories)
+}
+
+fn validate_unique_member_names(members: &[WorkspaceMember], manifest: &Path) -> Result<(), WorkspaceError> {
+    let mut paths_by_name = BTreeMap::new();
+    for member in members {
+        if let Some(previous) = paths_by_name.insert(member.name.as_str(), &member.path) {
+            return Err(invalid(
+                manifest,
+                format!(
+                    "workspace member name `{}` is duplicated by {} and {}",
+                    member.name,
+                    previous.display(),
+                    member.path.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_default_members(
+    members: &[WorkspaceMember],
+    root: &Path,
+    workspace: &WorkspaceSection,
+    manifest: &Path,
+) -> Result<Vec<String>, WorkspaceError> {
+    let mut resolved = Vec::new();
+    for selector in &workspace.default_members {
+        let selector = selector.trim();
+        let matched = members.iter().find(|member| member.name == selector).or_else(|| {
+            let path = canonical_path(&root.join(selector)).ok()?;
+            members.iter().find(|member| member.path == path)
+        });
+        let Some(member) = matched else {
+            return Err(invalid(
+                manifest,
+                format!("[workspace].default-members entry `{selector}` does not resolve to a member"),
+            ));
+        };
+        if !resolved.contains(&member.name) {
+            resolved.push(member.name.clone());
+        }
+    }
+    Ok(resolved)
+}
+
+/// Build the effective Incan library dependency map for every member from local declarations and explicit workspace
+/// opt-ins. RFC 077 does not permit member-level refinements for these dependencies.
+fn resolve_effective_library_dependencies(
+    members: &[WorkspaceMember],
+    manifests: &BTreeMap<PathBuf, ProjectManifest>,
+    shared: &BTreeMap<String, LibraryDependencySpec>,
+    workspace_manifest: &Path,
+) -> Result<BTreeMap<PathBuf, BTreeMap<String, LibraryDependencySpec>>, WorkspaceError> {
+    let mut effective_by_member = BTreeMap::new();
+    for member in members {
+        let manifest = manifests.get(&member.path).ok_or_else(|| {
+            invalid(
+                workspace_manifest,
+                format!("missing parsed manifest for workspace member {}", member.path.display()),
+            )
+        })?;
+        let mut effective = manifest
+            .library_dependencies()
+            .iter()
+            .map(|(name, spec)| (name.clone(), spec.clone()))
+            .collect::<BTreeMap<_, _>>();
+        for name in manifest.workspace_library_dependencies().keys() {
+            let baseline = shared.get(name).ok_or_else(|| {
+                invalid(
+                    workspace_manifest,
+                    format!(
+                        "workspace member `{}` inherits library dependency `{name}`, but [workspace.dependencies] does not declare it",
+                        member.name
+                    ),
+                )
+            })?;
+            effective.insert(name.clone(), baseline.clone());
+        }
+        effective_by_member.insert(member.path.clone(), effective);
+    }
+    Ok(effective_by_member)
+}
+
+/// Build the effective Rust dependency map for every member from local declarations and explicit workspace opt-ins.
+fn resolve_effective_rust_dependencies(
+    members: &[WorkspaceMember],
+    manifests: &BTreeMap<PathBuf, ProjectManifest>,
+    shared: &BTreeMap<String, DependencySpec>,
+    workspace_manifest: &Path,
+) -> Result<BTreeMap<PathBuf, BTreeMap<String, DependencySpec>>, WorkspaceError> {
+    let mut effective_by_member = BTreeMap::new();
+    for member in members {
+        let manifest = manifests.get(&member.path).ok_or_else(|| {
+            invalid(
+                workspace_manifest,
+                format!("missing parsed manifest for workspace member {}", member.path.display()),
+            )
+        })?;
+        let mut effective = manifest
+            .rust_dependencies()
+            .iter()
+            .map(|(name, spec)| (name.clone(), spec.clone().normalized()))
+            .collect::<BTreeMap<_, _>>();
+        for (name, refinement) in manifest.workspace_rust_dependencies() {
+            let baseline = shared.get(name).ok_or_else(|| {
+                invalid(
+                    workspace_manifest,
+                    format!(
+                        "workspace member `{}` inherits Rust dependency `{name}`, but [workspace.rust-dependencies] does not declare it",
+                        member.name
+                    ),
+                )
+            })?;
+            let mut spec = baseline.clone();
+            spec.features.extend(refinement.features.iter().cloned());
+            spec.features.sort();
+            spec.features.dedup();
+            spec.optional = refinement.optional;
+            effective.insert(name.clone(), spec);
+        }
+        effective_by_member.insert(member.path.clone(), effective);
+    }
+    Ok(effective_by_member)
+}
+
+fn resolve_effective_rust_dev_dependencies(
+    members: &[WorkspaceMember],
+    manifests: &BTreeMap<PathBuf, ProjectManifest>,
+    shared: &BTreeMap<String, DependencySpec>,
+    workspace_manifest: &Path,
+) -> Result<BTreeMap<PathBuf, BTreeMap<String, DependencySpec>>, WorkspaceError> {
+    let mut effective_by_member = BTreeMap::new();
+    for member in members {
+        let manifest = manifests.get(&member.path).ok_or_else(|| {
+            invalid(
+                workspace_manifest,
+                format!("missing parsed manifest for workspace member {}", member.path.display()),
+            )
+        })?;
+        let mut effective = manifest
+            .rust_dev_dependencies()
+            .iter()
+            .map(|(name, spec)| (name.clone(), spec.clone().normalized()))
+            .collect::<BTreeMap<_, _>>();
+        for (name, refinement) in manifest.workspace_rust_dev_dependencies() {
+            let baseline = shared.get(name).ok_or_else(|| {
+                invalid(
+                    workspace_manifest,
+                    format!(
+                        "workspace member `{}` inherits Rust dev dependency `{name}`, but [workspace.rust-dev-dependencies] does not declare it",
+                        member.name
+                    ),
+                )
+            })?;
+            let mut spec = baseline.clone();
+            spec.features.extend(refinement.features.iter().cloned());
+            spec.features.sort();
+            spec.features.dedup();
+            spec.optional = refinement.optional;
+            effective.insert(name.clone(), spec);
+        }
+        effective_by_member.insert(member.path.clone(), effective);
+    }
+    Ok(effective_by_member)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn write_manifest(root: &Path, relative: &str, content: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let path = root.join(relative);
+        let parent = path.parent().ok_or("manifest path needs a parent")?;
+        fs::create_dir_all(parent)?;
+        fs::write(path, content)?;
+        Ok(())
+    }
+
+    #[test]
+    fn rooted_workspace_has_implicit_root_and_deterministic_glob_members() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write_manifest(
+            temp.path(),
+            "incan.toml",
+            "[project]\nname = 'root'\n[workspace]\nmembers = ['packages/*']\nexclude = ['packages/experimental']\ndefault-members = ['storage']\n[workspace.dependencies]\nshared = { path = 'packages/shared' }\n[workspace.rust-dependencies]\nserde = { version = '1', default-features = false }\n[workspace.rust-dev-dependencies]\npretty_assertions = '1'\n[workspace.policy]\nrequire-approval = true\n[dependencies]\nshared = { workspace = true }\n[rust-dependencies]\nserde = { workspace = true, features = ['derive'] }\n[rust-dev-dependencies]\npretty_assertions = { workspace = true }\n",
+        )?;
+        write_manifest(
+            temp.path(),
+            "packages/storage/incan.toml",
+            "[project]\nname = 'storage'\n[dependencies]\nshared = { workspace = true }\n[rust-dependencies]\nserde = { workspace = true, features = ['std'], optional = true }\n[rust-dev-dependencies]\npretty_assertions = { workspace = true, features = ['diff'] }\n",
+        )?;
+        write_manifest(
+            temp.path(),
+            "packages/experimental/incan.toml",
+            "[project]\nname = 'experimental'\n",
+        )?;
+
+        let graph = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        assert_eq!(
+            graph
+                .members
+                .iter()
+                .map(|member| member.name.as_str())
+                .collect::<Vec<_>>(),
+            ["root", "storage"]
+        );
+        assert_eq!(graph.default_members(), ["storage"]);
+        assert_eq!(graph.shared().rust_dependencies.keys().collect::<Vec<_>>(), ["serde"]);
+        assert!(graph.shared().policy.is_some());
+        let root_member = graph.members().first().ok_or("missing root member")?;
+        let root_shared = graph
+            .effective_library_dependencies_for(root_member)
+            .and_then(|dependencies| dependencies.get("shared"))
+            .ok_or("missing effective root shared library dependency")?;
+        assert_eq!(root_shared.path, graph.root().join("packages/shared"));
+        let root_serde = graph
+            .effective_rust_dependencies_for(root_member)
+            .and_then(|dependencies| dependencies.get("serde"))
+            .ok_or("missing effective root serde dependency")?;
+        assert_eq!(root_serde.features, ["derive"]);
+        assert!(!root_serde.default_features);
+        assert!(!root_serde.optional);
+        let root_pretty_assertions = graph
+            .effective_rust_dev_dependencies_for(root_member)
+            .and_then(|dependencies| dependencies.get("pretty_assertions"))
+            .ok_or("missing effective root pretty_assertions dev dependency")?;
+        assert_eq!(root_pretty_assertions.features, Vec::<String>::new());
+        let storage = graph
+            .members()
+            .iter()
+            .find(|member| member.name == "storage")
+            .ok_or("missing storage")?;
+        let storage_shared = graph
+            .effective_library_dependencies_for(storage)
+            .and_then(|dependencies| dependencies.get("shared"))
+            .ok_or("missing effective storage shared library dependency")?;
+        assert_eq!(storage_shared.path, graph.root().join("packages/shared"));
+        let storage_serde = graph
+            .effective_rust_dependencies_for(storage)
+            .and_then(|dependencies| dependencies.get("serde"))
+            .ok_or("missing effective storage serde dependency")?;
+        assert_eq!(storage_serde.features, ["std"]);
+        assert!(storage_serde.optional);
+        let storage_pretty_assertions = graph
+            .effective_rust_dev_dependencies_for(storage)
+            .and_then(|dependencies| dependencies.get("pretty_assertions"))
+            .ok_or("missing effective storage pretty_assertions dev dependency")?;
+        assert_eq!(storage_pretty_assertions.features, ["diff"]);
+        assert_eq!(graph.selected_members_for(temp.path())?[0].name, "storage");
+        assert_eq!(
+            graph.selected_members_for(&temp.path().join("packages/storage"))?[0].name,
+            "storage"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn virtual_workspace_defaults_to_all_members_at_root() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write_manifest(temp.path(), "incan.toml", "[workspace]\nmembers = ['members/*']\n")?;
+        write_manifest(temp.path(), "members/first/incan.toml", "[project]\nname = 'first'\n")?;
+        write_manifest(temp.path(), "members/second/incan.toml", "[project]\nname = 'second'\n")?;
+
+        let graph = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        assert!(graph.members.iter().all(|member| !member.root_member));
+        assert_eq!(
+            graph
+                .selected_members_for(temp.path())?
+                .iter()
+                .map(|member| member.name.as_str())
+                .collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_rejects_root_repeated_in_members_and_duplicate_names() -> Result<(), Box<dyn std::error::Error>> {
+        let root = tempfile::tempdir()?;
+        write_manifest(
+            root.path(),
+            "incan.toml",
+            "[project]\nname = 'root'\n[workspace]\nmembers = ['.']\n",
+        )?;
+        let error = WorkspaceGraph::discover(root.path())
+            .err()
+            .ok_or("root member should be rejected")?;
+        assert!(error.to_string().contains("implicit root member"));
+
+        let duplicate = tempfile::tempdir()?;
+        write_manifest(
+            duplicate.path(),
+            "incan.toml",
+            "[workspace]\nmembers = ['one', 'two']\n",
+        )?;
+        write_manifest(duplicate.path(), "one/incan.toml", "[project]\nname = 'same'\n")?;
+        write_manifest(duplicate.path(), "two/incan.toml", "[project]\nname = 'same'\n")?;
+        let error = WorkspaceGraph::discover(duplicate.path())
+            .err()
+            .ok_or("duplicate name should be rejected")?;
+        assert!(error.to_string().contains("duplicated"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_warns_for_unmatched_globs_and_rejects_invalid_defaults() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write_manifest(
+            temp.path(),
+            "incan.toml",
+            "[project]\nname = 'root'\n[workspace]\nmembers = ['packages/*']\ndefault-members = ['missing']\n",
+        )?;
+        let error = WorkspaceGraph::discover(temp.path())
+            .err()
+            .ok_or("invalid default should fail")?;
+        assert!(error.to_string().contains("default-members"));
+
+        write_manifest(
+            temp.path(),
+            "incan.toml",
+            "[project]\nname = 'root'\n[workspace]\nmembers = ['packages/*']\n",
+        )?;
+        let graph = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        assert!(graph.warnings()[0].contains("matched no directories"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_selection_uses_deterministic_graph_order_and_rejects_unknown_members()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write_manifest(
+            temp.path(),
+            "incan.toml",
+            "[project]\nname = 'root'\n[workspace]\nmembers = ['members/*']\n",
+        )?;
+        write_manifest(temp.path(), "members/alpha/incan.toml", "[project]\nname = 'alpha'\n")?;
+        write_manifest(temp.path(), "members/beta/incan.toml", "[project]\nname = 'beta'\n")?;
+        let graph = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+
+        let selectors = vec!["beta".to_string(), "alpha".to_string()];
+        assert_eq!(
+            graph
+                .select_members(temp.path(), false, &selectors)?
+                .iter()
+                .map(|member| member.name.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+        assert_eq!(
+            graph
+                .select_members(temp.path(), true, &[])?
+                .iter()
+                .map(|member| member.name.as_str())
+                .collect::<Vec<_>>(),
+            ["root", "alpha", "beta"]
+        );
+        let error = graph
+            .select_members(temp.path(), false, &["missing".to_string()])
+            .err()
+            .ok_or("unknown member should fail")?;
+        assert!(error.to_string().contains("does not resolve"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_rejects_member_inheritance_without_a_shared_declaration() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write_manifest(temp.path(), "incan.toml", "[workspace]\nmembers = ['member']\n")?;
+        write_manifest(
+            temp.path(),
+            "member/incan.toml",
+            "[project]\nname = 'member'\n[rust-dependencies]\nserde = { workspace = true }\n",
+        )?;
+        let error = WorkspaceGraph::discover(temp.path())
+            .err()
+            .ok_or("undeclared inheritance should fail")?;
+        assert!(error.to_string().contains("does not declare it"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_rejects_missing_or_refined_library_inheritance() -> Result<(), Box<dyn std::error::Error>> {
+        let missing = tempfile::tempdir()?;
+        write_manifest(missing.path(), "incan.toml", "[workspace]\nmembers = ['member']\n")?;
+        write_manifest(
+            missing.path(),
+            "member/incan.toml",
+            "[project]\nname = 'member'\n[dependencies]\nshared = { workspace = true }\n",
+        )?;
+        let error = WorkspaceGraph::discover(missing.path())
+            .err()
+            .ok_or("undeclared library inheritance should fail")?;
+        assert!(
+            error
+                .to_string()
+                .contains("[workspace.dependencies] does not declare it")
+        );
+
+        let refined = tempfile::tempdir()?;
+        write_manifest(
+            refined.path(),
+            "incan.toml",
+            "[workspace]\nmembers = ['member']\n[workspace.dependencies]\nshared = { path = 'shared' }\n",
+        )?;
+        write_manifest(
+            refined.path(),
+            "member/incan.toml",
+            "[project]\nname = 'member'\n[dependencies]\nshared = { workspace = true, path = '../other' }\n",
+        )?;
+        let error = WorkspaceGraph::discover(refined.path())
+            .err()
+            .ok_or("refined library inheritance should fail")?;
+        assert!(error.to_string().contains("may only set `workspace = true`"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_inspection_reports_missing_valid_and_invalid_root_locks() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write_manifest(temp.path(), "incan.toml", "[workspace]\nmembers = ['member']\n")?;
+        write_manifest(temp.path(), "member/incan.toml", "[project]\nname = 'member'\n")?;
+
+        let missing = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        assert_eq!(missing.lock().status, WorkspaceLockStatus::Missing);
+        assert_eq!(missing.lock().path, missing.root().join("incan.lock"));
+        fs::write(temp.path().join("member/incan.lock"), "version = 4\n")?;
+        let with_stale_member_lock = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        assert_eq!(
+            with_stale_member_lock.lock().stale_member_lockfiles,
+            [with_stale_member_lock.members()[0].path.join("incan.lock")]
+        );
+        assert!(
+            with_stale_member_lock
+                .warnings()
+                .iter()
+                .any(|warning| warning.contains("member-local lockfile") && warning.contains("non-authoritative"))
+        );
+
+        IncanLock::new(
+            "sha256:workspace-lock".to_string(),
+            crate::lockfile::CargoFeatureSelection::default(),
+            "version = 4\n".to_string(),
+        )
+        .write(&temp.path().join("incan.lock"))?;
+        let valid = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        assert_eq!(valid.lock().status, WorkspaceLockStatus::Valid);
+        assert_eq!(valid.lock().deps_fingerprint.as_deref(), Some("sha256:workspace-lock"));
+
+        fs::write(temp.path().join("incan.lock"), "[incan\n")?;
+        let invalid = WorkspaceGraph::discover(temp.path())?.ok_or("workspace should be discovered")?;
+        assert_eq!(invalid.lock().status, WorkspaceLockStatus::Invalid);
+        assert!(invalid.lock().error.is_some());
+        Ok(())
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use globset::Glob;
+use globset::{Glob, GlobBuilder};
 use serde::Serialize;
 
 use crate::lockfile::IncanLock;
@@ -370,6 +370,26 @@ impl WorkspaceGraph {
         self.effective_rust_dev_dependencies.get(&member.path)
     }
 
+    /// Load one member manifest with its explicit workspace dependency opt-ins resolved.
+    ///
+    /// Commands must consume this view when they resolve source, Cargo, or lock inputs. Reading the raw member
+    /// manifest would discard `{ workspace = true }` declarations and create a dependency graph that disagrees with
+    /// inspection and the workspace root lock.
+    pub fn effective_manifest_for(&self, member: &WorkspaceMember) -> Result<ProjectManifest, WorkspaceError> {
+        let manifest = read_manifest(&member.manifest_path)?;
+        Ok(manifest.with_effective_workspace_dependencies(
+            self.effective_library_dependencies_for(member)
+                .cloned()
+                .unwrap_or_default(),
+            self.effective_rust_dependencies_for(member)
+                .cloned()
+                .unwrap_or_default(),
+            self.effective_rust_dev_dependencies_for(member)
+                .cloned()
+                .unwrap_or_default(),
+        ))
+    }
+
     /// Resolve the member scope implied by `start` before any command execution.
     pub fn selected_members_for(&self, start: &Path) -> Result<Vec<&WorkspaceMember>, WorkspaceError> {
         let start = canonical_start_path(start)?;
@@ -558,7 +578,9 @@ fn expand_patterns(
             ));
         }
         if contains_glob(pattern) {
-            let glob = Glob::new(pattern)
+            let glob = GlobBuilder::new(pattern)
+                .literal_separator(true)
+                .build()
                 .map_err(|error| {
                     invalid(
                         manifest,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -492,6 +492,14 @@ impl WorkspaceGraph {
 }
 
 fn canonical_start_path(path: &Path) -> Result<PathBuf, WorkspaceError> {
+    // `Path::parent()` is an empty path for a bare relative filename. Test and compiler callers use that parent as
+    // their discovery start, where it means the current directory rather than a path that should be handed to the
+    // filesystem verbatim.
+    let path = if path.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        path
+    };
     canonical_path(path)
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2313,6 +2313,46 @@ fn workspace_run_requires_one_member_and_preserves_program_stdout() -> Result<()
 }
 
 #[test]
+fn workspace_version_requires_one_member_before_mutating() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n",
+    )?;
+    for name in ["alpha", "beta"] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(&member)?;
+        fs::write(
+            member.join("incan.toml"),
+            format!("[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n"),
+        )?;
+    }
+
+    let multiple = run_incan(tmp.path(), &["version", "patch", "--workspace", "--dry-run"])?;
+    assert_failure(&multiple, "multi-member workspace version");
+    assert!(
+        String::from_utf8_lossy(&multiple.stderr).contains("requires exactly one workspace member"),
+        "multi-member version should explain the selector requirement:\n{}",
+        String::from_utf8_lossy(&multiple.stderr)
+    );
+
+    let selected = run_incan(tmp.path(), &["version", "patch", "--member", "beta", "--dry-run"])?;
+    assert_success(&selected, "selected workspace member version dry run");
+    let stdout = String::from_utf8_lossy(&selected.stdout);
+    assert!(stdout.contains("member beta"), "missing selected scope:\n{stdout}");
+    assert!(
+        stdout.contains("packages/beta/incan.toml"),
+        "version plan targeted the wrong manifest:\n{stdout}"
+    );
+    assert_eq!(
+        fs::read_to_string(tmp.path().join("packages/beta/incan.toml"))?,
+        "[project]\nname = \"beta\"\nversion = \"0.1.0\"\n",
+        "dry run must not mutate the selected member manifest"
+    );
+    Ok(())
+}
+
+#[test]
 fn lock_preheats_dependency_graph_for_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let helper_dir = tmp.path().join("preheat_helper");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1994,6 +1994,64 @@ fn build_from_workspace_member_uses_the_root_lockfile() -> Result<(), Box<dyn st
 }
 
 #[test]
+fn build_from_workspace_member_uses_inherited_rust_dependency() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n\n[workspace.rust-dependencies]\ntiny_workspace = { path = \"shared/tiny_workspace\" }\n",
+    )?;
+    let helper_src = tmp.path().join("shared/tiny_workspace/src");
+    fs::create_dir_all(&helper_src)?;
+    fs::write(
+        helper_src
+            .parent()
+            .ok_or("helper source has no parent")?
+            .join("Cargo.toml"),
+        "[package]\nname = \"tiny_workspace\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(
+        helper_src.join("lib.rs"),
+        "pub fn plus_one(value: i64) -> i64 { value + 1 }\n",
+    )?;
+
+    for name in ["alpha", "beta"] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(member.join("src"))?;
+        let inherited_dependency = if name == "alpha" {
+            "\n[rust-dependencies]\ntiny_workspace = { workspace = true }\n"
+        } else {
+            ""
+        };
+        fs::write(
+            member.join("incan.toml"),
+            format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[project.scripts]\nmain = \"src/main.incn\"{inherited_dependency}"
+            ),
+        )?;
+        let source = if name == "alpha" {
+            "from rust::tiny_workspace import plus_one\n\npub def value() -> int:\n    return plus_one(41)\n\ndef main() -> None:\n    println(value())\n"
+        } else {
+            "def main() -> None:\n    return\n"
+        };
+        fs::write(member.join("src/main.incn"), source)?;
+    }
+    let tests = tmp.path().join("packages/alpha/tests");
+    fs::create_dir_all(&tests)?;
+    fs::write(
+        tests.join("test_main.incn"),
+        "from std.testing import assert_eq\nfrom crate.main import value\n\ndef test_inherited_rust_dependency() -> None:\n    assert_eq(value(), 42)\n",
+    )?;
+
+    let output = run_incan(&tmp.path().join("packages/alpha"), &["build"])?;
+    assert_success(&output, "workspace member build with inherited Rust dependency");
+    let test_output = run_incan(&tmp.path().join("packages/alpha"), &["test"])?;
+    assert_success(&test_output, "workspace member test with inherited Rust dependency");
+    assert!(tmp.path().join("incan.lock").is_file());
+    assert!(!tmp.path().join("packages/alpha/incan.lock").exists());
+    Ok(())
+}
+
+#[test]
 fn lock_preheats_dependency_graph_for_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let helper_dir = tmp.path().join("preheat_helper");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2052,6 +2052,70 @@ fn build_from_workspace_member_uses_inherited_rust_dependency() -> Result<(), Bo
 }
 
 #[test]
+fn workspace_test_selection_fans_out_with_member_scoped_json() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n",
+    )?;
+    for name in ["alpha", "beta"] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(member.join("src"))?;
+        fs::create_dir_all(member.join("tests"))?;
+        fs::write(
+            member.join("incan.toml"),
+            format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n"
+            ),
+        )?;
+        fs::write(member.join("src/main.incn"), "def main() -> None:\n    return\n")?;
+        fs::write(
+            member.join("tests/test_member.incn"),
+            "from std.testing import assert_eq\n\ndef test_member() -> None:\n    assert_eq(1, 1)\n",
+        )?;
+    }
+
+    let output = run_incan(tmp.path(), &["test", "--workspace", "--format", "json"])?;
+    assert_success(&output, "workspace test fan-out");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout
+            .lines()
+            .all(|line| line.trim().is_empty() || line.trim_start().starts_with('{')),
+        "workspace JSON output contained a non-JSON line:\n{stdout}"
+    );
+    let records = parse_jsonl_stdout(&output)?;
+    let summaries = records
+        .iter()
+        .filter(|record| record.get("summary").is_some())
+        .collect::<Vec<_>>();
+    assert_eq!(summaries.len(), 2);
+    let root = fs::canonicalize(tmp.path())?.to_string_lossy().into_owned();
+    for (summary, member) in summaries.into_iter().zip(["alpha", "beta"]) {
+        assert_eq!(summary["workspace"]["root"], serde_json::json!(root));
+        assert_eq!(
+            summary["workspace"]["selected_members"],
+            serde_json::json!(["alpha", "beta"])
+        );
+        assert_eq!(summary["workspace"]["member"], serde_json::json!(member));
+    }
+
+    let selected = run_incan(tmp.path(), &["test", "--member", "beta", "--format", "json"])?;
+    assert_success(&selected, "selected workspace member test");
+    let selected_records = parse_jsonl_stdout(&selected)?;
+    let selected_summary = selected_records
+        .iter()
+        .find(|record| record.get("summary").is_some())
+        .ok_or("selected member test listing did not emit a summary")?;
+    assert_eq!(
+        selected_summary["workspace"]["selected_members"],
+        serde_json::json!(["beta"])
+    );
+    assert_eq!(selected_summary["workspace"]["member"], serde_json::json!("beta"));
+    Ok(())
+}
+
+#[test]
 fn lock_preheats_dependency_graph_for_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let helper_dir = tmp.path().join("preheat_helper");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2264,6 +2264,55 @@ fn workspace_build_selection_fans_out_without_shared_outputs() -> Result<(), Box
 }
 
 #[test]
+fn workspace_run_requires_one_member_and_preserves_program_stdout() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n",
+    )?;
+    for name in ["alpha", "beta"] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(member.join("src"))?;
+        fs::write(
+            member.join("incan.toml"),
+            format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n"
+            ),
+        )?;
+        fs::write(
+            member.join("src/main.incn"),
+            format!("def main() -> None:\n    println(\"{name}\")\n"),
+        )?;
+    }
+
+    let multiple = run_incan(tmp.path(), &["run", "--workspace"])?;
+    assert_failure(&multiple, "multi-member workspace run");
+    assert!(
+        String::from_utf8_lossy(&multiple.stderr).contains("requires exactly one workspace member"),
+        "multi-member run should explain the selector requirement:\n{}",
+        String::from_utf8_lossy(&multiple.stderr)
+    );
+
+    let selected = run_incan(tmp.path(), &["run", "--member", "beta"])?;
+    assert_success(&selected, "selected workspace member run");
+    let stdout = String::from_utf8_lossy(&selected.stdout);
+    assert!(
+        stdout.lines().any(|line| line == "beta"),
+        "selected member output missing:\n{stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&selected.stderr);
+    assert!(
+        stderr.contains("member beta"),
+        "scope should be emitted on stderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("member beta"),
+        "scope must not contaminate program stdout:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn lock_preheats_dependency_graph_for_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let helper_dir = tmp.path().join("preheat_helper");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2198,6 +2198,47 @@ fn workspace_check_selection_emits_one_scoped_json_report() -> Result<(), Box<dy
 }
 
 #[test]
+fn workspace_build_selection_fans_out_without_shared_outputs() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n",
+    )?;
+    for name in ["alpha", "beta"] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(member.join("src"))?;
+        fs::write(
+            member.join("incan.toml"),
+            format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n"
+            ),
+        )?;
+        fs::write(member.join("src/main.incn"), "def main() -> None:\n    return\n")?;
+    }
+
+    let output = run_incan(tmp.path(), &["build", "--workspace"])?;
+    assert_success(&output, "workspace build fan-out");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("member alpha"), "missing alpha scope:\n{stdout}");
+    assert!(stdout.contains("member beta"), "missing beta scope:\n{stdout}");
+    for name in ["alpha", "beta"] {
+        assert!(
+            tmp.path().join("target/incan").join(name).join("Cargo.toml").is_file(),
+            "workspace build did not generate an isolated project for {name}:\n{stdout}"
+        );
+    }
+
+    let report = run_incan(tmp.path(), &["build", "--workspace", "--report", "json"])?;
+    assert_failure(&report, "multi-member workspace build report");
+    assert!(
+        String::from_utf8_lossy(&report.stderr).contains("multi-member build reports are not available yet"),
+        "report guard should explain the unsupported machine output:\n{}",
+        String::from_utf8_lossy(&report.stderr)
+    );
+    Ok(())
+}
+
+#[test]
 fn lock_preheats_dependency_graph_for_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let helper_dir = tmp.path().join("preheat_helper");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2116,6 +2116,41 @@ fn workspace_test_selection_fans_out_with_member_scoped_json() -> Result<(), Box
 }
 
 #[test]
+fn workspace_format_selection_requires_explicit_cross_member_mutation() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n",
+    )?;
+    for name in ["alpha", "beta"] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(member.join("src"))?;
+        fs::write(
+            member.join("incan.toml"),
+            format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n"
+            ),
+        )?;
+        fs::write(member.join("src/main.incn"), "def main() -> None:\n    return\n")?;
+    }
+
+    let implicit = run_incan(tmp.path(), &["fmt"])?;
+    assert_failure(&implicit, "implicit virtual-workspace formatting");
+    assert!(
+        String::from_utf8_lossy(&implicit.stderr).contains("would modify multiple members"),
+        "implicit cross-member formatting should explain the required selector:\n{}",
+        String::from_utf8_lossy(&implicit.stderr)
+    );
+
+    let checked = run_incan(tmp.path(), &["fmt", "--workspace", "--check"])?;
+    assert_success(&checked, "explicit workspace formatting check");
+    let stdout = String::from_utf8_lossy(&checked.stdout);
+    assert!(stdout.contains("member alpha"), "missing alpha scope:\n{stdout}");
+    assert!(stdout.contains("member beta"), "missing beta scope:\n{stdout}");
+    Ok(())
+}
+
+#[test]
 fn lock_preheats_dependency_graph_for_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let helper_dir = tmp.path().join("preheat_helper");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1940,6 +1940,60 @@ fn lock_generates_lockfile_for_manifest_project() -> Result<(), Box<dyn std::err
 }
 
 #[test]
+fn lock_from_workspace_member_publishes_only_the_root_lockfile() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n",
+    )?;
+    for name in ["alpha", "beta"] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(member.join("src"))?;
+        fs::write(
+            member.join("incan.toml"),
+            format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n"
+            ),
+        )?;
+        fs::write(member.join("src/main.incn"), "def main() -> None:\n    return\n")?;
+    }
+
+    let output = run_incan(&tmp.path().join("packages/alpha"), &["lock"])?;
+    assert_success(&output, "workspace lock");
+    assert!(tmp.path().join("incan.lock").is_file());
+    assert!(!tmp.path().join("packages/alpha/incan.lock").exists());
+    assert!(!tmp.path().join("packages/beta/incan.lock").exists());
+    Ok(())
+}
+
+#[test]
+fn build_from_workspace_member_uses_the_root_lockfile() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n",
+    )?;
+    for name in ["alpha", "beta"] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(member.join("src"))?;
+        fs::write(
+            member.join("incan.toml"),
+            format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n"
+            ),
+        )?;
+        fs::write(member.join("src/main.incn"), "def main() -> None:\n    return\n")?;
+    }
+
+    let output = run_incan(&tmp.path().join("packages/alpha"), &["build"])?;
+    assert_success(&output, "workspace member build");
+    assert!(tmp.path().join("incan.lock").is_file());
+    assert!(!tmp.path().join("packages/alpha/incan.lock").exists());
+    assert!(!tmp.path().join("packages/beta/incan.lock").exists());
+    Ok(())
+}
+
+#[test]
 fn lock_preheats_dependency_graph_for_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let helper_dir = tmp.path().join("preheat_helper");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2228,6 +2228,18 @@ fn workspace_build_selection_fans_out_without_shared_outputs() -> Result<(), Box
         );
     }
 
+    let selected = run_incan(tmp.path(), &["build", "--member", "beta"])?;
+    assert_success(&selected, "selected workspace member build");
+    let selected_stdout = String::from_utf8_lossy(&selected.stdout);
+    assert!(
+        selected_stdout.contains("member beta"),
+        "missing beta scope:\n{selected_stdout}"
+    );
+    assert!(
+        !selected_stdout.contains("member alpha"),
+        "selected build should not build alpha:\n{selected_stdout}"
+    );
+
     let report = run_incan(tmp.path(), &["build", "--workspace", "--report", "json"])?;
     assert_failure(&report, "multi-member workspace build report");
     assert!(

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2151,6 +2151,53 @@ fn workspace_format_selection_requires_explicit_cross_member_mutation() -> Resul
 }
 
 #[test]
+fn workspace_check_selection_emits_one_scoped_json_report() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::write(
+        tmp.path().join("incan.toml"),
+        "[workspace]\nmembers = [\"packages/*\"]\n",
+    )?;
+    for (name, source) in [
+        ("alpha", "def main() -> None:\n    return\n"),
+        ("beta", "def main() -> None:\n    missing()\n"),
+    ] {
+        let member = tmp.path().join("packages").join(name);
+        fs::create_dir_all(member.join("src"))?;
+        fs::write(
+            member.join("incan.toml"),
+            format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n"
+            ),
+        )?;
+        fs::write(member.join("src/main.incn"), source)?;
+    }
+
+    let output = run_incan(tmp.path(), &["check", ".", "--workspace", "--format", "json"])?;
+    assert_failure(&output, "workspace check with an invalid member");
+    let report = parse_json_stdout(&output)?;
+    assert_eq!(report["schema_version"], serde_json::json!(1));
+    assert_eq!(report["ok"], serde_json::json!(false));
+    assert_eq!(
+        report["workspace"]["selected_members"],
+        serde_json::json!(["alpha", "beta"])
+    );
+    assert_eq!(report["members"].as_array().map(Vec::len), Some(2));
+    assert_eq!(report["members"][0]["member"], serde_json::json!("alpha"));
+    assert_eq!(
+        report["members"][0]["report"]["ok"],
+        serde_json::json!(true),
+        "valid workspace member should pass:\n{report}"
+    );
+    assert_eq!(report["members"][1]["member"], serde_json::json!("beta"));
+    assert_eq!(report["members"][1]["report"]["ok"], serde_json::json!(false));
+    assert_eq!(
+        report["members"][1]["report"]["diagnostics"][0]["code"],
+        serde_json::json!("INCAN-T0001")
+    );
+    Ok(())
+}
+
+#[test]
 fn lock_preheats_dependency_graph_for_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let helper_dir = tmp.path().join("preheat_helper");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2241,12 +2241,25 @@ fn workspace_build_selection_fans_out_without_shared_outputs() -> Result<(), Box
     );
 
     let report = run_incan(tmp.path(), &["build", "--workspace", "--report", "json"])?;
-    assert_failure(&report, "multi-member workspace build report");
-    assert!(
-        String::from_utf8_lossy(&report.stderr).contains("multi-member build reports are not available yet"),
-        "report guard should explain the unsupported machine output:\n{}",
-        String::from_utf8_lossy(&report.stderr)
+    assert_success(&report, "multi-member workspace build report");
+    let report = parse_json_stdout(&report)?;
+    assert_eq!(report["schema_version"], serde_json::json!(1));
+    assert_eq!(report["ok"], serde_json::json!(true));
+    assert_eq!(
+        report["workspace"]["selected_members"],
+        serde_json::json!(["alpha", "beta"])
     );
+    assert_eq!(report["members"].as_array().map(Vec::len), Some(2));
+    for (member, name) in report["members"]
+        .as_array()
+        .ok_or("workspace report members were not an array")?
+        .iter()
+        .zip(["alpha", "beta"])
+    {
+        assert_eq!(member["member"], serde_json::json!(name));
+        assert_eq!(member["ok"], serde_json::json!(true));
+        assert_eq!(member["report"]["project"]["name"], serde_json::json!(name));
+    }
     Ok(())
 }
 

--- a/workspaces/docs-site/docs/language/reference/project_lifecycle.md
+++ b/workspaces/docs-site/docs/language/reference/project_lifecycle.md
@@ -27,6 +27,24 @@ incan run -c "import this"
 
 Project-level features such as manifest dependencies, version management, and named environments require `incan.toml`.
 
+## Workspaces
+
+A workspace root has an `incan.toml` with `[workspace]` and coordinates several ordinary member projects. A rooted
+workspace also has `[project]`; that root project is an implicit member. A virtual workspace has only `[workspace]`
+and names its members explicitly.
+
+```toml title="incan.toml"
+[workspace]
+members = ["packages/*"]
+default-members = ["packages/api", "packages/cli"]
+```
+
+Run `incan workspace inspect --format json` to validate the member graph, effective inherited dependencies, canonical
+root `incan.lock`, and the current selection. Lifecycle commands can select a scope with `--workspace` or repeated
+`--member <name-or-path>`. Build, check, test, and formatter checks can fan out deterministically; `run` and
+`version` require exactly one selected member. See the [CLI workspace command reference](../../tooling/reference/cli_reference.md#workspace-scoped-commands)
+for report and mutation behavior.
+
 ## `incan.toml`
 
 `incan.toml` is the project manifest. It is intended to be edited and committed.

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -17,6 +17,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 - **Compiler foundation**: The 0.5 backend-foundation lane now has a behavior inventory, generated-Rust deprecation policy, stable semantic identity scaffolding, typed compiler facts, initial HIR structures, and a Hees.ai dependency inventory so backend migration work has a shared review surface (#646, #647, #648, #649, #650, #651).
 - **Stdlib**: `std.checksum` adds CRC32 value, digest-byte, and incremental helpers for compatibility and accidental-corruption checks, separate from `std.hash` security and hashing contracts (#709).
 - **Stdlib**: `std.environ` adds redacted, read-only Unicode environment access through required, optional, and defaulted string reads, plus typed reads for primitives, explicit `TryFrom[str]` adopters, and validated newtypes (RFC 089, #557).
+- **Workspace tooling**: RFC 077 workspaces validate deterministic member topology, resolve shared root lock state and inherited dependencies, and let build/check/test/fmt fan out by member while keeping run/version single-member. Workspace inspection, diagnostics, test JSONL, and build reports expose the selected scope (#405).
 
 ## Tooling
 

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -20,6 +20,7 @@ Commands:
 - `explain` - Explain a stable diagnostic code
 - `build` - Compile to Rust and build an executable
 - `inspect` - Inspect compiler artifacts such as generated Rust output
+- `workspace` - Inspect validated workspace topology and the selected member scope
 - `run` - Compile and run a program
 - `fmt` - Format Incan source files
 - `test` - Run tests (pytest-style)
@@ -35,6 +36,29 @@ Commands:
 Incan 0.4 exposes several machine-readable inspection commands that are meant to agree on schema version, compiler version, project identity, source-file breadcrumbs, generated artifact paths, diagnostics, and provenance where their scopes overlap. Use `incan check --format json` for the stable diagnostic plane, `incan build --report json` for successful build and artifact metadata, `incan inspect rust --format json` for current generated Rust output, and `incan inspect codegraph --format jsonl` for source-structure graph facts.
 
 These commands are intentionally not a single full semantic database yet. They are the 0.4 baseline for the broader RFC 102 semantic inspection direction: stable public JSON surfaces that tools can join without scraping terminal prose, generated Rust, or source text independently. When a fact appears in more than one surface, consumers should prefer compiler-owned identity fields, source paths, schema versions, and explicit degraded-state or diagnostic records over human output.
+
+### `incan workspace inspect`
+
+Usage:
+
+```text
+incan workspace inspect [PATH] [--workspace | --member <NAME_OR_PATH>...] --format json
+```
+
+Emits the validated RFC 077 workspace topology as JSON. The report includes the canonical root and root manifest, deterministic member order, implicit-root membership, default selection, shared declarations, effective inherited dependencies, root lock state, stale member-local lockfile warnings, and the member scope selected for `PATH`.
+
+`--workspace` selects every member. Repeat `--member` to select named members or workspace-relative paths. Without a selector, the command reports the scope implied by the current location: a member when inside one, `default-members` at the workspace root when configured, the implicit root member in a rooted workspace, or every member in a virtual workspace.
+
+This command validates and reports topology only. It does not build, test, publish, or mutate member manifests.
+
+Examples:
+
+```bash
+incan workspace inspect --format json
+incan workspace inspect packages/storage --format json
+incan workspace inspect --member storage --member examples/demo --format json
+incan workspace inspect --workspace --format json
+```
 
 ## Global options
 

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -541,6 +541,10 @@ Resolves all dependencies (manifest + inline + test files) and generates or upda
 
 If `FILE` is omitted, uses the `[project.scripts].main` entry from `incan.toml`.
 
+Within an RFC 077 workspace, `incan lock` resolves every workspace member and writes the single authoritative
+`incan.lock` at the workspace root, even when invoked from a member directory. `incan build` and `incan test` use
+that same root lock automatically; member-local lockfiles are not authoritative.
+
 Options:
 
 - `--cargo-features <FEATURES>`: Enable specific Cargo features for resolution.

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -60,6 +60,36 @@ incan workspace inspect --member storage --member examples/demo --format json
 incan workspace inspect --workspace --format json
 ```
 
+### Workspace-scoped commands
+
+The project commands `build`, `check`, `test`, `fmt`, `run`, and `version` accept `--workspace` or one or more
+`--member <NAME_OR_PATH>` selectors when the current directory is inside a validated workspace. A selector is
+resolved before any member is compiled, tested, formatted, or mutated. Member order always follows the workspace
+manifest, not command-line selector order.
+
+Without a selector, a command run inside a member selects that member. At a workspace root it selects
+`default-members` when configured, the implicit root member for a rooted workspace, or all members for a virtual
+workspace.
+
+| Command | Multi-member behavior |
+| --- | --- |
+| `incan build` | Builds each selected member. Default output directories remain separated by member package name. `--report json` emits one workspace envelope containing one compiler build report per member; a single explicit `OUTPUT_DIR` is rejected for several members. |
+| `incan check` | Type-checks each selected member. `--format json` emits one workspace envelope with root, selected members, and a canonical diagnostic report per member. |
+| `incan test` | Runs each selected member in deterministic order. JSON Lines test records and summaries include `workspace.root`, `workspace.selected_members`, and `workspace.member`. `--junit` requires one selected member so reports cannot overwrite each other. |
+| `incan fmt` | `--check` may inspect an inferred multi-member scope. Formatting several members in place requires explicit `--workspace` or `--member` selection. |
+| `incan run` and `incan version` | Require exactly one member. Use `--member api`; `--workspace` is rejected if it selects more than one. Run scope is printed to stderr so program stdout remains available to the program. |
+
+Examples:
+
+```bash
+incan test --workspace --format json
+incan check . --member packages/api --format json
+incan build --workspace --report json
+incan fmt --workspace --check
+incan run --member cli
+incan version patch --member api --dry-run
+```
+
 ## Global options
 
 - `--no-banner`: suppress the ASCII logo banner when a command would otherwise show it (also via `INCAN_NO_BANNER=1`).


### PR DESCRIPTION
## Summary

This PR delivers the constrained RFC 077 workspace foundation for v0.5: validated rooted and virtual workspace topology, deterministic member selection, shared dependency refinement, one canonical workspace lock, machine-readable inspection, and scoped lifecycle command execution. It keeps single-project behavior intact and does not broaden v0.5 into registry, publication, capability, or workspace-environment product work.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan workspace inspect`, `--workspace`, and repeated `--member` provide explicit, deterministic workspace scope for `check`, `build`, `test`, `fmt`, `run`, and `version`. JSON reports identify root, selected members, and per-member results.
- **Internals**: a validated `WorkspaceGraph` owns rooted/virtual topology, shared dependency refinement, effective manifests, root lock ownership, and selection. Build, test, and diagnostics consume that shared model instead of rediscovering scope independently.
- **Risks**: workspace commands deliberately reject ambiguous multi-member mutation or single-target operations. Bare relative test filenames retain their existing current-directory meaning after workspace discovery.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (via `make smoke-test`)
- [x] `incan fmt --check .` (via `make pre-commit`)
- [x] Manual verification described below

Manual verification notes:

- `CARGO_NET_OFFLINE=true make pre-commit` passed formatting, rustdoc, the full test suite, and Clippy. Its only sandbox limitation was the read-only cargo-deny advisory lock; `make cargo-deny-ci` passed outside the sandbox.
- `CARGO_NET_OFFLINE=true make smoke-test` passed release build, assertion canary, 57 examples, and 9 benchmark builds.
- Workspace integration tests cover topology/inspection, root-lock behavior, inherited dependencies, deterministic test/build fan-out, scoped JSON reports, formatter safety, single-member run/version behavior, and bare relative-file test discovery.
- RFC lifecycle remains **Planned**: this is the complete constrained v0.5 foundation from #405; workspace environment and capability workflows remain later work rather than being misrepresented as shipped.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Workspace command scope reference and project lifecycle guidance
- v0.5 release note entry

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
