### PR TITLE
bugfix - borrow owned Read.by_ref receivers without dereference (#878)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "blake2",
  "blake3",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1526,14 +1526,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1542,14 +1542,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "axum",
  "incan_core",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -251,6 +251,13 @@ pub const METADATA_FREE_METHOD_SIGNATURE_RULES: &[MetadataFreeMethodSignatureRul
 /// part of Rust's public contract and whose result shapes matter for Incan source typing.
 pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[MetadataFreeFunctionSignatureRule] = &[
     MetadataFreeFunctionSignatureRule {
+        path: "std::io::stdin",
+        params: &[],
+        return_type: "std::io::Stdin",
+        is_async: false,
+        is_unsafe: false,
+    },
+    MetadataFreeFunctionSignatureRule {
         path: "std::fs::metadata",
         params: &[MetadataFreeFunctionParamRule {
             name: Some("path"),
@@ -1387,5 +1394,18 @@ pub fn run_inline<D: FnMut(&mut Data, &OutputCallbackInfo)>(callback: D) {
         assert!(!signature.is_async);
         assert!(!signature.is_unsafe);
         assert!(metadata_free_function_signature("std::fs::remove_file").is_none());
+    }
+
+    #[test]
+    fn metadata_free_function_signature_preserves_stdin_receiver_type() -> Result<(), String> {
+        let Some(signature) = metadata_free_function_signature("std::io::stdin") else {
+            return Err("std::io::stdin should have a metadata-free signature".to_string());
+        };
+
+        assert_eq!(signature.return_type, "std::io::Stdin");
+        assert!(signature.params.is_empty());
+        assert!(!signature.is_async);
+        assert!(!signature.is_unsafe);
+        Ok(())
     }
 }

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -14,7 +14,7 @@ use super::super::super::expr::{
 };
 use super::super::super::ownership::{
     ArgumentPassingPlan, AssociatedFunctionArgumentContext, RegularMethodArgumentContext, ValueUseSite,
-    associated_function_argument_use_site, is_byte_buffer_type, is_string_buffer_type,
+    associated_function_argument_use_site, is_byte_buffer_type, is_string_buffer_type, plan_read_by_ref_receiver,
     regular_method_argument_use_site,
 };
 use super::super::super::reference_shape::{expr_has_rust_reference_shape, type_has_rust_reference_shape};
@@ -453,7 +453,7 @@ impl<'a> IrEmitter<'a> {
                     };
                 }
                 if idx == 0 && method == "by_ref" {
-                    emitted = quote! { &mut *#emitted };
+                    emitted = plan_read_by_ref_receiver(&arg.ty).apply(emitted);
                 }
                 if idx == 0
                     && Self::receiver_type_for_method_dispatch(&receiver.ty).nominal_type_name() == Some("Path")

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -1517,6 +1517,72 @@ mod tests {
         }
     }
 
+    /// Build the imported-trait associated call shape used by `Read.by_ref(value)` regressions.
+    fn read_by_ref_call(receiver_name: &str, receiver_ty: IrType) -> TypedExpr {
+        TypedExpr::new(
+            IrExprKind::MethodCall {
+                receiver: Box::new(TypedExpr::new(
+                    IrExprKind::Var {
+                        name: "Read".to_string(),
+                        access: VarAccess::Copy,
+                        ref_kind: VarRefKind::ExternalRustName,
+                    },
+                    IrType::Trait("std::io::Read".to_string()),
+                )),
+                method: "by_ref".to_string(),
+                dispatch: None,
+                type_args: Vec::new(),
+                args: vec![IrCallArg {
+                    name: None,
+                    kind: IrCallArgKind::Positional,
+                    expr: TypedExpr::new(
+                        IrExprKind::Var {
+                            name: receiver_name.to_string(),
+                            access: VarAccess::Read,
+                            ref_kind: VarRefKind::Value,
+                        },
+                        receiver_ty,
+                    ),
+                }],
+                callable_signature: None,
+                arg_policy: MethodCallArgPolicy::Default,
+            },
+            IrType::Unknown,
+        )
+    }
+
+    #[test]
+    fn read_by_ref_receiver_borrows_owned_reader_without_dereference() -> Result<(), String> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let emitted = emitter
+            .emit_expr(&read_by_ref_call("input", IrType::Struct("std::io::Stdin".to_string())))
+            .map_err(|err| format!("expected successful expression emission, got {err:?}"))?;
+        let rendered = emitted.to_string();
+
+        assert_eq!(rendered, "Read :: by_ref (& mut input)");
+        Ok(())
+    }
+
+    #[test]
+    fn read_by_ref_receiver_reborrows_through_refmut_guard() -> Result<(), String> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let emitted = emitter
+            .emit_expr(&read_by_ref_call(
+                "cursor",
+                IrType::NamedGeneric(
+                    "std::cell::RefMut".to_string(),
+                    vec![IrType::Struct("std::io::Cursor<Vec<u8>>".to_string())],
+                ),
+            ))
+            .map_err(|err| format!("expected successful expression emission, got {err:?}"))?;
+        let rendered = emitted.to_string();
+
+        assert_eq!(rendered, "Read :: by_ref (& mut * cursor)");
+        Ok(())
+    }
+
     #[test]
     fn type_name_associated_call_does_not_borrow_string_arguments() -> Result<(), String> {
         let registry = FunctionRegistry::new();

--- a/src/backend/ir/ownership.rs
+++ b/src/backend/ir/ownership.rs
@@ -567,6 +567,50 @@ pub fn plan_collection_receiver(receiver_ty: &IrType, mutable: bool) -> Collecti
     }
 }
 
+/// How an owned or guard-backed value should satisfy `Read::by_ref`'s mutable receiver parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadByRefReceiverPlan {
+    /// Emit `&mut receiver` for an owned mutable value.
+    BorrowOwned,
+    /// Emit `&mut *receiver` to reborrow the value behind a mutable dereference guard.
+    ReborrowThroughDeref,
+}
+
+impl ReadByRefReceiverPlan {
+    /// Apply the planned receiver shape to an already-emitted value.
+    pub fn apply(&self, tokens: TokenStream) -> TokenStream {
+        match self {
+            Self::BorrowOwned => quote! { &mut #tokens },
+            Self::ReborrowThroughDeref => quote! { &mut *#tokens },
+        }
+    }
+}
+
+/// Plan a `Read::by_ref` receiver without assuming every source value can be dereferenced.
+///
+/// Incan's stdlib passes `RefMut<T>` guards to associated trait calls such as `Read.by_ref`, where Rust needs a
+/// reborrow of the guarded `T`. Ordinary imported Rust values such as `Stdin` instead need a direct mutable borrow.
+#[must_use]
+pub fn plan_read_by_ref_receiver(receiver_ty: &IrType) -> ReadByRefReceiverPlan {
+    let is_refmut_guard = match receiver_ty {
+        // Metadata-free stdlib compilation cannot yet recover `RefMut<T>` from `borrow_mut()`. Preserve the existing
+        // dereferenced reborrow for that compatibility lane until the return type is available in IR.
+        IrType::Unknown | IrType::RefMut(_) => true,
+        IrType::NamedGeneric(name, _) | IrType::Struct(name) => name
+            .rsplit("::")
+            .next()
+            .and_then(|segment| segment.split('<').next())
+            .is_some_and(|name| name == "RefMut"),
+        _ => false,
+    };
+
+    if is_refmut_guard {
+        ReadByRefReceiverPlan::ReborrowThroughDeref
+    } else {
+        ReadByRefReceiverPlan::BorrowOwned
+    }
+}
+
 /// How a dictionary lookup-style probe key should be shaped.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DictLookupKeyPlan {
@@ -1252,6 +1296,33 @@ mod tests {
         assert_eq!(
             plan_collection_receiver(&IrType::List(Box::new(IrType::Int)), false),
             CollectionReceiverPlan::BorrowShared
+        );
+    }
+
+    #[test]
+    fn plan_read_by_ref_receiver_borrows_owned_value() {
+        assert_eq!(
+            plan_read_by_ref_receiver(&IrType::Struct("std::io::Stdin".to_string())),
+            ReadByRefReceiverPlan::BorrowOwned
+        );
+    }
+
+    #[test]
+    fn plan_read_by_ref_receiver_reborrows_refmut_guard() {
+        assert_eq!(
+            plan_read_by_ref_receiver(&IrType::NamedGeneric(
+                "std::cell::RefMut".to_string(),
+                vec![IrType::Struct("std::io::Cursor<Vec<u8>>".to_string())]
+            )),
+            ReadByRefReceiverPlan::ReborrowThroughDeref
+        );
+    }
+
+    #[test]
+    fn plan_read_by_ref_receiver_preserves_metadata_free_guard_fallback() {
+        assert_eq!(
+            plan_read_by_ref_receiver(&IrType::Unknown),
+            ReadByRefReceiverPlan::ReborrowThroughDeref
         );
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -156,6 +156,42 @@ def main() -> Result[None, str]:
 }
 
 #[test]
+fn rust_read_by_ref_borrows_owned_receiver_issue878() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "rust_read_by_ref_owned_receiver", "")?;
+    fs::write(
+        &main_path,
+        r#"from rust::std::io import Read, stdin
+
+
+def main() -> None:
+    mut input = stdin()
+    _ = Read.by_ref(input)
+"#,
+    )?;
+    let main_arg = main_path.to_str().ok_or("non-utf8 main path")?;
+
+    let lock_output = run_incan(tmp.path(), &["lock", main_arg])?;
+    assert_success(&lock_output, "incan lock for Read.by_ref owned receiver");
+    let build_output = run_incan(tmp.path(), &["build", main_arg, "--locked"])?;
+    assert_success(&build_output, "incan build for Read.by_ref owned receiver");
+
+    let generated = fs::read_to_string(
+        tmp.path()
+            .join("target/incan/rust_read_by_ref_owned_receiver/src/main.rs"),
+    )?;
+    assert!(
+        generated.contains("Read::by_ref(&mut input)"),
+        "owned Rust trait receiver must be borrowed without dereference:\n{generated}"
+    );
+    assert!(
+        !generated.contains("Read::by_ref(&mut *input)"),
+        "owned Rust trait receiver must not use the guard reborrow shape:\n{generated}"
+    );
+    Ok(())
+}
+
+#[test]
 fn rust_trait_object_method_arguments_borrow_by_metadata_issue832() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -225,8 +225,8 @@
     {
       "path": "src/backend/ir/ownership.rs",
       "category": "central external Rust duckborrower buffer planning",
-      "expected_count": 4,
-      "expected_fingerprint": "0xe78ae9c1c06afb76"
+      "expected_count": 5,
+      "expected_fingerprint": "0xe0f92591a022208b"
     },
     {
       "path": "src/backend/ir/reference_shape.rs",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3423,8 +3423,12 @@ def main() -> None:
             .stderr(Stdio::piped())
             .spawn()?;
 
+        // A cold CI runner must compile the generated holder project before it can create the readiness file. Keep
+        // this deadline comfortably above observed cold MSRV compilation time while retaining a finite failure bound.
+        let holder_ready_started = std::time::Instant::now();
+        let holder_ready_timeout = Duration::from_secs(120);
         let mut holder_ready = false;
-        for _ in 0..1200 {
+        while holder_ready_started.elapsed() < holder_ready_timeout {
             if ready.exists() {
                 holder_ready = true;
                 break;

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -26,6 +26,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: Imported mutable Rust trait receivers now distinguish owned values from dereferenceable guards, so calls such as `Read.by_ref(input)` emit a valid direct borrow for `Stdin` while stdlib `RefMut` readers retain their required reborrow (#878).
 - **Compiler**: Rust interop method calls with inferred `Into`-bound generic parameters now keep string literals in an inferable shape instead of generating ambiguous `.into()` calls (#804).
 - **Compiler**: Generic Rust function results can now be inferred from an annotated return or parameter context through `Result.unwrap()`, including generated package-test builds such as `serde_json::from_str` (#852).
 - **Compiler**: Rust interop now preserves callable bounds such as `FnMut(&mut T, &U)` when checking generic callback parameters, so by-value Incan callbacks are rejected at typecheck instead of reaching Rust codegen with an invalid borrowed callback shape (#805).


### PR DESCRIPTION
## Summary

Fixes imported `Read.by_ref(input)` calls for owned Rust readers. The backend previously emitted `&mut *input` for every receiver, which fails for owned values such as `std::io::Stdin`; it now borrows owned values directly while preserving dereferenced reborrows for `RefMut`-backed stdlib readers.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `Read.by_ref(input)` now builds when `input` is an owned mutable `Stdin`.
- **Internals**: Adds metadata-free typing for `std::io::stdin` and a scoped ownership plan that distinguishes owned receivers from dereferenceable `RefMut` guards.
- **CI hardening**: The filesystem-lock coordination regression now allows 120 seconds for a cold generated-project build while retaining a finite readiness deadline; the previous 30-second wait expired during MSRV shard 3/5 compilation.
- **Risks**: Metadata-free unknown receivers retain the previous dereferenced-guard fallback for stdlib compatibility; focused unit, snapshot, generated-Rust, and locked-build regressions cover both shapes.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed after the CI hardening update: 2,831 tests, clippy, cargo-deny, release build, assertion canary, examples, and benchmark smoke builds.
- Rust 1.93.0 exact regression passed: `cargo +1.93.0 test --locked --test integration_tests -- codegen_tests::test_std_fs_locks_coordinate_between_incan_processes --exact --nocapture`.
- The isolated issue source passed `incan lock` followed by `incan build src/main.incn --locked`.
- Generated Rust contains `Read::by_ref(&mut input)` and does not contain `Read::by_ref(&mut *input)`.
- The existing stdlib `RefMut` generated-Rust snapshot remains unchanged.
- `cargo check --lib --no-default-features` passed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_5.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #878