### PR TITLE
docs - mark RFC 062 planned (#340)

### DIFF
--- a/workspaces/docs-site/docs/RFCs/062_std_archive.md
+++ b/workspaces/docs-site/docs/RFCs/062_std_archive.md
@@ -10,7 +10,7 @@
     - RFC 056 (`std.io` in-memory byte streams and binary parsing helpers)
     - RFC 061 (`std.compression` codec-based compression and decompression)
 - **Issue:** https://github.com/encero-systems/incan/issues/340
-- **RFC PR:** —
+- **RFC PR:** #859
 - **Written against:** v0.2
 - **Shipped in:** —
 

--- a/workspaces/docs-site/docs/RFCs/062_std_archive.md
+++ b/workspaces/docs-site/docs/RFCs/062_std_archive.md
@@ -1,6 +1,6 @@
 # RFC 062: `std.archive` — archive container creation and extraction
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-04-14
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**


### PR DESCRIPTION
## Summary

Transitions RFC 062 (`std.archive`) from Draft to Planned after review confirmed that its capability, portability, failure, and security contract is settled. This is the completed RFC-status slice; it intentionally does **not** implement or close #340.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: records `std.archive` as a planned v0.5 capability; no runtime or API behavior changes in this PR.
- **Internals**: completes the RFC lifecycle transition needed before implementation work begins.
- **Risks**: documentation-only status change; archive implementation remains separately scoped under #340.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make docs-build`
- `git diff --check`
- RFC review confirmed no unresolved design decisions remain.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- RFC 062 status metadata.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
