### PR TITLE
bugfix - preserve stdout result types for Rust extension traits (#888)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "blake2",
  "blake3",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -270,6 +270,13 @@ pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[MetadataFreeFunctionSignatur
         is_unsafe: false,
     },
     MetadataFreeFunctionSignatureRule {
+        path: "std::io::stdout",
+        params: &[],
+        return_type: "std::io::Stdout",
+        is_async: false,
+        is_unsafe: false,
+    },
+    MetadataFreeFunctionSignatureRule {
         path: "std::fs::metadata",
         params: &[MetadataFreeFunctionParamRule {
             name: Some("path"),
@@ -1536,6 +1543,19 @@ pub fn run_inline<D: FnMut(&mut Data, &OutputCallbackInfo)>(callback: D) {
         };
 
         assert_eq!(signature.return_type, "std::io::Stdin");
+        assert!(signature.params.is_empty());
+        assert!(!signature.is_async);
+        assert!(!signature.is_unsafe);
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_free_function_signature_preserves_stdout_receiver_type() -> Result<(), String> {
+        let Some(signature) = metadata_free_function_signature("std::io::stdout") else {
+            return Err("std::io::stdout should have a metadata-free signature".to_string());
+        };
+
+        assert_eq!(signature.return_type, "std::io::Stdout");
         assert!(signature.params.is_empty());
         assert!(!signature.is_async);
         assert!(!signature.is_unsafe);

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -204,6 +204,102 @@ def main() -> None:
 }
 
 #[test]
+fn rust_stdout_extension_trait_result_supports_try_operator_issue888() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(
+        tmp.path(),
+        "rust_stdout_extension_trait_result",
+        r#"
+
+[rust-dependencies]
+console_interop = { path = "rust/console_interop" }
+"#,
+    )?;
+    fs::write(
+        &main_path,
+        r#"from rust::std::io import Error as IoError, stdout
+from rust::console_interop import EnterAlternateScreen, ExecutableCommand
+
+def enter_alternate_screen() -> Result[None, IoError]:
+    mut output = stdout()
+    _ = output.execute(EnterAlternateScreen)?
+    return Ok(None)
+
+def inspect_alternate_screen_result() -> None:
+    mut output = stdout()
+    match output.execute(EnterAlternateScreen):
+        Ok(_) => pass
+        Err(_) => pass
+
+def main() -> None:
+    inspect_alternate_screen_result()
+    match enter_alternate_screen():
+        Ok(_) => pass
+        Err(_) => pass
+"#,
+    )?;
+
+    let helper_src = tmp.path().join("rust/console_interop/src");
+    fs::create_dir_all(&helper_src)?;
+    fs::write(
+        helper_src
+            .parent()
+            .ok_or("console interop source directory had no parent")?
+            .join("Cargo.toml"),
+        r#"[package]
+name = "console_interop"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )?;
+    fs::write(
+        helper_src.join("lib.rs"),
+        r#"use std::io::{self, Write};
+
+pub struct EnterAlternateScreen;
+
+pub trait Command {}
+
+impl Command for EnterAlternateScreen {}
+
+pub trait ExecutableCommand {
+    fn execute(&mut self, command: impl Command) -> io::Result<&mut Self>;
+}
+
+impl<W: Write + ?Sized> ExecutableCommand for W {
+    fn execute(&mut self, _command: impl Command) -> io::Result<&mut Self> {
+        Ok(self)
+    }
+}
+"#,
+    )?;
+
+    let main_arg = main_path.to_str().ok_or("non-utf8 main path")?;
+    let lock_output = run_incan(tmp.path(), &["lock", main_arg])?;
+    assert_success(&lock_output, "incan lock for stdout extension-trait Result");
+    let build_output = run_incan(tmp.path(), &["build", main_arg, "--locked"])?;
+    assert_success(
+        &build_output,
+        "incan build for stdout extension-trait Result postfix try",
+    );
+
+    let generated = fs::read_to_string(
+        tmp.path()
+            .join("target/incan/rust_stdout_extension_trait_result/src/main.rs"),
+    )?;
+    let compact = generated.split_whitespace().collect::<String>();
+    assert!(
+        compact.contains("output.execute(EnterAlternateScreen)?"),
+        "generated Rust must preserve the fallible extension-trait call:\n{generated}"
+    );
+    assert!(
+        compact.contains("matchoutput.execute(EnterAlternateScreen)"),
+        "generated Rust must preserve direct Result inspection for the extension-trait call:\n{generated}"
+    );
+    Ok(())
+}
+
+#[test]
 fn rust_trait_object_method_arguments_borrow_by_metadata_issue832() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -30,6 +30,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: `std::io::stdout()` now retains its stable `Stdout` receiver type when sysroot metadata is unavailable, so fallible extension-trait calls such as crossterm's `ExecutableCommand.execute(...)` expose their native `Result` and support postfix `?` (#888).
 - **Compiler**: Class-field privacy now survives checked metadata and compiled package boundaries. Named construction through a compiled package uses an exact package-owned constructor bridge—including aliases, inherited fields, and provider-owned defaults—while later private member access receives an Incan diagnostic instead of a Rust privacy failure; older manifests without field visibility retain their compatible public behavior (#883).
 - **Stdlib**: `std.regex` replacement and split operations now reconstruct strings with the regex engine's UTF-8 byte spans, preserving characters adjacent to non-ASCII matches while keeping public match offsets byte-based (#893).
 - **Compiler**: String literals returned from closures now materialize owned Incan `str` values, so `Result.map_err` and other closure consumers generate Rust `String` values instead of borrowed `&str` values (#880).


### PR DESCRIPTION
## Summary

This PR preserves `std::io::stdout()` as `std::io::Stdout` when Rust sysroot metadata is unavailable. Native
extension-trait methods such as crossterm 0.29's `ExecutableCommand.execute(...) -> Result<&mut Self,
std::io::Error>` therefore retain their `Result` type, allowing postfix `?` and explicit result matching instead of
degrading to unknown `?`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP / VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Fallible Rust extension-trait calls on `stdout()` expose their native `Result`, so
  crossterm's `execute(...)?` compiles on the default metadata-free interop path.
- **Internals**: The existing stable metadata-free signature registry now includes
  `std::io::stdout() -> std::io::Stdout`, symmetric with `stdin()`. A deterministic local Rust fixture exercises
  nested `Self` substitution, postfix `?`, explicit matching, generated Rust, and the final Cargo build.
- **Risks**: The stable signature applies only when inspected Rust metadata is unavailable; ordinary inspected
  metadata retains precedence.
- **Integration**: Rebases cleanly on merged PRs #862, #890, and #895, drops the former #895 readiness overlap, and
  advances the workspace to `0.5.0-dev.9`.

## Testing / verification

- [x] `cargo +1.93.0 test -p incan_core --locked metadata_free_function_signature_preserves_stdout_receiver_type -- --nocapture`
- [x] `cargo +1.93.0 test --locked --test cli_integration rust_stdout_extension_trait_result_supports_try_operator_issue888 -- --nocapture`
- [x] `make pre-commit INCAN_SKIP_CARGO_BIN_LINK=1`

The full gate passed 3,007 Rust tests, clippy, cargo-deny, release smoke, the assertion canary, 60 examples (35 run,
one intentional long-running skip), and nine benchmark builds.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Release-note coverage: `workspaces/docs-site/docs/release_notes/0_5.md`.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #888
