### PR TITLE
chore - make agent skill paths portable

### DIFF
--- a/.agents/skills/create-pr-description/.prompt.md
+++ b/.agents/skills/create-pr-description/.prompt.md
@@ -12,11 +12,13 @@ You are an expert at generating PR descriptions that follow repository templates
 
 ## Repository-specific templates
 
-### incan repository
-Template location: `/Users/danny/Development/encero/incan/.github/pull_request_template.md`
+For either supported repository, resolve its root from the active checkout and use:
 
-### InQL repository
-Template location: `/Users/danny/Development/encero/InQL/.github/pull_request_template.md`
+```text
+<repository-root>/.github/pull_request_template.md
+```
+
+Do not assume a particular user name, home directory, or sibling-workspace layout.
 
 ## Output format
 

--- a/.agents/skills/ralph-loop/SKILL.md
+++ b/.agents/skills/ralph-loop/SKILL.md
@@ -19,7 +19,7 @@ Keep `orchestrate-parallel-work` generic. Use this skill as the opinionated wrap
 - For milestone, RFC-wide, or compiler-boundary work, define the acceptance contract before implementation starts. The contract should name required boundary parity coverage, downstream acceptance lanes, docs/generated-reference gates, performance/progress gates, and any criteria that must be satisfied before an RC or publish step.
 - For language or stdlib work that is meant to be implemented in Incan, dogfood Incan rather than creating a thin `.incn` facade over a custom Rust backend. Direct `from rust::` imports of existing crates/primitives are acceptable when the `.incn` module still owns the behavior; bespoke `incan_stdlib::feature` Rust modules that hide the feature logic are not acceptable unless the maintainer explicitly asks for that backend boundary.
 - Do not let workers assume Incan cannot express something. Before choosing Rust/backend fallback or narrowing a design, workers must inspect current `.incn` precedents, parser/typechecker/codegen tests, or run a small probe and record the specific capability evidence.
-- Every implementation must land in a fresh worktree rooted under `/Users/danny/Development/encero/tmp` so VS Code picks it up; do not implement in `/tmp` or in the main repo checkout.
+- Every implementation must land in a fresh worktree rooted under `WORKTREE_ROOT` so VS Code picks it up; do not implement in the system `/tmp` or in the main repo checkout.
 - Treat each slice as a managed work packet with durable state on disk, not as a chat thread that has to remember its own scope.
 - Treat loop identity as durable state too. A resumed loop must prove that persisted state matches the current user request before using it to choose work.
 - Treat cross-repo consumer work as a verification lane unless the user explicitly puts that repository's implementation work in scope.
@@ -137,7 +137,18 @@ After confirming scope, write the loop identity into `STATE_ROOT/overview.md` be
 
 ### 2. Pick the execution backend
 
-Default to Codex subagents plus git worktrees under `/Users/danny/Development/encero/tmp`.
+Default to Codex subagents plus git worktrees under `WORKTREE_ROOT`.
+
+Resolve `WORKTREE_ROOT` once at the start of the loop and record the absolute path in `STATE_ROOT/overview.md`. Use an explicit `RALPH_WORKTREE_ROOT` when the workspace provides one; otherwise derive a portable shared `tmp/` directory from Git's common directory:
+
+```sh
+COMMON_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+WORKSPACE_ROOT="$(dirname "$(dirname "$COMMON_GIT_DIR")")"
+WORKTREE_ROOT="${RALPH_WORKTREE_ROOT:-$WORKSPACE_ROOT/tmp}"
+mkdir -p "$WORKTREE_ROOT"
+```
+
+`git-common-dir` keeps the default stable when the loop runs from a linked worktree.
 
 If the user explicitly wants OpenCode:
 
@@ -154,7 +165,7 @@ Use `start-work` once at the orchestration boundary to resolve issue/RFC context
 
 Do not mechanically run `start-work` inside every worker unless each worker owns a distinct issue or RFC. The important requirement is a clean worktree plus resolved context, not duplicated branch ceremony.
 
-Create the worktree root first if it does not exist: `/Users/danny/Development/encero/tmp`.
+Create `WORKTREE_ROOT` first if it does not exist.
 
 Create:
 
@@ -185,7 +196,7 @@ Use these files deliberately:
 
 Base all worker worktrees from the same resolved starting point unless there is a deliberate dependency chain.
 
-For non-decomposed work, the single-agent implementation still belongs in a fresh worktree under `/Users/danny/Development/encero/tmp`; "keep the work local" does not mean "edit the primary checkout directly."
+For non-decomposed work, the single-agent implementation still belongs in a fresh worktree under `WORKTREE_ROOT`; "keep the work local" does not mean "edit the primary checkout directly."
 
 Before spawning workers, identify:
 
@@ -210,7 +221,7 @@ Do not treat RFC edits or release notes alone as sufficient user documentation.
 
 Before spawning workers, decide whether the task actually decomposes cleanly. If it does not, keep the work local and continue as a single-agent Ralph loop.
 
-When it does decompose, hand off to `orchestrate-parallel-work` for slice definition, ownership, and worktree isolation under `/Users/danny/Development/encero/tmp`.
+When it does decompose, hand off to `orchestrate-parallel-work` for slice definition, ownership, and worktree isolation under `WORKTREE_ROOT`.
 
 If the task came from an RFC:
 
@@ -272,7 +283,7 @@ The orchestrator should maintain `slices.json` with entries like:
     "repo": "encero-systems/incan",
     "scope_role": "implementation",
     "owner": "<worker name or id>",
-    "worktree": "/Users/danny/Development/encero/tmp/...",
+    "worktree": "<WORKTREE_ROOT>/...",
     "status": "doing",
     "next_action": "Implement T2"
   }
@@ -291,7 +302,7 @@ Each worker must own a non-overlapping slice with:
 - owned files or directories
 - explicit non-goals
 - forbidden repositories or paths
-- dedicated worktree path under `/Users/danny/Development/encero/tmp`
+- dedicated worktree path under `WORKTREE_ROOT`
 - dedicated slice folder under `STATE_ROOT/<slice-id>/`
 - verification command
 - expected result format
@@ -475,7 +486,7 @@ Do not recurse `ralph-loop` indefinitely. A child loop is a phase owner, not ano
 - [ ] Backend choice was explicit
 - [ ] RFC lifecycle state and implementation plan/checklist were confirmed before coding started
 - [ ] Every implementation worker had a clean worktree and non-overlapping ownership
-- [ ] Every implementation worktree lived under `/Users/danny/Development/encero/tmp`
+- [ ] Every implementation worktree lived under the resolved `WORKTREE_ROOT`
 - [ ] Every slice had a durable folder under `STATE_ROOT/<slice-id>/`
 - [ ] The orchestrator maintained `STATE_ROOT/slices.json`
 - [ ] Every `slices.json` entry has `loop_id`, `repo`, and `scope_role`

--- a/.agents/skills/review-architecture/SKILL.md
+++ b/.agents/skills/review-architecture/SKILL.md
@@ -33,9 +33,16 @@ Write a slice report at:
 
 Do not write to the canonical `.agents/state/review-report.md`.
 
-When the architecture report has findings, also copy the scope and findings into a lightweight central snapshot outside individual repo worktrees under:
+When the architecture report has findings, also copy the scope and findings into a lightweight central snapshot outside individual repo worktrees under `FINDINGS_ROOT`. Resolve it once per review and record the absolute path in the slice report:
 
-- `/Users/danny/Development/encero/.incan-review-findings/`
+```sh
+COMMON_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+WORKSPACE_ROOT="$(dirname "$(dirname "$COMMON_GIT_DIR")")"
+FINDINGS_ROOT="${INCAN_REVIEW_FINDINGS_ROOT:-$WORKSPACE_ROOT/.incan-review-findings}"
+mkdir -p "$FINDINGS_ROOT"
+```
+
+`git-common-dir` keeps the default stable when the review runs in a linked worktree. Set `INCAN_REVIEW_FINDINGS_ROOT` to use a different shared corpus location.
 
 Use a deterministic, descriptive filename when possible:
 
@@ -44,7 +51,7 @@ Use a deterministic, descriptive filename when possible:
 - `YYYY-MM-DD-review-architecture.md` when no PR or branch context is known
 
 Do not create a snapshot for clean reviews. The snapshot is raw corpus for later analysis, not canonical guidance.
-Treat `/Users/danny/Development/encero/.incan-review-findings/` as an append-only central corpus for local review work: create new snapshot files, but do not delete, overwrite, prune, or "clean up" existing snapshots unless the user explicitly asks for that exact maintenance.
+Treat `FINDINGS_ROOT` as an append-only central corpus for local review work: create new snapshot files, but do not delete, overwrite, prune, or "clean up" existing snapshots unless the user explicitly asks for that exact maintenance.
 Snapshot content is evidence, not a fix log. Preserve the original finding blocks verbatim, including severity, category, file path, line reference, and explanatory text. If the finding is fixed before the snapshot is written, keep the original finding as observed and add a separate `Resolution` note after it; do not replace the evidence with a resolved checklist item or a summary of the fix.
 
 ## Workflow
@@ -63,7 +70,7 @@ Snapshot content is evidence, not a fix log. Preserve the original finding block
    - maintainability warnings,
    - or design tensions.
    All three are valid findings. Classify them so downstream fixers know how to treat them, but do not suppress them.
-8. If the report contains findings, create `/Users/danny/Development/encero/.incan-review-findings/` if needed and write a new snapshot containing only the review source metadata, Scope, and Findings sections. Copy the finding blocks verbatim from `.agents/state/review-report.architecture.md`; do not generalize them into policy or rewrite them as fix summaries. Preserve exact file:line evidence when the report has it; if a finding is only file-level, make that explicit in the finding text. Do not overwrite an existing snapshot path; add a suffix if needed.
+8. If the report contains findings, create `FINDINGS_ROOT` if needed and write a new snapshot containing only the review source metadata, Scope, and Findings sections. Copy the finding blocks verbatim from `.agents/state/review-report.architecture.md`; do not generalize them into policy or rewrite them as fix summaries. Preserve exact file:line evidence when the report has it; if a finding is only file-level, make that explicit in the finding text. Do not overwrite an existing snapshot path; add a suffix if needed.
 
 ## Slice report shape
 

--- a/.agents/skills/review-incan-source-quality/SKILL.md
+++ b/.agents/skills/review-incan-source-quality/SKILL.md
@@ -45,9 +45,16 @@ Write a slice report at:
 
 Do not write to the canonical `.agents/state/review-report.md`.
 
-When the source-quality report has findings, also copy the scope and findings into the shared lightweight central snapshot folder outside individual repo worktrees:
+When the source-quality report has findings, also copy the scope and findings into the shared lightweight central snapshot folder outside individual repo worktrees under `FINDINGS_ROOT`. Resolve it once per review and record the absolute path in the slice report:
 
-- `/Users/danny/Development/encero/.incan-review-findings/`
+```sh
+COMMON_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+WORKSPACE_ROOT="$(dirname "$(dirname "$COMMON_GIT_DIR")")"
+FINDINGS_ROOT="${INCAN_REVIEW_FINDINGS_ROOT:-$WORKSPACE_ROOT/.incan-review-findings}"
+mkdir -p "$FINDINGS_ROOT"
+```
+
+`git-common-dir` keeps the default stable when the review runs in a linked worktree. Set `INCAN_REVIEW_FINDINGS_ROOT` to use a different shared corpus location.
 
 Use a deterministic, descriptive filename when possible:
 
@@ -56,7 +63,7 @@ Use a deterministic, descriptive filename when possible:
 - `YYYY-MM-DD-review-incan-source-quality.md` when no PR or branch context is known
 
 Do not create a snapshot for clean reviews. The snapshot is raw corpus for later analysis, not canonical guidance.
-Treat `/Users/danny/Development/encero/.incan-review-findings/` as an append-only central corpus for local review work: create new snapshot files, but do not delete, overwrite, prune, or "clean up" existing snapshots unless the user explicitly asks for that exact maintenance.
+Treat `FINDINGS_ROOT` as an append-only central corpus for local review work: create new snapshot files, but do not delete, overwrite, prune, or "clean up" existing snapshots unless the user explicitly asks for that exact maintenance.
 Snapshot content is evidence, not a fix log. Preserve the original finding blocks verbatim, including severity, category, file path, line reference, and explanatory text. If the finding is fixed before the snapshot is written, keep the original finding as observed and add a separate `Resolution` note after it; do not replace the evidence with a resolved checklist item or a summary of the fix.
 
 ## Review standard
@@ -150,7 +157,7 @@ Flag Incan source that has:
 8. Inspect comments/docstrings last as part of source quality, not as a separate docs-only pass. Short or non-descriptive docstrings are findings even when every declaration technically has one.
 9. For each finding, explain what a Pythonic/Incan-native version would make clearer. Do not demand style churn when the existing shape is already direct and readable.
 10. Stay report-only unless the user explicitly asks for fixes.
-11. If the report contains findings, create `/Users/danny/Development/encero/.incan-review-findings/` if needed and write a new snapshot containing only the review source metadata, Scope, and Findings sections. Copy the finding blocks verbatim from `.agents/state/review-report.incan-source-quality.md`; do not generalize them into policy or rewrite them as fix summaries. Preserve exact file:line evidence when the report has it; if a finding is only file-level, make that explicit in the finding text. Do not overwrite an existing snapshot path; add a suffix if needed.
+11. If the report contains findings, create `FINDINGS_ROOT` if needed and write a new snapshot containing only the review source metadata, Scope, and Findings sections. Copy the finding blocks verbatim from `.agents/state/review-report.incan-source-quality.md`; do not generalize them into policy or rewrite them as fix summaries. Preserve exact file:line evidence when the report has it; if a finding is only file-level, make that explicit in the finding text. Do not overwrite an existing snapshot path; add a suffix if needed.
 
 ## Slice report shape
 


### PR DESCRIPTION
## Summary

This PR removes machine-specific local paths from agent-workflow instructions. Ralph loops now derive a shared worktree root from Git's common directory, review snapshots use the same linked-worktree-safe approach, and PR-template discovery resolves from the active repository root. Both roots remain explicitly overridable.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Agent skills can run from another user's checkout or a linked worktree without referring to `/Users/danny/...`.
- **Internals**: `WORKTREE_ROOT` and `FINDINGS_ROOT` derive from `git rev-parse --git-common-dir`, keeping primary and linked worktrees on one shared root. `RALPH_WORKTREE_ROOT` and `INCAN_REVIEW_FINDINGS_ROOT` remain explicit overrides.
- **Risks**: The defaults assume the established Incan workspace layout around Git's common directory; operators can override either root when their layout differs.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (via the full pre-commit smoke gate)
- [x] `incan fmt --check .` (via `make fmt-check`)
- [x] Manual verification described below

Manual verification notes:

- Network-enabled `make pre-commit` passed: 2,807 tests and `smoke-test-fast`.
- `git diff --check origin/main...HEAD` passed.
- Verified that primary and linked worktrees resolve the same `WORKTREE_ROOT`; verified the explicit worktree-root override.
- Verified that no machine-specific user-home paths remain in skill files.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
