### PR TITLE
bugfix - preserve Unicode regex reconstruction spans (#893)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "blake2",
  "blake3",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/incan_core/src/strings.rs
+++ b/crates/incan_core/src/strings.rs
@@ -155,6 +155,43 @@ pub fn str_slice(
     Ok(out)
 }
 
+/// Slice a string between two UTF-8 byte offsets.
+///
+/// This is a narrow interop helper for host APIs, such as regex engines, whose spans are byte-based. Ordinary Incan
+/// string indexing and slicing remain Unicode-scalar based through [`str_char_at`] and [`str_slice`].
+///
+/// ## Parameters
+/// - `s`: String to slice.
+/// - `start`: Inclusive UTF-8 byte offset.
+/// - `end`: Exclusive UTF-8 byte offset.
+///
+/// ## Returns
+/// - `Ok(String)`: The requested byte range when both offsets are valid UTF-8 boundaries.
+/// - `Err(StringAccessError)`: If either offset is negative, out of range, not a character boundary, or reversed.
+pub fn str_slice_byte_range(s: &str, start: i64, end: i64) -> Result<String, StringAccessError> {
+    let start = usize::try_from(start).map_err(|_| StringAccessError::IndexOutOfRange)?;
+    let end = usize::try_from(end).map_err(|_| StringAccessError::IndexOutOfRange)?;
+    s.get(start..end)
+        .map(str::to_string)
+        .ok_or(StringAccessError::IndexOutOfRange)
+}
+
+/// Slice a string from one UTF-8 byte offset through the end.
+///
+/// ## Parameters
+/// - `s`: String to slice.
+/// - `start`: Inclusive UTF-8 byte offset.
+///
+/// ## Returns
+/// - `Ok(String)`: The suffix beginning at `start` when it is a valid UTF-8 boundary.
+/// - `Err(StringAccessError)`: If `start` is negative, out of range, or not a character boundary.
+pub fn str_slice_from_byte_offset(s: &str, start: i64) -> Result<String, StringAccessError> {
+    let start = usize::try_from(start).map_err(|_| StringAccessError::IndexOutOfRange)?;
+    s.get(start..)
+        .map(str::to_string)
+        .ok_or(StringAccessError::IndexOutOfRange)
+}
+
 // ---- String methods (shared policy) -------------------------------------------------------------
 
 /// Convert a string to uppercase.
@@ -294,4 +331,35 @@ pub fn fstring(parts: &[&str], args: &[String]) -> String {
     }
     out.push_str(parts.last().unwrap_or(&""));
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StringAccessError, str_slice_byte_range, str_slice_from_byte_offset};
+
+    #[test]
+    fn byte_range_slices_preserve_utf8_boundaries() {
+        let text = "beforeé;31m";
+
+        assert_eq!(str_slice_byte_range(text, 0, 6), Ok("before".to_string()));
+        assert_eq!(str_slice_byte_range(text, 6, 8), Ok("é".to_string()));
+        assert_eq!(str_slice_from_byte_offset(text, 8), Ok(";31m".to_string()));
+    }
+
+    #[test]
+    fn byte_range_slices_reject_invalid_offsets() {
+        let text = "é";
+
+        for result in [
+            str_slice_byte_range(text, -1, 2),
+            str_slice_byte_range(text, 0, 3),
+            str_slice_byte_range(text, 0, 1),
+            str_slice_byte_range(text, 2, 0),
+            str_slice_from_byte_offset(text, -1),
+            str_slice_from_byte_offset(text, 1),
+            str_slice_from_byte_offset(text, 3),
+        ] {
+            assert_eq!(result, Err(StringAccessError::IndexOutOfRange));
+        }
+    }
 }

--- a/crates/incan_stdlib/src/strings.rs
+++ b/crates/incan_stdlib/src/strings.rs
@@ -9,7 +9,9 @@ use incan_core::strings::{
     StringAccessError, fstring as semantics_fstring, str_char_at as semantics_str_char_at,
     str_cmp as semantics_str_cmp, str_concat as semantics_str_concat, str_contains as semantics_str_contains,
     str_ends_with as semantics_str_ends_with, str_join as semantics_str_join, str_lower as semantics_str_lower,
-    str_replace as semantics_str_replace, str_slice as semantics_str_slice, str_split as semantics_str_split,
+    str_replace as semantics_str_replace, str_slice as semantics_str_slice,
+    str_slice_byte_range as semantics_str_slice_byte_range,
+    str_slice_from_byte_offset as semantics_str_slice_from_byte_offset, str_split as semantics_str_split,
     str_starts_with as semantics_str_starts_with, str_strip as semantics_str_strip, str_upper as semantics_str_upper,
 };
 
@@ -61,6 +63,35 @@ pub fn str_slice<S: AsRef<str>>(s: S, start: Option<i64>, end: Option<i64>, step
             // Should not happen because slice clamps; keep aligned if policy changes.
             raise(IncanError::string_index_out_of_range())
         }
+    }
+}
+
+/// Slice a string between UTF-8 byte offsets supplied by a host API.
+///
+/// Ordinary Incan slices use Unicode-scalar indices. This helper is for stdlib interop code that reconstructs strings
+/// from byte spans, such as `std.regex`.
+///
+/// ## Panics
+///
+/// - If either offset is invalid, out of range, reversed, or not a UTF-8 character boundary.
+pub fn str_slice_byte_range(s: &str, start: i64, end: i64) -> String {
+    match semantics_str_slice_byte_range(s, start, end) {
+        Ok(out) => out,
+        Err(StringAccessError::IndexOutOfRange) => raise(IncanError::string_index_out_of_range()),
+        Err(StringAccessError::SliceStepZero) => unreachable!("byte-range slices do not accept a step"),
+    }
+}
+
+/// Slice a string from a UTF-8 byte offset supplied by a host API through the end.
+///
+/// ## Panics
+///
+/// - If the offset is invalid, out of range, or not a UTF-8 character boundary.
+pub fn str_slice_from_byte_offset(s: &str, start: i64) -> String {
+    match semantics_str_slice_from_byte_offset(s, start) {
+        Ok(out) => out,
+        Err(StringAccessError::IndexOutOfRange) => raise(IncanError::string_index_out_of_range()),
+        Err(StringAccessError::SliceStepZero) => unreachable!("byte-offset slices do not accept a step"),
     }
 }
 

--- a/crates/incan_stdlib/stdlib/regex/_core.incn
+++ b/crates/incan_stdlib/stdlib/regex/_core.incn
@@ -7,8 +7,12 @@ replacement dispatch together.
 """
 
 from rust::regex import Regex as RustRegex, RegexBuilder
+from rust::incan_stdlib::strings import str_slice_byte_range, str_slice_from_byte_offset
 from std.regex._replacement import _expand_replacement
 from std.regex.types import Captures, CapturesIterator, Match, MatchIterator, SplitIterator, _offset_from_usize
+
+# Keep native byte-slice results in explicit `str` locals before `+=`; cold SDK codegen otherwise loses the Rust
+# `String` result type and emits invalid `String + String` (#896).
 
 
 pub model RegexError:
@@ -255,12 +259,11 @@ pub model Regex:
             text: Text to match.
 
         Returns:
-            `Some(Captures)` when group `0` starts at byte offset `0` and ends at `len(text)`, otherwise `None`.
+            `Some(Captures)` when group `0` starts at byte offset `0` and contains the entire input, otherwise `None`.
         """
         if let Some(caps) = self.captures(text):
             if let Some(full) = caps.full_match():
-                start, end = full.span()
-                if start == 0 and end == len(text):
+                if full.start() == 0 and full.as_str() == text:
                     return Some(caps)
         return None
 
@@ -332,11 +335,13 @@ pub model Regex:
             while let Some(caps) = captures.__next__():
                 if let Some(full) = caps.full_match():
                     start, end = full.span()
-                    out += text[last_end:start]
+                    unchanged: str = str_slice_byte_range(text, last_end, start)
+                    out += unchanged
                     out += repl(caps)
                     last_end = end
 
-            out += text[last_end:]
+            suffix: str = str_slice_from_byte_offset(text, last_end)
+            out += suffix
             return out
 
     def replacen(self, text: str, limit: int, repl: str | Callable[Captures, str]) -> str:
@@ -371,12 +376,14 @@ pub model Regex:
 
                 if let Some(full) = caps.full_match():
                     start, end = full.span()
-                    out += text[last_end:start]
+                    unchanged: str = str_slice_byte_range(text, last_end, start)
+                    out += unchanged
                     out += repl(caps)
                     last_end = end
                     replaced += 1
 
-            out += text[last_end:]
+            suffix: str = str_slice_from_byte_offset(text, last_end)
+            out += suffix
             return out
 
     def replace_literal(self, text: str, repl: str) -> str:
@@ -479,12 +486,14 @@ pub model Regex:
 
             if let Some(full) = caps.full_match():
                 start, end = full.span()
-                out += text[last_end:start]
+                unchanged: str = str_slice_byte_range(text, last_end, start)
+                out += unchanged
                 out += _string_replacement(repl, caps, literal)
                 last_end = end
                 replaced += 1
 
-        out += text[last_end:]
+        suffix: str = str_slice_from_byte_offset(text, last_end)
+        out += suffix
         return out
 
 

--- a/crates/incan_stdlib/stdlib/regex/types.incn
+++ b/crates/incan_stdlib/stdlib/regex/types.incn
@@ -7,6 +7,7 @@ Incan callers: matches, capture sets, and iterators over collected results.
 
 from std.derives.collection import Iterator
 from std.derives.copying import Clone
+from rust::incan_stdlib::strings import str_slice_byte_range, str_slice_from_byte_offset
 
 
 @derive(Clone)
@@ -271,19 +272,19 @@ pub model SplitIterator with Iterator[str]:
         if self.limit > 0 and self.produced >= self.limit - 1:
             self.done = true
             self.produced += 1
-            return Some(self.text[self.last_end:])
+            return Some(str_slice_from_byte_offset(self.text, self.last_end))
 
         match self.matches.__next__():
             Some(found) =>
                 start, end = found.span()
-                part = self.text[self.last_end:start]
+                part = str_slice_byte_range(self.text, self.last_end, start)
                 self.last_end = end
                 self.produced += 1
                 return Some(part)
             None =>
                 self.done = true
                 self.produced += 1
-                return Some(self.text[self.last_end:])
+                return Some(str_slice_from_byte_offset(self.text, self.last_end))
 
 
 pub def _offset_from_usize(value: usize) -> int:

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3357,6 +3357,7 @@ fn test_rust_owner_path_expands_crate_relative_signature_displays() {
 fn test_rust_never_return_is_bottom_compatible_issue381() {
     let checker = TypeChecker::new();
     let signature = RustFunctionSig {
+        type_params: Vec::new(),
         params: Vec::new(),
         return_type: "!".to_string(),
         is_async: false,

--- a/tests/fixtures/valid/std_regex_surface.incn
+++ b/tests/fixtures/valid/std_regex_surface.incn
@@ -15,6 +15,10 @@ def show_span(value: Option[Tuple[int, int]]) -> str:
 def flip_name(caps: Captures) -> str:
     return f"{show(caps.group('last'))}, {show(caps.group('first'))}"
 
+def blank_match(_caps: Captures) -> str:
+    """Return one space for callable replacement coverage."""
+    return " "
+
 def run() -> Result[None, RegexError]:
     flags = Regex("^alpha$", ignore_case=true, multiline=true, dotall=true, verbose=true)?
     println(flags.is_match("ALPHA"))
@@ -75,6 +79,47 @@ def run() -> Result[None, RegexError]:
     println(name_re.replace_all_literal("Ada Lovelace", "$2, $1"))
     println(word_re.replacen("one two three", 2, "x"))
     println(word_re.replacen_literal("one two", 1, "$1"))
+
+    unicode_re = Regex("é")?
+    match unicode_re.find("beforeéafter"):
+        Some(found) =>
+            span_start, span_end = found.span()
+            println(f"{found.as_str()}@{found.start()}:{found.end()}|{span_start}:{span_end}")
+        None => println("missing-unicode-find")
+    match unicode_re.full_match("é"):
+        Some(_) => println("unicode-full")
+        None => println("missing-unicode-full")
+    println(unicode_re.replace("é;31m", " "))
+    println(unicode_re.replace_all("é;31m", " "))
+    println(unicode_re.replacen("é;31m", 1, " "))
+    println(unicode_re.replace_literal("é;31m", " "))
+    println(unicode_re.replace_all_literal("é;31m", " "))
+    println(unicode_re.replacen_literal("é;31m", 1, " "))
+    println(unicode_re.replace("é;31m", blank_match))
+    println(unicode_re.replace_all("é;31m", blank_match))
+    println(unicode_re.replacen("é;31m", 1, blank_match))
+    println(unicode_re.replace_all("é;é!", " "))
+    println(unicode_re.replace_all("é;é!", blank_match))
+    println(comma_re.replace_all("é,a", "|"))
+
+    control_re = Regex("\\p{Cc}")?
+    # U+009B is intentionally literal here so this is the exact C1 regression from #893.
+    println(control_re.replace_all("before;31mafter", " "))
+
+    mut unicode_parts: list[str] = []
+    for part in unicode_re.split("beforeé;31m"):
+        unicode_parts.append(part)
+    println("|".join(unicode_parts))
+
+    mut limited_unicode_parts: list[str] = []
+    for part in unicode_re.splitn("beforeé;31m", 2):
+        limited_unicode_parts.append(part)
+    println("|".join(limited_unicode_parts))
+
+    mut repeated_unicode_parts: list[str] = []
+    for part in unicode_re.split("é;é!"):
+        repeated_unicode_parts.append(part)
+    println("|".join(repeated_unicode_parts))
     return Ok(None)
 
 def main() -> None:

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6854,9 +6854,23 @@ async def main() -> None:
     }
 
     #[test]
-    fn test_run_std_regex_rfc059_surface() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_run_std_regex_rfc059_surface_from_cold_sdk_provider() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let source = tmp.path().join("std_regex_surface.incn");
+        fs::copy(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/valid/std_regex_surface.incn"),
+            &source,
+        )?;
+        let generated_project = tmp.path().join("target/incan/std_regex_surface");
+        let provider_store = tmp.path().join("sdk-provider-store");
+        let generated_cargo_target = tmp.path().join("generated-cargo-target");
+
         let output = incan_command()
-            .args(["run", "tests/fixtures/valid/std_regex_surface.incn"])
+            .current_dir(tmp.path())
+            .env("INCAN_INTERNAL_SDK_PROVIDER_STORE", &provider_store)
+            .env("INCAN_GENERATED_CARGO_TARGET_DIR", &generated_cargo_target)
+            .arg("run")
+            .arg(&source)
             .output()?;
 
         assert!(
@@ -6892,17 +6906,43 @@ async def main() -> None:
                 "$2, $1",
                 "x x three",
                 "$1 two",
+                "é@6:8|6:8",
+                "unicode-full",
+                ";31m",
+                ";31m",
+                ";31m",
+                ";31m",
+                ";31m",
+                ";31m",
+                ";31m",
+                ";31m",
+                ";31m",
+                "; !",
+                "; !",
+                "é|a",
+                "before ;31mafter",
+                "before|;31m",
+                "before|;31m",
+                "|;|!",
             ],
             "unexpected std.regex output:\n{stdout}"
         );
-        let consumer_core = Path::new("target/incan/std_regex_surface/src/__incan_std/regex/_core.rs");
+        let consumer_core = generated_project.join("src/__incan_std/regex/_core.rs");
         assert!(
             !consumer_core.exists(),
             "a compiled std.regex module must not be materialized in the consumer: {}",
             consumer_core.display()
         );
-        let artifact_root =
-            compiled_sdk_provider_artifact_root(Path::new("target/incan/std_regex_surface"), "incan_stdlib_data")?;
+        let artifact_root = fs::canonicalize(compiled_sdk_provider_artifact_root(
+            &generated_project,
+            "incan_stdlib_data",
+        )?)?;
+        let provider_store = fs::canonicalize(&provider_store)?;
+        assert!(
+            artifact_root.starts_with(&provider_store),
+            "std.regex should be compiled from the isolated cold SDK provider store: {}",
+            artifact_root.display()
+        );
         let generated_core = fs::read_to_string(artifact_root.join("src/regex/_core.rs"))?;
         for unexpected in [
             "RegexBuilder::new(&(pattern).to_string())",

--- a/tests/semantic_core_parity_strings.rs
+++ b/tests/semantic_core_parity_strings.rs
@@ -4,8 +4,14 @@
 use incan::frontend::typechecker::{ConstValue, TypeCheckInfo};
 use incan::frontend::{lexer, parser, typechecker};
 use incan_core::errors::IncanError;
-use incan_core::strings::{StringAccessError, str_char_at, str_concat, str_contains, str_slice};
-use incan_stdlib::strings::{str_concat as rt_str_concat, str_index as rt_str_index, str_slice as rt_str_slice};
+use incan_core::strings::{
+    StringAccessError, str_char_at, str_concat, str_contains, str_slice, str_slice_byte_range,
+    str_slice_from_byte_offset,
+};
+use incan_stdlib::strings::{
+    str_concat as rt_str_concat, str_index as rt_str_index, str_slice as rt_str_slice,
+    str_slice_byte_range as rt_str_slice_byte_range, str_slice_from_byte_offset as rt_str_slice_from_byte_offset,
+};
 
 fn run_const_eval_with_info(src: &str) -> Result<TypeCheckInfo, Vec<String>> {
     let tokens = lexer::lex(src).map_err(|errs| errs.into_iter().map(|e| e.message).collect::<Vec<_>>())?;
@@ -62,6 +68,10 @@ fn semantics_vs_runtime_index_and_slice() -> Result<(), StringAccessError> {
         str_slice(s, Some(-2), None, None)?
     );
 
+    // Host byte-span reconstruction remains separate from ordinary Unicode-scalar slices.
+    assert_eq!(rt_str_slice_byte_range(s, 1, 3), str_slice_byte_range(s, 1, 3)?);
+    assert_eq!(rt_str_slice_from_byte_offset(s, 3), str_slice_from_byte_offset(s, 3)?);
+
     // Methods parity
     assert_eq!(incan_stdlib::strings::str_upper("héllo"), "HÉLLO");
     assert_eq!(incan_stdlib::strings::str_lower("HÉLLO"), "héllo");
@@ -90,6 +100,18 @@ fn runtime_index_panics_on_oob() {
 #[should_panic(expected = "ValueError: slice step cannot be zero")]
 fn runtime_slice_panics_on_zero_step() {
     let _ = rt_str_slice("abc", None, None, Some(0));
+}
+
+#[test]
+#[should_panic(expected = "IndexError: string index out of range")]
+fn runtime_byte_range_panics_on_mid_codepoint() {
+    let _ = rt_str_slice_byte_range("é", 0, 1);
+}
+
+#[test]
+#[should_panic(expected = "IndexError: string index out of range")]
+fn runtime_byte_suffix_panics_on_mid_codepoint() {
+    let _ = rt_str_slice_from_byte_offset("é", 1);
 }
 
 #[test]

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -30,6 +30,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 ## Bugfixes
 
 - **Compiler**: Class-field privacy now survives checked metadata and compiled package boundaries. Named construction through a compiled package uses an exact package-owned constructor bridge—including aliases, inherited fields, and provider-owned defaults—while later private member access receives an Incan diagnostic instead of a Rust privacy failure; older manifests without field visibility retain their compatible public behavior (#883).
+- **Stdlib**: `std.regex` replacement and split operations now reconstruct strings with the regex engine's UTF-8 byte spans, preserving characters adjacent to non-ASCII matches while keeping public match offsets byte-based (#893).
 - **Compiler**: String literals returned from closures now materialize owned Incan `str` values, so `Result.map_err` and other closure consumers generate Rust `String` values instead of borrowed `&str` values (#880).
 - **Compiler**: Imported mutable Rust trait receivers now distinguish owned values from dereferenceable guards, so calls such as `Read.by_ref(input)` emit a valid direct borrow for `Stdin` while stdlib `RefMut` readers retain their required reborrow (#878).
 - **Compiler**: Rust interop method calls with inferred `Into`-bound generic parameters now keep string literals in an inferable shape instead of generating ambiguous `.into()` calls (#804).


### PR DESCRIPTION
## Summary

Fixes `std.regex` replacement and split corruption around non-ASCII matches.

Rust regex exposes UTF-8 byte spans, while ordinary Incan string slices index Unicode scalars. The stdlib previously fed match byte offsets into scalar slices, so replacing U+009B in `before<U+009B>;31mafter` also removed the semicolon. This PR adds a validated byte-range interop seam, uses it across every replacement and split reconstruction path, and preserves the documented public byte-offset contract.

Closes #893 and #897. Tracks the underlying cold compound-assignment inference seam separately in #896.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `Regex.replace`, `replace_all`, `replacen`, their literal/callable forms, `split`, and `splitn` now preserve characters adjacent to non-ASCII matches. `Match.start()`, `end()`, and `span()` remain UTF-8 byte offsets.
- **Internals**: shared string semantics validate byte ranges and UTF-8 boundaries; runtime wrappers adapt invalid ranges to the standard `IndexError`; Incan-authored `std.regex` keeps ownership of replacement/split control flow. Unicode `full_match` compares the owned full-match text instead of relying on current byte-based `len(str)` lowering. Native byte-slice results are materialized as typed `str` values so fresh compiled-SDK providers take the string concat lowering; #896 tracks that compiler seam.
- **Main readiness**: current main combined #834's required `RustFunctionSig.type_params` field with #381's never-return test initializer without updating the initializer. This branch carries the one-field #897 repair so required gates compile.
- **Risks**: the new runtime functions are intentionally narrow and reject negative, reversed, out-of-range, and mid-codepoint offsets. The branch rebases onto `c7fbd6c0a` and advances the workspace from `0.5.0-dev.7` to `dev.8`; another version-bumping PR landing first will require the usual rebase/next-version update.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Released Incan 0.4.0 and current pre-fix main produced `before 31mafter` from the exact U+009B input; the fixed compiler produces `before ;31mafter` for string and callable replacement and preserves `;31mafter` in split output.
- Focused core, runtime-parity (9/9), and isolated cold-provider end-to-end regex tests pass on stable and exact Rust 1.93.0.
- The exact #897 unit test passes on stable and Rust 1.93.0.
- Final rebased `make pre-commit` passed 2,995/2,995 tests, nightly formatting, rustdoc, clippy, cargo-deny, release build, assertion canary, 60 example checks / 35 example runs, and 9 benchmark builds.
- Ralph review/fix slices are clean after coverage, parity, error-mapping, `full_match`, cold-provider isolation, and generated-Rust findings were resolved.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_5.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
