### PR TITLE
bugfix - preserve private class fields across library boundaries (#883)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "blake2",
  "blake3",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/backend/ir/emit/decls/structures.rs
+++ b/src/backend/ir/emit/decls/structures.rs
@@ -146,24 +146,37 @@ impl<'a> IrEmitter<'a> {
                 })
                 .collect();
 
-            let constructor = if !s.fields.is_empty() && self.should_emit_struct_constructor(&s.name) {
-                let param_tokens: Vec<TokenStream> = s
-                    .fields
-                    .iter()
-                    .map(|f| {
-                        let fname = format_ident!("{}", &f.name);
-                        let fty = self.emit_type(&f.ty);
-                        quote! { #fname: #fty }
-                    })
-                    .collect();
-                let field_assigns: Vec<TokenStream> = s
-                    .fields
-                    .iter()
-                    .map(|f| {
-                        let fname = format_ident!("{}", &f.name);
-                        quote! { #fname }
-                    })
-                    .collect();
+            let constructor = if !s.fields.is_empty() && self.should_emit_struct_constructor(s) {
+                let mut param_tokens = Vec::with_capacity(s.fields.len());
+                let mut field_assigns = Vec::with_capacity(s.fields.len());
+                for field in &s.fields {
+                    let field_name = format_ident!("{}", &field.name);
+                    let field_ty = self.emit_type(&field.ty);
+                    if let Some(default) = field.default.as_ref() {
+                        let default = if matches!(field.ty, IrType::String)
+                            && let crate::backend::ir::expr::IrExprKind::BinOp {
+                                op: crate::backend::ir::expr::BinOp::Add,
+                                left,
+                                right,
+                            } = &default.kind
+                            && let Some(static_default) = self.try_emit_static_str_add(left, right)?
+                        {
+                            quote! { #static_default.to_string() }
+                        } else {
+                            self.emit_expr_for_use(
+                                default,
+                                crate::backend::ir::ownership::ValueUseSite::StructField {
+                                    target_ty: Some(&field.ty),
+                                },
+                            )?
+                        };
+                        param_tokens.push(quote! { #field_name: Option<#field_ty> });
+                        field_assigns.push(quote! { #field_name: #field_name.unwrap_or_else(|| #default) });
+                    } else {
+                        param_tokens.push(quote! { #field_name: #field_ty });
+                        field_assigns.push(quote! { #field_name });
+                    }
+                }
 
                 quote! {
                     #[allow(non_snake_case, clippy::too_many_arguments)]

--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -751,9 +751,9 @@ impl<'a> IrEmitter<'a> {
                 .iter()
                 .filter_map(|arg| arg.name.as_ref().map(|name| (name.clone(), arg.expr.clone())))
                 .collect::<Vec<_>>();
-            if let Some(metadata) = self
-                .struct_constructor_metadata_for_fields(target_name, &fields)
-                .or_else(|| self.unique_struct_constructor_metadata_for_fields(&fields))
+            if let Some(metadata) = canonical_path
+                .and_then(|path| self.public_dependency_constructor_metadata_for_path(path, &fields))
+                .or_else(|| self.struct_constructor_metadata_for_fields(target_name, &fields))
             {
                 let mut provided: std::collections::HashMap<&str, &TypedExpr> = std::collections::HashMap::new();
                 for (name, expr) in &fields {
@@ -768,10 +768,26 @@ impl<'a> IrEmitter<'a> {
                     let target_ty = metadata.field_types.get(field_name);
                     if let Some(value) = provided.get(field_name.as_str()) {
                         let value = self.emit_expr_for_use(value, ValueUseSite::StructField { target_ty })?;
-                        out_fields.push(quote! { #field_ident: #value });
-                    } else if let Some(default_expr) = metadata.field_defaults.get(field_name) {
-                        let value = self.emit_expr_for_use(default_expr, ValueUseSite::StructField { target_ty })?;
-                        out_fields.push(quote! { #field_ident: #value });
+                        let value =
+                            if metadata.requires_constructor_function && metadata.default_fields.contains(field_name) {
+                                quote! { Some(#value) }
+                            } else {
+                                value
+                            };
+                        out_fields.push((quote! { #field_ident }, value));
+                    } else if metadata.default_fields.contains(field_name) {
+                        let value = if metadata.requires_constructor_function {
+                            quote! { None }
+                        } else {
+                            let default_expr = metadata.field_defaults.get(field_name).ok_or_else(|| {
+                                EmitError::Unsupported(format!(
+                                    "default for field '{}' on '{}' cannot be materialized",
+                                    field_name, target_name
+                                ))
+                            })?;
+                            self.emit_expr_for_use(default_expr, ValueUseSite::StructField { target_ty })?
+                        };
+                        out_fields.push((quote! { #field_ident }, value));
                     } else {
                         return Err(EmitError::Unsupported(format!(
                             "missing required field '{}' when constructing '{}'",
@@ -780,7 +796,12 @@ impl<'a> IrEmitter<'a> {
                     }
                 }
 
-                return Ok(quote! { #f { #(#out_fields),* } });
+                if metadata.requires_constructor_function {
+                    let values = out_fields.iter().map(|(_, value)| value);
+                    return Ok(quote! { #f(#(#values),*) });
+                }
+                let fields = out_fields.iter().map(|(field, value)| quote! { #field: #value });
+                return Ok(quote! { #f { #(#fields),* } });
             }
         }
 
@@ -1466,6 +1487,86 @@ mod tests {
             kind: IrCallArgKind::Positional,
             expr,
         }
+    }
+
+    #[test]
+    fn alternate_type_name_call_uses_exact_private_library_constructor_bridge_issue883()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::backend::ir::emit::StructConstructorMetadata;
+        use crate::library_manifest::{FieldExport, FieldVisibilityExport, ParamDefaultExport, TypeRef};
+
+        let sealed_fields = vec![
+            FieldExport {
+                name: "secret".to_string(),
+                ty: TypeRef::Named {
+                    name: "int".to_string(),
+                },
+                visibility: FieldVisibilityExport::Private,
+                has_default: false,
+                default: None,
+                alias: None,
+                description: None,
+            },
+            FieldExport {
+                name: "label".to_string(),
+                ty: TypeRef::Named {
+                    name: "str".to_string(),
+                },
+                visibility: FieldVisibilityExport::Public,
+                has_default: true,
+                default: Some(ParamDefaultExport::String("sealed".to_string())),
+                alias: None,
+                description: None,
+            },
+        ];
+        let decoy_fields = vec![FieldExport {
+            name: "unrelated".to_string(),
+            ty: TypeRef::Named {
+                name: "bool".to_string(),
+            },
+            visibility: FieldVisibilityExport::Public,
+            has_default: false,
+            default: None,
+            alias: None,
+            description: None,
+        }];
+        let registry = FunctionRegistry::new();
+        let mut emitter = IrEmitter::new(&registry);
+        emitter.pub_dependency_constructor_metadata.insert(
+            ("sealed".to_string(), "Vault".to_string()),
+            StructConstructorMetadata::from_manifest_fields("sealed", &sealed_fields),
+        );
+        emitter.pub_dependency_constructor_metadata.insert(
+            ("decoy".to_string(), "Vault".to_string()),
+            StructConstructorMetadata::from_manifest_fields("decoy", &decoy_fields),
+        );
+        let func = TypedExpr::new(
+            IrExprKind::Var {
+                name: "PublicVault".to_string(),
+                access: VarAccess::Read,
+                ref_kind: VarRefKind::TypeName,
+            },
+            IrType::Unknown,
+        );
+        let args = vec![IrCallArg {
+            name: Some("secret".to_string()),
+            kind: IrCallArgKind::Named,
+            expr: TypedExpr::new(IrExprKind::Int(42), IrType::Int),
+        }];
+        let target = IrType::Struct("PublicVault".to_string());
+        let path = vec!["pub".to_string(), "sealed".to_string(), "Vault".to_string()];
+        let tokens = emitter.emit_call_expr_for_use(
+            &func,
+            &[],
+            &args,
+            None,
+            Some(&path),
+            ValueUseSite::Assignment {
+                target_ty: Some(&target),
+            },
+        )?;
+        assert_eq!(render(tokens), "sealed::Vault(42,None)");
+        Ok(())
     }
 
     fn typed_rust_call_target(name: &str, params: Vec<IrType>) -> TypedExpr {

--- a/src/backend/ir/emit/expressions/structs_enums.rs
+++ b/src/backend/ir/emit/expressions/structs_enums.rs
@@ -100,17 +100,31 @@ impl<'a> IrEmitter<'a> {
                 return Ok(quote! { #n {} });
             }
 
-            let mut out_fields: Vec<TokenStream> = Vec::new();
+            let mut out_fields: Vec<(TokenStream, TokenStream)> = Vec::new();
             for fname in field_names {
                 let fn_ident = Self::rust_ident(fname);
                 let target_type = metadata.field_types.get(fname);
                 if let Some(fval) = provided.get(fname.as_str()) {
                     let fv = self.emit_expr_for_use(fval, ValueUseSite::StructField { target_ty: target_type })?;
-                    out_fields.push(quote! { #fn_ident: #fv });
-                } else if let Some(default_expr) = metadata.field_defaults.get(fname) {
-                    let fv =
-                        self.emit_expr_for_use(default_expr, ValueUseSite::StructField { target_ty: target_type })?;
-                    out_fields.push(quote! { #fn_ident: #fv });
+                    let fv = if metadata.requires_constructor_function && metadata.default_fields.contains(fname) {
+                        quote! { Some(#fv) }
+                    } else {
+                        fv
+                    };
+                    out_fields.push((quote! { #fn_ident }, fv));
+                } else if metadata.default_fields.contains(fname) {
+                    let fv = if metadata.requires_constructor_function {
+                        quote! { None }
+                    } else {
+                        let default_expr = metadata.field_defaults.get(fname).ok_or_else(|| {
+                            EmitError::Unsupported(format!(
+                                "default for field '{}' on '{}' cannot be materialized",
+                                fname, name
+                            ))
+                        })?;
+                        self.emit_expr_for_use(default_expr, ValueUseSite::StructField { target_ty: target_type })?
+                    };
+                    out_fields.push((quote! { #fn_ident }, fv));
                 } else {
                     return Err(EmitError::Unsupported(format!(
                         "missing required field '{}' when constructing '{}'",
@@ -119,7 +133,13 @@ impl<'a> IrEmitter<'a> {
                 }
             }
 
-            Ok(quote! { #n { #(#out_fields),* } })
+            if metadata.requires_constructor_function {
+                let values = out_fields.iter().map(|(_, value)| value);
+                Ok(quote! { #n(#(#values),*) })
+            } else {
+                let fields = out_fields.iter().map(|(field, value)| quote! { #field: #value });
+                Ok(quote! { #n { #(#fields),* } })
+            }
         }
     }
 }

--- a/src/backend/ir/emit/mod.rs
+++ b/src/backend/ir/emit/mod.rs
@@ -33,8 +33,13 @@ use std::collections::{HashMap, HashSet};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use super::decl::{FunctionParam, IrDeclKind, IrEnumValue, IrEnumValueType, IrStruct, VariantFields, Visibility};
-use super::expr::{IrDictEntry, IrExprKind, IrListEntry, Literal as IrLiteral, TypedExpr};
+use super::decl::{
+    FunctionParam, IrDeclKind, IrEnumValue, IrEnumValueType, IrImportOrigin, IrStruct, VariantFields, Visibility,
+};
+use super::expr::{
+    IrCallArg, IrCallArgKind, IrDictEntry, IrExprKind, IrListEntry, Literal as IrLiteral, TypedExpr, VarAccess,
+    VarRefKind,
+};
 use super::types::{IR_UNION_TYPE_NAME, IrType, Mutability};
 use super::{FunctionRegistry, FunctionSignature, IrProgram};
 use crate::frontend::api_metadata::{
@@ -44,8 +49,8 @@ use crate::frontend::api_metadata::{
 use crate::frontend::library_manifest_index::{LibraryManifestIndex, LibraryManifestIndexEntry};
 use crate::frontend::symbols::ResolvedType;
 use crate::library_manifest::{
-    FieldExport, LibraryManifest, MethodExport, NewtypeExport, ParamDefaultExport, ParamKindExport, TypeRef,
-    resolved_type_from_manifest_type_ref,
+    FieldExport, FieldVisibilityExport, LibraryManifest, MethodExport, NewtypeExport, ParamDefaultCallSignatureExport,
+    ParamDefaultExport, ParamExport, ParamKindExport, TypeRef, resolved_type_from_manifest_type_ref,
 };
 use incan_core::lang::types::collections::{self, CollectionTypeId};
 use incan_core::lang::{rust_keywords, stdlib};
@@ -170,16 +175,20 @@ impl GeneratedUseAnalysis {
 
 #[derive(Clone)]
 pub(super) struct StructConstructorMetadata {
+    dependency: Option<String>,
     fields: Vec<String>,
     field_types: HashMap<String, IrType>,
     field_defaults: HashMap<String, super::IrExpr>,
+    default_fields: HashSet<String>,
     field_aliases: HashMap<String, String>,
+    requires_constructor_function: bool,
 }
 
 impl StructConstructorMetadata {
     /// Build constructor-emission metadata from one lowered source-defined struct.
     fn from_struct(s: &IrStruct) -> Self {
         Self {
+            dependency: None,
             fields: s.fields.iter().map(|field| field.name.clone()).collect(),
             field_types: s
                 .fields
@@ -196,6 +205,12 @@ impl StructConstructorMetadata {
                         .map(|default| (field.name.clone(), default.clone()))
                 })
                 .collect(),
+            default_fields: s
+                .fields
+                .iter()
+                .filter(|field| field.default.is_some())
+                .map(|field| field.name.clone())
+                .collect(),
             field_aliases: s
                 .fields
                 .iter()
@@ -207,6 +222,55 @@ impl StructConstructorMetadata {
                         .map(|alias| (alias.clone(), field.name.clone()))
                 })
                 .collect(),
+            requires_constructor_function: false,
+        }
+    }
+
+    /// Build constructor-emission metadata from one compiled-library export.
+    fn from_manifest_fields(library: &str, fields: &[FieldExport]) -> Self {
+        let requires_constructor_function = fields
+            .iter()
+            .any(|field| matches!(field.visibility, FieldVisibilityExport::Private));
+        Self {
+            dependency: Some(library.to_string()),
+            fields: fields.iter().map(|field| field.name.clone()).collect(),
+            field_types: fields
+                .iter()
+                .map(|field| (field.name.clone(), IrEmitter::manifest_type_ref_to_ir_type(&field.ty)))
+                .collect(),
+            field_defaults: fields
+                .iter()
+                .filter(|_| !requires_constructor_function)
+                .filter_map(|field| {
+                    field
+                        .default
+                        .as_ref()
+                        .and_then(|default| IrEmitter::manifest_default_to_ir_expr(library, default))
+                        .map(|default| (field.name.clone(), default))
+                })
+                .collect(),
+            default_fields: fields
+                .iter()
+                .filter(|field| {
+                    if requires_constructor_function {
+                        field.has_default
+                    } else {
+                        field.default.is_some()
+                    }
+                })
+                .map(|field| field.name.clone())
+                .collect(),
+            field_aliases: fields
+                .iter()
+                .filter_map(|field| {
+                    field
+                        .alias
+                        .as_ref()
+                        .filter(|alias| *alias != &field.name)
+                        .map(|alias| (alias.clone(), field.name.clone()))
+                })
+                .collect(),
+            requires_constructor_function,
         }
     }
 
@@ -232,7 +296,7 @@ impl StructConstructorMetadata {
             .collect::<HashSet<_>>();
         self.fields
             .iter()
-            .all(|field| provided.contains(field.as_str()) || self.field_defaults.contains_key(field))
+            .all(|field| provided.contains(field.as_str()) || self.default_fields.contains(field))
     }
 }
 
@@ -302,6 +366,8 @@ pub struct IrEmitter<'a> {
     struct_field_defaults: std::collections::HashMap<(String, String), super::IrExpr>,
     /// Constructor metadata variants for source-defined structs that share a simple name across modules.
     struct_constructor_metadata: HashMap<String, Vec<StructConstructorMetadata>>,
+    /// Constructor metadata keyed by the exact public dependency and public export spelling.
+    pub_dependency_constructor_metadata: HashMap<(String, String), StructConstructorMetadata>,
     /// Transparent local type aliases keyed by alias name.
     type_aliases: HashMap<String, IrType>,
     /// Incan `rusttype` aliases that should use compiler-owned call conversion rules at the surface boundary.
@@ -435,6 +501,7 @@ impl<'a> IrEmitter<'a> {
             struct_field_descriptions: std::collections::HashMap::new(),
             struct_field_defaults: std::collections::HashMap::new(),
             struct_constructor_metadata: HashMap::new(),
+            pub_dependency_constructor_metadata: HashMap::new(),
             type_aliases: HashMap::new(),
             rusttype_alias_names: HashSet::new(),
             method_signatures: HashMap::new(),
@@ -1059,9 +1126,14 @@ impl<'a> IrEmitter<'a> {
     }
 
     /// True when the generated free constructor function for a struct should be retained.
-    pub(super) fn should_emit_struct_constructor(&self, struct_name: &str) -> bool {
+    pub(super) fn should_emit_struct_constructor(&self, s: &IrStruct) -> bool {
         let analysis = self.generated_use_analysis.borrow();
-        analysis.used_constructors.contains(struct_name)
+        let has_private_fields = s
+            .fields
+            .iter()
+            .any(|field| matches!(field.visibility, Visibility::Private));
+        analysis.used_constructors.contains(&s.name)
+            || (has_private_fields && matches!(s.visibility, Visibility::Public))
     }
 
     /// True when a generated private field needs a narrow `dead_code` expectation because Rust cannot see an
@@ -1181,11 +1253,24 @@ impl<'a> IrEmitter<'a> {
             let Some(LibraryManifestIndexEntry::Loaded { manifest, .. }) = index.get(&library) else {
                 continue;
             };
-            for model in &manifest.exports.models {
-                *counts.entry(model.name.clone()).or_default() += 1;
-            }
-            for class in &manifest.exports.classes {
-                *counts.entry(class.name.clone()).or_default() += 1;
+            let mut public_names = manifest
+                .exports
+                .models
+                .iter()
+                .map(|model| model.name.clone())
+                .chain(manifest.exports.classes.iter().map(|class| class.name.clone()))
+                .chain(manifest.exports.aliases.iter().map(|alias| alias.name.clone()))
+                .collect::<Vec<_>>();
+            public_names.sort();
+            public_names.dedup();
+            for public_name in public_names {
+                if let Some(fields) = Self::manifest_constructor_fields_for_public_name(manifest, &public_name) {
+                    self.pub_dependency_constructor_metadata.insert(
+                        (library.clone(), public_name.clone()),
+                        StructConstructorMetadata::from_manifest_fields(&library, &fields),
+                    );
+                    *counts.entry(public_name).or_default() += 1;
+                }
             }
         }
 
@@ -1193,16 +1278,121 @@ impl<'a> IrEmitter<'a> {
             let Some(LibraryManifestIndexEntry::Loaded { manifest, .. }) = index.get(&library) else {
                 continue;
             };
-            for model in &manifest.exports.models {
-                if counts.get(&model.name).copied().unwrap_or_default() == 1 {
-                    self.register_manifest_constructor_metadata(&model.name, &model.fields);
+            let mut public_names = manifest
+                .exports
+                .models
+                .iter()
+                .map(|model| model.name.clone())
+                .chain(manifest.exports.classes.iter().map(|class| class.name.clone()))
+                .chain(manifest.exports.aliases.iter().map(|alias| alias.name.clone()))
+                .collect::<Vec<_>>();
+            public_names.sort();
+            public_names.dedup();
+            for public_name in public_names {
+                if counts.get(&public_name).copied().unwrap_or_default() == 1
+                    && let Some(fields) = Self::manifest_constructor_fields_for_public_name(manifest, &public_name)
+                {
+                    self.register_manifest_constructor_metadata(&library, &public_name, &fields);
                 }
             }
-            for class in &manifest.exports.classes {
-                if counts.get(&class.name).copied().unwrap_or_default() == 1 {
-                    self.register_manifest_constructor_metadata(&class.name, &class.fields);
-                }
-            }
+        }
+    }
+
+    /// Resolve the constructor fields behind one exact public export, including facade aliases backed by checked API
+    /// metadata.
+    fn manifest_constructor_fields_for_public_name(
+        manifest: &LibraryManifest,
+        public_name: &str,
+    ) -> Option<Vec<FieldExport>> {
+        if let Some(model) = manifest.exports.models.iter().find(|model| model.name == public_name) {
+            return Some(model.fields.clone());
+        }
+        if let Some(class) = manifest.exports.classes.iter().find(|class| class.name == public_name) {
+            return Some(class.fields.clone());
+        }
+        let target_path = manifest
+            .contract_metadata
+            .identity_graph
+            .entry_for_public_name(public_name)
+            .and_then(|entry| entry.target_path())
+            .or_else(|| {
+                manifest
+                    .exports
+                    .aliases
+                    .iter()
+                    .find(|alias| alias.name == public_name)
+                    .map(|alias| alias.target_path.as_slice())
+            })?;
+        if let Some(api) = manifest.contract_metadata.api.as_ref()
+            && let Some(declaration) = Self::api_declaration_for_target_path(api, target_path)
+        {
+            return match declaration {
+                ApiDeclaration::Model(model) => Some(model_export_from_api(model).fields),
+                ApiDeclaration::Class(class) => Some(class_export_from_api(class).fields),
+                _ => None,
+            };
+        }
+        let target_name = target_path.last()?;
+        manifest
+            .exports
+            .models
+            .iter()
+            .find(|model| &model.name == target_name)
+            .map(|model| model.fields.clone())
+            .or_else(|| {
+                manifest
+                    .exports
+                    .classes
+                    .iter()
+                    .find(|class| &class.name == target_name)
+                    .map(|class| class.fields.clone())
+            })
+    }
+
+    /// Resolve one exact checked API declaration from its provider-local identity path.
+    fn api_declaration_for_target_path<'api>(
+        api: &'api crate::frontend::api_metadata::CheckedApiMetadataPackage,
+        target_path: &[String],
+    ) -> Option<&'api ApiDeclaration> {
+        let name = target_path.last()?;
+        let path = target_path.strip_prefix(&["crate".to_string()]).unwrap_or(target_path);
+        let module_path = path.get(..path.len().saturating_sub(1))?;
+        let module = api.modules.iter().find(|module| module.module_path == module_path)?;
+        module.declarations.iter().find(|declaration| match declaration {
+            ApiDeclaration::Model(model) => model.name == *name,
+            ApiDeclaration::Class(class) => class.name == *name,
+            _ => false,
+        })
+    }
+
+    /// Bind exact public dependency constructor metadata to the local names introduced by this program's imports.
+    fn bind_public_dependency_constructor_metadata(&mut self, program: &IrProgram) {
+        let bindings = program
+            .declarations
+            .iter()
+            .filter_map(|decl| {
+                let IrDeclKind::Import {
+                    origin: IrImportOrigin::PubLibrary { dependency_key },
+                    items,
+                    ..
+                } = &decl.kind
+                else {
+                    return None;
+                };
+                Some(items.iter().filter_map(|item| {
+                    self.pub_dependency_constructor_metadata
+                        .get(&(dependency_key.clone(), item.name.clone()))
+                        .cloned()
+                        .map(|metadata| (item.alias.clone().unwrap_or_else(|| item.name.clone()), metadata))
+                }))
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+        for (binding, metadata) in bindings {
+            // An explicit import carries exact package/export identity. Replace any short-name fallback seeded before
+            // this program rather than letting a same-shaped declaration from another dependency win by insertion
+            // order.
+            self.struct_constructor_metadata.insert(binding, vec![metadata]);
         }
     }
 
@@ -1212,7 +1402,9 @@ impl<'a> IrEmitter<'a> {
     /// therefore the sole metadata source for whether a receiver uses Incan call semantics and whether a member is an
     /// enum variant rather than a Rust field access.
     pub(crate) fn seed_sdk_provider_manifest_metadata(&mut self, manifest: &LibraryManifest) {
+        let provider_crate = manifest.name.replace('-', "_");
         self.seed_compiled_provider_export_metadata(
+            &provider_crate,
             &manifest.exports.models,
             &manifest.exports.classes,
             &manifest.exports.enums,
@@ -1257,7 +1449,7 @@ impl<'a> IrEmitter<'a> {
                 }
             }
         }
-        self.seed_compiled_provider_export_metadata(&models, &classes, &enums, &newtypes);
+        self.seed_compiled_provider_export_metadata(&provider_crate, &models, &classes, &enums, &newtypes);
         self.seed_compiled_provider_factory_metadata(&functions, &models, &classes);
     }
 
@@ -1299,17 +1491,18 @@ impl<'a> IrEmitter<'a> {
     /// Seed nominal metadata represented by one artifact export surface.
     fn seed_compiled_provider_export_metadata(
         &mut self,
+        provider_crate: &str,
         models: &[crate::library_manifest::ModelExport],
         classes: &[crate::library_manifest::ClassExport],
         enums: &[crate::library_manifest::EnumExport],
         newtypes: &[NewtypeExport],
     ) {
         for model in models {
-            self.register_manifest_constructor_metadata(&model.name, &model.fields);
+            self.register_manifest_constructor_metadata(provider_crate, &model.name, &model.fields);
             self.register_manifest_method_metadata(&model.name, &model.methods, &model.type_params);
         }
         for class in classes {
-            self.register_manifest_constructor_metadata(&class.name, &class.fields);
+            self.register_manifest_constructor_metadata(provider_crate, &class.name, &class.fields);
             self.register_manifest_method_metadata(&class.name, &class.methods, &class.type_params);
         }
         for enum_ in enums {
@@ -1482,45 +1675,28 @@ impl<'a> IrEmitter<'a> {
     /// Register one struct's constructor metadata unless an equivalent field layout is already known.
     fn register_struct_constructor_metadata(&mut self, s: &IrStruct) {
         let metadata = StructConstructorMetadata::from_struct(s);
-        let variants = self.struct_constructor_metadata.entry(s.name.clone()).or_default();
-        if !variants.iter().any(|existing| existing.fields == metadata.fields) {
+        self.register_constructor_metadata_variant(&s.name, metadata);
+    }
+
+    /// Register one constructor metadata variant under a source-visible binding.
+    fn register_constructor_metadata_variant(&mut self, name: &str, metadata: StructConstructorMetadata) {
+        let variants = self.struct_constructor_metadata.entry(name.to_string()).or_default();
+        if !variants.iter().any(|existing| {
+            existing.dependency == metadata.dependency
+                && existing.fields == metadata.fields
+                && existing.field_types == metadata.field_types
+                && existing.default_fields == metadata.default_fields
+                && existing.field_aliases == metadata.field_aliases
+                && existing.requires_constructor_function == metadata.requires_constructor_function
+        }) {
             variants.push(metadata);
         }
     }
 
     /// Register constructor metadata reconstructed from a public dependency manifest.
-    fn register_manifest_constructor_metadata(&mut self, name: &str, fields: &[FieldExport]) {
-        let metadata = StructConstructorMetadata {
-            fields: fields.iter().map(|field| field.name.clone()).collect(),
-            field_types: fields
-                .iter()
-                .map(|field| (field.name.clone(), Self::manifest_type_ref_to_ir_type(&field.ty)))
-                .collect(),
-            field_defaults: fields
-                .iter()
-                .filter_map(|field| {
-                    field
-                        .default
-                        .as_ref()
-                        .and_then(Self::manifest_default_to_ir_expr)
-                        .map(|default| (field.name.clone(), default))
-                })
-                .collect(),
-            field_aliases: fields
-                .iter()
-                .filter_map(|field| {
-                    field
-                        .alias
-                        .as_ref()
-                        .filter(|alias| *alias != &field.name)
-                        .map(|alias| (alias.clone(), field.name.clone()))
-                })
-                .collect(),
-        };
-        let variants = self.struct_constructor_metadata.entry(name.to_string()).or_default();
-        if !variants.iter().any(|existing| existing.fields == metadata.fields) {
-            variants.push(metadata);
-        }
+    fn register_manifest_constructor_metadata(&mut self, library: &str, name: &str, fields: &[FieldExport]) {
+        let metadata = StructConstructorMetadata::from_manifest_fields(library, fields);
+        self.register_constructor_metadata_variant(name, metadata);
         self.struct_field_names.insert(
             name.to_string(),
             fields.iter().map(|field| field.name.clone()).collect(),
@@ -1538,7 +1714,7 @@ impl<'a> IrEmitter<'a> {
     }
 
     /// Convert manifest-safe field defaults into the IR required by artifact-backed constructors.
-    fn manifest_default_to_ir_expr(default: &ParamDefaultExport) -> Option<TypedExpr> {
+    fn manifest_default_to_ir_expr(library: &str, default: &ParamDefaultExport) -> Option<TypedExpr> {
         match default {
             ParamDefaultExport::Int(value) => Some(TypedExpr::new(IrExprKind::Int(*value), IrType::Int)),
             ParamDefaultExport::Float(value) => value
@@ -1556,7 +1732,7 @@ impl<'a> IrEmitter<'a> {
                 IrExprKind::List(
                     values
                         .iter()
-                        .map(|value| Self::manifest_default_to_ir_expr(value).map(IrListEntry::Element))
+                        .map(|value| Self::manifest_default_to_ir_expr(library, value).map(IrListEntry::Element))
                         .collect::<Option<Vec<_>>>()?,
                 ),
                 IrType::List(Box::new(IrType::Unknown)),
@@ -1567,16 +1743,131 @@ impl<'a> IrEmitter<'a> {
                         .iter()
                         .map(|entry| {
                             Some(IrDictEntry::Pair(
-                                Self::manifest_default_to_ir_expr(&entry.key)?,
-                                Box::new(Self::manifest_default_to_ir_expr(&entry.value)?),
+                                Self::manifest_default_to_ir_expr(library, &entry.key)?,
+                                Box::new(Self::manifest_default_to_ir_expr(library, &entry.value)?),
                             ))
                         })
                         .collect::<Option<Vec<_>>>()?,
                 ),
                 IrType::Dict(Box::new(IrType::Unknown), Box::new(IrType::Unknown)),
             )),
-            ParamDefaultExport::ConstRef(_) | ParamDefaultExport::Call { .. } | ParamDefaultExport::Unsupported => None,
+            ParamDefaultExport::ConstRef(path) => Self::manifest_default_const_ref_to_ir_expr(library, path),
+            ParamDefaultExport::Call { path, args, signature } => {
+                let function_name = path.last()?.clone();
+                let args = args
+                    .iter()
+                    .map(|arg| {
+                        Some(IrCallArg {
+                            name: arg.name.clone(),
+                            kind: if arg.name.is_some() {
+                                IrCallArgKind::Named
+                            } else {
+                                IrCallArgKind::Positional
+                            },
+                            expr: Self::manifest_default_to_ir_expr(library, &arg.value)?,
+                        })
+                    })
+                    .collect::<Option<Vec<_>>>()?;
+                let callable_signature = signature
+                    .as_ref()
+                    .map(|signature| Self::manifest_default_call_signature_to_ir(library, signature));
+                let return_type = callable_signature
+                    .as_ref()
+                    .map(|signature| signature.return_type.clone())
+                    .unwrap_or(IrType::Unknown);
+                let mut canonical_path = vec!["pub".to_string(), library.to_string()];
+                canonical_path.extend(path.iter().cloned());
+                Some(TypedExpr::new(
+                    IrExprKind::Call {
+                        func: Box::new(TypedExpr::new(
+                            IrExprKind::Var {
+                                name: function_name,
+                                access: VarAccess::Read,
+                                ref_kind: VarRefKind::Value,
+                            },
+                            IrType::Unknown,
+                        )),
+                        type_args: Vec::new(),
+                        args,
+                        callable_signature,
+                        canonical_path: Some(canonical_path),
+                    },
+                    return_type,
+                ))
+            }
+            ParamDefaultExport::Unsupported => None,
         }
+    }
+
+    /// Convert a compiled-library constant default into an exact dependency-qualified value path.
+    fn manifest_default_const_ref_to_ir_expr(library: &str, path: &[String]) -> Option<TypedExpr> {
+        if path.is_empty() {
+            return None;
+        }
+        let mut expr = TypedExpr::new(
+            IrExprKind::Var {
+                name: library.to_string(),
+                access: VarAccess::Read,
+                ref_kind: VarRefKind::ExternalName,
+            },
+            IrType::Unknown,
+        );
+        for segment in path {
+            expr = TypedExpr::new(
+                IrExprKind::Field {
+                    object: Box::new(expr),
+                    field: segment.clone(),
+                },
+                IrType::Unknown,
+            );
+        }
+        Some(expr)
+    }
+
+    /// Rebuild the checked callable surface retained for a compiled-library field default helper.
+    fn manifest_default_call_signature_to_ir(
+        library: &str,
+        signature: &ParamDefaultCallSignatureExport,
+    ) -> FunctionSignature {
+        FunctionSignature {
+            params: signature
+                .params
+                .iter()
+                .map(|param| {
+                    let kind = match param.kind {
+                        ParamKindExport::Normal => crate::frontend::ast::ParamKind::Normal,
+                        ParamKindExport::RestPositional => crate::frontend::ast::ParamKind::RestPositional,
+                        ParamKindExport::RestKeyword => crate::frontend::ast::ParamKind::RestKeyword,
+                    };
+                    let base_ty = Self::manifest_type_ref_to_ir_type(&param.ty);
+                    let ty = match kind {
+                        crate::frontend::ast::ParamKind::Normal => base_ty,
+                        crate::frontend::ast::ParamKind::RestPositional => IrType::List(Box::new(base_ty)),
+                        crate::frontend::ast::ParamKind::RestKeyword => {
+                            IrType::Dict(Box::new(IrType::String), Box::new(base_ty))
+                        }
+                    };
+                    FunctionParam {
+                        name: param.name.clone(),
+                        ty,
+                        mutability: Mutability::Immutable,
+                        is_self: false,
+                        kind,
+                        default: Self::manifest_param_default_to_ir_expr(library, param),
+                    }
+                })
+                .collect(),
+            return_type: Self::manifest_type_ref_to_ir_type(&signature.return_type),
+        }
+    }
+
+    /// Lower one nested callable-parameter default retained inside a field-default call signature.
+    fn manifest_param_default_to_ir_expr(library: &str, param: &ParamExport) -> Option<TypedExpr> {
+        param
+            .default
+            .as_ref()
+            .filter(|default| default.is_materializable())
+            .and_then(|default| Self::manifest_default_to_ir_expr(library, default))
     }
 
     /// Convert a public manifest type reference into the IR vocabulary used by emission metadata.
@@ -1730,27 +2021,25 @@ impl<'a> IrEmitter<'a> {
         candidates.first().copied().or_else(|| variants.first())
     }
 
-    /// Select a unique constructor metadata variant by provided fields when an imported type was called through a
-    /// source alias and the IR no longer carries the canonical declaration name.
-    pub(super) fn unique_struct_constructor_metadata_for_fields(
+    /// Select constructor metadata by exact `pub::<dependency>` identity carried on a lowered canonical call path.
+    pub(super) fn public_dependency_constructor_metadata_for_path(
         &self,
+        path: &[String],
         fields: &[(String, TypedExpr)],
     ) -> Option<&StructConstructorMetadata> {
+        if path.first().map(String::as_str) != Some("pub") {
+            return None;
+        }
+        let dependency = path.get(1)?;
+        let public_name = path.last()?;
+        let metadata = self
+            .pub_dependency_constructor_metadata
+            .get(&(dependency.clone(), public_name.clone()))?;
         let provided = fields
             .iter()
             .filter_map(|(field, _)| (!field.is_empty()).then_some(field.as_str()))
             .collect::<HashSet<_>>();
-        let candidates = self
-            .struct_constructor_metadata
-            .values()
-            .flat_map(|variants| variants.iter())
-            .filter(|metadata| metadata.supports_named_fields(&provided) && metadata.constructible_from(&provided))
-            .collect::<Vec<_>>();
-        if candidates.len() == 1 {
-            candidates.first().copied()
-        } else {
-            None
-        }
+        (metadata.supports_named_fields(&provided) && metadata.constructible_from(&provided)).then_some(metadata)
     }
 
     /// Return an Incan-owned method signature for a receiver type when typechecker call-site metadata is unavailable.

--- a/src/backend/ir/emit/program.rs
+++ b/src/backend/ir/emit/program.rs
@@ -2897,6 +2897,7 @@ impl<'a> IrEmitter<'a> {
         if self.rust_module_path.is_none() {
             self.rust_module_path = program.rust_module_path.clone();
         }
+        self.bind_public_dependency_constructor_metadata(program);
         self.seed_nominal_metadata_from_program(program);
         self.newtype_construction = program.newtype_construction.clone();
 

--- a/src/frontend/api_metadata.rs
+++ b/src/frontend/api_metadata.rs
@@ -1007,7 +1007,10 @@ fn api_class(
         traits: export.traits.clone(),
         trait_adoptions: export.trait_adoptions.iter().map(type_bound).collect(),
         derives: export.derives.clone(),
-        fields: fields_in_source_order(&class.fields, &export.fields),
+        // Class export order is the provider's constructor ABI: inherited fields first, then the class's own fields.
+        // Reordering the checked sequence to the child's AST declaration order would make manifest-backed consumers
+        // pass positional bridge arguments in a different order than the generated Rust constructor.
+        fields: export.fields.iter().map(field).collect(),
         methods: methods(
             &class.methods,
             &class.method_aliases,
@@ -1042,6 +1045,7 @@ fn api_trait(
             .map(|(name, ty)| FieldExport {
                 name: name.clone(),
                 ty: type_ref_from_resolved(ty),
+                visibility: crate::library_manifest::FieldVisibilityExport::Public,
                 has_default: false,
                 default: None,
                 alias: None,
@@ -1407,11 +1411,16 @@ fn type_bound(bound: &CheckedTypeBound) -> TypeBoundExport {
 
 /// Convert a checked field into API metadata.
 fn field(field: &crate::frontend::library_exports::CheckedField) -> FieldExport {
+    let default = field.default.as_ref().and_then(param_default_from_checked);
     FieldExport {
         name: field.name.clone(),
         ty: type_ref_from_resolved(&field.ty),
+        visibility: match field.visibility {
+            Visibility::Private => crate::library_manifest::FieldVisibilityExport::Private,
+            Visibility::Public => crate::library_manifest::FieldVisibilityExport::Public,
+        },
         has_default: field.has_default,
-        default: field.default.as_ref().and_then(param_default_from_checked),
+        default,
         alias: field.alias.clone(),
         description: field.description.clone(),
     }

--- a/src/frontend/library_exports.rs
+++ b/src/frontend/library_exports.rs
@@ -92,6 +92,7 @@ pub struct CheckedTypeBound {
 pub struct CheckedField {
     pub name: String,
     pub ty: ResolvedType,
+    pub visibility: Visibility,
     pub has_default: bool,
     pub default: Option<CheckedParamDefault>,
     pub alias: Option<String>,
@@ -1099,13 +1100,24 @@ fn checked_model_export(model: &ModelDecl, checker: &TypeChecker) -> Option<Chec
         return None;
     };
 
+    let defaults = model
+        .fields
+        .iter()
+        .filter_map(|field| {
+            field
+                .node
+                .default
+                .as_ref()
+                .map(|default| (field.node.name.clone(), default.clone()))
+        })
+        .collect();
     Some(CheckedModelExport {
         name: model.name.clone(),
         type_params: checked_type_params(&model.type_params, checker),
         traits: sorted_vec(traits.to_vec()),
         trait_adoptions: sorted_type_bounds(map_type_bound_infos(trait_adoptions)),
         derives: sorted_vec(derives.to_vec()),
-        fields: map_fields(fields, field_order, &model.fields, checker),
+        fields: map_fields(fields, field_order, &defaults, None, checker),
         methods: map_method_overloads_with_defaults(method_overloads, &model.methods, checker),
     })
 }
@@ -1119,6 +1131,8 @@ fn checked_class_export(class: &ClassDecl, checker: &TypeChecker) -> Option<Chec
         trait_adoptions,
         derives,
         fields,
+        field_defaults,
+        field_default_metadata,
         field_order,
         method_overloads,
         ..
@@ -1134,7 +1148,13 @@ fn checked_class_export(class: &ClassDecl, checker: &TypeChecker) -> Option<Chec
         traits: sorted_vec(traits.to_vec()),
         trait_adoptions: sorted_type_bounds(map_type_bound_infos(trait_adoptions)),
         derives: sorted_vec(derives.to_vec()),
-        fields: map_fields(fields, field_order, &class.fields, checker),
+        fields: map_fields(
+            fields,
+            field_order,
+            field_defaults,
+            Some(field_default_metadata),
+            checker,
+        ),
         methods: map_method_overloads_with_defaults(method_overloads, &class.methods, checker),
     })
 }
@@ -1338,22 +1358,24 @@ fn type_args_sort_key(args: &[ResolvedType]) -> String {
 fn map_fields(
     fields: &HashMap<String, FieldInfo>,
     field_order: &[String],
-    source_fields: &[Spanned<crate::frontend::ast::FieldDecl>],
+    default_exprs: &HashMap<String, Spanned<Expr>>,
+    preserved_defaults: Option<&HashMap<String, CheckedParamDefault>>,
     checker: &TypeChecker,
 ) -> Vec<CheckedField> {
-    let defaults = source_fields
+    let mut defaults = default_exprs
         .iter()
-        .map(|field| {
+        .map(|(name, default)| {
             (
-                field.node.name.as_str(),
-                field
-                    .node
-                    .default
-                    .as_ref()
-                    .map(|default| checked_param_default(default, DefaultPathContext::for_checker(checker))),
+                name.as_str(),
+                checked_param_default(default, DefaultPathContext::for_checker(checker)),
             )
         })
         .collect::<HashMap<_, _>>();
+    if let Some(preserved_defaults) = preserved_defaults {
+        for (name, default) in preserved_defaults {
+            defaults.insert(name.as_str(), default.clone());
+        }
+    }
     let mut used = std::collections::HashSet::new();
     let mut entries = Vec::with_capacity(fields.len());
     for name in field_order {
@@ -1362,8 +1384,9 @@ fn map_fields(
             entries.push(CheckedField {
                 name: name.clone(),
                 ty: info.ty.clone(),
-                has_default: info.has_default,
-                default: defaults.get(name.as_str()).cloned().flatten(),
+                visibility: info.visibility,
+                has_default: defaults.contains_key(name.as_str()),
+                default: defaults.get(name.as_str()).cloned(),
                 alias: info.alias.clone(),
                 description: info.description.clone(),
             });
@@ -1377,8 +1400,9 @@ fn map_fields(
     entries.extend(remaining.into_iter().map(|(name, info)| CheckedField {
         name: name.clone(),
         ty: info.ty.clone(),
-        has_default: info.has_default,
-        default: defaults.get(name.as_str()).cloned().flatten(),
+        visibility: info.visibility,
+        has_default: defaults.contains_key(name.as_str()),
+        default: defaults.get(name.as_str()).cloned(),
         alias: info.alias.clone(),
         description: info.description.clone(),
     }));

--- a/src/frontend/symbols.rs
+++ b/src/frontend/symbols.rs
@@ -584,6 +584,19 @@ pub struct ClassInfo {
     pub trait_adoptions: Vec<TypeBoundInfo>,
     pub derives: Vec<String>,
     pub fields: HashMap<String, FieldInfo>,
+    /// Constructor defaults keyed by field name, including inherited fields.
+    ///
+    /// Keeping these with the ordered class metadata lets compiled-library exports preserve the same constructor ABI
+    /// as source lowering instead of trying to recover inherited defaults from the child's own AST fields.
+    /// Boxed because default expressions are AST-heavy metadata and should not inflate every `SymbolKind` variant.
+    pub field_defaults: Box<HashMap<String, crate::frontend::ast::Spanned<crate::frontend::ast::Expr>>>,
+    /// Canonical defaults inherited from compiled-library parents.
+    ///
+    /// Synthetic AST is still retained for ordinary typechecking, but it cannot preserve a manifest call's checked
+    /// signature or distinguish an already-canonical provider path from a child module's local path. This sidecar
+    /// keeps the original checked metadata intact when a local child is exported again, including an `Unsupported`
+    /// sentinel that preserves provider-owned default optionality when the expression cannot cross the manifest.
+    pub field_default_metadata: HashMap<String, crate::frontend::library_exports::CheckedParamDefault>,
     pub field_order: Vec<String>,
     pub properties: HashMap<String, PropertyInfo>,
     pub methods: HashMap<String, MethodInfo>,

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -25,6 +25,9 @@ use self::decl_helpers::{
 
 type InheritedMembers = (
     HashMap<String, FieldInfo>,
+    HashMap<String, Spanned<Expr>>,
+    HashMap<String, crate::frontend::library_exports::CheckedParamDefault>,
+    Vec<String>,
     HashMap<String, PropertyInfo>,
     HashMap<String, MethodInfo>,
     HashMap<String, Vec<MethodInfo>>,
@@ -576,15 +579,30 @@ impl TypeChecker {
 
     /// Register a class declaration, inheriting from parent if present.
     fn collect_class(&mut self, class: &ClassDecl, span: Span) {
-        let (mut fields, mut properties, mut methods, mut method_overloads) = self.inherit_from_parent(&class.extends);
+        let (
+            mut fields,
+            mut field_defaults,
+            mut field_default_metadata,
+            mut field_order,
+            mut properties,
+            mut methods,
+            mut method_overloads,
+        ) = self.inherit_from_parent(&class.extends);
 
         // Add own fields (can override inherited ones)
         fields.extend(collect_fields(&class.fields, self, &class.name, &class.type_params));
-        let field_order = class
-            .fields
-            .iter()
-            .map(|field| field.node.name.clone())
-            .collect::<Vec<_>>();
+        for field in &class.fields {
+            if !field_order.iter().any(|name| name == &field.node.name) {
+                field_order.push(field.node.name.clone());
+            }
+            if let Some(default) = &field.node.default {
+                field_defaults.insert(field.node.name.clone(), default.clone());
+                field_default_metadata.remove(&field.node.name);
+            } else {
+                field_defaults.remove(&field.node.name);
+                field_default_metadata.remove(&field.node.name);
+            }
+        }
         properties.extend(collect_properties(
             &class.properties,
             self,
@@ -614,6 +632,8 @@ impl TypeChecker {
                 trait_adoptions,
                 derives,
                 fields,
+                field_defaults: Box::new(field_defaults),
+                field_default_metadata,
                 field_order,
                 properties,
                 methods,
@@ -628,13 +648,32 @@ impl TypeChecker {
     /// Inherit fields and methods from a parent class if present.
     fn inherit_from_parent(&self, extends: &Option<String>) -> InheritedMembers {
         let Some(parent_name) = extends else {
-            return (HashMap::new(), HashMap::new(), HashMap::new(), HashMap::new());
+            return (
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                Vec::new(),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+            );
         };
         let Some(TypeInfo::Class(parent_info)) = self.lookup_type_info(parent_name) else {
-            return (HashMap::new(), HashMap::new(), HashMap::new(), HashMap::new());
+            return (
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                Vec::new(),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+            );
         };
         (
             parent_info.fields.clone(),
+            parent_info.field_defaults.as_ref().clone(),
+            parent_info.field_default_metadata.clone(),
+            parent_info.field_order.clone(),
             parent_info.properties.clone(),
             parent_info.methods.clone(),
             parent_info.method_overloads.clone(),

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -12,6 +12,7 @@ use crate::frontend::api_metadata::{
 };
 use crate::frontend::ast::*;
 use crate::frontend::diagnostics::errors;
+use crate::frontend::library_exports::{CheckedParamDefault, CheckedParamDefaultArg, CheckedParamDefaultCallSignature};
 use crate::frontend::library_manifest_index::{LibraryManifestFailureKind, LibraryManifestIndexEntry};
 use crate::frontend::module::{ExportedSymbol, canonicalize_source_module_segments};
 use crate::frontend::symbols::*;
@@ -2126,7 +2127,7 @@ impl TypeChecker {
             traits: export.traits.clone(),
             trait_adoptions: Self::trait_adoptions_from_manifest(&export.traits, &export.trait_adoptions),
             derives: export.derives.clone(),
-            fields: self.fields_from_manifest(&export.fields),
+            fields: self.fields_from_manifest(&export.name, &export.fields, false),
             field_order: export.fields.iter().map(|field| field.name.clone()).collect(),
             properties: std::collections::HashMap::new(),
             method_overloads,
@@ -2145,13 +2146,144 @@ impl TypeChecker {
             traits: export.traits.clone(),
             trait_adoptions: Self::trait_adoptions_from_manifest(&export.traits, &export.trait_adoptions),
             derives: export.derives.clone(),
-            fields: self.fields_from_manifest(&export.fields),
+            fields: self.fields_from_manifest(
+                &export.name,
+                &export.fields,
+                export.fields.iter().any(|field| {
+                    matches!(
+                        field.visibility,
+                        crate::library_manifest::FieldVisibilityExport::Private
+                    )
+                }),
+            ),
+            field_defaults: Box::new(
+                export
+                    .fields
+                    .iter()
+                    .filter_map(|field| {
+                        field.default.as_ref().and_then(|default| {
+                            Self::manifest_param_default_expr(default, Span::default())
+                                .map(|expr| (field.name.clone(), expr))
+                        })
+                    })
+                    .collect(),
+            ),
+            field_default_metadata: export
+                .fields
+                .iter()
+                .filter_map(|field| {
+                    field.default.as_ref().map_or_else(
+                        || {
+                            field
+                                .has_default
+                                .then(|| (field.name.clone(), CheckedParamDefault::Unsupported))
+                        },
+                        |default| Some((field.name.clone(), self.checked_param_default_from_manifest(default))),
+                    )
+                })
+                .collect(),
             field_order: export.fields.iter().map(|field| field.name.clone()).collect(),
             properties: std::collections::HashMap::new(),
             method_overloads,
             methods,
             method_aliases: Self::method_aliases_from_manifest(&export.methods),
         }
+    }
+
+    /// Preserve a compiled-library field default in the checked export vocabulary without reparsing or rebasing it.
+    fn checked_param_default_from_manifest(&self, default: &ParamDefaultExport) -> CheckedParamDefault {
+        match default {
+            ParamDefaultExport::Int(value) => CheckedParamDefault::Int(*value),
+            ParamDefaultExport::Float(value) => value
+                .parse::<f64>()
+                .map(CheckedParamDefault::Float)
+                .unwrap_or(CheckedParamDefault::Unsupported),
+            ParamDefaultExport::Bool(value) => CheckedParamDefault::Bool(*value),
+            ParamDefaultExport::String(value) => CheckedParamDefault::String(value.clone()),
+            ParamDefaultExport::Bytes(value) => CheckedParamDefault::Bytes(value.clone()),
+            ParamDefaultExport::None => CheckedParamDefault::None,
+            ParamDefaultExport::List(values) => CheckedParamDefault::List(
+                values
+                    .iter()
+                    .map(|value| self.checked_param_default_from_manifest(value))
+                    .collect(),
+            ),
+            ParamDefaultExport::Dict(entries) => CheckedParamDefault::Dict(
+                entries
+                    .iter()
+                    .map(|entry| {
+                        (
+                            self.checked_param_default_from_manifest(&entry.key),
+                            self.checked_param_default_from_manifest(&entry.value),
+                        )
+                    })
+                    .collect(),
+            ),
+            ParamDefaultExport::ConstRef(path) => CheckedParamDefault::ConstRef(path.clone()),
+            ParamDefaultExport::Call { path, args, signature } => CheckedParamDefault::Call {
+                path: path.clone(),
+                args: args
+                    .iter()
+                    .map(|arg| CheckedParamDefaultArg {
+                        name: arg.name.clone(),
+                        value: self.checked_param_default_from_manifest(&arg.value),
+                    })
+                    .collect(),
+                signature: signature.as_ref().map(|signature| CheckedParamDefaultCallSignature {
+                    params: self.params_from_manifest(&signature.params),
+                    return_type: resolved_type_from_manifest_type_ref(&signature.return_type),
+                }),
+            },
+            ParamDefaultExport::Unsupported => CheckedParamDefault::Unsupported,
+        }
+    }
+
+    /// Rebuild a manifest-safe field default as synthetic source metadata for inherited constructor exports.
+    fn manifest_param_default_expr(default: &ParamDefaultExport, span: Span) -> Option<Spanned<Expr>> {
+        let expr = match default {
+            ParamDefaultExport::Int(value) => Expr::Literal(Literal::Int(IntLiteral::synthetic(*value))),
+            ParamDefaultExport::Float(value) => Expr::Literal(Literal::Float(FloatLiteral {
+                value: value.parse().ok()?,
+                repr: value.clone(),
+            })),
+            ParamDefaultExport::Bool(value) => Expr::Literal(Literal::Bool(*value)),
+            ParamDefaultExport::String(value) => Expr::Literal(Literal::String(value.clone())),
+            ParamDefaultExport::Bytes(value) => Expr::Literal(Literal::Bytes(value.clone())),
+            ParamDefaultExport::None => Expr::Literal(Literal::None),
+            ParamDefaultExport::List(values) => Expr::List(
+                values
+                    .iter()
+                    .map(|value| Self::manifest_param_default_expr(value, span).map(ListEntry::Element))
+                    .collect::<Option<Vec<_>>>()?,
+            ),
+            ParamDefaultExport::Dict(entries) => Expr::Dict(
+                entries
+                    .iter()
+                    .map(|entry| {
+                        Some(DictEntry::Pair(
+                            Self::manifest_param_default_expr(&entry.key, span)?,
+                            Self::manifest_param_default_expr(&entry.value, span)?,
+                        ))
+                    })
+                    .collect::<Option<Vec<_>>>()?,
+            ),
+            ParamDefaultExport::ConstRef(path) => Self::manifest_const_ref_expr(path, span)?.node,
+            ParamDefaultExport::Call { path, args, .. } => Expr::Call(
+                Box::new(Self::manifest_const_ref_expr(path, span)?),
+                Vec::new(),
+                args.iter()
+                    .map(|arg| {
+                        let value = Self::manifest_param_default_expr(&arg.value, span)?;
+                        Some(match &arg.name {
+                            Some(name) => CallArg::Named(name.clone(), value),
+                            None => CallArg::Positional(value),
+                        })
+                    })
+                    .collect::<Option<Vec<_>>>()?,
+            ),
+            ParamDefaultExport::Unsupported => return None,
+        };
+        Some(Spanned::new(expr, span))
     }
 
     /// Convert one manifest trait export into semantic trait metadata.
@@ -2453,7 +2585,12 @@ impl TypeChecker {
     }
 
     /// Convert exported manifest fields into semantic field metadata for imported-library typechecking.
-    fn fields_from_manifest(&self, fields: &[FieldExport]) -> std::collections::HashMap<String, FieldInfo> {
+    fn fields_from_manifest(
+        &self,
+        owner: &str,
+        fields: &[FieldExport],
+        uses_provider_constructor_bridge: bool,
+    ) -> std::collections::HashMap<String, FieldInfo> {
         fields
             .iter()
             .map(|field| {
@@ -2461,9 +2598,23 @@ impl TypeChecker {
                     field.name.clone(),
                     FieldInfo {
                         ty: resolved_type_from_manifest_type_ref(&field.ty),
-                        visibility: crate::frontend::ast::Visibility::Public,
-                        owner: None,
-                        has_default: field.has_default,
+                        visibility: match field.visibility {
+                            crate::library_manifest::FieldVisibilityExport::Private => {
+                                crate::frontend::ast::Visibility::Private
+                            }
+                            crate::library_manifest::FieldVisibilityExport::Public => {
+                                crate::frontend::ast::Visibility::Public
+                            }
+                        },
+                        owner: Some(owner.to_string()),
+                        has_default: if uses_provider_constructor_bridge {
+                            field.has_default
+                        } else {
+                            field
+                                .default
+                                .as_ref()
+                                .is_some_and(ParamDefaultExport::is_materializable)
+                        },
                         alias: field.alias.clone(),
                         description: field.description.clone(),
                     },

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -4306,6 +4306,8 @@ impl TypeChecker {
                         trait_adoptions: Vec::new(),
                         derives: Vec::new(),
                         fields: HashMap::new(),
+                        field_defaults: Box::new(HashMap::new()),
+                        field_default_metadata: HashMap::new(),
                         field_order: Vec::new(),
                         properties: HashMap::new(),
                         methods: HashMap::new(),

--- a/src/frontend/typechecker/stdlib_loader.rs
+++ b/src/frontend/typechecker/stdlib_loader.rs
@@ -1024,6 +1024,20 @@ fn extract_type_signatures(program: &ast::Program) -> Vec<(String, TypeInfo)> {
                         trait_adoptions: trait_adoption_infos_from_bounds(&class.traits, &tp_names, &stdlib_imports),
                         derives: Vec::new(),
                         fields: extract_field_signatures(&class.name, &class.fields, &tp_names, &rust_imports),
+                        field_defaults: Box::new(
+                            class
+                                .fields
+                                .iter()
+                                .filter_map(|field| {
+                                    field
+                                        .node
+                                        .default
+                                        .as_ref()
+                                        .map(|default| (field.node.name.clone(), default.clone()))
+                                })
+                                .collect(),
+                        ),
+                        field_default_metadata: HashMap::new(),
                         field_order: class.fields.iter().map(|field| field.node.name.clone()).collect(),
                         properties: std::collections::HashMap::new(),
                         method_overloads,

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -17,7 +17,7 @@ use crate::frontend::testing_markers::TestingFixtureScope;
 use crate::frontend::{lexer, parser};
 use crate::library_manifest::{
     AliasExport, ClassExport, ConstExport, EnumExport, EnumValueExport, EnumValueTypeExport, EnumVariantExport,
-    ExportIdentity, ExportIdentityKind, ExportIdentityProjection, FunctionExport,
+    ExportIdentity, ExportIdentityKind, ExportIdentityProjection, FieldExport, FieldVisibilityExport, FunctionExport,
     LIBRARY_IDENTITY_GRAPH_SCHEMA_VERSION, LibraryContractMetadata, LibraryExports, LibraryIdentityGraph,
     LibraryManifest, LibraryRustAbi, MethodExport, ModelExport, ParamDefaultCallArgExport,
     ParamDefaultCallSignatureExport, ParamDefaultExport, ParamExport, ParamKindExport, PartialExport,
@@ -101,6 +101,17 @@ fn check_str_err(source: &str, context: &str) -> Vec<CompileError> {
     match check_str(source) {
         Err(errs) => errs,
         Ok(()) => panic!("{context}"),
+    }
+}
+
+fn check_str_with_library_index_err(
+    source: &str,
+    library_index: LibraryManifestIndex,
+    context: &str,
+) -> Result<Vec<CompileError>, String> {
+    match check_str_with_library_index(source, library_index) {
+        Err(errs) => Ok(errs),
+        Ok(()) => Err(context.to_string()),
     }
 }
 
@@ -1922,6 +1933,85 @@ fn library_index_with_mylib_exports() -> LibraryManifestIndex {
         LibraryManifestIndexEntry::Loaded {
             manifest: Box::new(manifest),
             metadata: LibraryArtifactMetadata::from_crate_root("mylib", "mylib", synthetic_artifact_root("mylib")),
+        },
+    )]))
+}
+
+fn library_index_with_private_class_field_issue883() -> LibraryManifestIndex {
+    let mut manifest = LibraryManifest::new("sealed_class_lib", "0.1.0");
+    manifest.exports.classes.push(ClassExport {
+        name: "Vault".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        traits: Vec::new(),
+        trait_adoptions: Vec::new(),
+        derives: Vec::new(),
+        fields: vec![
+            FieldExport {
+                name: "secret".to_string(),
+                ty: TypeRef::Named {
+                    name: "str".to_string(),
+                },
+                visibility: FieldVisibilityExport::Private,
+                has_default: false,
+                default: None,
+                alias: None,
+                description: None,
+            },
+            FieldExport {
+                name: "label".to_string(),
+                ty: TypeRef::Named {
+                    name: "str".to_string(),
+                },
+                visibility: FieldVisibilityExport::Public,
+                has_default: true,
+                default: Some(ParamDefaultExport::Call {
+                    path: vec!["defaults".to_string(), "make_label".to_string()],
+                    args: vec![ParamDefaultCallArgExport {
+                        name: None,
+                        value: ParamDefaultExport::ConstRef(vec!["defaults".to_string(), "FALLBACK".to_string()]),
+                    }],
+                    signature: Some(ParamDefaultCallSignatureExport {
+                        params: vec![ParamExport {
+                            name: "value".to_string(),
+                            ty: TypeRef::Named {
+                                name: "str".to_string(),
+                            },
+                            kind: ParamKindExport::Normal,
+                            has_default: false,
+                            default: None,
+                        }],
+                        return_type: TypeRef::Named {
+                            name: "str".to_string(),
+                        },
+                    }),
+                }),
+                alias: None,
+                description: None,
+            },
+            FieldExport {
+                name: "computed_secret".to_string(),
+                ty: TypeRef::Named {
+                    name: "int".to_string(),
+                },
+                visibility: FieldVisibilityExport::Private,
+                has_default: true,
+                default: None,
+                alias: None,
+                description: None,
+            },
+        ],
+        methods: Vec::new(),
+    });
+    LibraryManifestIndex::from_entries(HashMap::from([(
+        "sealed_class_lib".to_string(),
+        LibraryManifestIndexEntry::Loaded {
+            manifest: Box::new(manifest),
+            metadata: LibraryArtifactMetadata::from_crate_root(
+                "sealed_class_lib",
+                "sealed_class_lib",
+                synthetic_artifact_root("private_class_field_issue883"),
+            ),
         },
     )]))
 }
@@ -13027,6 +13117,137 @@ def build() -> Widget:
 "#;
     let result = check_str_with_library_index(source, library_index_with_mylib_exports());
     assert!(result.is_ok(), "expected pub import to typecheck, got: {result:?}");
+}
+
+#[test]
+fn test_pub_imported_private_class_field_access_is_rejected_issue883() -> Result<(), String> {
+    let source = r#"
+from pub::sealed_class_lib import Vault
+
+def leak(value: Vault) -> str:
+  return value.secret
+"#;
+    let errors = check_str_with_library_index_err(
+        source,
+        library_index_with_private_class_field_issue883(),
+        "compiled-library private class field access should fail typechecking",
+    )?;
+    assert!(
+        has_private_field_error(&errors, "Vault", "secret"),
+        "expected private field error, got: {:?}",
+        errors.iter().map(|error| &error.message).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pub_imported_private_parent_field_access_is_rejected_in_child_issue883() -> Result<(), String> {
+    let source = r#"
+from pub::sealed_class_lib import Vault
+
+class Child extends Vault:
+  def leak(self) -> str:
+    return self.secret
+"#;
+    let errors = check_str_with_library_index_err(
+        source,
+        library_index_with_private_class_field_issue883(),
+        "compiled-library private parent field access should fail in a child method",
+    )?;
+    assert!(
+        has_private_field_error(&errors, "Child", "secret"),
+        "expected imported parent private field error, got: {:?}",
+        errors.iter().map(|error| &error.message).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pub_imported_class_preserves_public_access_and_named_construction_issue883() {
+    let source = r#"
+from pub::sealed_class_lib import Vault
+
+def build() -> Vault:
+  return Vault(secret="authority", label="sealed")
+
+def label(value: Vault) -> str:
+  return value.label
+"#;
+    let result = check_str_with_library_index(source, library_index_with_private_class_field_issue883());
+    assert!(
+        result.is_ok(),
+        "expected public access and existing named construction to typecheck, got: {result:?}"
+    );
+}
+
+#[test]
+fn test_imported_parent_field_default_keeps_provider_path_and_signature_issue883()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from pub::sealed_class_lib import Vault
+
+pub class Child extends Vault:
+  pub marker: int = 1
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(vec!["child".to_string()]));
+    checker.set_library_manifest_index(library_index_with_private_class_field_issue883());
+    checker
+        .check_program(&ast)
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+
+    let exports = collect_checked_public_exports(&ast, &checker);
+    let manifest = LibraryManifest::from_checked_exports("child_lib".to_string(), "0.1.0".to_string(), &exports);
+    let child = manifest
+        .exports
+        .classes
+        .iter()
+        .find(|class| class.name == "Child")
+        .ok_or("missing Child export")?;
+    let label = child
+        .fields
+        .iter()
+        .find(|field| field.name == "label")
+        .ok_or("missing inherited label field")?;
+
+    assert_eq!(
+        label.default,
+        Some(ParamDefaultExport::Call {
+            path: vec!["defaults".to_string(), "make_label".to_string()],
+            args: vec![ParamDefaultCallArgExport {
+                name: None,
+                value: ParamDefaultExport::ConstRef(vec!["defaults".to_string(), "FALLBACK".to_string()]),
+            }],
+            signature: Some(ParamDefaultCallSignatureExport {
+                params: vec![ParamExport {
+                    name: "value".to_string(),
+                    ty: TypeRef::Named {
+                        name: "str".to_string(),
+                    },
+                    kind: ParamKindExport::Normal,
+                    has_default: false,
+                    default: None,
+                }],
+                return_type: TypeRef::Named {
+                    name: "str".to_string(),
+                },
+            }),
+        }),
+        "compiled parent defaults must retain their original provider path and checked call signature"
+    );
+    let computed_secret = child
+        .fields
+        .iter()
+        .find(|field| field.name == "computed_secret")
+        .ok_or("missing inherited computed_secret field")?;
+    assert!(
+        computed_secret.has_default,
+        "compiled parent defaults that are provider-owned but not consumer-materializable must retain bridge optionality"
+    );
+    assert_eq!(computed_secret.default, None);
+    Ok(())
 }
 
 #[test]

--- a/src/library_manifest/model.rs
+++ b/src/library_manifest/model.rs
@@ -696,6 +696,12 @@ pub enum TypeRef {
 pub struct FieldExport {
     pub name: String,
     pub ty: TypeRef,
+    /// Source-level field visibility enforced for compiled-library consumers.
+    ///
+    /// Older manifests omitted this field and exposed every recorded field to consumers, so absence remains public for
+    /// backward compatibility. New manifests only need to serialize the private case.
+    #[serde(default, skip_serializing_if = "FieldVisibilityExport::is_public")]
+    pub visibility: FieldVisibilityExport,
     /// Whether the field has a declared default value.
     pub has_default: bool,
     /// Materializable source default used when a consumer constructs this type through the artifact boundary.
@@ -705,6 +711,27 @@ pub struct FieldExport {
     pub alias: Option<String>,
     /// Optional human-readable field description.
     pub description: Option<String>,
+}
+
+/// Source-level visibility of a model or class field published through a library manifest.
+///
+/// Public models currently emit public fields only. Private visibility is valid for class fields; manifest validation
+/// rejects private model fields until the language defines that source state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FieldVisibilityExport {
+    /// Access is limited to the declaring class's own methods.
+    Private,
+    /// Access is available to source and compiled-library consumers.
+    #[default]
+    Public,
+}
+
+impl FieldVisibilityExport {
+    /// Return whether this field retains the legacy public consumer behavior.
+    fn is_public(&self) -> bool {
+        matches!(self, Self::Public)
+    }
 }
 
 /// Receiver mutability for an exported method.
@@ -1573,11 +1600,16 @@ fn method_from_checked(method: &crate::frontend::library_exports::CheckedMethod)
 
 /// Convert checked field metadata into artifact metadata, including a materializable default when available.
 fn field_from_checked(field: &crate::frontend::library_exports::CheckedField) -> FieldExport {
+    let default = field.default.as_ref().and_then(param_default_from_checked);
     FieldExport {
         name: field.name.clone(),
         ty: type_ref_from_resolved(&field.ty),
+        visibility: match field.visibility {
+            crate::frontend::ast::Visibility::Private => FieldVisibilityExport::Private,
+            crate::frontend::ast::Visibility::Public => FieldVisibilityExport::Public,
+        },
         has_default: field.has_default,
-        default: field.default.as_ref().and_then(param_default_from_checked),
+        default,
         alias: field.alias.clone(),
         description: field.description.clone(),
     }

--- a/src/library_manifest/tests.rs
+++ b/src/library_manifest/tests.rs
@@ -1,5 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::frontend::api_metadata::{
+    ApiDeclaration, ApiModel, ApiTrait, CHECKED_API_METADATA_SCHEMA_VERSION, CheckedApiMetadata,
+    CheckedApiMetadataPackage, SourceAnchor, SourceSpan,
+};
+
 use super::*;
 
 #[test]
@@ -57,6 +62,230 @@ fn manifest_io_round_trip_preserves_recursive_types_and_bounds() -> Result<(), B
     let loaded = LibraryManifest::read_from_path(&path)?;
 
     assert_eq!(loaded, manifest);
+    Ok(())
+}
+
+#[test]
+fn manifest_io_preserves_private_class_field_visibility_issue883() -> Result<(), Box<dyn std::error::Error>> {
+    let checked_class = crate::frontend::library_exports::CheckedClassExport {
+        name: "Vault".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        traits: Vec::new(),
+        trait_adoptions: Vec::new(),
+        derives: Vec::new(),
+        fields: vec![
+            crate::frontend::library_exports::CheckedField {
+                name: "secret".to_string(),
+                ty: crate::frontend::symbols::ResolvedType::Str,
+                visibility: crate::frontend::ast::Visibility::Private,
+                has_default: false,
+                default: None,
+                alias: None,
+                description: None,
+            },
+            crate::frontend::library_exports::CheckedField {
+                name: "label".to_string(),
+                ty: crate::frontend::symbols::ResolvedType::Str,
+                visibility: crate::frontend::ast::Visibility::Public,
+                has_default: false,
+                default: None,
+                alias: None,
+                description: None,
+            },
+        ],
+        methods: Vec::new(),
+    };
+    let manifest = LibraryManifest::from_checked_exports(
+        "sealed_class_lib",
+        "0.1.0",
+        &[crate::frontend::library_exports::CheckedNamedExport {
+            name: "Vault".to_string(),
+            identity: crate::frontend::library_exports::CheckedExportIdentity::direct(vec!["Vault".to_string()]),
+            kind: crate::frontend::library_exports::CheckedExportKind::Class(checked_class),
+        }],
+    );
+
+    let tmp = tempfile::tempdir()?;
+    let path = tmp.path().join("sealed_class_lib.incnlib");
+    manifest.write_to_path(&path)?;
+    let content = std::fs::read_to_string(&path)?;
+    let loaded = LibraryManifest::read_from_path(&path)?;
+
+    assert!(
+        content.contains(r#""visibility": "private""#),
+        "expected private visibility in manifest:\n{content}"
+    );
+    assert!(
+        !content.contains(r#""visibility": "public""#),
+        "public visibility should retain the compact legacy representation:\n{content}"
+    );
+    assert_eq!(loaded, manifest);
+    assert_eq!(
+        loaded.exports.classes[0].fields[0].visibility,
+        FieldVisibilityExport::Private
+    );
+    assert_eq!(
+        loaded.exports.classes[0].fields[1].visibility,
+        FieldVisibilityExport::Public
+    );
+    Ok(())
+}
+
+#[test]
+fn legacy_manifest_fields_without_visibility_remain_public_issue883() -> Result<(), Box<dyn std::error::Error>> {
+    let mut manifest = LibraryManifest::new("legacy_class_lib", "0.1.0");
+    manifest.exports.classes.push(ClassExport {
+        name: "Legacy".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        traits: Vec::new(),
+        trait_adoptions: Vec::new(),
+        derives: Vec::new(),
+        fields: vec![FieldExport {
+            name: "value".to_string(),
+            ty: TypeRef::Named {
+                name: "str".to_string(),
+            },
+            visibility: FieldVisibilityExport::Public,
+            has_default: false,
+            default: None,
+            alias: None,
+            description: None,
+        }],
+        methods: Vec::new(),
+    });
+
+    let tmp = tempfile::tempdir()?;
+    let path = tmp.path().join("legacy_class_lib.incnlib");
+    manifest.write_to_path(&path)?;
+    let content = std::fs::read_to_string(&path)?;
+    assert!(
+        !content.contains("visibility"),
+        "legacy-compatible public field should omit visibility"
+    );
+
+    let loaded = LibraryManifest::from_json_str(&content)?;
+    assert_eq!(
+        loaded.exports.classes[0].fields[0].visibility,
+        FieldVisibilityExport::Public
+    );
+    Ok(())
+}
+
+#[test]
+fn manifest_rejects_unsupported_private_model_field_visibility_issue883() -> Result<(), Box<dyn std::error::Error>> {
+    let mut manifest = LibraryManifest::new("private_model_lib", "0.1.0");
+    manifest.exports.models.push(ModelExport {
+        name: "Record".to_string(),
+        type_params: Vec::new(),
+        traits: Vec::new(),
+        trait_adoptions: Vec::new(),
+        derives: Vec::new(),
+        fields: vec![FieldExport {
+            name: "secret".to_string(),
+            ty: TypeRef::Named {
+                name: "str".to_string(),
+            },
+            visibility: FieldVisibilityExport::Private,
+            has_default: false,
+            default: None,
+            alias: None,
+            description: None,
+        }],
+        methods: Vec::new(),
+    });
+
+    let tmp = tempfile::tempdir()?;
+    let error = manifest.write_to_path(&tmp.path().join("private_model_lib.incnlib"));
+    assert!(
+        matches!(error, Err(LibraryManifestError::Invalid(ref message)) if message.contains("model `Record` field `secret` cannot be private")),
+        "expected unsupported private model field visibility to fail validation, got: {error:?}"
+    );
+    Ok(())
+}
+
+fn private_api_field_issue883() -> FieldExport {
+    FieldExport {
+        name: "secret".to_string(),
+        ty: TypeRef::Named {
+            name: "str".to_string(),
+        },
+        visibility: FieldVisibilityExport::Private,
+        has_default: false,
+        default: None,
+        alias: None,
+        description: None,
+    }
+}
+
+fn api_anchor_issue883(name: &str) -> SourceAnchor {
+    SourceAnchor {
+        id: format!("private_api.{name}"),
+        span: SourceSpan { start: 0, end: 1 },
+    }
+}
+
+fn manifest_with_api_declaration_issue883(declaration: ApiDeclaration) -> LibraryManifest {
+    let mut manifest = LibraryManifest::new("private_api_lib", "0.1.0");
+    manifest.contract_metadata.api = Some(CheckedApiMetadataPackage {
+        schema_version: CHECKED_API_METADATA_SCHEMA_VERSION,
+        package: None,
+        modules: vec![CheckedApiMetadata {
+            schema_version: CHECKED_API_METADATA_SCHEMA_VERSION,
+            module_path: vec!["private_api".to_string()],
+            declarations: vec![declaration],
+        }],
+    });
+    manifest
+}
+
+#[test]
+fn manifest_rejects_private_model_field_in_embedded_api_metadata_issue883() -> Result<(), Box<dyn std::error::Error>> {
+    let manifest = manifest_with_api_declaration_issue883(ApiDeclaration::Model(ApiModel {
+        name: "Record".to_string(),
+        anchor: api_anchor_issue883("Record"),
+        docstring: None,
+        docstring_sections: None,
+        decorators: Vec::new(),
+        type_params: Vec::new(),
+        traits: Vec::new(),
+        trait_adoptions: Vec::new(),
+        derives: Vec::new(),
+        fields: vec![private_api_field_issue883()],
+        methods: Vec::new(),
+    }));
+
+    let tmp = tempfile::tempdir()?;
+    let error = manifest.write_to_path(&tmp.path().join("private_api_model.incnlib"));
+    assert!(
+        matches!(error, Err(LibraryManifestError::Invalid(ref message)) if message.contains("API model `Record` field `secret` cannot be private")),
+        "expected embedded private API model field to fail validation, got: {error:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn manifest_rejects_private_trait_requirement_in_embedded_api_metadata_issue883()
+-> Result<(), Box<dyn std::error::Error>> {
+    let manifest = manifest_with_api_declaration_issue883(ApiDeclaration::Trait(ApiTrait {
+        name: "RequiresSecret".to_string(),
+        anchor: api_anchor_issue883("RequiresSecret"),
+        docstring: None,
+        docstring_sections: None,
+        decorators: Vec::new(),
+        type_params: Vec::new(),
+        supertraits: Vec::new(),
+        requires: vec![private_api_field_issue883()],
+        methods: Vec::new(),
+    }));
+
+    let tmp = tempfile::tempdir()?;
+    let error = manifest.write_to_path(&tmp.path().join("private_api_trait.incnlib"));
+    assert!(
+        matches!(error, Err(LibraryManifestError::Invalid(ref message)) if message.contains("API trait `RequiresSecret` required field `secret` cannot be private")),
+        "expected embedded private API trait requirement to fail validation, got: {error:?}"
+    );
     Ok(())
 }
 

--- a/src/library_manifest/validation.rs
+++ b/src/library_manifest/validation.rs
@@ -13,21 +13,61 @@ use semver::Version;
 use super::wire::{RawLibraryExports, RawLibraryManifest};
 use super::{
     COMPILED_PROVIDER_METADATA_SCHEMA_VERSION, CompiledProviderMetadata, EnumExport, EnumValueExport,
-    EnumValueTypeExport, LIBRARY_MANIFEST_FORMAT, LibraryManifestError, ParamExport, ParamKindExport, PartialExport,
-    ProviderCargoDependencySource, RUST_ABI_SCHEMA_VERSION, VocabProviderManifest,
+    EnumValueTypeExport, FieldVisibilityExport, LIBRARY_MANIFEST_FORMAT, LibraryManifestError, ParamExport,
+    ParamKindExport, PartialExport, ProviderCargoDependencySource, RUST_ABI_SCHEMA_VERSION, VocabProviderManifest,
 };
-use crate::frontend::api_metadata::CHECKED_API_METADATA_SCHEMA_VERSION;
+use crate::frontend::api_metadata::{ApiDeclaration, CHECKED_API_METADATA_SCHEMA_VERSION};
 use crate::frontend::contract_metadata::CONTRACT_METADATA_SCHEMA_VERSION;
 
 /// Validate one raw manifest payload before it is written or decoded into the semantic model.
 pub(super) fn validate_raw_manifest(raw: &RawLibraryManifest) -> Result<(), LibraryManifestError> {
     validate_manifest_version(raw)?;
+    validate_field_visibilities(raw)?;
     validate_callable_param_exports(&raw.exports)?;
     validate_value_enum_exports(&raw.exports)?;
     validate_contract_metadata(raw)?;
     validate_rust_abi(raw)?;
     validate_vocab_payload(raw)?;
     validate_soft_keyword_activations(raw)?;
+    Ok(())
+}
+
+/// Reject field-visibility states that the current source language cannot author or enforce.
+fn validate_field_visibilities(raw: &RawLibraryManifest) -> Result<(), LibraryManifestError> {
+    for model in &raw.exports.models {
+        reject_private_fields(&format!("model `{}`", model.name), &model.fields)?;
+    }
+    if let Some(api) = &raw.contract_metadata.api {
+        for module in &api.modules {
+            for declaration in &module.declarations {
+                match declaration {
+                    ApiDeclaration::Model(model) => {
+                        reject_private_fields(&format!("API model `{}`", model.name), &model.fields)?;
+                    }
+                    ApiDeclaration::Trait(trait_decl) => {
+                        reject_private_fields(
+                            &format!("API trait `{}` required", trait_decl.name),
+                            &trait_decl.requires,
+                        )?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reject private fields on one manifest surface that currently supports public fields only.
+fn reject_private_fields(owner: &str, fields: &[super::FieldExport]) -> Result<(), LibraryManifestError> {
+    for field in fields {
+        if matches!(field.visibility, FieldVisibilityExport::Private) {
+            return Err(LibraryManifestError::Invalid(format!(
+                "{owner} field `{}` cannot be private in a library manifest",
+                field.name
+            )));
+        }
+    }
     Ok(())
 }
 

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -48,8 +48,8 @@ use crate::frontend::symbols::{FunctionInfo, ResolvedType, SymbolKind as Fronten
 use crate::frontend::typechecker::stdlib_loader::{StdlibAstCache, StdlibFunctionLspMetadata};
 use crate::frontend::{lexer, parser, typechecker};
 use crate::library_manifest::{
-    EnumValueExport, EnumValueTypeExport, FieldExport, ParamExport, ParamKindExport, ReceiverExport, TypeBoundExport,
-    TypeParamExport, TypeRef,
+    EnumValueExport, EnumValueTypeExport, FieldExport, FieldVisibilityExport, ParamExport, ParamKindExport,
+    ReceiverExport, TypeBoundExport, TypeParamExport, TypeRef,
 };
 #[cfg(feature = "rust_inspect")]
 use crate::lockfile::CargoFeatureSelection;
@@ -1338,6 +1338,35 @@ pub model Order:
     }
 
     #[test]
+    fn checked_api_previews_preserve_private_class_field_visibility_issue883() -> Result<(), String> {
+        let source = r#"
+pub class Vault:
+    secret: str
+    pub label: str
+"#;
+        let (ast, metadata) = checked_metadata_for(source)?;
+        let previews = api_metadata_previews(&ast, &metadata);
+        let secret_offset = source
+            .find("secret")
+            .ok_or_else(|| "expected private field in fixture".to_string())?;
+        let secret_preview = api_metadata_preview_at_offset(&previews, secret_offset)
+            .ok_or_else(|| "expected checked private field preview".to_string())?;
+        assert!(
+            secret_preview
+                .markdown
+                .contains("*checked API metadata: private field*"),
+            "expected private field metadata preview, got:\n{}",
+            secret_preview.markdown
+        );
+        assert!(
+            secret_preview.markdown.contains("field Vault.secret: str"),
+            "expected private field signature in preview, got:\n{}",
+            secret_preview.markdown
+        );
+        Ok(())
+    }
+
+    #[test]
     fn checked_api_previews_skip_private_declarations() -> Result<(), String> {
         let source = r#"
 model Secret:
@@ -2615,7 +2644,7 @@ fn api_static_markdown(static_decl: &ApiStatic) -> String {
     )
 }
 
-/// Format a checked public model/class field preview as hover markdown.
+/// Format a checked field preview on a public model or class as hover markdown.
 fn api_field_markdown(owner: &str, field: &FieldExport) -> String {
     let mut facts = Vec::new();
     if field.has_default {
@@ -2627,9 +2656,13 @@ fn api_field_markdown(owner: &str, field: &FieldExport) -> String {
     if let Some(description) = &field.description {
         facts.push(format!("description: {}", inline_code(description)));
     }
+    let kind = match field.visibility {
+        FieldVisibilityExport::Private => "private field",
+        FieldVisibilityExport::Public => "public field",
+    };
     checked_api_markdown(
         format!("field {}.{}: {}", owner, field.name, format_type_ref(&field.ty)),
-        "public field",
+        kind,
         facts,
     )
 }

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -146,9 +146,9 @@
     },
     {
       "path": "src/backend/ir/emit/mod.rs",
-      "category": "Rust path segment escaping compatibility",
-      "expected_count": 1,
-      "expected_fingerprint": "0x90822765d714d957"
+      "category": "Rust path segment escaping and public dependency identity compatibility",
+      "expected_count": 2,
+      "expected_fingerprint": "0xc2bd138f45463567"
     },
     {
       "path": "src/backend/ir/emit/program.rs",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10911,7 +10911,9 @@ def database() -> Database:
 
 mod rfc031_pub_import_integration_tests {
     use super::*;
-    use incan::library_manifest::{FunctionExport, LibraryManifest, ModelExport, ParamExport, TypeRef};
+    use incan::library_manifest::{
+        FieldVisibilityExport, FunctionExport, LibraryManifest, ModelExport, ParamExport, TypeRef,
+    };
     use incan::manifest::{INTERNAL_MANIFEST_OVERRIDE_ENV, INTERNAL_PROJECT_ROOT_OVERRIDE_ENV};
     use sha2::{Digest, Sha256};
     use std::collections::BTreeSet;
@@ -13296,6 +13298,208 @@ pub def aggregate_default(expr: ColumnExpr, output_name: str = DEFAULT_LABEL) ->
             "expected consumer check to accept pub:: alias and generic carrier imports.\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&consumer_check.stdout),
             String::from_utf8_lossy(&consumer_check.stderr)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn build_lib_consumer_preserves_private_class_field_visibility_issue883() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let tmp = tempfile::tempdir()?;
+        let producer_root = tmp.path().join("sealed_class_lib");
+        std::fs::create_dir_all(producer_root.join("src"))?;
+        std::fs::write(
+            producer_root.join("incan.toml"),
+            "[project]\nname = \"sealed_class_lib\"\nversion = \"0.1.0\"\n",
+        )?;
+        std::fs::write(
+            producer_root.join("src/vaults.incn"),
+            r#"const DEFAULT_PRIVATE_TEXT: str = "authority"
+
+def default_label() -> str:
+  return "sealed"
+
+pub class VaultBase:
+  private_text: str = DEFAULT_PRIVATE_TEXT
+  computed_secret: int = 1 + 2
+  pub base_count: int
+
+pub class Vault extends VaultBase:
+  secret: str
+  pub label: str = default_label()
+
+  def reveal(self) -> str:
+    return self.secret
+
+pub def make_vault(secret: str) -> Vault:
+  return Vault(base_count=7, secret=secret)
+"#,
+        )?;
+        std::fs::write(
+            producer_root.join("src/lib.incn"),
+            "pub from crate.vaults import Vault as PublicVault, VaultBase, make_vault\n",
+        )?;
+
+        let producer_build = run_build_lib(&producer_root)?;
+        assert!(
+            producer_build.status.success(),
+            "expected private-field provider library build to succeed.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&producer_build.stdout),
+            String::from_utf8_lossy(&producer_build.stderr)
+        );
+        let provider_manifest =
+            LibraryManifest::read_from_path(&producer_root.join("target/lib/sealed_class_lib.incnlib"))?;
+        let vault = provider_manifest
+            .contract_metadata
+            .api
+            .as_ref()
+            .and_then(|api| api.modules.iter().find(|module| module.module_path == ["vaults"]))
+            .and_then(|module| {
+                module.declarations.iter().find_map(|declaration| match declaration {
+                    incan::frontend::api_metadata::ApiDeclaration::Class(class) if class.name == "Vault" => Some(class),
+                    _ => None,
+                })
+            })
+            .ok_or("expected facade-backed Vault in checked API metadata")?;
+        assert_eq!(
+            vault.fields.iter().map(|field| field.name.as_str()).collect::<Vec<_>>(),
+            vec!["private_text", "computed_secret", "base_count", "secret", "label"],
+            "manifest constructor fields must retain the provider's parent-first ABI order"
+        );
+        let private_text = vault
+            .fields
+            .iter()
+            .find(|field| field.name == "private_text")
+            .ok_or("expected inherited private_text field in provider manifest")?;
+        let secret = vault
+            .fields
+            .iter()
+            .find(|field| field.name == "secret")
+            .ok_or("expected secret field in provider manifest")?;
+        let computed_secret = vault
+            .fields
+            .iter()
+            .find(|field| field.name == "computed_secret")
+            .ok_or("expected computed_secret field in provider manifest")?;
+        let label = vault
+            .fields
+            .iter()
+            .find(|field| field.name == "label")
+            .ok_or("expected label field in provider manifest")?;
+        assert_eq!(secret.visibility, FieldVisibilityExport::Private);
+        assert_eq!(label.visibility, FieldVisibilityExport::Public);
+        assert_eq!(private_text.visibility, FieldVisibilityExport::Private);
+        assert_eq!(computed_secret.visibility, FieldVisibilityExport::Private);
+        assert!(computed_secret.has_default);
+        assert_eq!(computed_secret.default, None);
+        assert!(private_text.has_default);
+        assert_eq!(
+            private_text.default,
+            Some(incan::library_manifest::ParamDefaultExport::ConstRef(vec![
+                "vaults".to_string(),
+                "DEFAULT_PRIVATE_TEXT".to_string(),
+            ]))
+        );
+        assert!(label.has_default);
+        assert!(matches!(
+            label.default,
+            Some(incan::library_manifest::ParamDefaultExport::Call {
+                ref path,
+                ref signature,
+                ..
+            }) if path == &["vaults".to_string(), "default_label".to_string()] && signature.is_some()
+        ));
+
+        let decoy_root = tmp.path().join("decoy_class_lib");
+        std::fs::create_dir_all(decoy_root.join("src"))?;
+        std::fs::write(
+            decoy_root.join("incan.toml"),
+            "[project]\nname = \"decoy_class_lib\"\nversion = \"0.1.0\"\n",
+        )?;
+        std::fs::write(
+            decoy_root.join("src/lib.incn"),
+            r#"pub class PublicVault:
+  private_text: int = 11
+  computed_secret: str = "wrong" + "provider"
+  pub base_count: str
+  secret: int
+  pub label: int = 99
+"#,
+        )?;
+        let decoy_build = run_build_lib(&decoy_root)?;
+        assert!(
+            decoy_build.status.success(),
+            "expected duplicate-short-name decoy library build to succeed.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&decoy_build.stdout),
+            String::from_utf8_lossy(&decoy_build.stderr)
+        );
+
+        let consumer_root = tmp.path().join("consumer");
+        let consumer_main = write_project_files(
+            &consumer_root,
+            "[project]\nname = \"sealed_class_consumer\"\n\n[dependencies]\nsealed_class_lib = { path = \"../sealed_class_lib\" }\ndecoy_class_lib = { path = \"../decoy_class_lib\" }\n",
+            r#"from pub::sealed_class_lib import PublicVault
+
+def main() -> None:
+  value: PublicVault = PublicVault(base_count=9, secret="authority")
+  overridden: PublicVault = PublicVault(computed_secret=4, base_count=10, secret="override")
+  println(value.label)
+  println(value.base_count)
+  println(overridden.base_count)
+"#,
+        )?;
+
+        let public_check = run_check(&consumer_main)?;
+        assert!(
+            public_check.status.success(),
+            "expected public field access and existing named class construction to remain valid.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&public_check.stdout),
+            String::from_utf8_lossy(&public_check.stderr)
+        );
+        let public_build = run_build(&consumer_main, &consumer_root.join("out"))?;
+        assert!(
+            public_build.status.success(),
+            "expected public access and named construction to generate valid Rust.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&public_build.stdout),
+            String::from_utf8_lossy(&public_build.stderr)
+        );
+
+        std::fs::write(
+            &consumer_main,
+            r#"from pub::sealed_class_lib import PublicVault as ConsumerVault
+
+def main() -> None:
+  value: ConsumerVault = ConsumerVault(base_count=9, secret="authority")
+  println(value.label)
+"#,
+        )?;
+        let alias_build = run_build(&consumer_main, &consumer_root.join("out"))?;
+        assert!(
+            alias_build.status.success(),
+            "expected a consumer alias of a facade-renamed class to retain the exact provider bridge.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&alias_build.stdout),
+            String::from_utf8_lossy(&alias_build.stderr)
+        );
+
+        std::fs::write(
+            &consumer_main,
+            r#"from pub::sealed_class_lib import PublicVault as ConsumerVault
+
+def main() -> None:
+  value: ConsumerVault = ConsumerVault(base_count=7, secret="authority")
+  println(value.secret)
+"#,
+        )?;
+        let private_check = run_check(&consumer_main)?;
+        assert!(
+            !private_check.status.success(),
+            "expected compiled-library private field access to fail Incan typechecking"
+        );
+        let stderr = strip_ansi_escapes(&String::from_utf8_lossy(&private_check.stderr));
+        assert!(
+            stderr.contains("Field 'secret' on 'ConsumerVault' is private"),
+            "expected source-level private field diagnostic, got:\n{stderr}"
         );
 
         Ok(())

--- a/tests/snapshots/codegen_snapshot_tests__issue246_class_field_visibility.snap
+++ b/tests/snapshots/codegen_snapshot_tests__issue246_class_field_visibility.snap
@@ -12,6 +12,10 @@ pub struct LazyFrame {
     _cursor: i64,
     pub schema: String,
 }
+#[allow(non_snake_case, clippy::too_many_arguments)]
+pub fn LazyFrame(_cursor: i64, schema: String) -> LazyFrame {
+    LazyFrame { _cursor, schema }
+}
 impl incan_stdlib::reflection::HasClassName for LazyFrame {
     fn __class_name__(&self) -> &'static str {
         <Self as incan_stdlib::reflection::HasTypeClassName>::__class_name__()

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -29,6 +29,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: Class-field privacy now survives checked metadata and compiled package boundaries. Named construction through a compiled package uses an exact package-owned constructor bridge—including aliases, inherited fields, and provider-owned defaults—while later private member access receives an Incan diagnostic instead of a Rust privacy failure; older manifests without field visibility retain their compatible public behavior (#883).
 - **Compiler**: String literals returned from closures now materialize owned Incan `str` values, so `Result.map_err` and other closure consumers generate Rust `String` values instead of borrowed `&str` values (#880).
 - **Compiler**: Imported mutable Rust trait receivers now distinguish owned values from dereferenceable guards, so calls such as `Read.by_ref(input)` emit a valid direct borrow for `Stdin` while stdlib `RefMut` readers retain their required reborrow (#878).
 - **Compiler**: Rust interop method calls with inferred `Into`-bound generic parameters now keep string literals in an inferable shape instead of generating ambiguous `.into()` calls (#804).

--- a/workspaces/docs-site/docs/tooling/how-to/lsp.md
+++ b/workspaces/docs-site/docs/tooling/how-to/lsp.md
@@ -94,7 +94,7 @@ Hover over any symbol to see its type:
 def process(data: List[str]) -> Result[int, Error]
 ```
 
-When the file type-checks successfully, hover also previews checked public API metadata for public declarations, public partial callable presets, public model/class fields, checked public methods, and public enum variants. These previews use the same checked metadata extractor as `incan tools metadata api`, so they can include raw docstrings, checked signatures, partial target/preset provenance, field aliases/descriptions, enum backing values, derives, trait adoption, and safe const values. For value enums, enum and variant hover details show the backing type and variant raw value where available.
+When the file type-checks successfully, hover also previews checked public API metadata for public declarations, public partial callable presets, fields on public models/classes, checked public methods, and public enum variants. These previews use the same checked metadata extractor as `incan tools metadata api`, so they can include raw docstrings, checked signatures, partial target/preset provenance, field visibility and aliases/descriptions, enum backing values, derives, trait adoption, and safe const values. Private class fields are labeled private in their field preview without becoming accessible outside the declaring class. For value enums, enum and variant hover details show the backing type and variant raw value where available.
 
 If the file has parse or type errors, diagnostics remain the source of truth and the LSP falls back to syntax-oriented hover details. The current LSP does not expose a workspace command for fetching the full checked API metadata JSON package from the editor; use `incan tools metadata api` for that.
 

--- a/workspaces/docs-site/docs/tooling/reference/checked_api_metadata.md
+++ b/workspaces/docs-site/docs/tooling/reference/checked_api_metadata.md
@@ -156,7 +156,7 @@ The metadata is derived from parsed and typechecked semantics. Public declaratio
 
 - stable source anchors: `anchor.id`, `anchor.span.start`, and `anchor.span.end`
 - checked signatures, parameters, type parameters, bounds, receiver kind, and return type
-- model and class fields, including model field `alias`, `description`, and `has_default`
+- model and class fields, including source `visibility` plus model field `alias`, `description`, and `has_default`
 - trait requirements and checked method signatures
 - enum variants and value-enum raw values
 - public import aliases with resolved `target_path` segments
@@ -167,6 +167,8 @@ The metadata is derived from parsed and typechecked semantics. Public declaratio
 - safe const values for public consts and safe decorator arguments
 
 Types use the same structural `TypeRef` encoding as library manifest exports. For example, a non-generic type is encoded as `{"Named": {"name": "str"}}`, while a generic application is encoded as `{"Applied": {"name": "List", "args": [...]}}`.
+
+Private class-field entries include `"visibility": "private"`. An omitted field visibility means public, preserving compatibility with schema-v1 metadata and manifests that predate explicit visibility. Public model fields and public class fields therefore retain the compact representation without a `visibility` key.
 
 Function metadata keeps the source declaration's public callable surface. For a decorated callable, each decorator entry also carries `decorated_callable`, which contains the decorated declaration's checked public identity, source anchor, type parameters, parameter names and types, return type, receiver when applicable, and async marker. Registry and catalog tooling should read that field instead of asking authors to repeat the decorated function name or signature in decorator arguments.
 
@@ -230,7 +232,7 @@ Docstring validation is strict for mechanically checkable drift. If an `Args:` o
 
 ## Editor Previews
 
-The language server uses the same checked metadata extractor for hover previews after a document type-checks successfully. Hovering a public declaration, a checked public method, a public model/class field, or a public enum variant can show the checked signature, raw docstring text, field alias/description metadata, value-enum backing and raw-value metadata, derives, trait adoption, and safe const values. Public partial hover shows the projected callable signature plus target and preset provenance. If a decorated function's checked binding is callable-valued, its hover uses the same callable signature exposed by checked API metadata.
+The language server uses the same checked metadata extractor for hover previews after a document type-checks successfully. Hovering a public declaration, a checked public method, a field on a public model or class, or a public enum variant can show the checked signature, raw docstring text, field visibility and alias/description metadata, value-enum backing and raw-value metadata, derives, trait adoption, and safe const values. Private class fields are labeled private in their field preview; the preview does not make them accessible outside the declaring class. Public partial hover shows the projected callable signature plus target and preset provenance. If a decorated function's checked binding is callable-valued, its hover uses the same callable signature exposed by checked API metadata.
 
 The LSP exposes these facts through `textDocument/hover`. Use `incan tools metadata api` when an integration needs the full JSON package.
 


### PR DESCRIPTION
## Summary

Preserve authored private class-field visibility across checked API metadata and compiled `.incnlib` package boundaries.

Public compiled classes now retain their field visibility and expose a provider-owned constructor bridge. Consumers can still construct those classes with named arguments—including through package facades, consumer aliases, inheritance, and provider-owned defaults—but direct access to private fields is rejected by the Incan typechecker. Legacy manifests that omit field visibility continue to treat fields as public.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: private fields on public compiled classes remain private to consumers, while valid named construction keeps working through exact dependency and alias identities.
- **Internals**: checked field metadata and manifests carry backward-compatible visibility; imported class symbols preserve ordered inherited defaults; codegen emits and targets provider-owned constructor bridges for classes that need private-field initialization.
- **Risks**: constructor bridge selection spans package aliases, duplicate public names, inherited fields, and defaults that cannot be materialized in a consumer. Focused unit and end-to-end fixtures cover those cases, including an identically shaped decoy dependency.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` (2,984/2,984 tests; clippy, cargo-deny, release smoke build, examples, and benchmarks passed)
- `cargo test issue883 --lib --features lsp` (11/11)
- `cargo test --test integration_tests build_lib_consumer_preserves_private_class_field_visibility_issue883 --features lsp`
- `cargo +1.93.0 test issue883 --lib --features lsp` (11/11)
- `cargo +1.93.0 test --test integration_tests build_lib_consumer_preserves_private_class_field_visibility_issue883 --features lsp`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_5.md`, `workspaces/docs-site/docs/tooling/how-to/lsp.md`, `workspaces/docs-site/docs/tooling/reference/checked_api_metadata.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #883
