### PR TITLE
docs - mark RFC 063 planned (#341)

### DIFF
--- a/workspaces/docs-site/docs/RFCs/063_std_process.md
+++ b/workspaces/docs-site/docs/RFCs/063_std_process.md
@@ -12,7 +12,7 @@
     - RFC 056 (`std.io` in-memory byte streams and binary parsing helpers)
     - RFC 058 (`std.datetime` durations and time handling)
 - **Issue:** https://github.com/encero-systems/incan/issues/341
-- **RFC PR:** —
+- **RFC PR:** #860
 - **Written against:** v0.2
 - **Shipped in:** —
 

--- a/workspaces/docs-site/docs/RFCs/063_std_process.md
+++ b/workspaces/docs-site/docs/RFCs/063_std_process.md
@@ -1,6 +1,6 @@
 # RFC 063: `std.process` — process spawning and command execution
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-04-14
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**


### PR DESCRIPTION
## Summary

Transitions RFC 063 (`std.process`) from Draft to Planned after review confirmed that its argument-vector-first API, explicit shell lane, pipeline, I/O, and lifecycle contract is settled. This is the completed RFC-status slice; it intentionally does **not** implement or close #341.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: records `std.process` as a planned v0.5 capability; no runtime, API, or shell DSL behavior changes in this PR.
- **Internals**: completes the RFC lifecycle transition needed before implementation work begins.
- **Risks**: documentation-only status change; process implementation remains separately scoped under #341.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make docs-build`
- `git diff --check`
- RFC review confirmed no unresolved design decisions remain.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- RFC 063 status metadata.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
