### PR TITLE
bugfix - preserve Tokenizer Into string inference (#804)

### DIFF
--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -119,6 +119,8 @@ impl RustItemMetadata {
 pub enum MetadataFreeMethodArgBorrowPolicy {
     Shared,
     Mutable,
+    /// Preserve string literals as `&str` and adapt owned Incan strings with `.as_str()`.
+    StringAsStr,
 }
 
 /// Receiver class used by metadata-free external method compatibility policy.
@@ -126,6 +128,7 @@ pub enum MetadataFreeMethodArgBorrowPolicy {
 pub enum MetadataFreeReceiverClass {
     IoValue,
     EncodingInstance,
+    TokenizerInstance,
     ExternalAssociated,
 }
 
@@ -212,6 +215,12 @@ pub const METADATA_FREE_METHOD_BORROW_RULES: &[MetadataFreeMethodBorrowRule] = &
         receiver: MetadataFreeReceiverClass::EncodingInstance,
         arg: MetadataFreeArgClass::Any,
         policy: MetadataFreeMethodArgBorrowPolicy::Shared,
+    },
+    MetadataFreeMethodBorrowRule {
+        methods: &["encode"],
+        receiver: MetadataFreeReceiverClass::TokenizerInstance,
+        arg: MetadataFreeArgClass::StringBuffer,
+        policy: MetadataFreeMethodArgBorrowPolicy::StringAsStr,
     },
     MetadataFreeMethodBorrowRule {
         methods: &["decode"],

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -468,6 +468,16 @@ impl<'a> IrEmitter<'a> {
                             quote! { &#emitted }
                         }
                         MetadataFreeMethodArgBorrowPolicy::Mutable => quote! { &mut #emitted },
+                        MetadataFreeMethodArgBorrowPolicy::StringAsStr
+                            if !matches!(
+                                arg.kind,
+                                IrExprKind::String(_)
+                                    | IrExprKind::Literal(super::super::super::expr::Literal::StaticStr(_))
+                            ) =>
+                        {
+                            quote! { (#emitted).as_str() }
+                        }
+                        MetadataFreeMethodArgBorrowPolicy::StringAsStr => emitted,
                         MetadataFreeMethodArgBorrowPolicy::Shared => emitted,
                     };
                 }
@@ -525,6 +535,9 @@ impl<'a> IrEmitter<'a> {
             MetadataFreeReceiverClass::IoValue => Self::receiver_allows_io_method_fallback(receiver),
             MetadataFreeReceiverClass::EncodingInstance => {
                 Self::receiver_type_matches_any(receiver, &["Encoding", "encoding_rs::Encoding"])
+            }
+            MetadataFreeReceiverClass::TokenizerInstance => {
+                Self::receiver_type_matches_any(receiver, &["Tokenizer", "tokenizers::Tokenizer"])
             }
             MetadataFreeReceiverClass::ExternalAssociated => Self::is_external_associated_receiver(receiver),
         }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -7180,6 +7180,85 @@ def test_generic_callable_name_ignores_unrelated_signatures() -> None:
 }
 
 #[test]
+fn build_metadata_free_into_bound_tokenizer_encode_issue804() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let helper_dir = tmp.path().join("rust").join("tokenizers");
+    fs::create_dir_all(helper_dir.join("src"))?;
+    fs::write(
+        helper_dir.join("Cargo.toml"),
+        "[package]\nname = \"tokenizers\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(
+        helper_dir.join("src").join("lib.rs"),
+        r#"pub struct Tokenizer;
+
+pub struct EncodeInput<'a>(&'a str);
+
+impl<'a> From<&'a str> for EncodeInput<'a> {
+    fn from(value: &'a str) -> Self {
+        Self(value)
+    }
+}
+
+impl Tokenizer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn encode<'a, E>(&self, value: E, _add_special_tokens: bool) -> Result<(), ()>
+    where
+        E: Into<EncodeInput<'a>>,
+    {
+        let _ = value.into();
+        Ok(())
+    }
+}
+"#,
+    )?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "metadata_free_into_bound_tokenizer_encode_issue804",
+        r#"
+[rust-dependencies]
+tokenizers = { path = "rust/tokenizers" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::tokenizers import Tokenizer
+
+def main() -> None:
+    tokenizer = Tokenizer.new()
+    literal = tokenizer.encode("literal", False)
+    text = "variable"
+    variable = tokenizer.encode(text, False)
+"#,
+    )?;
+
+    let build_output = run_incan(
+        tmp.path(),
+        &["build", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(
+        &build_output,
+        "incan build for metadata-free Into-bound tokenizer encode issue804",
+    );
+    let generated = fs::read_to_string(
+        tmp.path()
+            .join("target/incan/metadata_free_into_bound_tokenizer_encode_issue804/src/main.rs"),
+    )?;
+    assert!(
+        generated.contains("tokenizer.encode(\"literal\", false)"),
+        "literal must preserve its direct &str shape, got:\n{generated}"
+    );
+    assert!(
+        generated.contains("tokenizer.encode((text).as_str(), false)"),
+        "owned Incan strings must become &str for the Into-bound method, got:\n{generated}"
+    );
+    Ok(())
+}
+
+#[test]
 fn build_frozen_uses_existing_lockfile_without_network() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "cli_frozen_existing_lock_project", "")?;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -3571,6 +3571,85 @@ where
 }
 
 #[test]
+fn rust_method_into_bound_keeps_string_argument_inferable_issue804() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "cli_rust_method_into_bound",
+        r#"
+
+[rust-dependencies.into_method_helper]
+path = "rust/into_method_helper"
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::into_method_helper import Tokenizer
+
+def main() -> None:
+  tokenizer = Tokenizer.new()
+  println(tokenizer.encode("hello world", false))
+"#,
+    )?;
+
+    let helper_src = tmp.path().join("rust").join("into_method_helper").join("src");
+    fs::create_dir_all(&helper_src)?;
+    fs::write(
+        helper_src
+            .parent()
+            .ok_or("into_method_helper src has no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "into_method_helper"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        helper_src.join("lib.rs"),
+        r#"pub struct Tokenizer;
+
+impl Tokenizer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn encode<E: Into<String>>(&self, input: E, uppercase: bool) -> String {
+        let text = input.into();
+        if uppercase {
+            text.to_uppercase()
+        } else {
+            text
+        }
+    }
+}
+"#,
+    )?;
+
+    let output = run_incan(
+        tmp.path(),
+        &["run", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(&output, "incan run with a Rust Into-bound method argument");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "hello world",
+        "Rust Into-bound method should receive the original string type"
+    );
+
+    let generated = fs::read_to_string(tmp.path().join("target/incan/cli_rust_method_into_bound/src/main.rs"))?;
+    assert!(
+        generated.contains("tokenizer.encode(\"hello world\", false)"),
+        "unresolved Rust method generic should preserve the string literal shape, got:\n{generated}"
+    );
+    assert!(
+        !generated.contains("tokenizer.encode(\"hello world\".into(), false)"),
+        "unresolved Rust method generic must not emit an ambiguous `.into()`, got:\n{generated}"
+    );
+    Ok(())
+}
+
+#[test]
 fn run_types_rust_callback_closures_in_every_match_arm_issue733() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -15,8 +15,8 @@
     {
       "path": "crates/incan_core/src/interop/metadata.rs",
       "category": "registry-backed Rust collection metadata policy and shared Rust type-shape parsing, including borrowed impl-trait interop bounds",
-      "expected_count": 24,
-      "expected_fingerprint": "0x486c17db5edb246e"
+      "expected_count": 25,
+      "expected_fingerprint": "0x14563632957da1e4"
     },
     {
       "path": "crates/rust_inspect/src/cache.rs",


### PR DESCRIPTION
## Summary

This is the canonical #804 fix for Rust `Into`-bound method calls.

- Metadata-free `tokenizers::Tokenizer.encode` preserves inference-friendly input shapes: literals remain direct and owned Incan strings emit `.as_str()`.
- An independent local-Rust regression proves unresolved `E: Into<String>` method generics keep a literal argument direct rather than emitting an ambiguous `.into()`.
- The semantic-string audit baseline records the deliberate metadata policy expansion.

This folds the complementary regression coverage from #850. Draft #840 was superseded by this broader implementation.

Closes #804

## Verification

- `cargo test --features rust_inspect --test cli_integration build_metadata_free_into_bound_tokenizer_encode_issue804 -- --nocapture`
- `cargo test --test cli_integration rust_method_into_bound_keeps_string_argument_inferable_issue804 -- --nocapture`
- `cargo test --test vocab_guardrails semantic_string_checks_are_classified -- --nocapture`
- `make pre-commit` — 2,809 tests, Clippy, cargo-deny, release build, examples, and benchmarks
- `make smoke-test` — 2,809 tests, release build, 57 example checks, and nine benchmark builds
- `git diff --check`

## Scope

This changes only compiler Rust-interop argument lowering, its semantic-string audit, focused regression coverage, release-note coverage, and the generated-Rust/package compilation paths exercised by those regressions.