### PR TITLE
bugfix - preserve generated Cargo project metadata (#889)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "blake2",
  "blake3",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/backend/project/cargo_toml.rs
+++ b/src/backend/project/cargo_toml.rs
@@ -20,7 +20,7 @@ use crate::manifest::{DependencySource, DependencySpec, GitReference};
 use super::INCAN_STDLIB_CRATE_NAME;
 use super::generator::{ProjectGenerator, is_sdk_provider_build};
 
-/// Incan compiler version stamped into generated `Cargo.toml` files.
+/// Incan compiler version stamped into generated `Cargo.toml` files and used as the package-version fallback.
 pub(crate) const INCAN_VERSION: &str = crate::version::INCAN_VERSION;
 
 // ============================================================================
@@ -50,6 +50,8 @@ struct PackageSection {
     name: String,
     version: String,
     edition: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    license: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -223,7 +225,7 @@ impl ProjectGenerator {
     /// The output is valid TOML by construction.
     pub(super) fn generate_cargo_toml(&self) -> io::Result<String> {
         let edition = self.rust_edition.as_deref().unwrap_or("2021").to_string();
-        let package_name = self.package_name.as_deref().unwrap_or(&self.name).to_string();
+        let package_name = self.cargo_package_name().to_string();
 
         // ---- Resolve toolchain-owned support crates for generated Rust projects ----
         let stdlib_path = toolchain_crate_path(INCAN_STDLIB_CRATE_NAME);
@@ -337,8 +339,9 @@ impl ProjectGenerator {
         let manifest = CargoManifest {
             package: PackageSection {
                 name: package_name,
-                version: INCAN_VERSION.to_string(),
+                version: self.cargo_package_version().to_string(),
                 edition,
+                license: self.package_license.clone(),
             },
             workspace: toml::Table::new(), // empty — opt out of parent workspace
             dependencies: deps,
@@ -402,7 +405,7 @@ mod tests {
     use crate::backend::project::generator::ProjectGenerator;
     use crate::manifest::{DependencySource, DependencySpec};
 
-    use super::path_dependency;
+    use super::{INCAN_VERSION, path_dependency};
 
     fn parsed_manifest(toml: &str) -> Result<toml::Value, Box<dyn std::error::Error>> {
         Ok(toml::from_str(toml)?)
@@ -504,6 +507,43 @@ mod tests {
             PathBuf::from(support_path).is_absolute(),
             "ordinary generated projects should keep stable absolute toolchain paths"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn cargo_toml_uses_authored_project_package_metadata() -> Result<(), Box<dyn std::error::Error>> {
+        let mut generator = ProjectGenerator::new("/tmp/test_project_metadata", "project_metadata", true);
+        generator.set_package_metadata(Some("1.2.3".to_string()), Some("MIT OR Apache-2.0".to_string()));
+
+        let manifest = parsed_manifest(&generator.generate_cargo_toml()?)?;
+        let package = manifest
+            .get("package")
+            .and_then(toml::Value::as_table)
+            .ok_or("generated Cargo.toml missing [package] table")?;
+
+        assert_eq!(package.get("version").and_then(toml::Value::as_str), Some("1.2.3"));
+        assert_eq!(
+            package.get("license").and_then(toml::Value::as_str),
+            Some("MIT OR Apache-2.0")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cargo_toml_defaults_to_compiler_package_metadata() -> Result<(), Box<dyn std::error::Error>> {
+        let generator = ProjectGenerator::new("/tmp/test_default_metadata", "default_metadata", true);
+
+        let manifest = parsed_manifest(&generator.generate_cargo_toml()?)?;
+        let package = manifest
+            .get("package")
+            .and_then(toml::Value::as_table)
+            .ok_or("generated Cargo.toml missing [package] table")?;
+
+        assert_eq!(
+            package.get("version").and_then(toml::Value::as_str),
+            Some(INCAN_VERSION)
+        );
+        assert!(package.get("license").is_none());
         Ok(())
     }
 

--- a/src/backend/project/generator.rs
+++ b/src/backend/project/generator.rs
@@ -7,6 +7,7 @@
 //! - [`super::cargo_toml`] — `Cargo.toml` rendering (`generate_cargo_toml`, `format_dependency_spec`)
 //! - [`super::runner`] — `build()`, `run()`, `run_with_cwd()` and result types
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::io;
@@ -17,6 +18,7 @@ use crate::manifest::DependencySpec;
 use crate::provider::{ProviderPlan, SDK_PROVIDER_BUILD_ENV};
 use incan_core::lang::{rust_keywords, stdlib};
 use sha2::{Digest as _, Sha256};
+use toml_edit::{DocumentMut, Item, value};
 
 const MOD_INSERT_MARKER: &str = "// __INCAN_INSERT_MODS__";
 pub(crate) const GENERATED_CARGO_TARGET_DIR_ENV: &str = "INCAN_GENERATED_CARGO_TARGET_DIR";
@@ -65,6 +67,10 @@ pub struct ProjectGenerator {
     pub(super) name: String,
     /// Optional Cargo package name when it should differ from the generated target name.
     pub(super) package_name: Option<String>,
+    /// Optional project version to use for the generated Cargo package.
+    pub(super) package_version: Option<String>,
+    /// Optional SPDX license identifier or expression for the generated Cargo package.
+    pub(super) package_license: Option<String>,
     /// Whether this is a binary (true) or library (false)
     pub(super) is_binary: bool,
     /// Enabled stdlib feature flags for the generated project (for example `json`, `async`, `web`).
@@ -107,6 +113,8 @@ impl ProjectGenerator {
             output_dir: output_dir.as_ref().to_path_buf(),
             name: name.to_string(),
             package_name: None,
+            package_version: None,
+            package_license: None,
             is_binary,
             stdlib_features: Vec::new(),
             dependencies: Vec::new(),
@@ -137,6 +145,22 @@ impl ProjectGenerator {
     /// Override the Cargo package name while preserving the generated Rust target name.
     pub fn set_package_name(&mut self, package_name: Option<String>) {
         self.package_name = package_name;
+    }
+
+    /// Set optional authored project metadata for the generated Cargo package.
+    pub fn set_package_metadata(&mut self, version: Option<String>, license: Option<String>) {
+        self.package_version = version;
+        self.package_license = license;
+    }
+
+    /// Return the Cargo package name selected for the generated manifest and lockfile root.
+    pub(super) fn cargo_package_name(&self) -> &str {
+        self.package_name.as_deref().unwrap_or(&self.name)
+    }
+
+    /// Return the authored Cargo package version or the compiler-version fallback.
+    pub(super) fn cargo_package_version(&self) -> &str {
+        self.package_version.as_deref().unwrap_or(crate::version::INCAN_VERSION)
     }
 
     /// Set resolved Rust dependencies.
@@ -794,7 +818,44 @@ impl ProjectGenerator {
         let Some(payload) = &self.cargo_lock_payload else {
             return Ok(false);
         };
-        Self::write_file_if_changed(&self.output_dir.join("Cargo.lock"), payload)
+        let payload = self.cargo_lock_payload_for_package(payload)?;
+        Self::write_file_if_changed(&self.output_dir.join("Cargo.lock"), payload.as_ref())
+    }
+
+    /// Align the source-less Cargo.lock root entry with this generated package's version.
+    ///
+    /// Canonical Incan locks resolve dependencies through an internal package identity. Generated application and
+    /// library manifests can carry an authored project version, and Cargo treats a root-version difference as a lock
+    /// mutation under `--locked` or `--frozen`. Rewriting only the matching source-less root entry preserves the
+    /// resolved dependency closure while making the materialized lock agree with its generated manifest.
+    fn cargo_lock_payload_for_package<'a>(&self, payload: &'a str) -> io::Result<Cow<'a, str>> {
+        let mut document = payload
+            .parse::<DocumentMut>()
+            .map_err(|error| io::Error::other(format!("failed to parse generated Cargo.lock payload: {error}")))?;
+        let package_name = self.cargo_package_name();
+        let package_version = self.cargo_package_version();
+        let mut changed = false;
+
+        if let Some(packages) = document.get_mut("package").and_then(Item::as_array_of_tables_mut) {
+            for package in packages.iter_mut() {
+                let matches_root =
+                    package.get("name").and_then(Item::as_str) == Some(package_name) && package.get("source").is_none();
+                if !matches_root {
+                    continue;
+                }
+                if package.get("version").and_then(Item::as_str) != Some(package_version) {
+                    package["version"] = value(package_version);
+                    changed = true;
+                }
+                break;
+            }
+        }
+
+        if changed {
+            Ok(Cow::Owned(document.to_string()))
+        } else {
+            Ok(Cow::Borrowed(payload))
+        }
     }
 }
 
@@ -1186,6 +1247,47 @@ mod tests {
             !stale_module.exists(),
             "artifact-owned modules discovered from the manifest must be removed from reused consumer projects"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn cargo_lock_payload_uses_generated_package_version() -> Result<(), Box<dyn std::error::Error>> {
+        let mut generator = ProjectGenerator::new("/tmp/generated_lock_metadata", "generated_target", true);
+        generator.set_package_name(Some("locked_root".to_string()));
+        generator.set_package_metadata(Some("1.2.3".to_string()), None);
+        let payload = r#"version = 4
+
+[[package]]
+name = "locked_root"
+version = "0.5.0-dev.8"
+
+[[package]]
+name = "locked_root"
+version = "9.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#;
+
+        let rewritten = generator.cargo_lock_payload_for_package(payload)?;
+        let lock: toml::Value = toml::from_str(rewritten.as_ref())?;
+        let packages = lock
+            .get("package")
+            .and_then(toml::Value::as_array)
+            .ok_or("rewritten Cargo.lock had no package array")?;
+        let root_version = packages
+            .iter()
+            .find(|package| package.get("source").is_none())
+            .and_then(|package| package.get("version"))
+            .and_then(toml::Value::as_str)
+            .ok_or("rewritten Cargo.lock had no source-less root version")?;
+        let registry_version = packages
+            .iter()
+            .find(|package| package.get("source").is_some())
+            .and_then(|package| package.get("version"))
+            .and_then(toml::Value::as_str)
+            .ok_or("rewritten Cargo.lock had no registry package version")?;
+
+        assert_eq!(root_version, "1.2.3");
+        assert_eq!(registry_version, "9.9.9");
         Ok(())
     }
 

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -873,6 +873,9 @@ fn prepare_project_with_options(
     }
     // ---- Setup project generator ----
     let mut generator = ProjectGenerator::new(&out_dir, project_name.as_str(), true);
+    if let Some(project) = manifest.as_ref().and_then(|manifest| manifest.project.as_ref()) {
+        generator.set_package_metadata(project.version.clone(), project.license.clone());
+    }
     generator.set_provider_plan(&provider_plan);
     generator.set_cargo_target_dir_override(options.generated_cargo_target_dir.map(Path::to_path_buf));
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
@@ -1423,6 +1426,7 @@ fn prepare_library_project(
         .as_ref()
         .and_then(|project| project.version.clone())
         .unwrap_or_else(|| "0.1.0".to_string());
+    let project_license = manifest.project.as_ref().and_then(|project| project.license.clone());
 
     let mut library_manifest =
         LibraryManifest::from_checked_exports(project_name.clone(), project_version.clone(), &selected_exports);
@@ -1494,6 +1498,7 @@ fn prepare_library_project(
     }
     let mut generator = ProjectGenerator::new(&out_dir, project_name.as_str(), false);
     generator.set_package_name(Some(cargo_package_name.clone()));
+    generator.set_package_metadata(Some(project_version.clone()), project_license);
     generator.set_provider_plan(&provider_plan);
     generator.set_cargo_target_dir_override(generated_cargo_target_dir.map(Path::to_path_buf));
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -894,13 +894,13 @@ members = ["packages/*"]
 itoa = "1"
 "#,
     )?;
-    for name in ["alpha", "zebra"] {
+    for (name, version) in [("alpha", "1.2.3"), ("zebra", "4.5.6")] {
         let member_root = root.path().join("packages").join(name);
         fs::create_dir_all(member_root.join("src"))?;
         fs::write(
             member_root.join("incan.toml"),
             format!(
-                "[project]\nname = \"{name}\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n\n[project.features]\ndefault = [\"{name}\"]\n{name} = []\n{}",
+                "[project]\nname = \"{name}\"\nversion = \"{version}\"\n\n[project.scripts]\nmain = \"src/main.incn\"\n\n[project.features]\ndefault = [\"{name}\"]\n{name} = []\n{}",
                 if name == "alpha" {
                     "\n[rust-dependencies]\nitoa = { workspace = true }\n"
                 } else {
@@ -971,11 +971,23 @@ itoa = "1"
             && !root.path().join("packages/zebra/incan.lock").exists(),
         "workspace members must not receive authoritative lockfiles"
     );
-    for name in ["alpha", "zebra"] {
+    for (name, version) in [("alpha", "1.2.3"), ("zebra", "4.5.6")] {
         let build_output = run_incan(&root.path().join("packages").join(name), &["build", "--locked"])?;
         assert_success(
             &build_output,
             &format!("incan build --locked from workspace member {name}"),
+        );
+        let generated_manifest = fs::read_to_string(
+            root.path()
+                .join("packages")
+                .join(name)
+                .join("target/incan")
+                .join(name)
+                .join("Cargo.toml"),
+        )?;
+        assert!(
+            generated_manifest.contains(&format!("version = \"{version}\"")),
+            "workspace member {name} did not preserve its authored package version:\n{generated_manifest}"
         );
     }
     Ok(())

--- a/tests/generated_rust_artifact_tests.rs
+++ b/tests/generated_rust_artifact_tests.rs
@@ -123,8 +123,14 @@ fn generated_application_artifact_matches_baseline() -> Result<(), Box<dyn std::
     fs::create_dir_all(&src_dir)?;
     fs::write(
         project_root.join("incan.toml"),
-        "[project]\nname = \"artifact_app_baseline\"\nversion = \"0.1.0\"\n",
+        r#"[project]
+name = "artifact_app_baseline"
+version = "2.3.4"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+"#,
     )?;
+    fs::write(project_root.join("LICENSE"), "Apache License 2.0\n")?;
     write_fixture(&src_dir.join("main.incn"), "app_main.incn")?;
 
     let out_dir = project_root.join("out");
@@ -146,7 +152,13 @@ fn generated_application_artifact_matches_baseline() -> Result<(), Box<dyn std::
     let cargo_toml = read_cargo_toml(&out_dir.join("Cargo.toml"))?;
     let package = toml_table_at(&cargo_toml, "package")?;
     assert_eq!(toml_string_at(package, "name")?, "artifact_app_baseline");
+    assert_eq!(toml_string_at(package, "version")?, "2.3.4");
     assert_eq!(toml_string_at(package, "edition")?, "2021");
+    assert_eq!(toml_string_at(package, "license")?, "Apache-2.0");
+    assert!(
+        package.get("license-file").is_none(),
+        "Incan's plural license-files metadata must not become Cargo's singular license-file field"
+    );
     let dependencies = toml_table_at(&cargo_toml, "dependencies")?;
     assert!(
         toml_at(dependencies, "incan_stdlib").is_ok(),
@@ -161,6 +173,39 @@ fn generated_application_artifact_matches_baseline() -> Result<(), Box<dyn std::
 }
 
 #[test]
+fn generated_application_without_package_metadata_uses_compiler_defaults() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let project_root = tmp.path().join("artifact_default_metadata_project");
+    let src_dir = project_root.join("src");
+    fs::create_dir_all(&src_dir)?;
+    fs::write(
+        project_root.join("incan.toml"),
+        "[project]\nname = \"artifact_default_metadata\"\n",
+    )?;
+    write_fixture(&src_dir.join("main.incn"), "app_main.incn")?;
+
+    let out_dir = project_root.join("out");
+    let main_arg = src_dir
+        .join("main.incn")
+        .to_str()
+        .ok_or("application source path was not valid UTF-8")?
+        .to_string();
+    let out_arg = out_dir
+        .to_str()
+        .ok_or("application output path was not valid UTF-8")?
+        .to_string();
+    let output = run_incan(&project_root, &["build", &main_arg, &out_arg])?;
+    assert_success(&output, "incan build application artifact with default metadata");
+
+    let cargo_toml = read_cargo_toml(&out_dir.join("Cargo.toml"))?;
+    let package = toml_table_at(&cargo_toml, "package")?;
+    assert_eq!(toml_string_at(package, "version")?, env!("CARGO_PKG_VERSION"));
+    assert!(package.get("license").is_none());
+
+    Ok(())
+}
+
+#[test]
 fn generated_library_and_pub_dependency_consumer_artifacts_match_baseline() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let project_root = tmp.path().join("artifact_widgets_project");
@@ -168,8 +213,15 @@ fn generated_library_and_pub_dependency_consumer_artifacts_match_baseline() -> R
     fs::create_dir_all(&src_dir)?;
     fs::write(
         project_root.join("incan.toml"),
-        "[project]\nname = \"artifact_widgets_core\"\nversion = \"0.1.0\"\n",
+        r#"[project]
+name = "artifact_widgets_core"
+version = "4.5.6"
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE-MIT", "LICENSE-APACHE"]
+"#,
     )?;
+    fs::write(project_root.join("LICENSE-MIT"), "MIT License\n")?;
+    fs::write(project_root.join("LICENSE-APACHE"), "Apache License 2.0\n")?;
     write_fixture(&src_dir.join("widgets.incn"), "library_widgets.incn")?;
     write_fixture(&src_dir.join("lib.incn"), "library_lib.incn")?;
 
@@ -186,7 +238,7 @@ fn generated_library_and_pub_dependency_consumer_artifacts_match_baseline() -> R
 
     let manifest = LibraryManifest::read_from_path(&artifact_root.join("artifact_widgets_core.incnlib"))?;
     assert_eq!(manifest.name, "artifact_widgets_core");
-    assert_eq!(manifest.version, "0.1.0");
+    assert_eq!(manifest.version, "4.5.6");
     assert!(
         manifest.exports.models.iter().any(|model| model.name == "Widget"),
         "generated .incnlib should export Widget, got {:#?}",
@@ -203,9 +255,13 @@ fn generated_library_and_pub_dependency_consumer_artifacts_match_baseline() -> R
     );
 
     let cargo_toml = read_cargo_toml(&artifact_root.join("Cargo.toml"))?;
-    assert_eq!(
-        toml_string_at(toml_table_at(&cargo_toml, "package")?, "name")?,
-        "artifact_widgets_core"
+    let package = toml_table_at(&cargo_toml, "package")?;
+    assert_eq!(toml_string_at(package, "name")?, "artifact_widgets_core");
+    assert_eq!(toml_string_at(package, "version")?, manifest.version);
+    assert_eq!(toml_string_at(package, "license")?, "MIT OR Apache-2.0");
+    assert!(
+        package.get("license-file").is_none(),
+        "Incan's plural license-files metadata must not become Cargo's singular license-file field"
     );
     assert_eq!(
         toml_string_at(toml_table_at(&cargo_toml, "lib")?, "path")?,

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -30,6 +30,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: Generated Cargo packages now preserve the authored Incan project version and SPDX license for application and library builds, keeping library `Cargo.toml` versions aligned with their `.incnlib` manifests (#889).
 - **Compiler**: `std::io::stdout()` now retains its stable `Stdout` receiver type when sysroot metadata is unavailable, so fallible extension-trait calls such as crossterm's `ExecutableCommand.execute(...)` expose their native `Result` and support postfix `?` (#888).
 - **Compiler**: Class-field privacy now survives checked metadata and compiled package boundaries. Named construction through a compiled package uses an exact package-owned constructor bridge—including aliases, inherited fields, and provider-owned defaults—while later private member access receives an Incan diagnostic instead of a Rust privacy failure; older manifests without field visibility retain their compatible public behavior (#883).
 - **Compiler**: Absolute sibling-module imports such as `from crate.types import Decision` now retain public model fields and enum variants across direct checks, generated builds, library builds, re-exports, and test batches (#882).

--- a/workspaces/docs-site/docs/tooling/reference/project_configuration.md
+++ b/workspaces/docs-site/docs/tooling/reference/project_configuration.md
@@ -35,6 +35,8 @@ requires-incan = ">=0.2"
 
 `requires-incan` is enforced by project-aware execution commands. If the active compiler does not satisfy the requirement, `incan run` in project mode, `incan build`, `incan test`, `incan lock`, and `incan env run` fail before compiling, locking, or launching scripts. Single-file or inline commands without a discovered project manifest do not infer a toolchain requirement.
 
+For `incan build` and `incan build --lib`, declared `version` and `license` values are preserved in the generated Cargo package. A generated library's Cargo version therefore matches its `.incnlib` version. The plural Incan `license-files` field remains source-package metadata and is not translated to Cargo's singular `license-file` field.
+
 ### `[project.scripts]`
 
 Named entry points for CLI commands:


### PR DESCRIPTION
## Summary

Preserve the Incan project's authored package version and SPDX license in generated Cargo application and library projects. Keep compiler-owned generated crates on the compiler-version fallback, align generated library Cargo metadata with the `.incnlib` manifest, and materialize lockfile root entries with the generated package's actual version so `--locked` and `--frozen` remain valid.

Closes #889.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Generated application and library `Cargo.toml` files now use `[project].version` and `[project].license`. A declared `license-files` list is not incorrectly converted into Cargo's singular `license-file` key.
- **Internals**: `ProjectGenerator` carries optional authored package metadata into Cargo generation, with the compiler version retained as the fallback for compiler-owned projects. Lockfile root package versions are rewritten copy-on-write to match the generated package identity, including locked/frozen builds and workspaces whose members legitimately have different versions.
- **Integration sequencing**: the branch is rebased onto merged #894 at `75e12cbc8`, advances the workspace to `0.5.0-dev.11`, and removes the superseded #897 compatibility overlap without leaving the duplicate field produced by automatic merge.
- **Risks**: Generated manifest and lock root identity are release-sensitive. Coverage includes application/library artifacts, fallback generation, direct locked/frozen builds, and a distinct-version workspace.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- The original implementation passed the complete pre-commit gate: 2,995/2,995 tests plus clippy, cargo-deny, release build, assertion canary, examples, and benchmark builds.
- On the final rebased branch, lock-root normalization passed, all four generated application/library/fallback/path-dependency artifact regressions passed, and workspace root-lock publication passed.
- `make fmt` and `git diff --check` passed after conflict resolution.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

- `workspaces/docs-site/docs/tooling/reference/project_configuration.md`
- `workspaces/docs-site/docs/release_notes/0_5.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
