### PR TITLE
bugfix - infer generic Rust returns from expected types (#852)

### DIFF
--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -18,6 +18,7 @@ use incan_core::interop::{
 };
 use incan_core::lang::magic_methods;
 use incan_core::lang::surface::collection_helpers::{self, BuiltinCollectionHelperId};
+use incan_core::lang::surface::result_methods::ResultMethodId;
 use incan_core::lang::surface::types as surface_types;
 use incan_core::lang::surface::types::{SEMAPHORE_ACQUIRE_ERROR_TYPE_NAME, SEMAPHORE_PERMIT_TYPE_NAME, SurfaceTypeId};
 use incan_core::lang::surface::{
@@ -3283,7 +3284,10 @@ impl TypeChecker {
 
         let mut base_ty = self.check_type_receiver_expr(base);
         if let Some(expected) = expected_return_ty
-            && matches!(method, "unwrap" | "unwrap_or")
+            && matches!(
+                result_methods::from_str(method),
+                Some(ResultMethodId::Unwrap | ResultMethodId::UnwrapOr)
+            )
             && matches!(&base.node, Expr::Call(_, _, _))
             && matches!(
                 &base_ty,
@@ -3292,8 +3296,10 @@ impl TypeChecker {
                         && args.first().is_some_and(Self::contains_unbound_rust_type_var)
             )
         {
-            let expected_result =
-                ResolvedType::Generic("Result".to_string(), vec![expected.clone(), ResolvedType::Unknown]);
+            let expected_result = ResolvedType::Generic(
+                collection_name(CollectionTypeId::Result).to_string(),
+                vec![expected.clone(), ResolvedType::Unknown],
+            );
             base_ty = self.check_expr_with_expected(base, Some(&expected_result));
         }
 

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -3281,7 +3281,21 @@ impl TypeChecker {
             return self.check_builtin_list_repeat_call(args, span);
         }
 
-        let base_ty = self.check_type_receiver_expr(base);
+        let mut base_ty = self.check_type_receiver_expr(base);
+        if let Some(expected) = expected_return_ty
+            && matches!(method, "unwrap" | "unwrap_or")
+            && matches!(&base.node, Expr::Call(_, _, _))
+            && matches!(
+                &base_ty,
+                ResolvedType::Generic(name, args)
+                    if collection_type_id(name.as_str()) == Some(CollectionTypeId::Result)
+                        && args.first().is_some_and(Self::contains_unbound_rust_type_var)
+            )
+        {
+            let expected_result =
+                ResolvedType::Generic("Result".to_string(), vec![expected.clone(), ResolvedType::Unknown]);
+            base_ty = self.check_expr_with_expected(base, Some(&expected_result));
+        }
 
         // If the receiver type is Unknown, be permissive and do not error on methods.
         if matches!(base_ty, ResolvedType::Unknown) {

--- a/src/frontend/typechecker/check_expr/calls.rs
+++ b/src/frontend/typechecker/check_expr/calls.rs
@@ -340,7 +340,13 @@ impl TypeChecker {
                             match &meta.kind {
                                 RustItemKind::Function(sig) => {
                                     let error_count_before = self.errors.len();
-                                    let result = self.validate_rust_function_call(info.path.as_str(), sig, args, span);
+                                    let result = self.validate_rust_function_call_with_expected(
+                                        info.path.as_str(),
+                                        sig,
+                                        args,
+                                        span,
+                                        expected_return_ty,
+                                    );
                                     if self.errors.len() == error_count_before {
                                         self.record_expr_type(
                                             callee.span,
@@ -401,7 +407,13 @@ impl TypeChecker {
                             }
                         } else if let Some(sig) = metadata_free_function_signature(info.path.as_str()) {
                             let error_count_before = self.errors.len();
-                            let result = self.validate_rust_function_call(info.path.as_str(), &sig, args, span);
+                            let result = self.validate_rust_function_call_with_expected(
+                                info.path.as_str(),
+                                &sig,
+                                args,
+                                span,
+                                expected_return_ty,
+                            );
                             if self.errors.len() == error_count_before {
                                 self.record_expr_type(
                                     callee.span,

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -229,6 +229,55 @@ impl TypeChecker {
         }
     }
 
+    /// Substitute inspected Rust generic placeholders from a compatible expected result shape.
+    ///
+    /// Rust metadata names unbound function generics T, U, and similar. These are not Incan type variables, but an
+    /// expected result such as Result[Value, _] supplies an unambiguous binding for the matching return position.
+    fn refine_unbound_rust_return_type_with_expected(actual: &ResolvedType, expected: &ResolvedType) -> ResolvedType {
+        match actual {
+            ResolvedType::RustPath(path) if Self::rust_display_type_var_name(path.trim()).is_some() => expected.clone(),
+            ResolvedType::Ref(inner) => match expected {
+                ResolvedType::Ref(expected_inner) => ResolvedType::Ref(Box::new(
+                    Self::refine_unbound_rust_return_type_with_expected(inner, expected_inner),
+                )),
+                _ => actual.clone(),
+            },
+            ResolvedType::RefMut(inner) => match expected {
+                ResolvedType::RefMut(expected_inner) => ResolvedType::RefMut(Box::new(
+                    Self::refine_unbound_rust_return_type_with_expected(inner, expected_inner),
+                )),
+                _ => actual.clone(),
+            },
+            ResolvedType::Generic(name, args) => match expected {
+                ResolvedType::Generic(expected_name, expected_args)
+                    if name == expected_name && args.len() == expected_args.len() =>
+                {
+                    ResolvedType::Generic(
+                        name.clone(),
+                        args.iter()
+                            .zip(expected_args)
+                            .map(|(actual, expected)| {
+                                Self::refine_unbound_rust_return_type_with_expected(actual, expected)
+                            })
+                            .collect(),
+                    )
+                }
+                _ => actual.clone(),
+            },
+            ResolvedType::Tuple(items) => match expected {
+                ResolvedType::Tuple(expected_items) if items.len() == expected_items.len() => ResolvedType::Tuple(
+                    items
+                        .iter()
+                        .zip(expected_items)
+                        .map(|(actual, expected)| Self::refine_unbound_rust_return_type_with_expected(actual, expected))
+                        .collect(),
+                ),
+                _ => actual.clone(),
+            },
+            _ => actual.clone(),
+        }
+    }
+
     /// Record an ownership conversion for borrowed Rust scalar-like returns that Incan exposes as owned values.
     pub(in crate::frontend::typechecker) fn record_rust_return_coercion_from_display(
         &mut self,
@@ -839,12 +888,25 @@ impl TypeChecker {
     }
 
     /// Validate a direct Rust function call (`rust::path::item(...)`) and record boundary coercions.
+    #[cfg(test)]
     pub(in crate::frontend::typechecker::check_expr) fn validate_rust_function_call(
         &mut self,
         path: &str,
         sig: &RustFunctionSig,
         args: &[CallArg],
         span: Span,
+    ) -> ResolvedType {
+        self.validate_rust_function_call_with_expected(path, sig, args, span, None)
+    }
+
+    /// Validate a direct Rust function call while using an expected result type to bind return-only generics.
+    pub(in crate::frontend::typechecker::check_expr) fn validate_rust_function_call_with_expected(
+        &mut self,
+        path: &str,
+        sig: &RustFunctionSig,
+        args: &[CallArg],
+        span: Span,
+        expected_return_ty: Option<&ResolvedType>,
     ) -> ResolvedType {
         if sig.is_async {
             self.type_info
@@ -875,6 +937,9 @@ impl TypeChecker {
         }
 
         let ret = self.resolved_rust_call_type_from_sig(sig, path, span);
+        let ret = expected_return_ty
+            .map(|expected| Self::refine_unbound_rust_return_type_with_expected(&ret, expected))
+            .unwrap_or(ret);
         self.record_rust_return_coercion_from_display(sig.return_type.as_str(), &ret, span);
         ret
     }

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -267,8 +267,8 @@
     {
       "path": "src/frontend/typechecker/check_expr/access.rs",
       "category": "method/type access surface classification",
-      "expected_count": 47,
-      "expected_fingerprint": "0x3c8d1c37b34bd570"
+      "expected_count": 46,
+      "expected_fingerprint": "0xadce01bf76021778"
     },
     {
       "path": "src/frontend/typechecker/check_expr/basics.rs",

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -267,8 +267,8 @@
     {
       "path": "src/frontend/typechecker/check_expr/access.rs",
       "category": "method/type access surface classification",
-      "expected_count": 46,
-      "expected_fingerprint": "0xadce01bf76021778"
+      "expected_count": 47,
+      "expected_fingerprint": "0x3c8d1c37b34bd570"
     },
     {
       "path": "src/frontend/typechecker/check_expr/basics.rs",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10837,8 +10837,13 @@ def parse_value() -> Value:
     return json_parse("{}").unwrap()
 
 
+def accept_value(value: Value) -> None:
+    pass
+
+
 def main() -> None:
     value: Value = parse_value()
+    accept_value(json_parse("{}").unwrap())
 "#,
         )?;
 
@@ -10857,6 +10862,31 @@ def main() -> None:
             "expected generated Rust to compile for the inferred generic JSON result.\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&build_output.stdout),
             String::from_utf8_lossy(&build_output.stderr)
+        );
+
+        let tests_dir = tmp.path().join("tests");
+        std::fs::create_dir_all(&tests_dir)?;
+        std::fs::write(
+            tests_dir.join("test_generic_json_return.incn"),
+            r#"from rust::serde_json import Value
+from rust::serde_json import from_str as json_parse
+
+
+def accept_value(value: Value) -> None:
+    pass
+
+
+def test_generic_json_result_infers_from_parameter_context() -> None:
+    accept_value(json_parse("{}").unwrap())
+    assert true
+"#,
+        )?;
+        let test_output = run_test(&tests_dir)?;
+        assert!(
+            test_output.status.success(),
+            "expected the package test batch to compile and run the inferred generic JSON result.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&test_output.stdout),
+            String::from_utf8_lossy(&test_output.stderr)
         );
         Ok(())
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10822,6 +10822,45 @@ mod rfc031_pub_import_integration_tests {
             .output()?)
     }
 
+    #[test]
+    fn consumer_build_infers_rust_generic_return_from_unwrap_context_issue852() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let tmp = tempfile::tempdir()?;
+        let main_path = write_project_files(
+            tmp.path(),
+            "[project]\nname = \"generic_json_return_repro\"\n\n[rust-dependencies.serde_json]\nversion = \"1.0\"\n",
+            r#"from rust::serde_json import Value
+from rust::serde_json import from_str as json_parse
+
+
+def parse_value() -> Value:
+    return json_parse("{}").unwrap()
+
+
+def main() -> None:
+    value: Value = parse_value()
+"#,
+        )?;
+
+        let check_output = run_check(&main_path)?;
+        assert!(
+            check_output.status.success(),
+            "expected generic Rust JSON parser result to infer through unwrap context.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&check_output.stdout),
+            String::from_utf8_lossy(&check_output.stderr)
+        );
+
+        let out_dir = tmp.path().join("out");
+        let build_output = run_build(&main_path, &out_dir)?;
+        assert!(
+            build_output.status.success(),
+            "expected generated Rust to compile for the inferred generic JSON result.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build_output.stdout),
+            String::from_utf8_lossy(&build_output.stderr)
+        );
+        Ok(())
+    }
+
     fn run_run(main_path: &Path) -> Result<std::process::Output, Box<dyn std::error::Error>> {
         Ok(super::incan_command()
             .args(["run", main_path.to_string_lossy().as_ref()])

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -26,5 +26,6 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 ## Bugfixes
 
 - **Compiler**: Rust interop method calls with inferred `Into`-bound generic parameters now keep string literals in an inferable shape instead of generating ambiguous `.into()` calls (#804).
+- **Compiler**: Generic Rust function results can now be inferred from an annotated return or parameter context through `Result.unwrap()`, including generated package-test builds such as `serde_json::from_str` (#852).
 - **Compiler**: Rust interop now preserves callable bounds such as `FnMut(&mut T, &U)` when checking generic callback parameters, so by-value Incan callbacks are rejected at typecheck instead of reaching Rust codegen with an invalid borrowed callback shape (#805).
 - **Compiler**: Generic value-reflection bounds are preserved for impl-method-owned type parameters, and direct dependency-module generation now typechecks before lowering so root Rust trait imports stay available in generated module tests (#819, #827).


### PR DESCRIPTION
## Summary

Fixes #852: direct imported Rust functions can now refine return-only generic placeholders from a compatible surrounding Incan type. This unblocks the Hees JSON-schema adapter's `serde_json::from_str(...).unwrap()` path without a source workaround.

Closes #852

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- A compatible expected return or parameter type is carried into direct Rust-call validation and refines only matching unbound Rust return positions.
- `Result.unwrap()` and `Result.unwrap_or()` propagate their expected output back into the nested Rust call, using the canonical Result-method and collection registries.
- Incompatible or absent context retains the inspected Rust return type; this does not invent unconstrained generic bindings.
- The regression uses a real `serde_json` package consumer, checks and builds generated Rust, then compiles and runs a package test batch.

## Testing / verification

- [x] Focused `cargo test` coverage
- [x] `make examples` (via `make pre-commit` smoke)
- [x] `cargo fmt` / `make lint-fast-ci`
- [x] Manual verification described below

**Focused checks:**

- `cargo test --test integration_tests consumer_build_infers_rust_generic_return_from_unwrap_context_issue852 -- --nocapture`
- `cargo test --features rust_inspect --test integration_tests consumer_build_infers_rust_generic_return_from_unwrap_context_issue852 -- --nocapture`
- `cargo test --test vocab_guardrails semantic_string_checks_are_classified`
- `make docs-build`
- `make pre-commit` — passed on the rebased head: 2,808 tests, clippy, cargo-deny, 57 example checks (34 run), and 9 benchmark builds.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The v0.5 release notes record the supported contextual inference through `Result.unwrap()`.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
