### PR TITLE
feature - add compiler-owned diagnostic graph facts (#771)

### DIFF
--- a/crates/incan_codegraph/src/lib.rs
+++ b/crates/incan_codegraph/src/lib.rs
@@ -75,6 +75,15 @@ pub struct CodegraphSourceSpan {
     pub end_column: usize,
 }
 
+/// Labeled secondary source location attached to a diagnostic fact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodegraphDiagnosticRelatedSpan {
+    /// Secondary source span.
+    pub span: CodegraphSourceSpan,
+    /// Compiler-owned explanation for this relationship.
+    pub label: String,
+}
+
 /// Header record emitted first in every JSONL export.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodegraphHeaderRecord {
@@ -297,6 +306,9 @@ pub struct CodegraphDiagnosticRecord {
     pub severity: String,
     /// Compiler phase that produced the diagnostic.
     pub phase: String,
+    /// Compiler subsystem that produced the diagnostic fact.
+    #[serde(default = "unknown_diagnostic_origin")]
+    pub origin: String,
     /// User-facing diagnostic message.
     pub message: String,
     /// Primary source span.
@@ -305,12 +317,26 @@ pub struct CodegraphDiagnosticRecord {
     pub notes: Vec<String>,
     /// Suggested fixes or hints.
     pub hints: Vec<String>,
+    /// Structured expected value or type when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected: Option<String>,
+    /// Structured actual value or type when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actual: Option<String>,
+    /// Secondary compiler-owned source locations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub related_spans: Vec<CodegraphDiagnosticRelatedSpan>,
     /// Explain command for the diagnostic code.
     pub explain: String,
     /// Fact provenance.
     pub provenance: CodegraphProvenance,
     /// Diagnostic records always indicate degraded graph state.
     pub degraded: bool,
+}
+
+/// Supply the safe legacy value when a schema-v1 diagnostic has no origin field.
+fn unknown_diagnostic_origin() -> String {
+    "unknown".to_string()
 }
 
 /// One newline-delimited codegraph record.
@@ -352,8 +378,8 @@ pub fn to_jsonl(records: &[CodegraphRecord]) -> Result<String, serde_json::Error
 #[cfg(test)]
 mod tests {
     use super::{
-        CODEGRAPH_SCHEMA_VERSION, CodegraphFileRecord, CodegraphHeaderRecord, CodegraphLanguage, CodegraphMode,
-        CodegraphProvenance, CodegraphRecord, to_jsonl,
+        CODEGRAPH_SCHEMA_VERSION, CodegraphDiagnosticRecord, CodegraphFileRecord, CodegraphHeaderRecord,
+        CodegraphLanguage, CodegraphMode, CodegraphProvenance, CodegraphRecord, CodegraphSourceSpan, to_jsonl,
     };
 
     #[test]
@@ -385,6 +411,45 @@ mod tests {
         assert!(lines[0].contains("\"record\":\"header\""));
         assert!(lines[0].contains("\"schema_version\":1"));
         assert!(lines[1].contains("\"record\":\"file\""));
+        Ok(())
+    }
+
+    #[test]
+    fn diagnostic_records_without_origin_remain_readable() -> Result<(), Box<dyn std::error::Error>> {
+        let record = CodegraphRecord::Diagnostic(CodegraphDiagnosticRecord {
+            id: "diagnostic:0".to_string(),
+            language: CodegraphLanguage::Incan,
+            code: "INCAN-T0001".to_string(),
+            severity: "error".to_string(),
+            phase: "typecheck".to_string(),
+            origin: "typechecker".to_string(),
+            message: "type mismatch".to_string(),
+            primary_span: CodegraphSourceSpan {
+                file: "main.incn".to_string(),
+                start: 0,
+                end: 1,
+                start_line: 1,
+                start_column: 1,
+                end_line: 1,
+                end_column: 2,
+            },
+            notes: Vec::new(),
+            hints: Vec::new(),
+            expected: None,
+            actual: None,
+            related_spans: Vec::new(),
+            explain: "incan explain INCAN-T0001".to_string(),
+            provenance: CodegraphProvenance::Diagnostic,
+            degraded: true,
+        });
+        let mut legacy = serde_json::to_value(record)?;
+        legacy.as_object_mut().ok_or("expected record object")?.remove("origin");
+
+        let parsed: CodegraphRecord = serde_json::from_value(legacy)?;
+        let CodegraphRecord::Diagnostic(diagnostic) = parsed else {
+            return Err("expected diagnostic record".into());
+        };
+        assert_eq!(diagnostic.origin, "unknown");
         Ok(())
     }
 }

--- a/crates/incan_syntax/src/diagnostics/base.rs
+++ b/crates/incan_syntax/src/diagnostics/base.rs
@@ -15,6 +15,19 @@ pub struct RelatedSpan {
     pub label: String,
 }
 
+/// Optional structured detail carried only by diagnostics that have extra tooling facts.
+///
+/// Keeping this payload out of the common [`CompileError`] layout matters because parser
+/// APIs return `Result<_, CompileError>` pervasively. The indirection preserves a compact
+/// error variant for ordinary syntax and type errors while still retaining rich facts when
+/// a producer supplies them.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct StructuredDiagnosticDetails {
+    related_spans: Vec<RelatedSpan>,
+    expected: Option<String>,
+    actual: Option<String>,
+}
+
 /// A compile-time error with location information.
 ///
 /// Every diagnostic produced by the Incan compiler is represented as a
@@ -33,12 +46,8 @@ pub struct CompileError {
     pub notes: Vec<String>,
     /// Actionable suggestions ("= hint: …") rendered after the notes.
     pub hints: Vec<String>,
-    /// Compiler-owned secondary locations retained for structured tooling projections.
-    pub related_spans: Vec<RelatedSpan>,
-    /// Expected value or type when the diagnostic has a structured expectation.
-    pub expected: Option<String>,
-    /// Actual value or type when the diagnostic has a structured expectation.
-    pub actual: Option<String>,
+    /// Compiler-owned detail retained for structured tooling projections when present.
+    details: Option<Box<StructuredDiagnosticDetails>>,
 }
 
 impl CompileError {
@@ -50,9 +59,7 @@ impl CompileError {
             kind: ErrorKind::Error,
             notes: Vec::new(),
             hints: Vec::new(),
-            related_spans: Vec::new(),
-            expected: None,
-            actual: None,
+            details: None,
         }
     }
 
@@ -64,9 +71,7 @@ impl CompileError {
             kind: ErrorKind::Syntax,
             notes: Vec::new(),
             hints: Vec::new(),
-            related_spans: Vec::new(),
-            expected: None,
-            actual: None,
+            details: None,
         }
     }
 
@@ -78,9 +83,7 @@ impl CompileError {
             kind: ErrorKind::Type,
             notes: Vec::new(),
             hints: Vec::new(),
-            related_spans: Vec::new(),
-            expected: None,
-            actual: None,
+            details: None,
         }
     }
 
@@ -95,9 +98,19 @@ impl CompileError {
             kind: ErrorKind::Warning,
             notes: Vec::new(),
             hints: Vec::new(),
-            related_spans: Vec::new(),
-            expected: None,
-            actual: None,
+            details: None,
+        }
+    }
+
+    /// Create a non-fatal lint advisory.
+    pub fn lint(message: String, span: Span) -> Self {
+        Self {
+            message,
+            span,
+            kind: ErrorKind::Lint,
+            notes: Vec::new(),
+            hints: Vec::new(),
+            details: None,
         }
     }
 
@@ -115,7 +128,7 @@ impl CompileError {
 
     /// Attach a second compiler-owned source location to this diagnostic.
     pub fn with_related_span(mut self, span: Span, label: impl Into<String>) -> Self {
-        self.related_spans.push(RelatedSpan {
+        self.structured_details_mut().related_spans.push(RelatedSpan {
             span,
             label: label.into(),
         });
@@ -124,9 +137,33 @@ impl CompileError {
 
     /// Attach structured expected and actual values without requiring tooling to parse prose.
     pub fn with_expected_actual(mut self, expected: impl Into<String>, actual: impl Into<String>) -> Self {
-        self.expected = Some(expected.into());
-        self.actual = Some(actual.into());
+        let details = self.structured_details_mut();
+        details.expected = Some(expected.into());
+        details.actual = Some(actual.into());
         self
+    }
+
+    /// Return compiler-owned secondary locations for structured tooling projections.
+    pub fn related_spans(&self) -> &[RelatedSpan] {
+        self.details
+            .as_deref()
+            .map_or(&[], |details| details.related_spans.as_slice())
+    }
+
+    /// Return the structured expected value or type, when the diagnostic provides one.
+    pub fn expected(&self) -> Option<&str> {
+        self.details.as_deref().and_then(|details| details.expected.as_deref())
+    }
+
+    /// Return the structured actual value or type, when the diagnostic provides one.
+    pub fn actual(&self) -> Option<&str> {
+        self.details.as_deref().and_then(|details| details.actual.as_deref())
+    }
+
+    /// Return the optional structured payload, allocating it only for a rich diagnostic.
+    fn structured_details_mut(&mut self) -> &mut StructuredDiagnosticDetails {
+        self.details
+            .get_or_insert_with(|| Box::new(StructuredDiagnosticDetails::default()))
     }
 }
 
@@ -272,6 +309,21 @@ fn get_line_info(source: &str, offset: usize) -> (usize, usize, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn structured_details_stay_out_of_the_common_error_layout() {
+        let error = CompileError::type_error("type mismatch".to_string(), Span::new(8, 11))
+            .with_expected_actual("int", "str")
+            .with_related_span(Span::new(0, 3), "value declared here");
+
+        assert_eq!(error.expected(), Some("int"));
+        assert_eq!(error.actual(), Some("str"));
+        assert_eq!(error.related_spans().len(), 1);
+        assert!(
+            std::mem::size_of::<CompileError>() <= 128,
+            "CompileError must remain small enough for pervasive Result<_, CompileError> parser APIs"
+        );
+    }
 
     #[test]
     fn test_get_line_info() {

--- a/crates/incan_syntax/src/diagnostics/base.rs
+++ b/crates/incan_syntax/src/diagnostics/base.rs
@@ -6,6 +6,15 @@
 
 use crate::ast::Span;
 
+/// A secondary source location that explains one compiler diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelatedSpan {
+    /// Source range associated with the diagnostic.
+    pub span: Span,
+    /// Compiler-owned explanation of why this location is related.
+    pub label: String,
+}
+
 /// A compile-time error with location information.
 ///
 /// Every diagnostic produced by the Incan compiler is represented as a
@@ -24,6 +33,12 @@ pub struct CompileError {
     pub notes: Vec<String>,
     /// Actionable suggestions ("= hint: …") rendered after the notes.
     pub hints: Vec<String>,
+    /// Compiler-owned secondary locations retained for structured tooling projections.
+    pub related_spans: Vec<RelatedSpan>,
+    /// Expected value or type when the diagnostic has a structured expectation.
+    pub expected: Option<String>,
+    /// Actual value or type when the diagnostic has a structured expectation.
+    pub actual: Option<String>,
 }
 
 impl CompileError {
@@ -35,6 +50,9 @@ impl CompileError {
             kind: ErrorKind::Error,
             notes: Vec::new(),
             hints: Vec::new(),
+            related_spans: Vec::new(),
+            expected: None,
+            actual: None,
         }
     }
 
@@ -46,6 +64,9 @@ impl CompileError {
             kind: ErrorKind::Syntax,
             notes: Vec::new(),
             hints: Vec::new(),
+            related_spans: Vec::new(),
+            expected: None,
+            actual: None,
         }
     }
 
@@ -57,6 +78,9 @@ impl CompileError {
             kind: ErrorKind::Type,
             notes: Vec::new(),
             hints: Vec::new(),
+            related_spans: Vec::new(),
+            expected: None,
+            actual: None,
         }
     }
 
@@ -71,6 +95,9 @@ impl CompileError {
             kind: ErrorKind::Warning,
             notes: Vec::new(),
             hints: Vec::new(),
+            related_spans: Vec::new(),
+            expected: None,
+            actual: None,
         }
     }
 
@@ -83,6 +110,22 @@ impl CompileError {
     /// Append an actionable hint ("= hint: …") to this error.
     pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
         self.hints.push(hint.into());
+        self
+    }
+
+    /// Attach a second compiler-owned source location to this diagnostic.
+    pub fn with_related_span(mut self, span: Span, label: impl Into<String>) -> Self {
+        self.related_spans.push(RelatedSpan {
+            span,
+            label: label.into(),
+        });
+        self
+    }
+
+    /// Attach structured expected and actual values without requiring tooling to parse prose.
+    pub fn with_expected_actual(mut self, expected: impl Into<String>, actual: impl Into<String>) -> Self {
+        self.expected = Some(expected.into());
+        self.actual = Some(actual.into());
         self
     }
 }

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/rust_module.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/rust_module.rs
@@ -4,7 +4,7 @@
 //! sanitization and crate resolution.
 
 use crate::ast::Span;
-use crate::diagnostics::{CompileError, ErrorKind};
+use crate::diagnostics::CompileError;
 
 // -- rust.module() directive --------------------------------------------------
 
@@ -50,18 +50,11 @@ pub fn unresolved_rust_module_crate(crate_name: &str, path: &str, span: Span) ->
 
 /// `rust.module()` directive with no `@rust.extern` items in the module (warning).
 pub fn unused_rust_module(span: Span) -> CompileError {
-    CompileError {
-        message: "`rust.module()` directive has no effect — no `@rust.extern` items found".to_string(),
+    CompileError::warning(
+        "`rust.module()` directive has no effect — no `@rust.extern` items found".to_string(),
         span,
-        kind: ErrorKind::Warning,
-        notes: Vec::new(),
-        hints: vec![
-            "Remove it if this module is pure Incan, or add `@rust.extern` to Rust-backed functions".to_string(),
-        ],
-        related_spans: Vec::new(),
-        expected: None,
-        actual: None,
-    }
+    )
+    .with_hint("Remove it if this module is pure Incan, or add `@rust.extern` to Rust-backed functions")
 }
 
 // -- @rust.extern decorator ---------------------------------------------------

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/rust_module.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/rust_module.rs
@@ -58,6 +58,9 @@ pub fn unused_rust_module(span: Span) -> CompileError {
         hints: vec![
             "Remove it if this module is pure Incan, or add `@rust.extern` to Rust-backed functions".to_string(),
         ],
+        related_spans: Vec::new(),
+        expected: None,
+        actual: None,
     }
 }
 

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -107,9 +107,13 @@ pub fn regular_enum_variant_value_not_allowed(enum_name: &str, variant_name: &st
 }
 
 /// Build the diagnostic for passing the same call argument more than once.
-pub fn duplicate_call_argument(callee: &str, name: &str, span: Span) -> CompileError {
-    CompileError::type_error(format!("Duplicate argument '{name}' when calling '{callee}'"), span)
-        .with_hint("Pass each fixed parameter at most once")
+pub fn duplicate_call_argument(callee: &str, name: &str, first_span: Span, duplicate_span: Span) -> CompileError {
+    CompileError::type_error(
+        format!("Duplicate argument '{name}' when calling '{callee}'"),
+        duplicate_span,
+    )
+    .with_related_span(first_span, format!("First argument named '{name}'"))
+    .with_hint("Pass each fixed parameter at most once")
 }
 
 /// Build the diagnostic for a keyword argument that the callee does not accept.
@@ -294,11 +298,13 @@ pub fn rust_allow_unsupported_attachment(kind: &str, span: Span) -> CompileError
 
 // -- Type mismatches ---------------------------------------------------------
 
+/// Build the generic expected-versus-actual type mismatch diagnostic.
 pub fn type_mismatch(expected: &str, found: &str, span: Span) -> CompileError {
     let mut error = CompileError::type_error(
         format!("Type mismatch: expected '{}', found '{}'", expected, found),
         span,
-    );
+    )
+    .with_expected_actual(expected, found);
     error = add_type_mismatch_hints(error, expected, found);
     error
 }
@@ -310,6 +316,7 @@ pub fn return_type_mismatch(expected: &str, found: &str, span: Span) -> CompileE
             format!("Return type mismatch: expected '{}', found '{}'", expected, found),
             span,
         )
+        .with_expected_actual(expected, found)
         .with_note(format!(
             "This return expression must match the function return type '{}'",
             expected
@@ -329,6 +336,7 @@ pub fn assignment_type_mismatch(binding: &str, expected: &str, found: &str, span
             ),
             span,
         )
+        .with_expected_actual(expected, found)
         .with_note(format!("'{}' is declared as '{}'", binding, expected)),
         expected,
         found,
@@ -363,7 +371,13 @@ pub fn call_argument_type_mismatch(
             expected, callee
         ),
     };
-    add_type_mismatch_hints(CompileError::type_error(message, span).with_note(note), expected, found)
+    add_type_mismatch_hints(
+        CompileError::type_error(message, span)
+            .with_expected_actual(expected, found)
+            .with_note(note),
+        expected,
+        found,
+    )
 }
 
 /// Add smart hints based on the expected and found types.
@@ -1569,6 +1583,7 @@ pub fn duplicate_interop_edge(
         format!("Duplicate interop edge `{direction} {edge_ty}` on `{type_name}`"),
         second_span,
     )
+    .with_related_span(first_span, "First interop edge declaration")
     .with_note(format!("First declaration at span: {:?}", first_span))
 }
 
@@ -1591,11 +1606,13 @@ pub fn conflicting_interop_edge(
     .with_hint("Keep one canonical adapter edge for each directed type")
 }
 
+/// Build the diagnostic for two fields that claim the same serialized alias.
 pub fn duplicate_alias(type_name: &str, alias: &str, first_span: Span, second_span: Span) -> CompileError {
     CompileError::type_error(
         format!("Duplicate alias '{}' on type '{}'", alias, type_name),
         second_span,
     )
+    .with_related_span(first_span, format!("First field alias '{alias}'"))
     .with_note(format!(
         "Alias '{}' is already used by another field on '{}'",
         alias, type_name

--- a/crates/incan_syntax/src/diagnostics/catalog/lints.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/lints.rs
@@ -7,6 +7,7 @@ use crate::ast::Span;
 
 use super::super::{CompileError, ErrorKind};
 
+/// Build the lint warning emitted for an unused local binding.
 pub fn unused_variable(name: &str, span: Span) -> CompileError {
     CompileError {
         message: format!("Unused variable '{}'", name),
@@ -14,9 +15,13 @@ pub fn unused_variable(name: &str, span: Span) -> CompileError {
         kind: ErrorKind::Lint,
         notes: vec![],
         hints: vec!["Prefix with underscore to silence: _{}".to_string() + name],
+        related_spans: vec![],
+        expected: None,
+        actual: None,
     }
 }
 
+/// Build the lint warning emitted for an unused import.
 pub fn unused_import(name: &str, span: Span) -> CompileError {
     CompileError {
         message: format!("Unused import '{}'", name),
@@ -24,9 +29,13 @@ pub fn unused_import(name: &str, span: Span) -> CompileError {
         kind: ErrorKind::Lint,
         notes: vec![],
         hints: vec!["Remove the import or use it".to_string()],
+        related_spans: vec![],
+        expected: None,
+        actual: None,
     }
 }
 
+/// Build the lint warning emitted for a wildcard match arm.
 pub fn wildcard_match(span: Span) -> CompileError {
     CompileError {
         message: "Using wildcard '_' in match - consider handling all cases explicitly".to_string(),
@@ -34,5 +43,8 @@ pub fn wildcard_match(span: Span) -> CompileError {
         kind: ErrorKind::Lint,
         notes: vec![],
         hints: vec![],
+        related_spans: vec![],
+        expected: None,
+        actual: None,
     }
 }

--- a/crates/incan_syntax/src/diagnostics/catalog/lints.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/lints.rs
@@ -5,46 +5,23 @@
 
 use crate::ast::Span;
 
-use super::super::{CompileError, ErrorKind};
+use super::super::CompileError;
 
 /// Build the lint warning emitted for an unused local binding.
 pub fn unused_variable(name: &str, span: Span) -> CompileError {
-    CompileError {
-        message: format!("Unused variable '{}'", name),
-        span,
-        kind: ErrorKind::Lint,
-        notes: vec![],
-        hints: vec!["Prefix with underscore to silence: _{}".to_string() + name],
-        related_spans: vec![],
-        expected: None,
-        actual: None,
-    }
+    CompileError::lint(format!("Unused variable '{}'", name), span)
+        .with_hint("Prefix with underscore to silence: _".to_string() + name)
 }
 
 /// Build the lint warning emitted for an unused import.
 pub fn unused_import(name: &str, span: Span) -> CompileError {
-    CompileError {
-        message: format!("Unused import '{}'", name),
-        span,
-        kind: ErrorKind::Lint,
-        notes: vec![],
-        hints: vec!["Remove the import or use it".to_string()],
-        related_spans: vec![],
-        expected: None,
-        actual: None,
-    }
+    CompileError::lint(format!("Unused import '{}'", name), span).with_hint("Remove the import or use it")
 }
 
 /// Build the lint warning emitted for a wildcard match arm.
 pub fn wildcard_match(span: Span) -> CompileError {
-    CompileError {
-        message: "Using wildcard '_' in match - consider handling all cases explicitly".to_string(),
+    CompileError::lint(
+        "Using wildcard '_' in match - consider handling all cases explicitly".to_string(),
         span,
-        kind: ErrorKind::Lint,
-        notes: vec![],
-        hints: vec![],
-        related_spans: vec![],
-        expected: None,
-        actual: None,
-    }
+    )
 }

--- a/crates/incan_syntax/src/diagnostics/mod.rs
+++ b/crates/incan_syntax/src/diagnostics/mod.rs
@@ -12,10 +12,10 @@ mod catalog;
 mod miette;
 mod stable;
 
-pub use base::{CompileError, ErrorKind, format_error, print_error};
+pub use base::{CompileError, ErrorKind, RelatedSpan, format_error, print_error};
 pub use catalog::{errors, lints};
 pub use miette::{IncanDiagnostic, format_error_smart, render_miette};
 pub use stable::{
-    DIAGNOSTIC_SCHEMA_VERSION, DiagnosticCatalogEntry, DiagnosticPhase, StableDiagnostic, catalog_entries,
-    code_for_error, explain, phase_for_typecheck_span, stable_diagnostic,
+    DIAGNOSTIC_SCHEMA_VERSION, DiagnosticCatalogEntry, DiagnosticOrigin, DiagnosticPhase, DiagnosticRelatedSpan,
+    StableDiagnostic, catalog_entries, code_for_error, explain, phase_for_typecheck_span, stable_diagnostic,
 };

--- a/crates/incan_syntax/src/diagnostics/stable.rs
+++ b/crates/incan_syntax/src/diagnostics/stable.rs
@@ -25,6 +25,38 @@ pub enum DiagnosticPhase {
     Unknown,
 }
 
+/// Compiler subsystem that produced a diagnostic fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticOrigin {
+    /// Lexer tokenization.
+    Lexer,
+    /// Parser or syntax validation.
+    Parser,
+    /// Import, module, or package resolution.
+    ImportResolver,
+    /// Type checking and semantic validation.
+    Typechecker,
+    /// CLI or surrounding tooling.
+    Tooling,
+    /// The producer is not known precisely enough yet.
+    Unknown,
+}
+
+impl DiagnosticOrigin {
+    /// Return the stable lowercase origin label for non-Serde consumers.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DiagnosticOrigin::Lexer => "lexer",
+            DiagnosticOrigin::Parser => "parser",
+            DiagnosticOrigin::ImportResolver => "import_resolver",
+            DiagnosticOrigin::Typechecker => "typechecker",
+            DiagnosticOrigin::Tooling => "tooling",
+            DiagnosticOrigin::Unknown => "unknown",
+        }
+    }
+}
+
 impl DiagnosticPhase {
     /// Return the stable lowercase phase label used by human text and non-Serde call sites.
     pub fn as_str(self) -> &'static str {
@@ -86,6 +118,15 @@ pub struct DiagnosticSpan {
     pub end: DiagnosticPosition,
 }
 
+/// One compiler-owned related location in a structured diagnostic fact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DiagnosticRelatedSpan {
+    /// The secondary source span.
+    pub span: DiagnosticSpan,
+    /// Why this source span is related to the primary diagnostic.
+    pub label: String,
+}
+
 /// Machine-readable diagnostic payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct StableDiagnostic {
@@ -95,6 +136,8 @@ pub struct StableDiagnostic {
     pub severity: &'static str,
     /// Compiler or tooling phase that produced this diagnostic.
     pub phase: DiagnosticPhase,
+    /// Compiler subsystem that produced the fact.
+    pub origin: DiagnosticOrigin,
     /// User-facing diagnostic message.
     pub message: String,
     /// Primary source span for editors and structured tooling.
@@ -103,8 +146,15 @@ pub struct StableDiagnostic {
     pub notes: Vec<String>,
     /// Suggested fixes or hints carried by the compiler diagnostic.
     pub hints: Vec<String>,
-    /// Related spans reserved for diagnostics that can point at secondary source locations.
-    pub related_spans: Vec<DiagnosticSpan>,
+    /// Structured expected value or type when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected: Option<String>,
+    /// Structured actual value or type when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actual: Option<String>,
+    /// Related compiler-owned source locations.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub related_spans: Vec<DiagnosticRelatedSpan>,
     /// Command users can run to read the catalog explanation for `code`.
     pub explain: String,
 }
@@ -263,16 +313,43 @@ pub fn stable_diagnostic(
         code,
         severity,
         phase,
+        origin: origin_for_phase(phase),
         message: error.message.clone(),
-        primary_span: DiagnosticSpan {
-            file: file_name.to_string(),
-            start: position_for_offset(source, error.span.start),
-            end: position_for_offset(source, error.span.end.max(error.span.start + 1)),
-        },
+        primary_span: diagnostic_span(file_name, source, error.span),
         notes: error.notes.clone(),
         hints: error.hints.clone(),
-        related_spans: Vec::new(),
+        expected: error.expected.clone(),
+        actual: error.actual.clone(),
+        related_spans: error
+            .related_spans
+            .iter()
+            .map(|related| DiagnosticRelatedSpan {
+                span: diagnostic_span(file_name, source, related.span),
+                label: related.label.clone(),
+            })
+            .collect(),
         explain: format!("incan explain {code}"),
+    }
+}
+
+/// Select the stable producer identity for one compiler pipeline phase.
+fn origin_for_phase(phase: DiagnosticPhase) -> DiagnosticOrigin {
+    match phase {
+        DiagnosticPhase::Lex => DiagnosticOrigin::Lexer,
+        DiagnosticPhase::Parse => DiagnosticOrigin::Parser,
+        DiagnosticPhase::Typecheck => DiagnosticOrigin::Typechecker,
+        DiagnosticPhase::Import => DiagnosticOrigin::ImportResolver,
+        DiagnosticPhase::Tooling => DiagnosticOrigin::Tooling,
+        DiagnosticPhase::Unknown => DiagnosticOrigin::Unknown,
+    }
+}
+
+/// Convert a compiler byte span into the public source-span projection.
+fn diagnostic_span(file_name: &str, source: &str, span: Span) -> DiagnosticSpan {
+    DiagnosticSpan {
+        file: file_name.to_string(),
+        start: position_for_offset(source, span.start),
+        end: position_for_offset(source, span.end.max(span.start + 1)),
     }
 }
 
@@ -335,5 +412,20 @@ mod tests {
             phase_for_typecheck_span(&program, Span::new(42, 44)),
             DiagnosticPhase::Typecheck
         );
+    }
+
+    #[test]
+    fn stable_diagnostic_preserves_structured_facts_and_related_spans() {
+        let error = CompileError::type_error("type mismatch".to_string(), Span::new(8, 13))
+            .with_expected_actual("int", "str")
+            .with_related_span(Span::new(0, 7), "Function parameter declared here");
+        let diagnostic = stable_diagnostic("main.incn", "takes_x\n\"text\"\n", &error, DiagnosticPhase::Typecheck);
+
+        assert_eq!(diagnostic.origin, DiagnosticOrigin::Typechecker);
+        assert_eq!(diagnostic.expected.as_deref(), Some("int"));
+        assert_eq!(diagnostic.actual.as_deref(), Some("str"));
+        assert_eq!(diagnostic.related_spans.len(), 1);
+        assert_eq!(diagnostic.related_spans[0].label, "Function parameter declared here");
+        assert_eq!(diagnostic.related_spans[0].span.start.offset, 0);
     }
 }

--- a/crates/incan_syntax/src/diagnostics/stable.rs
+++ b/crates/incan_syntax/src/diagnostics/stable.rs
@@ -318,10 +318,10 @@ pub fn stable_diagnostic(
         primary_span: diagnostic_span(file_name, source, error.span),
         notes: error.notes.clone(),
         hints: error.hints.clone(),
-        expected: error.expected.clone(),
-        actual: error.actual.clone(),
+        expected: error.expected().map(str::to_owned),
+        actual: error.actual().map(str::to_owned),
         related_spans: error
-            .related_spans
+            .related_spans()
             .iter()
             .map(|related| DiagnosticRelatedSpan {
                 span: diagnostic_span(file_name, source, related.span),

--- a/src/cli/commands/codegraph.rs
+++ b/src/cli/commands/codegraph.rs
@@ -13,9 +13,9 @@ use std::path::{Path, PathBuf};
 use clap::ValueEnum;
 use incan_codegraph::{
     CODEGRAPH_SCHEMA_VERSION, CodegraphCallRecord, CodegraphContainmentRecord, CodegraphDeclarationRecord,
-    CodegraphDiagnosticRecord, CodegraphExportRecord, CodegraphFileRecord, CodegraphHeaderRecord,
-    CodegraphImportRecord, CodegraphLanguage, CodegraphMode, CodegraphModuleRecord, CodegraphPackage,
-    CodegraphProvenance, CodegraphRecord, CodegraphReferenceRecord, CodegraphSourceSpan, to_jsonl,
+    CodegraphDiagnosticRecord, CodegraphDiagnosticRelatedSpan, CodegraphExportRecord, CodegraphFileRecord,
+    CodegraphHeaderRecord, CodegraphImportRecord, CodegraphLanguage, CodegraphMode, CodegraphModuleRecord,
+    CodegraphPackage, CodegraphProvenance, CodegraphRecord, CodegraphReferenceRecord, CodegraphSourceSpan, to_jsonl,
 };
 
 use crate::cli::prelude::ParsedModule;
@@ -1500,6 +1500,7 @@ fn diagnostic_record(index: usize, diagnostic: &StableDiagnostic) -> CodegraphDi
         code: diagnostic.code.to_string(),
         severity: diagnostic.severity.to_string(),
         phase: diagnostic.phase.as_str().to_string(),
+        origin: diagnostic.origin.as_str().to_string(),
         message: diagnostic.message.clone(),
         primary_span: CodegraphSourceSpan {
             file: diagnostic.primary_span.file.clone(),
@@ -1512,6 +1513,24 @@ fn diagnostic_record(index: usize, diagnostic: &StableDiagnostic) -> CodegraphDi
         },
         notes: diagnostic.notes.clone(),
         hints: diagnostic.hints.clone(),
+        expected: diagnostic.expected.clone(),
+        actual: diagnostic.actual.clone(),
+        related_spans: diagnostic
+            .related_spans
+            .iter()
+            .map(|related| CodegraphDiagnosticRelatedSpan {
+                span: CodegraphSourceSpan {
+                    file: related.span.file.clone(),
+                    start: related.span.start.offset,
+                    end: related.span.end.offset,
+                    start_line: related.span.start.line,
+                    start_column: related.span.start.column,
+                    end_line: related.span.end.line,
+                    end_column: related.span.end.column,
+                },
+                label: related.label.clone(),
+            })
+            .collect(),
         explain: diagnostic.explain.clone(),
         provenance: CodegraphProvenance::Diagnostic,
         degraded: true,

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -500,8 +500,8 @@ impl TypeChecker {
     ) -> (Option<&'a Spanned<Expr>>, Option<&'a Spanned<Expr>>, bool) {
         let helper = BuiltinCollectionHelperId::ListRepeat;
         let callee = collection_helpers::full_name(helper);
-        let mut value = None;
-        let mut count = None;
+        let mut value: Option<&Spanned<Expr>> = None;
+        let mut count: Option<&Spanned<Expr>> = None;
         let mut valid = true;
         let mut positional_index = 0usize;
 
@@ -515,9 +515,13 @@ impl TypeChecker {
                     };
                     positional_index += 1;
                     if let Some((slot, name)) = target {
-                        if slot.is_some() {
-                            self.errors
-                                .push(errors::duplicate_call_argument(callee, name, expr.span));
+                        if let Some(first_expr) = *slot {
+                            self.errors.push(errors::duplicate_call_argument(
+                                callee,
+                                name,
+                                first_expr.span,
+                                expr.span,
+                            ));
                             self.check_expr(expr);
                             valid = false;
                         } else {
@@ -535,9 +539,13 @@ impl TypeChecker {
                         _ => None,
                     };
                     if let Some(slot) = slot {
-                        if slot.is_some() {
-                            self.errors
-                                .push(errors::duplicate_call_argument(callee, name, expr.span));
+                        if let Some(first_expr) = *slot {
+                            self.errors.push(errors::duplicate_call_argument(
+                                callee,
+                                name,
+                                first_expr.span,
+                                expr.span,
+                            ));
                             self.check_expr(expr);
                             valid = false;
                         } else {

--- a/src/frontend/typechecker/check_expr/calls/args.rs
+++ b/src/frontend/typechecker/check_expr/calls/args.rs
@@ -327,7 +327,7 @@ impl TypeChecker {
                 CallArg::Named(name, _) => {
                     if let Some(first_span) = named_seen.insert(name.as_str(), arg_span) {
                         self.errors
-                            .push(errors::duplicate_call_argument(callee, name, first_span));
+                            .push(errors::duplicate_call_argument(callee, name, first_span, arg_span));
                     }
 
                     if let Some((normal_idx, (_, param))) = normal_params
@@ -335,9 +335,9 @@ impl TypeChecker {
                         .enumerate()
                         .find(|(_, (_, param))| param.name() == Some(name.as_str()))
                     {
-                        if normal_bound_spans[normal_idx].is_some() {
+                        if let Some(first_span) = normal_bound_spans[normal_idx] {
                             self.errors
-                                .push(errors::duplicate_call_argument(callee, name, arg_span));
+                                .push(errors::duplicate_call_argument(callee, name, first_span, arg_span));
                             continue;
                         }
                         normal_bound_spans[normal_idx] = Some(arg_span);
@@ -377,7 +377,7 @@ impl TypeChecker {
                             if let Some(name) = Self::static_string_key(key) {
                                 if let Some(first_span) = named_seen.insert(name, key.span) {
                                     self.errors
-                                        .push(errors::duplicate_call_argument(callee, name, first_span));
+                                        .push(errors::duplicate_call_argument(callee, name, first_span, key.span));
                                 }
 
                                 if let Some((normal_idx, (_, param))) = normal_params
@@ -385,9 +385,9 @@ impl TypeChecker {
                                     .enumerate()
                                     .find(|(_, (_, param))| param.name() == Some(name))
                                 {
-                                    if normal_bound_spans[normal_idx].is_some() {
+                                    if let Some(first_span) = normal_bound_spans[normal_idx] {
                                         self.errors
-                                            .push(errors::duplicate_call_argument(callee, name, key.span));
+                                            .push(errors::duplicate_call_argument(callee, name, first_span, key.span));
                                         continue;
                                     }
                                     normal_bound_spans[normal_idx] = Some(value.span);

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -666,8 +666,12 @@ impl TypeChecker {
                     let param = &params[positional_index];
                     if let Some(bound_span) = bound_spans[positional_index] {
                         let name = param.name.as_deref().unwrap_or("<positional>");
-                        self.errors
-                            .push(errors::duplicate_call_argument(callable_display, name, bound_span));
+                        self.errors.push(errors::duplicate_call_argument(
+                            callable_display,
+                            name,
+                            bound_span,
+                            arg_span,
+                        ));
                     } else {
                         bound_spans[positional_index] = Some(arg_span);
                         bindings.push(RustCallArgBinding { arg, arg_ty, param });
@@ -676,17 +680,25 @@ impl TypeChecker {
                 }
                 CallArg::Named(name, _) => {
                     if let Some(first_span) = named_seen.insert(name.as_str(), arg_span) {
-                        self.errors
-                            .push(errors::duplicate_call_argument(callable_display, name, first_span));
+                        self.errors.push(errors::duplicate_call_argument(
+                            callable_display,
+                            name,
+                            first_span,
+                            arg_span,
+                        ));
                     }
                     let Some(param_index) = params_by_name.get(name.as_str()).copied() else {
                         self.errors
                             .push(errors::unknown_keyword_argument(callable_display, name, arg_span));
                         continue;
                     };
-                    if bound_spans[param_index].is_some() {
-                        self.errors
-                            .push(errors::duplicate_call_argument(callable_display, name, arg_span));
+                    if let Some(first_span) = bound_spans[param_index] {
+                        self.errors.push(errors::duplicate_call_argument(
+                            callable_display,
+                            name,
+                            first_span,
+                            arg_span,
+                        ));
                         continue;
                     }
                     let param = &params[param_index];

--- a/src/lsp/diagnostics.rs
+++ b/src/lsp/diagnostics.rs
@@ -13,7 +13,7 @@ use tower_lsp::lsp_types::{
     Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString, Position, Range, Url,
 };
 
-use crate::frontend::diagnostics::{CompileError, DiagnosticPhase, ErrorKind, code_for_error};
+use crate::frontend::diagnostics::{CompileError, DiagnosticPhase, ErrorKind, stable_diagnostic};
 
 // ============================================================================
 // Position/Offset Conversion Utilities
@@ -108,20 +108,21 @@ pub fn compile_error_to_diagnostic_with_phase(
     uri: &Url,
     phase: DiagnosticPhase,
 ) -> Diagnostic {
-    let range = span_to_range(source, error.span.start, error.span.end);
+    let stable = stable_diagnostic(uri.as_str(), source, error, phase);
+    let range = span_to_range(source, stable.primary_span.start.offset, stable.primary_span.end.offset);
     let severity = error_kind_to_severity(error.kind);
 
     // Build the message with notes and hints
-    let mut message = error.message.clone();
+    let mut message = stable.message.clone();
 
     // Add notes
-    for note in &error.notes {
+    for note in &stable.notes {
         message.push_str("\n\nnote: ");
         message.push_str(note);
     }
 
     // Add hints
-    for hint in &error.hints {
+    for hint in &stable.hints {
         message.push_str("\n\nhint: ");
         message.push_str(hint);
     }
@@ -129,7 +130,7 @@ pub fn compile_error_to_diagnostic_with_phase(
     // Create related information for notes/hints (shows in Problems panel)
     let mut related_information = Vec::new();
 
-    for note in &error.notes {
+    for note in &stable.notes {
         related_information.push(DiagnosticRelatedInformation {
             location: Location {
                 uri: uri.clone(),
@@ -139,7 +140,7 @@ pub fn compile_error_to_diagnostic_with_phase(
         });
     }
 
-    for hint in &error.hints {
+    for hint in &stable.hints {
         related_information.push(DiagnosticRelatedInformation {
             location: Location {
                 uri: uri.clone(),
@@ -149,10 +150,20 @@ pub fn compile_error_to_diagnostic_with_phase(
         });
     }
 
+    for related in &stable.related_spans {
+        related_information.push(DiagnosticRelatedInformation {
+            location: Location {
+                uri: uri.clone(),
+                range: span_to_range(source, related.span.start.offset, related.span.end.offset),
+            },
+            message: related.label.clone(),
+        });
+    }
+
     Diagnostic {
         range,
         severity: Some(severity),
-        code: Some(NumberOrString::String(code_for_error(error, phase).to_string())),
+        code: Some(NumberOrString::String(stable.code.to_string())),
         code_description: None,
         source: Some("incan".to_string()),
         message,
@@ -162,7 +173,7 @@ pub fn compile_error_to_diagnostic_with_phase(
             Some(related_information)
         },
         tags: None,
-        data: None,
+        data: serde_json::to_value(&stable).ok(),
     }
 }
 
@@ -218,5 +229,30 @@ mod tests {
             let back = position_to_offset(source, pos);
             assert_eq!(back, Some(offset), "roundtrip failed for offset {}", offset);
         }
+    }
+
+    #[test]
+    fn lsp_diagnostic_projects_the_shared_compiler_fact() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "first\nsecond\n";
+        let uri = Url::parse("file:///workspace/main.incn")?;
+        let error = CompileError::type_error("duplicate argument".to_string(), crate::frontend::ast::Span::new(6, 12))
+            .with_expected_actual("int", "str")
+            .with_related_span(crate::frontend::ast::Span::new(0, 5), "First argument named 'value'");
+
+        let diagnostic = compile_error_to_diagnostic_with_phase(&error, source, &uri, DiagnosticPhase::Typecheck);
+        let related = diagnostic
+            .related_information
+            .as_ref()
+            .ok_or("expected related information")?;
+        assert!(
+            related
+                .iter()
+                .any(|item| item.message == "First argument named 'value'")
+        );
+        let data = diagnostic.data.ok_or("expected compiler fact data")?;
+        assert_eq!(data["origin"], serde_json::json!("typechecker"));
+        assert_eq!(data["expected"], serde_json::json!("int"));
+        assert_eq!(data["actual"], serde_json::json!("str"));
+        Ok(())
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -981,6 +981,119 @@ fn check_json_reports_typechecker_diagnostics() -> Result<(), Box<dyn std::error
     Ok(())
 }
 
+#[test]
+fn diagnostic_facts_keep_related_spans_and_type_payloads_across_cli_and_codegraph()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let source_path = tmp.path().join("main.incn");
+    fs::write(
+        &source_path,
+        r#"model Wire:
+    id [alias="wire"]: int
+    label [alias="wire"]: str
+
+def accept(value: int) -> None:
+    pass
+
+def main() -> None:
+    accept(value=1, value=2)
+    accept("text")
+"#,
+    )?;
+    let source_arg = source_path.to_str().ok_or("source path was not valid UTF-8")?;
+
+    let check = run_incan(tmp.path(), &["check", source_arg, "--format", "json"])?;
+    assert_failure(&check, "incan check should emit diagnostic facts");
+    let check_json = parse_json_stdout(&check)?;
+    let cli_diagnostics = check_json["diagnostics"]
+        .as_array()
+        .ok_or("expected CLI diagnostics array")?;
+    let cli_alias = cli_diagnostics
+        .iter()
+        .find(|diagnostic| {
+            diagnostic["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("Duplicate alias"))
+        })
+        .ok_or("expected duplicate alias diagnostic")?;
+    let cli_duplicate_arg = cli_diagnostics
+        .iter()
+        .find(|diagnostic| {
+            diagnostic["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("Duplicate argument"))
+        })
+        .ok_or("expected duplicate argument diagnostic")?;
+    let cli_mismatch = cli_diagnostics
+        .iter()
+        .find(|diagnostic| {
+            diagnostic["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("Argument 'value' of 'accept'"))
+        })
+        .ok_or("expected call argument type mismatch diagnostic")?;
+
+    assert_eq!(cli_alias["origin"], serde_json::json!("typechecker"));
+    assert_eq!(
+        cli_alias["related_spans"][0]["label"],
+        serde_json::json!("First field alias 'wire'")
+    );
+    assert_eq!(
+        cli_duplicate_arg["related_spans"][0]["label"],
+        serde_json::json!("First argument named 'value'")
+    );
+    assert_eq!(cli_mismatch["expected"], serde_json::json!("int"));
+    assert_eq!(cli_mismatch["actual"], serde_json::json!("str"));
+
+    let codegraph = run_incan(
+        tmp.path(),
+        &[
+            "inspect",
+            "codegraph",
+            source_arg,
+            "--format",
+            "jsonl",
+            "--allow-errors",
+        ],
+    )?;
+    assert_success(&codegraph, "tolerant codegraph should project diagnostic facts");
+    let records = parse_jsonl_stdout(&codegraph)?;
+    let graph_alias = records
+        .iter()
+        .find(|record| record["record"] == serde_json::json!("diagnostic") && record["message"] == cli_alias["message"])
+        .ok_or("expected duplicate alias codegraph diagnostic")?;
+    let graph_duplicate_arg = records
+        .iter()
+        .find(|record| {
+            record["record"] == serde_json::json!("diagnostic") && record["message"] == cli_duplicate_arg["message"]
+        })
+        .ok_or("expected duplicate argument codegraph diagnostic")?;
+    let graph_mismatch = records
+        .iter()
+        .find(|record| {
+            record["record"] == serde_json::json!("diagnostic") && record["message"] == cli_mismatch["message"]
+        })
+        .ok_or("expected type mismatch codegraph diagnostic")?;
+
+    assert_eq!(graph_alias["origin"], cli_alias["origin"]);
+    assert_eq!(
+        graph_alias["related_spans"][0]["label"],
+        cli_alias["related_spans"][0]["label"]
+    );
+    assert_eq!(
+        graph_alias["related_spans"][0]["span"]["start"],
+        cli_alias["related_spans"][0]["span"]["start"]["offset"]
+    );
+    assert_eq!(
+        graph_duplicate_arg["related_spans"][0]["label"],
+        cli_duplicate_arg["related_spans"][0]["label"]
+    );
+    assert_eq!(graph_mismatch["expected"], cli_mismatch["expected"]);
+    assert_eq!(graph_mismatch["actual"], cli_mismatch["actual"]);
+
+    Ok(())
+}
+
 #[cfg(feature = "rust_inspect")]
 #[test]
 fn rust_std_result_interop_supports_try_operator_issue801() -> Result<(), Box<dyn std::error::Error>> {

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -81,7 +81,7 @@ Options:
 
 - `--format text|json`: Output human diagnostics or a stable machine-readable JSON report (default: `text`).
 
-JSON output uses `schema_version: 1` and prints a deterministic report with `ok` and `diagnostics`. Each diagnostic includes a stable `code`, `severity`, compiler `phase`, primary source span, message, notes, hints, related spans, and an `incan explain <CODE>` hook. Human output remains the default and continues to use source-highlighted compiler diagnostics.
+JSON output uses `schema_version: 1` and prints a deterministic report with `ok` and `diagnostics`. Each diagnostic includes a stable `code`, `severity`, compiler `phase` and `origin`, primary source span, message, notes, hints, labeled related spans, and an `incan explain <CODE>` hook. Diagnostics that compare two compiler-known values also include optional `expected` and `actual` fields, so consumers do not need to parse the message. The LSP and `incan inspect codegraph --allow-errors` project these same compiler-owned facts; codegraph uses byte offsets for source spans while the diagnostic JSON and LSP retain line and column positions. Human output remains the default and continues to use source-highlighted compiler diagnostics.
 
 Examples:
 


### PR DESCRIPTION
## Summary

Completes #771, the compiler-owned diagnostic-facts layer of RFC 106. Diagnostics retain structured origin, expected/actual values, and labelled related spans; CLI JSON, LSP, and tolerant codegraph JSONL project that same compiler fact.

RFC 106 remains planned. LSP graph consumption, MCP task-context packing, Architect findings, and importer/comparison work remain separately scoped to #772, #774, #773, and #776.

Closes #771

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- `CompileError` owns compact structured details: origin, optional expected/actual values, and compiler-owned related spans.
- Duplicate aliases, duplicate call arguments, and duplicate Rust interop edges supply first-occurrence related locations; type mismatch constructors supply structured expected/actual facts.
- Stable diagnostic projection is the shared source for CLI JSON, LSP diagnostic data/related information, and codegraph records.
- Codegraph JSONL fields are additive. The reader gives schema-v1 diagnostics without `origin` the explicit legacy value `unknown`.

## Testing / verification

- [x] Focused `cargo test` coverage
- [x] `make examples` (via `make pre-commit` smoke)
- [x] `cargo fmt` / `make lint-fast-ci`
- [x] Manual verification described below

**Focused checks:**

- `cargo test -p incan_syntax diagnostics --lib`
- `cargo test -p incan_codegraph`
- `cargo test --test cli_integration diagnostic_facts_keep_related_spans_and_type_payloads_across_cli_and_codegraph -- --nocapture`
- `cargo test --features lsp --lib lsp_diagnostic_projects_the_shared_compiler_fact -- --nocapture`
- `make docs-build`
- `make pre-commit` — passed on the rebased head: 2,812 tests, clippy, cargo-deny, 57 example checks (34 run), and 9 benchmark builds.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The CLI reference documents the expanded machine-readable diagnostic fact contract.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
