### PR TITLE
feature - share session analysis across critical CLI paths (#224, #225)

### DIFF
--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -37,6 +37,7 @@ use crate::frontend::ast::{Declaration, ImportKind, Program};
 use crate::frontend::diagnostics::CompileError;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::module::canonicalize_source_module_segments;
+use crate::frontend::typechecker::TypeCheckInfo;
 use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
 use crate::library_manifest::LibraryManifest;
 use crate::provider::ProviderPlan;
@@ -224,6 +225,15 @@ pub struct IrCodegen<'a> {
     /// Shared stdlib source metadata cache reused across the repeated internal typecheck/lowering passes that codegen
     /// performs for multi-module builds.
     stdlib_cache: StdlibAstCache,
+    /// Main-module facts supplied by the owning compilation session.
+    ///
+    /// Direct backend API callers may omit this temporarily; that fallback is
+    /// removed when every caller constructs its lowering request from a
+    /// [`CompilationSession`](crate::cli::commands::common::CompilationSession)
+    /// analysis (#225).
+    prechecked_main_type_info: Option<TypeCheckInfo>,
+    /// Dependency facts from the same session analysis, keyed by module identity.
+    prechecked_dependency_type_info: HashMap<Vec<String>, TypeCheckInfo>,
     /// Manifest/workspace root for rust-inspect-backed typechecking during IR generation.
     #[cfg(feature = "rust_inspect")]
     rust_inspect_manifest_dir: Option<PathBuf>,
@@ -250,6 +260,8 @@ impl<'a> IrCodegen<'a> {
             preserve_dependency_public_items: true,
             public_typecheck_module_paths: HashSet::new(),
             stdlib_cache: StdlibAstCache::new(),
+            prechecked_main_type_info: None,
+            prechecked_dependency_type_info: HashMap::new(),
             #[cfg(feature = "rust_inspect")]
             rust_inspect_manifest_dir: None,
         }
@@ -536,6 +548,24 @@ impl<'a> IrCodegen<'a> {
     /// Seed codegen with stdlib metadata already collected by an earlier typecheck phase.
     pub(crate) fn set_stdlib_cache(&mut self, cache: StdlibAstCache) {
         self.stdlib_cache = cache;
+    }
+
+    /// Supply the checked lowering inputs owned by one compilation session.
+    ///
+    /// Production command paths use this to prevent lowering from rechecking
+    /// source after diagnostics and semantic facts have already been produced.
+    pub(crate) fn set_prechecked_type_info(
+        &mut self,
+        main: TypeCheckInfo,
+        dependencies: HashMap<Vec<String>, TypeCheckInfo>,
+    ) {
+        self.prechecked_main_type_info = Some(main);
+        self.prechecked_dependency_type_info = dependencies;
+    }
+
+    /// Return session-owned facts for one dependency module when supplied.
+    fn prechecked_dependency_type_info(&self, path: &[String]) -> Option<TypeCheckInfo> {
+        self.prechecked_dependency_type_info.get(path).cloned()
     }
 
     /// Set declared Rust crate names from `incan.toml [rust-dependencies]`. (RFC 031)
@@ -931,7 +961,9 @@ impl<'a> IrCodegen<'a> {
         // Typecheck to obtain reusable type information for lowering.
         //
         // Strict policy: if typechecking fails, do NOT proceed to lowering/codegen.
-        let type_info_opt = {
+        let type_info_opt = if let Some(type_info) = self.prechecked_main_type_info.clone() {
+            type_info
+        } else {
             use crate::frontend::typechecker::TypeChecker;
             let mut tc = TypeChecker::new();
             self.configure_typechecker(&mut tc);
@@ -992,7 +1024,10 @@ impl<'a> IrCodegen<'a> {
 
         let mut dependency_ir_programs = Vec::new();
         for (dep_name, dep_ast, dep_path_segments) in dependency_modules.clone() {
-            let dep_type_info = {
+            let dep_path = dep_path_segments.clone().unwrap_or_else(|| vec![dep_name.to_string()]);
+            let dep_type_info = if let Some(type_info) = self.prechecked_dependency_type_info(&dep_path) {
+                type_info
+            } else {
                 use crate::frontend::typechecker::TypeChecker;
                 let mut tc = TypeChecker::new();
                 self.configure_typechecker(&mut tc);
@@ -1570,7 +1605,9 @@ impl<'a> IrCodegen<'a> {
                 module_paths.iter().find(|path| path.join("_") == *name)
             };
             if let Some(path) = matching_path {
-                let module_type_info = {
+                let module_type_info = if let Some(type_info) = self.prechecked_dependency_type_info(path) {
+                    type_info
+                } else {
                     use crate::frontend::typechecker::TypeChecker;
                     let mut tc = TypeChecker::new();
                     self.configure_typechecker(&mut tc);

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -227,10 +227,8 @@ pub struct IrCodegen<'a> {
     stdlib_cache: StdlibAstCache,
     /// Main-module facts supplied by the owning compilation session.
     ///
-    /// Direct backend API callers may omit this temporarily; that fallback is
-    /// removed when every caller constructs its lowering request from a
-    /// [`CompilationSession`](crate::cli::commands::common::CompilationSession)
-    /// analysis (#225).
+    /// Direct backend API callers may omit this temporarily; that fallback is removed when every caller constructs its
+    /// lowering request from a compilation-session analysis (#225).
     prechecked_main_type_info: Option<TypeCheckInfo>,
     /// Dependency facts from the same session analysis, keyed by module identity.
     prechecked_dependency_type_info: HashMap<Vec<String>, TypeCheckInfo>,
@@ -552,8 +550,8 @@ impl<'a> IrCodegen<'a> {
 
     /// Supply the checked lowering inputs owned by one compilation session.
     ///
-    /// Production command paths use this to prevent lowering from rechecking
-    /// source after diagnostics and semantic facts have already been produced.
+    /// Production command paths use this to prevent lowering from rechecking source after diagnostics and semantic
+    /// facts have already been produced.
     pub(crate) fn set_prechecked_type_info(
         &mut self,
         main: TypeCheckInfo,

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -54,7 +54,7 @@ use super::common::{
     collect_project_requirements, collect_rust_dependency_uses, discover_effective_project_manifest,
     enforce_project_toolchain_constraint, extend_requirements_with_provider_plan, format_dependency_error,
     imported_module_deps_for_with_index, merge_project_requirement_dependencies, module_key_index,
-    resolve_project_root, resolve_source_root, typecheck_modules_with_import_graph, validate_output_dir,
+    resolve_project_root, resolve_source_root, validate_output_dir,
 };
 use super::lock::{
     GeneratedLibraryDependencyPreheatRequest, LockResolutionRequest, resolve_lock_context,
@@ -965,13 +965,32 @@ fn prepare_project_with_options(
     // This must run after rust-inspect preparation. Direct Rust calls expose their callable signatures through the
     // prepared metadata workspace; checking before that step degrades those calls to `Unknown` and breaks source-level
     // constructs such as `?` on Rust `Result<T, E>` returns.
-    typecheck_modules_with_import_graph(
-        &modules,
-        manifest.as_ref(),
-        &provider_plan,
-        #[cfg(feature = "rust_inspect")]
-        rust_inspect_manifest_dir.as_deref(),
-    )?;
+    let compilation_analysis = compilation_session
+        .analyze_modules(
+            &modules,
+            #[cfg(feature = "rust_inspect")]
+            rust_inspect_manifest_dir.as_deref(),
+        )
+        .map_err(|failure| CliError::failure(failure.render_human()))?;
+    let main_type_info = compilation_analysis
+        .type_info_for_path(&main_module.file_path)
+        .cloned()
+        .ok_or_else(|| {
+            CliError::failure(format!(
+                "missing session analysis for {}",
+                main_module.file_path.display()
+            ))
+        })?;
+    let mut dependency_type_info = HashMap::with_capacity(dep_modules.len());
+    for module in dep_modules {
+        let type_info = compilation_analysis
+            .type_info_for_path(&module.file_path)
+            .cloned()
+            .ok_or_else(|| CliError::failure(format!("missing session analysis for {}", module.file_path.display())))?;
+        dependency_type_info.insert(module.path_segments.clone(), type_info);
+    }
+    codegen.set_stdlib_cache(compilation_analysis.stdlib_cache().clone());
+    codegen.set_prechecked_type_info(main_type_info, dependency_type_info);
     generator.set_cargo_lock_payload(lock_payload);
 
     let cargo_flags = cargo_command_flags(cargo_policy, &cargo_features);
@@ -1310,6 +1329,7 @@ fn prepare_library_project(
     let mut api_metadata_modules = Vec::new();
     let module_idx_by_key = module_key_index(&modules);
     let mut stdlib_cache = StdlibAstCache::new();
+    let mut checked_type_info_by_path = BTreeMap::new();
 
     for (idx, module) in modules.iter().enumerate() {
         let deps_for_module = imported_module_deps_for_with_index(&modules, idx, &module_idx_by_key);
@@ -1345,6 +1365,7 @@ fn prepare_library_project(
                     module_key(&module.path_segments),
                     checked_exports_by_name(module_exports),
                 );
+                checked_type_info_by_path.insert(module.file_path.clone(), checker.type_info().clone());
                 stdlib_cache = checker.stdlib_cache.clone();
             }
             Err(errs) => {
@@ -1478,6 +1499,29 @@ fn prepare_library_project(
     codegen.set_stdlib_cache(stdlib_cache);
     codegen.set_declared_crate_names(declared);
     codegen.set_provider_plan(Arc::clone(&provider_plan));
+    let main_type_info = checked_type_info_by_path
+        .get(&lib_module.file_path)
+        .cloned()
+        .ok_or_else(|| {
+            CliError::failure(format!(
+                "missing checked library analysis for {}",
+                lib_module.file_path.display()
+            ))
+        })?;
+    let mut dependency_type_info = HashMap::with_capacity(dep_modules.len());
+    for module in dep_modules {
+        let type_info = checked_type_info_by_path
+            .get(&module.file_path)
+            .cloned()
+            .ok_or_else(|| {
+                CliError::failure(format!(
+                    "missing checked library analysis for {}",
+                    module.file_path.display()
+                ))
+            })?;
+        dependency_type_info.insert(module.path_segments.clone(), type_info);
+    }
+    codegen.set_prechecked_type_info(main_type_info, dependency_type_info);
     codegen.set_public_ordinal_type_identities(public_ordinal_type_identities(
         lib_module,
         project_name.as_str(),

--- a/src/cli/commands/codegraph.rs
+++ b/src/cli/commands/codegraph.rs
@@ -22,6 +22,7 @@ use incan_codegraph::{
     CodegraphRecord, CodegraphReferenceRecord, CodegraphSdkComponentProjection, CodegraphSdkProjection,
     CodegraphSemanticContext, CodegraphSourceSpan, to_jsonl,
 };
+use incan_semantics_core::{CompilerNodeId, SemanticModuleSnapshot, SemanticSourceTarget};
 
 use crate::cli::prelude::ParsedModule;
 use crate::cli::{CliError, CliResult, ExitCode};
@@ -32,8 +33,6 @@ use crate::frontend::ast::{
 };
 use crate::frontend::diagnostics::{self, StableDiagnostic};
 use crate::frontend::module::canonicalize_source_module_segments;
-use crate::frontend::typechecker::{SourceTargetInfo, TypeCheckInfo};
-use crate::manifest::ProjectManifest;
 use crate::provider::{
     BackendImplementationRequirement, ComponentSelectionReason, FeatureActivationReason, FeatureSelection,
     ProviderParticipation, ProviderPlan, ProviderProvenance,
@@ -42,7 +41,7 @@ use crate::version::INCAN_VERSION;
 
 use super::common::{
     CliDiagnosticFailure, CompilationSession, collect_modules_detailed_with_selections,
-    discover_effective_project_manifest, read_source, resolve_project_root, typecheck_modules_with_import_graph_info,
+    collect_modules_detailed_with_session, discover_effective_project_manifest, read_source, resolve_project_root,
 };
 
 /// Output format for `incan inspect codegraph`.
@@ -86,13 +85,13 @@ fn collect_codegraph_records(
 
     if path.is_dir() {
         let files = discover_incan_files(path)?;
-        let (modules, diagnostics, type_info_by_path) =
+        let (modules, diagnostics, semantic_snapshots_by_path) =
             directory_modules_diagnostics_and_info(&files, feature_selection, sdk_profile_override)?;
         if !diagnostics.is_empty() && !allow_errors {
             return Err(CliError::failure(render_diagnostics(&diagnostics)));
         }
         if diagnostics.is_empty() {
-            builder.set_type_info(type_info_by_path);
+            builder.set_semantic_snapshots(semantic_snapshots_by_path);
             builder.seed_source_target_ids(&modules);
             for module in &modules {
                 builder.collect_parsed_module(module, Vec::new());
@@ -121,15 +120,14 @@ fn collect_codegraph_records(
             return Err(CliError::failure(render_diagnostics(builder.diagnostics())));
         }
     } else {
-        match collect_modules_detailed_with_selections(&path.to_string_lossy(), feature_selection, sdk_profile_override)
-        {
+        let session = CompilationSession::discover_with_selections(path, feature_selection, sdk_profile_override)?;
+        match collect_modules_detailed_with_session(path.to_path_buf(), &session) {
             Ok(modules) => {
-                let (diagnostics, type_info_by_path) =
-                    typecheck_diagnostics_and_info(path, &modules, feature_selection, sdk_profile_override)?;
+                let (diagnostics, semantic_snapshots_by_path) = typecheck_diagnostics_and_info(&session, &modules)?;
                 if !diagnostics.is_empty() && !allow_errors {
                     return Err(CliError::failure(render_diagnostics(&diagnostics)));
                 }
-                builder.set_type_info(type_info_by_path);
+                builder.set_semantic_snapshots(semantic_snapshots_by_path);
                 builder.seed_source_target_ids(&modules);
                 for module in &modules {
                     builder.collect_parsed_module(module, diagnostics_for_file(&diagnostics, &module.file_path));
@@ -149,7 +147,7 @@ fn collect_codegraph_records(
 type DirectoryTypecheckArtifacts = (
     Vec<ParsedModule>,
     Vec<StableDiagnostic>,
-    BTreeMap<PathBuf, TypeCheckInfo>,
+    BTreeMap<PathBuf, SemanticModuleSnapshot>,
 );
 
 /// Collect and typecheck every discovered directory source root, keeping semantic artifacts only when the whole
@@ -162,12 +160,24 @@ fn directory_modules_diagnostics_and_info(
     let file_set = files.iter().cloned().collect::<BTreeSet<_>>();
     let mut modules_by_path = BTreeMap::new();
     let mut diagnostics = Vec::new();
-    let mut contexts = BTreeMap::new();
-    let mut type_info_by_path = BTreeMap::new();
+    let mut sessions = BTreeMap::new();
+    let mut semantic_snapshots_by_path = BTreeMap::new();
 
     for file in files {
-        match collect_modules_detailed_with_selections(&file.to_string_lossy(), feature_selection, sdk_profile_override)
-        {
+        let project_root = resolve_project_root(file);
+        if !sessions.contains_key(&project_root) {
+            sessions.insert(
+                project_root.clone(),
+                CompilationSession::discover_with_selections(file, feature_selection, sdk_profile_override)?,
+            );
+        }
+        let Some(session) = sessions.get(&project_root) else {
+            return Err(CliError::failure(format!(
+                "failed to prepare codegraph compilation session for {}",
+                project_root.display()
+            )));
+        };
+        match collect_modules_detailed_with_session(file.clone(), session) {
             Ok(modules) => {
                 for module in &modules {
                     if file_set.contains(&module.file_path) {
@@ -176,30 +186,16 @@ fn directory_modules_diagnostics_and_info(
                             .or_insert_with(|| module.clone());
                     }
                 }
-                let project_root = resolve_project_root(file);
-                if !contexts.contains_key(&project_root) {
-                    contexts.insert(
-                        project_root.clone(),
-                        TypecheckContext::discover(file, feature_selection, sdk_profile_override)?,
-                    );
-                }
-                let Some(context) = contexts.get(&project_root) else {
-                    return Err(CliError::failure(format!(
-                        "failed to prepare codegraph typecheck context for {}",
-                        project_root.display()
-                    )));
-                };
-                let provider_plan = context.provider_plan_for_modules(&modules)?;
-                match typecheck_modules_with_import_graph_info(
+                match session.analyze_modules(
                     &modules,
-                    context.manifest.as_ref(),
-                    &provider_plan,
                     #[cfg(feature = "rust_inspect")]
                     None,
                 ) {
-                    Ok(module_type_info) => {
-                        for (path, type_info) in module_type_info {
-                            type_info_by_path.entry(path).or_insert(type_info);
+                    Ok(analysis) => {
+                        for (path, snapshot) in analysis.semantic_snapshots() {
+                            semantic_snapshots_by_path
+                                .entry(path.clone())
+                                .or_insert_with(|| snapshot.clone());
                         }
                     }
                     Err(failure) => {
@@ -214,52 +210,27 @@ fn directory_modules_diagnostics_and_info(
     }
 
     if diagnostics.is_empty() {
-        Ok((modules_by_path.into_values().collect(), diagnostics, type_info_by_path))
+        Ok((
+            modules_by_path.into_values().collect(),
+            diagnostics,
+            semantic_snapshots_by_path,
+        ))
     } else {
         Ok((Vec::new(), diagnostics, BTreeMap::new()))
     }
 }
 
-struct TypecheckContext {
-    manifest: Option<ProjectManifest>,
-    session: CompilationSession,
-}
-
-impl TypecheckContext {
-    /// Discover manifest and library metadata needed to typecheck codegraph entrypoint collections.
-    fn discover(
-        path: &Path,
-        feature_selection: &FeatureSelection,
-        sdk_profile_override: Option<&str>,
-    ) -> CliResult<Self> {
-        let session = CompilationSession::discover_with_selections(path, feature_selection, sdk_profile_override)?;
-        let manifest = session.manifest.clone();
-        Ok(Self { manifest, session })
-    }
-
-    /// Resolve the shared provider projection for one collected codegraph compilation.
-    fn provider_plan_for_modules(&self, modules: &[ParsedModule]) -> CliResult<Arc<ProviderPlan>> {
-        self.session.provider_plan_for_modules(modules)
-    }
-}
-
 /// Run typechecking and keep reusable semantic artifacts when the checked graph succeeds.
 fn typecheck_diagnostics_and_info(
-    path: &Path,
+    session: &CompilationSession,
     modules: &[ParsedModule],
-    feature_selection: &FeatureSelection,
-    sdk_profile_override: Option<&str>,
-) -> CliResult<(Vec<StableDiagnostic>, BTreeMap<PathBuf, TypeCheckInfo>)> {
-    let context = TypecheckContext::discover(path, feature_selection, sdk_profile_override)?;
-    let provider_plan = context.provider_plan_for_modules(modules)?;
-    match typecheck_modules_with_import_graph_info(
+) -> CliResult<(Vec<StableDiagnostic>, BTreeMap<PathBuf, SemanticModuleSnapshot>)> {
+    match session.analyze_modules(
         modules,
-        context.manifest.as_ref(),
-        &provider_plan,
         #[cfg(feature = "rust_inspect")]
         None,
     ) {
-        Ok(type_info_by_path) => Ok((Vec::new(), type_info_by_path)),
+        Ok(analysis) => Ok((Vec::new(), analysis.semantic_snapshots().clone())),
         Err(failure) => Ok((stable_diagnostics(failure), BTreeMap::new())),
     }
 }
@@ -602,7 +573,7 @@ struct CodegraphBuilder {
     package: Option<CodegraphPackage>,
     semantic_contexts: Vec<CodegraphSemanticContext>,
     next_body_fact_index: usize,
-    type_info_by_path: BTreeMap<PathBuf, TypeCheckInfo>,
+    semantic_snapshots_by_path: BTreeMap<PathBuf, SemanticModuleSnapshot>,
     source_target_ids: BTreeMap<(Vec<String>, String, String), String>,
 }
 
@@ -633,14 +604,14 @@ impl CodegraphBuilder {
             package,
             semantic_contexts: Vec::new(),
             next_body_fact_index: 0,
-            type_info_by_path: BTreeMap::new(),
+            semantic_snapshots_by_path: BTreeMap::new(),
             source_target_ids: BTreeMap::new(),
         }
     }
 
-    /// Attach successful typechecker artifacts for later body fact target population.
-    fn set_type_info(&mut self, type_info_by_path: BTreeMap<PathBuf, TypeCheckInfo>) {
-        self.type_info_by_path = type_info_by_path;
+    /// Attach session-owned semantic facts for checked body target population.
+    fn set_semantic_snapshots(&mut self, semantic_snapshots_by_path: BTreeMap<PathBuf, SemanticModuleSnapshot>) {
+        self.semantic_snapshots_by_path = semantic_snapshots_by_path;
     }
 
     /// Precompute declaration ids for source targets before body facts are emitted.
@@ -1610,14 +1581,29 @@ impl CodegraphBuilder {
 
     /// Return a declaration record id for a compiler-proven source target at `span`.
     fn source_target_id(&self, module: &ParsedModule, span: Span) -> Option<String> {
-        let target = self.type_info_by_path.get(&module.file_path)?.source_target(span)?;
+        let module_identity = if module.path_segments.is_empty() {
+            "<module>".to_string()
+        } else {
+            module.path_segments.join("::")
+        };
+        let subject = CompilerNodeId::expression_span(&module_identity, span.start, span.end);
+        let target = self
+            .semantic_snapshots_by_path
+            .get(&module.file_path)?
+            .facts
+            .source_targets_for(&subject)
+            .next()?;
         self.declaration_id_for_source_target(target)
     }
 
     /// Resolve one source target artifact to an emitted declaration id.
-    fn declaration_id_for_source_target(&self, target: &SourceTargetInfo) -> Option<String> {
+    fn declaration_id_for_source_target(&self, target: &SemanticSourceTarget) -> Option<String> {
         self.source_target_ids
-            .get(&(target.module_path.clone(), target.name.clone(), target.kind.clone()))
+            .get(&(
+                target.module_path.clone(),
+                target.name.clone(),
+                target.kind.as_str().to_string(),
+            ))
             .cloned()
     }
 }

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -24,6 +24,7 @@ use crate::frontend::ast::{ImportKind, Program, Span};
 use crate::frontend::contract_metadata::{
     CanonicalModelBundle, materialize_contract_models, read_project_model_bundles,
 };
+use crate::frontend::hir::build_semantic_module_snapshot_v0;
 use crate::frontend::library_manifest_index::{
     LibraryArtifactMetadata, LibraryManifestFailureKind, LibraryManifestIndex, LibraryManifestIndexEntry,
 };
@@ -34,6 +35,7 @@ use crate::frontend::testing_markers::{
     TestingMarkerSemantics, load_testing_marker_semantics, testing_marker_semantics_from_manifest,
 };
 use crate::frontend::typechecker::TypeCheckInfo;
+use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
 use crate::frontend::{ast_walk, diagnostics, lexer, parser, typechecker, vocab_desugar_pass};
 use crate::library_manifest::{
     LibraryManifest, ProviderCargoDependency, ProviderCargoDependencySource, ProviderModuleClaim,
@@ -1323,6 +1325,49 @@ pub(crate) fn discover_effective_project_manifest(start_dir: &Path) -> CliResult
         .map_err(|error| CliError::failure(error.to_string()))
 }
 
+/// Checked products produced by one [`CompilationSession`] analysis pass.
+///
+/// The current Rust-source backend still lowers from [`TypeCheckInfo`], while compiler-facing consumers use the
+/// portable snapshot. Keeping both products in one analysis result prevents a CLI command from independently checking
+/// the same sources and then treating its second result as authoritative.
+///
+/// The `TypeCheckInfo` half is a transition bridge. Remove it when Body IR owns every lowering query tracked by #225.
+#[derive(Debug, Clone)]
+pub(crate) struct CompilationAnalysis {
+    type_info_by_path: BTreeMap<PathBuf, TypeCheckInfo>,
+    type_info_by_module_path: BTreeMap<Vec<String>, TypeCheckInfo>,
+    semantic_snapshots_by_path: BTreeMap<PathBuf, incan_semantics_core::SemanticModuleSnapshot>,
+    stdlib_cache: StdlibAstCache,
+}
+
+impl CompilationAnalysis {
+    /// Return the lowering input for one collected source file.
+    pub(crate) fn type_info_for_path(&self, path: &Path) -> Option<&TypeCheckInfo> {
+        self.type_info_by_path.get(path)
+    }
+
+    /// Return the lowering input for one compiler module identity.
+    ///
+    /// Identity is distinct from a source file path because the test runner may create multiple compiler modules rooted
+    /// at the same file.
+    pub(crate) fn type_info_for_module_path(&self, path: &[String]) -> Option<&TypeCheckInfo> {
+        self.type_info_by_module_path.get(path)
+    }
+
+    /// Return portable HIR and semantic fact snapshots keyed by source path.
+    pub(crate) fn semantic_snapshots(&self) -> &BTreeMap<PathBuf, incan_semantics_core::SemanticModuleSnapshot> {
+        &self.semantic_snapshots_by_path
+    }
+
+    /// Return the source-backed stdlib metadata accumulated by this analysis.
+    ///
+    /// Lowering currently queries this cache for source-defined trait and type metadata. It stays part of the session
+    /// result until those queries move to portable semantic facts and Body IR (#225).
+    pub(crate) fn stdlib_cache(&self) -> &StdlibAstCache {
+        &self.stdlib_cache
+    }
+}
+
 /// Shared source-analysis context for CLI commands and the LSP.
 ///
 /// This owns the project-level inputs that affect context-sensitive parsing and typechecking so entrypoints do not
@@ -1523,6 +1568,53 @@ impl CompilationSession {
         })
         .map(Arc::new)
         .map_err(|error| CliError::failure(error.to_string()))
+    }
+
+    /// Analyze one collected module graph exactly once.
+    ///
+    /// This is the v0.5 session bridge: code generation receives the checked lowering inputs it currently needs, and
+    /// codegraph/LSP-facing callers receive compiler-owned semantic facts from the same pass. No command may re-run
+    /// typechecking merely to derive its own authority.
+    pub(crate) fn analyze_modules(
+        &self,
+        modules: &[ParsedModule],
+        #[cfg(feature = "rust_inspect")] rust_inspect_manifest_dir: Option<&Path>,
+    ) -> Result<CompilationAnalysis, CliDiagnosticFailure> {
+        let provider_plan = self.provider_plan_for_modules(modules).map_err(|error| {
+            let module = modules.last();
+            CliDiagnosticFailure::single(
+                module
+                    .map(|module| module.file_path.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+                module.map(|module| module.source.clone()).unwrap_or_default(),
+                diagnostics::CompileError::new(error.message, Span::default()),
+                diagnostics::DiagnosticPhase::Import,
+            )
+        })?;
+        let typecheck_artifacts = typecheck_modules_with_import_graph_artifacts(
+            modules,
+            self.manifest.as_ref(),
+            &provider_plan,
+            #[cfg(feature = "rust_inspect")]
+            rust_inspect_manifest_dir,
+        )?;
+        let mut type_info_by_path = BTreeMap::new();
+        let mut type_info_by_module_path = BTreeMap::new();
+        let mut semantic_snapshots_by_path = BTreeMap::new();
+
+        for (module, type_info) in modules.iter().zip(typecheck_artifacts.type_infos) {
+            let snapshot = build_semantic_module_snapshot_v0(&module.ast, &module.path_segments, &type_info);
+            type_info_by_path.insert(module.file_path.clone(), type_info.clone());
+            type_info_by_module_path.insert(module.path_segments.clone(), type_info);
+            semantic_snapshots_by_path.insert(module.file_path.clone(), snapshot);
+        }
+
+        Ok(CompilationAnalysis {
+            type_info_by_path,
+            type_info_by_module_path,
+            semantic_snapshots_by_path,
+            stdlib_cache: typecheck_artifacts.stdlib_cache,
+        })
     }
 
     /// Resolve the test runner's marker contract from the same checked provider plan used by compilation.
@@ -3599,6 +3691,7 @@ pub(crate) fn imported_module_deps_for_with_index<'m>(
 ///
 /// This helper centralizes the per-module checker setup used by `build` and `check` paths so warning/error rendering
 /// stays consistent across command flows.
+#[cfg(test)]
 pub(crate) fn typecheck_modules_with_import_graph(
     modules: &[ParsedModule],
     manifest: Option<&ProjectManifest>,
@@ -3639,15 +3732,48 @@ pub(crate) fn typecheck_modules_with_import_graph_info(
     provider_plan: &Arc<ProviderPlan>,
     #[cfg(feature = "rust_inspect")] rust_inspect_manifest_dir: Option<&Path>,
 ) -> Result<BTreeMap<PathBuf, TypeCheckInfo>, CliDiagnosticFailure> {
+    let typecheck_artifacts = typecheck_modules_with_import_graph_artifacts(
+        modules,
+        manifest,
+        provider_plan,
+        #[cfg(feature = "rust_inspect")]
+        rust_inspect_manifest_dir,
+    )?;
+    Ok(modules
+        .iter()
+        .zip(typecheck_artifacts.type_infos)
+        .map(|(module, type_info)| (module.file_path.clone(), type_info))
+        .collect())
+}
+
+/// Products retained from one dependency-safe typechecking pass.
+struct TypecheckModuleArtifacts {
+    type_infos: Vec<TypeCheckInfo>,
+    stdlib_cache: StdlibAstCache,
+}
+
+/// Typecheck a collected graph in dependency-safe order and retain one result for every input module plus the
+/// source-backed stdlib metadata lowering needs.
+///
+/// Ordering is intentional: session analysis also needs an identity-keyed representation for synthetic modules that
+/// share a source file path.
+fn typecheck_modules_with_import_graph_artifacts(
+    modules: &[ParsedModule],
+    manifest: Option<&ProjectManifest>,
+    provider_plan: &Arc<ProviderPlan>,
+    #[cfg(feature = "rust_inspect")] rust_inspect_manifest_dir: Option<&Path>,
+) -> Result<TypecheckModuleArtifacts, CliDiagnosticFailure> {
     let declared = manifest.map(|m| m.declared_rust_crate_names());
     let module_idx_by_key = module_key_index(modules);
     let mut diagnostics_out = Vec::new();
-    let mut type_info_by_path = BTreeMap::new();
+    let mut type_infos = Vec::with_capacity(modules.len());
+    let mut stdlib_cache = StdlibAstCache::new();
 
     for (idx, module) in modules.iter().enumerate() {
         let deps_for_module = imported_module_deps_for_with_index(modules, idx, &module_idx_by_key);
 
         let mut checker = typechecker::TypeChecker::new();
+        checker.stdlib_cache = stdlib_cache.clone();
         if let Some(names) = declared.clone() {
             checker.set_declared_crate_names(names);
         }
@@ -3672,9 +3798,11 @@ pub(crate) fn typecheck_modules_with_import_graph_info(
                         diagnostics::format_error(module.file_path.to_string_lossy().as_ref(), &module.source, warn)
                     );
                 }
-                type_info_by_path.insert(module.file_path.clone(), checker.type_info().clone());
+                type_infos.push(checker.type_info().clone());
+                stdlib_cache = checker.stdlib_cache.clone();
             }
             Err(errs) => {
+                stdlib_cache = checker.stdlib_cache.clone();
                 diagnostics_out.extend(errs.into_iter().map(|error| CliDiagnostic {
                     file_path: module.file_path.to_string_lossy().to_string(),
                     source: module.source.clone(),
@@ -3686,7 +3814,10 @@ pub(crate) fn typecheck_modules_with_import_graph_info(
     }
 
     if diagnostics_out.is_empty() {
-        Ok(type_info_by_path)
+        Ok(TypecheckModuleArtifacts {
+            type_infos,
+            stdlib_cache,
+        })
     } else {
         Err(CliDiagnosticFailure {
             diagnostics: diagnostics_out,
@@ -5491,6 +5622,89 @@ def main() -> None:
 
         assert!(message.contains("was built with package features [alpha]"));
         assert!(message.contains("requires [beta]"));
+        Ok(())
+    }
+
+    #[test]
+    fn compilation_session_analysis_bundles_lowering_inputs_with_semantic_facts()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project_root = tmp.path();
+        let source_root = project_root.join("src");
+        std::fs::create_dir_all(&source_root)?;
+        std::fs::write(
+            project_root.join("incan.toml"),
+            "[project]\nname = \"analysis_consumer\"\n",
+        )?;
+        let main_path = source_root.join("main.incn");
+        std::fs::write(
+            &main_path,
+            "from std.testing import assert_eq\n\ndef helper() -> int:\n  return 1\n\ndef main() -> int:\n  assert_eq(helper(), 1)\n  return helper()\n",
+        )?;
+
+        let session = CompilationSession::discover_with_feature_selection(&main_path, &FeatureSelection::default())?;
+        let modules = collect_modules_detailed_with_session(main_path.clone(), &session)
+            .map_err(|failure| failure.render_human())?;
+        let analysis = session
+            .analyze_modules(
+                &modules,
+                #[cfg(feature = "rust_inspect")]
+                None,
+            )
+            .map_err(|failure| failure.render_human())?;
+        let snapshot = analysis
+            .semantic_snapshots()
+            .get(&main_path)
+            .ok_or("expected a session semantic snapshot for the entry module")?;
+
+        assert!(analysis.type_info_for_path(&main_path).is_some());
+        assert!(snapshot.render_snapshot().contains("decl:main::helper type=() -> int"));
+        assert!(
+            snapshot
+                .render_snapshot()
+                .contains("symbol_target=function:main::helper")
+        );
+        let mut stdlib_cache = analysis.stdlib_cache().clone();
+        assert!(
+            stdlib_cache
+                .lookup_function_symbol(&["std".to_string(), "testing".to_string()], "assert_eq")
+                .is_some(),
+            "session analysis must retain source-backed stdlib metadata for lowering"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn compilation_session_analysis_preserves_same_file_module_identities() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let source_root = tmp.path().join("src");
+        std::fs::create_dir_all(&source_root)?;
+        std::fs::write(
+            tmp.path().join("incan.toml"),
+            "[project]\nname = \"identity_consumer\"\n",
+        )?;
+        let shared_path = source_root.join("shared.incn");
+        std::fs::write(&shared_path, "def value() -> int:\n  return 1\n")?;
+
+        let mut first = parsed_module_for_test("def first() -> int:\n  return 1\n")?;
+        first.name = "first".to_string();
+        first.path_segments = vec!["first".to_string()];
+        first.file_path = shared_path.clone();
+        let mut second = parsed_module_for_test("def second() -> int:\n  return 2\n")?;
+        second.name = "second".to_string();
+        second.path_segments = vec!["second".to_string()];
+        second.file_path = shared_path.clone();
+
+        let analysis = CompilationSession::discover_with_feature_selection(&shared_path, &FeatureSelection::default())?
+            .analyze_modules(
+                &[first, second],
+                #[cfg(feature = "rust_inspect")]
+                None,
+            )
+            .map_err(|failure| failure.render_human())?;
+
+        assert!(analysis.type_info_for_module_path(&["first".to_string()]).is_some());
+        assert!(analysis.type_info_for_module_path(&["second".to_string()]).is_some());
         Ok(())
     }
 }

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -3837,7 +3837,7 @@ fn typecheck_diagnostic_phase(module: &ParsedModule, span: Span) -> diagnostics:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::frontend::typechecker;
+    use crate::frontend::typechecker::{self, IdentKind};
     use crate::library_manifest::{LibraryManifest, ProviderFeatureMetadata, ProviderModuleClaim, VocabExports};
     use std::path::Path;
 
@@ -5016,6 +5016,106 @@ def main() -> Result[None, str]:
             )
             .into());
         }
+        Ok(())
+    }
+
+    #[test]
+    fn session_analysis_keeps_crate_root_facade_class_reexports_as_types() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project_root = tmp.path();
+        let source_root = project_root.join("src");
+        let session_root = source_root.join("session");
+        std::fs::create_dir_all(&session_root)?;
+        std::fs::write(
+            project_root.join("incan.toml"),
+            "[project]\nname = \"crate_root_facade\"\nversion = \"0.1.0\"\n",
+        )?;
+        std::fs::write(session_root.join("types.incn"), "pub class Session:\n    pub id: int\n")?;
+        std::fs::write(
+            session_root.join("mod.incn"),
+            "pub from crate.session.types import Session\n",
+        )?;
+        let main_path = source_root.join("main.incn");
+        let main_source = "from session import Session\n\ndef main() -> None:\n    session = Session(id=1)\n";
+        std::fs::write(&main_path, main_source)?;
+
+        let session = CompilationSession::discover_with_feature_selection(&main_path, &FeatureSelection::default())?;
+        let modules = collect_modules_detailed_with_session(main_path.clone(), &session)
+            .map_err(|failure| failure.render_human())?;
+        let module_idx_by_key = module_key_index(&modules);
+        let facade_index = modules
+            .iter()
+            .position(|module| module.file_path.ends_with("src/session/mod.incn"))
+            .ok_or("expected the session facade module")?;
+        let facade_dependencies = imported_module_deps_for_with_index(&modules, facade_index, &module_idx_by_key);
+        assert!(
+            facade_dependencies.iter().any(|(name, _)| *name == "session_types"),
+            "crate-root imports must contribute their source dependency to the session analysis closure; got: {:?}",
+            facade_dependencies
+                .iter()
+                .map(|(name, _)| (*name).to_string())
+                .collect::<Vec<_>>()
+        );
+
+        let analysis = session
+            .analyze_modules(
+                &modules,
+                #[cfg(feature = "rust_inspect")]
+                None,
+            )
+            .map_err(|failure| failure.render_human())?;
+        let callee_start = main_source.find("Session(id=1)").ok_or("expected constructor call")?;
+        assert_eq!(
+            analysis
+                .type_info_for_path(&main_path)
+                .ok_or("expected main session analysis")?
+                .ident_kind(Span::new(callee_start, callee_start + "Session".len())),
+            Some(IdentKind::TypeName),
+            "a public facade re-export of a crate-root class must stay a class constructor in shared session facts"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn dependency_closure_includes_crate_root_module_imports() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project_root = tmp.path();
+        let source_root = project_root.join("src");
+        let types_root = source_root.join("types");
+        std::fs::create_dir_all(&types_root)?;
+        std::fs::write(
+            project_root.join("incan.toml"),
+            "[project]\nname = \"crate_root_module_import\"\nversion = \"0.1.0\"\n",
+        )?;
+        std::fs::write(types_root.join("user.incn"), "pub class User:\n    pub id: int\n")?;
+        let consumer_path = source_root.join("consumer.incn");
+        std::fs::write(
+            &consumer_path,
+            "import crate.types.user\n\npub def consume() -> None:\n    pass\n",
+        )?;
+        let main_path = source_root.join("main.incn");
+        std::fs::write(
+            &main_path,
+            "from consumer import consume\n\ndef main() -> None:\n    consume()\n",
+        )?;
+
+        let session = CompilationSession::discover_with_feature_selection(&main_path, &FeatureSelection::default())?;
+        let modules = collect_modules_detailed_with_session(main_path.clone(), &session)
+            .map_err(|failure| failure.render_human())?;
+        let module_idx_by_key = module_key_index(&modules);
+        let consumer_index = modules
+            .iter()
+            .position(|module| module.file_path.ends_with("src/consumer.incn"))
+            .ok_or("expected the consumer module")?;
+        let dependencies = imported_module_deps_for_with_index(&modules, consumer_index, &module_idx_by_key);
+        assert!(
+            dependencies.iter().any(|(name, _)| *name == "types_user"),
+            "crate-root module imports must contribute their source dependency to the closure; got: {:?}",
+            dependencies
+                .iter()
+                .map(|(name, _)| (*name).to_string())
+                .collect::<Vec<_>>()
+        );
         Ok(())
     }
 

--- a/src/cli/commands/debug.rs
+++ b/src/cli/commands/debug.rs
@@ -4,12 +4,13 @@
 
 use crate::backend::IrCodegen;
 use crate::cli::{CliError, CliResult, ExitCode};
-use crate::frontend::library_manifest_index::LibraryManifestIndex;
+use crate::compiled_sdk::CompiledSdkModules;
 use crate::frontend::{diagnostics, lexer, parser};
 use std::env;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use super::common::{collect_modules, discover_effective_project_manifest, read_source, resolve_project_root};
+use super::common::{CompilationSession, collect_modules_detailed_with_session, read_source};
 use super::diagnostics::{DiagnosticOutputFormat, check_path};
 
 /// Lex and display tokens.
@@ -71,14 +72,6 @@ pub fn check_file(file_path: &str) -> CliResult<ExitCode> {
 /// If `strict` is true, the output uses stricter clippy attributes to produce warning-clean code suitable for direct
 /// use in Rust projects.
 pub fn emit_rust(file_path: &str, strict: bool) -> CliResult<ExitCode> {
-    let modules = collect_modules(file_path)?;
-
-    let Some(main_module) = modules.last() else {
-        return Err(CliError::failure("No modules found"));
-    };
-
-    let mut codegen = IrCodegen::new();
-    codegen.set_strict_generated_lints(strict);
     let normalized_file_path = if Path::new(file_path).is_absolute() {
         PathBuf::from(file_path)
     } else {
@@ -86,20 +79,69 @@ pub fn emit_rust(file_path: &str, strict: bool) -> CliResult<ExitCode> {
             .map_err(|e| CliError::failure(format!("failed to determine current directory: {e}")))?
             .join(file_path)
     };
-    let project_root = resolve_project_root(&normalized_file_path);
-    let manifest = discover_effective_project_manifest(&project_root)?;
-    if let Some(m) = manifest.as_ref() {
+    let session = CompilationSession::discover_with_feature_selection(
+        &normalized_file_path,
+        &crate::provider::FeatureSelection::default(),
+    )?;
+    let modules = collect_modules_detailed_with_session(normalized_file_path, &session)
+        .map_err(|failure| CliError::failure(failure.render_human()))?;
+    let Some(main_module) = modules.last() else {
+        return Err(CliError::failure("No modules found"));
+    };
+
+    let provider_plan = session.provider_plan_for_modules(&modules)?;
+    let compiled_sdk_modules = CompiledSdkModules::from_provider_plan(&provider_plan);
+    let mut codegen = IrCodegen::new();
+    codegen.set_strict_generated_lints(strict);
+    if let Some(m) = session.manifest.as_ref() {
         codegen.set_declared_crate_names(m.declared_rust_crate_names());
     }
-    let library_manifest_index = manifest
-        .as_ref()
-        .map(LibraryManifestIndex::from_project_manifest)
-        .unwrap_or_default();
-    codegen.set_library_manifest_index(library_manifest_index);
+    codegen.set_provider_plan(Arc::clone(&provider_plan));
 
-    for module in &modules[..modules.len() - 1] {
+    let dep_modules = &modules[..modules.len() - 1];
+    for module in dep_modules
+        .iter()
+        .filter(|module| compiled_sdk_modules.contains_emission_path(&module.path_segments))
+    {
+        codegen.add_dependency_symbol_module_with_path_segments(
+            &module.name,
+            &module.ast,
+            module.path_segments.clone(),
+        );
+    }
+    for module in dep_modules
+        .iter()
+        .filter(|module| !compiled_sdk_modules.contains_emission_path(&module.path_segments))
+    {
         codegen.add_module_with_path_segments(&module.name, &module.ast, module.path_segments.clone());
     }
+
+    let analysis = session
+        .analyze_modules(
+            &modules,
+            #[cfg(feature = "rust_inspect")]
+            None,
+        )
+        .map_err(|failure| CliError::failure(failure.render_human()))?;
+    let main_type_info = analysis
+        .type_info_for_path(&main_module.file_path)
+        .cloned()
+        .ok_or_else(|| {
+            CliError::failure(format!(
+                "missing session analysis for {}",
+                main_module.file_path.display()
+            ))
+        })?;
+    let mut dependency_type_info = std::collections::HashMap::with_capacity(dep_modules.len());
+    for module in dep_modules {
+        let type_info = analysis
+            .type_info_for_path(&module.file_path)
+            .cloned()
+            .ok_or_else(|| CliError::failure(format!("missing session analysis for {}", module.file_path.display())))?;
+        dependency_type_info.insert(module.path_segments.clone(), type_info);
+    }
+    codegen.set_stdlib_cache(analysis.stdlib_cache().clone());
+    codegen.set_prechecked_type_info(main_type_info, dependency_type_info);
 
     let rust_code = codegen
         .try_generate(&main_module.ast)

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -27,6 +27,8 @@ use crate::frontend::decorator_resolution;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
 use crate::frontend::module::logical_module_segments_from_file;
 use crate::frontend::testing_markers::{TestingMarkerKind, TestingMarkerSemantics, resolve_testing_marker_kind};
+use crate::frontend::typechecker::TypeCheckInfo;
+use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
 use crate::frontend::vocab_desugar_pass;
 use crate::frontend::{lexer, parser};
 use crate::lockfile::{CargoFeatureSelection, semantic_lock_state};
@@ -934,6 +936,8 @@ pub(super) struct PreparedTestFile {
     pub project_requirements: ProjectRequirements,
     pub cargo_package_name: String,
     pub lock_payload: Option<String>,
+    /// Checked lowering inputs supplied by the same session analysis as test diagnostics and semantic facts.
+    pub prechecked_type_info: (TypeCheckInfo, HashMap<Vec<String>, TypeCheckInfo>, StdlibAstCache),
     #[cfg(feature = "rust_inspect")]
     pub rust_inspect_manifest_dir: PathBuf,
 }
@@ -3126,8 +3130,8 @@ pub(super) fn run_file_tests_batch(
         let inline_imports = collect_test_dependency_inline_imports(&module_for_imports, &source_dependency_modules);
 
         let mut dependency_modules: Vec<ParsedModule> = Vec::with_capacity(1 + source_modules.len());
-        dependency_modules.push(module_for_imports);
-        dependency_modules.extend(source_dependency_modules);
+        dependency_modules.push(module_for_imports.clone());
+        dependency_modules.extend(source_dependency_modules.clone());
 
         let mut project_requirements =
             match common::collect_project_requirements(&dependency_modules, &library_manifest_index) {
@@ -3353,6 +3357,61 @@ pub(super) fn run_file_tests_batch(
             rust_inspect_manifest_dir
         };
 
+        let prechecked_type_info = {
+            let mut analysis_modules = source_dependency_modules.clone();
+            analysis_modules.push(module_for_imports.clone());
+            let analysis = match compilation_session.analyze_modules(
+                &analysis_modules,
+                #[cfg(feature = "rust_inspect")]
+                Some(&rust_inspect_manifest_dir),
+            ) {
+                Ok(analysis) => analysis,
+                Err(failure) => {
+                    let message = failure.render_human();
+                    return tests
+                        .iter()
+                        .map(|test| (test.clone(), TestResult::Failed(start.elapsed(), message.clone())))
+                        .collect();
+                }
+            };
+            let Some(main) = analysis
+                .type_info_for_module_path(&module_for_imports.path_segments)
+                .cloned()
+            else {
+                return tests
+                    .iter()
+                    .map(|test| {
+                        (
+                            test.clone(),
+                            TestResult::Failed(
+                                start.elapsed(),
+                                format!("missing session analysis for {}", first.file_path.display()),
+                            ),
+                        )
+                    })
+                    .collect();
+            };
+            let mut dependencies = HashMap::with_capacity(source_modules.len());
+            for module in &source_modules {
+                let Some(type_info) = analysis.type_info_for_module_path(&module.path_segments).cloned() else {
+                    return tests
+                        .iter()
+                        .map(|test| {
+                            (
+                                test.clone(),
+                                TestResult::Failed(
+                                    start.elapsed(),
+                                    format!("missing session analysis for {}", module.file_path.display()),
+                                ),
+                            )
+                        })
+                        .collect();
+                };
+                dependencies.insert(module.path_segments.clone(), type_info);
+            }
+            (main, dependencies, analysis.stdlib_cache().clone())
+        };
+
         let prepared = PreparedTestFile {
             provider_plan,
             ast: runner_ast,
@@ -3364,6 +3423,7 @@ pub(super) fn run_file_tests_batch(
             project_requirements: lock_resolution.project_requirements,
             cargo_package_name: lock_resolution.cargo_package_name,
             lock_payload,
+            prechecked_type_info,
             #[cfg(feature = "rust_inspect")]
             rust_inspect_manifest_dir,
         };
@@ -3383,6 +3443,9 @@ pub(super) fn run_file_tests_batch(
     let mut codegen = IrCodegen::new();
     codegen.set_preserve_dependency_public_items(false);
     codegen.set_provider_plan(Arc::clone(&prepared.provider_plan));
+    let (main_type_info, dependency_type_info, stdlib_cache) = &prepared.prechecked_type_info;
+    codegen.set_stdlib_cache(stdlib_cache.clone());
+    codegen.set_prechecked_type_info(main_type_info.clone(), dependency_type_info.clone());
     let compiled_sdk_modules = CompiledSdkModules::from_provider_plan(&prepared.provider_plan);
     #[cfg(feature = "rust_inspect")]
     {

--- a/workspaces/docs-site/docs/contributing/reference/backend_behavior_inventory.md
+++ b/workspaces/docs-site/docs/contributing/reference/backend_behavior_inventory.md
@@ -55,7 +55,7 @@ The first backend-foundation artifacts are compiler-facing. They make current fr
 | `IncanType`              | Backend-neutral type vocabulary independent of Rust spelling.                                         | Used for semantic type facts and ABI v0 hooks; it is compiler-facing and not a stable public ABI.                                           |
 | ABI v0 type facts        | Conservative ownership, representation, and reserved runtime/target slots for semantic types.         | Records unknowns explicitly; it does not promise layout or target compatibility yet.                                                        |
 | `HirModule`              | Declaration-level HIR v0 with source spans and optional type-fact subjects.                           | Body, statement, expression, and ownership HIR are later slices.                                                                            |
-| `SemanticModuleSnapshot` | Bundled HIR plus semantic facts for one module.                                                       | Intended for inspection and future middle-end handoff fixtures before backend cutover.                                                      |
+| `SemanticModuleSnapshot` | Bundled HIR plus semantic facts for one module.                                                       | Produced by `CompilationSession`; codegraph reads checked source-target facts from it, while legacy lowering inputs remain until Body IR owns every lowering query. |
 
 ## Seed behavior matrix
 

--- a/workspaces/docs-site/docs/contributing/reference/rust_source_backend_deprecation.md
+++ b/workspaces/docs-site/docs/contributing/reference/rust_source_backend_deprecation.md
@@ -37,16 +37,9 @@ Do not use the template as bureaucracy. Use it to prevent backend-only fixes fro
 
 ## Current v0.5 adoption
 
-`CompilationSession` now owns one checked analysis result for executable builds, generated-Rust inspection, and
-codegraph inspection. That result bundles the lowering inputs and source-backed stdlib metadata still required by the
-current backend with a `SemanticModuleSnapshot` per module. The build paths pass that analysis into `IrCodegen` rather
-than asking codegen to typecheck the same source again, and codegraph resolves checked call/reference targets from
-semantic facts rather than `TypeCheckInfo` directly.
+`CompilationSession` now owns one checked analysis result for executable builds, generated-Rust inspection, and codegraph inspection. That result bundles the lowering inputs and source-backed stdlib metadata still required by the current backend with a `SemanticModuleSnapshot` per module. The build paths pass that analysis into `IrCodegen` rather than asking codegen to typecheck the same source again, and codegraph resolves checked call/reference targets from semantic facts rather than `TypeCheckInfo` directly.
 
-The remaining internal `IrCodegen` typecheck fallback is deliberate and narrow: it serves direct backend API callers
-that do not yet supply a session analysis. Its owner is [#225](https://github.com/encero-systems/incan/issues/225);
-remove it when those callers supply session analysis and Body IR owns the lowering-specific queries that facts do not
-yet model. It must not receive new semantic decisions.
+The remaining internal `IrCodegen` typecheck fallback is deliberate and narrow: it serves direct backend API callers that do not yet supply a session analysis. Its owner is [#225](https://github.com/encero-systems/incan/issues/225); remove it when those callers supply session analysis and Body IR owns the lowering-specific queries that facts do not yet model. It must not receive new semantic decisions.
 
 ## Not allowed without explicit maintainer approval
 

--- a/workspaces/docs-site/docs/contributing/reference/rust_source_backend_deprecation.md
+++ b/workspaces/docs-site/docs/contributing/reference/rust_source_backend_deprecation.md
@@ -35,6 +35,19 @@ Use this template in the code comment, test name, issue note, or PR text:
 
 Do not use the template as bureaucracy. Use it to prevent backend-only fixes from becoming hidden architecture.
 
+## Current v0.5 adoption
+
+`CompilationSession` now owns one checked analysis result for executable builds, generated-Rust inspection, and
+codegraph inspection. That result bundles the lowering inputs and source-backed stdlib metadata still required by the
+current backend with a `SemanticModuleSnapshot` per module. The build paths pass that analysis into `IrCodegen` rather
+than asking codegen to typecheck the same source again, and codegraph resolves checked call/reference targets from
+semantic facts rather than `TypeCheckInfo` directly.
+
+The remaining internal `IrCodegen` typecheck fallback is deliberate and narrow: it serves direct backend API callers
+that do not yet supply a session analysis. Its owner is [#225](https://github.com/encero-systems/incan/issues/225);
+remove it when those callers supply session analysis and Body IR owns the lowering-specific queries that facts do not
+yet model. It must not receive new semantic decisions.
+
 ## Not allowed without explicit maintainer approval
 
 - Adding new source semantics only in an emitter branch.

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -15,6 +15,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 ## Features and Enhancements
 
 - **Compiler foundation**: The 0.5 backend-foundation lane now has a behavior inventory, generated-Rust deprecation policy, stable semantic identity scaffolding, typed compiler facts, initial HIR structures, and a Hees.ai dependency inventory so backend migration work has a shared review surface (#646, #647, #648, #649, #650, #651).
+- **Compiler foundation**: Executable builds, generated-Rust inspection, codegraph export, and ordinary test batches now share `CompilationSession` analysis. Checked lowering inputs, source-backed stdlib metadata, and `SemanticModuleSnapshot` facts are produced together, so codegraph no longer independently reconstructs source-target facts and the legacy backend no longer rechecks those critical CLI paths (#224, #225).
 - **Stdlib**: `std.checksum` adds CRC32 value, digest-byte, and incremental helpers for compatibility and accidental-corruption checks, separate from `std.hash` security and hashing contracts (#709).
 - **Stdlib**: `std.environ` adds redacted, read-only Unicode environment access through required, optional, and defaulted string reads, plus typed reads for primitives, explicit `TryFrom[str]` adopters, and validated newtypes (RFC 089, #557).
 - **Stdlib**: `std.fs` adds same-filesystem atomic publication, explicit directory synchronization, and OS-backed shared/exclusive advisory locks for crash-safe local state (RFC 112, #829).


### PR DESCRIPTION
## Summary

This PR makes `CompilationSession` the shared analysis owner on the first critical v0.5 compiler paths. Executable builds, generated-Rust inspection, codegraph export, and ordinary test batches now consume one checked analysis result instead of independently rechecking the same source.

The session result carries the existing lowering inputs and source-backed stdlib metadata alongside `SemanticModuleSnapshot` facts. Codegraph resolves checked source targets from those semantic facts, while `IrCodegen` consumes the session-owned lowering inputs on the critical CLI paths.

The implementation is rebased onto RFC 114's component/provider model. Session analysis derives the same module-aware provider projection used by build, test, and code generation; it does not restore the superseded library-index plumbing.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Build, `--emit-rust`, `inspect codegraph`, and ordinary `incan test` batches preserve their existing behavior while sharing the same compiler analysis. Codegraph continues to emit checked target records deterministically.
- **Compiler ownership**: `CompilationAnalysis` owns checked type information, source-backed stdlib metadata, and semantic snapshots. Production CLI paths pass this result to lowering; the direct backend API fallback remains bounded and documented for callers that have not yet adopted a session.
- **Provider compatibility**: The shared analysis uses `CompilationSession`'s feature-, package-, and SDK-component-aware provider plan. Compiled SDK modules remain linked through provider artifacts instead of being rematerialized into generated projects.
- **Regression repaired**: Absolute `crate.*` source imports remain part of the transitive dependency closure, preserving facade-reexported class identity in session analysis and generated Rust.
- **Remaining boundary**: The direct-API fallback must not acquire new semantic authority. Its removal remains part of #225 and the Body IR cutover.

## Testing / verification

- [x] `make fmt`
- [x] `make pre-commit` — 3,043/3,043 tests, rustdoc, Clippy, and cargo-deny passed
- [x] Release smoke — assertion canary, 60 examples, and 9 Incan benchmarks passed
- [x] `make docs-build`
- [x] Focused session, codegraph, test-batch, and generated-Rust regressions

Focused commands included:

- `cargo test --locked --lib session_analysis -- --nocapture`
- `cargo test --locked --lib crate_root -- --nocapture`
- `cargo test --locked --test cli_integration semantic_inspection_surfaces_share_project_identity -- --nocapture`
- `cargo test --locked --test cli_integration inspect_codegraph_exports_multifile_imports_and_public_symbols -- --nocapture`
- `cargo test --locked --test cli_integration test_multi_file_test_batch_keeps_file_local_import_scopes_issue57 -- --nocapture`
- `cargo test --locked --test integration_tests build_succeeds_for_pub_import_regression_batch -- --nocapture`

The fresh hosted CI run was cancelled before execution because the repository's GitHub Actions allowance is exhausted; the completed verification above is local macOS evidence.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

- [Backend behavior inventory](workspaces/docs-site/docs/contributing/reference/backend_behavior_inventory.md)
- [Rust-source backend deprecation policy](workspaces/docs-site/docs/contributing/reference/rust_source_backend_deprecation.md)
- [v0.5 release notes](workspaces/docs-site/docs/release_notes/0_5.md)

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs where appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added or updated tests where they materially reduce regressions

Closes #224

Advances #225 and #282; those broader cutover and explicit-stage contracts remain open.
