### PR TITLE
bugfix - preserve pub import alias identity (#892)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "blake2",
  "blake3",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/backend/ir/emit/program.rs
+++ b/src/backend/ir/emit/program.rs
@@ -2266,7 +2266,15 @@ impl<'a> IrEmitter<'a> {
     /// payloads can preserve public dependency ownership across nested argument and collection positions.
     fn target_external_union_covers_expr(target_ty: &IrType, expr_ty: &IrType) -> bool {
         match (target_ty, expr_ty) {
-            (IrType::ExternalUnion { .. }, _) => target_ty.union_type_name() == expr_ty.union_type_name(),
+            (
+                IrType::ExternalUnion { library, .. },
+                IrType::ExternalUnion {
+                    library: expr_library, ..
+                },
+            ) if library != expr_library => false,
+            (IrType::ExternalUnion { library, .. }, _) => {
+                target_ty.union_type_name() == expr_ty.provider_localized(library).union_type_name()
+            }
             (IrType::List(target), IrType::List(expr)) | (IrType::Set(target), IrType::Set(expr)) => {
                 Self::target_external_union_covers_expr(target, expr)
             }
@@ -3582,6 +3590,27 @@ mod tests {
         assert!(!IrEmitter::target_external_union_covers_expr(
             &IrType::Result(Box::new(external_provider_union()), Box::new(IrType::String)),
             &IrType::Result(Box::new(provider_union()), Box::new(local_union()))
+        ));
+    }
+
+    #[test]
+    fn external_union_coverage_localizes_only_the_target_provider_issue892() {
+        let qualified_provider_union = union(vec![
+            IrType::Struct("provider::ProviderColumn".to_string()),
+            IrType::Int,
+        ]);
+        let foreign_union = IrType::ExternalUnion {
+            library: "other".to_string(),
+            union: Box::new(qualified_provider_union.clone()),
+        };
+
+        assert!(IrEmitter::target_external_union_covers_expr(
+            &external_provider_union(),
+            &qualified_provider_union
+        ));
+        assert!(!IrEmitter::target_external_union_covers_expr(
+            &external_provider_union(),
+            &foreign_union
         ));
     }
 

--- a/src/backend/ir/lower/types.rs
+++ b/src/backend/ir/lower/types.rs
@@ -17,6 +17,7 @@ use crate::frontend::ast;
 use crate::frontend::library_manifest_index::LibraryManifestIndexEntry;
 use crate::frontend::resolved_type_subst::{substitute_resolved_type, type_param_subst_map};
 use crate::frontend::symbols::ResolvedType;
+use crate::frontend::typechecker::split_canonical_public_library_type_name;
 use crate::library_manifest::{TypeAliasExport, resolved_type_from_manifest_type_ref};
 use crate::numeric_adapters::{ir_type_to_numeric_ty, numeric_op_from_ast};
 use incan_core::lang::conventions;
@@ -120,6 +121,7 @@ impl AstLowering {
         if matches!(ty, IrType::ExternalUnion { .. }) {
             return ty;
         }
+        let ty = ty.provider_localized(library);
         if ty.union_type_name().is_some() {
             return IrType::ExternalUnion {
                 library: library.to_string(),
@@ -668,6 +670,19 @@ impl AstLowering {
     /// This is used when lowering is driven by the typechecker output rather than AST heuristics.
     #[allow(clippy::only_used_in_recursion)]
     pub(super) fn lower_resolved_type(&self, ty: &ResolvedType) -> IrType {
+        if let ResolvedType::Named(name) = ty
+            && let Some((library, public_name)) = split_canonical_public_library_type_name(name)
+        {
+            return IrType::Struct(format!("{library}::{public_name}"));
+        }
+        if let ResolvedType::Generic(name, args) = ty
+            && let Some((library, public_name)) = split_canonical_public_library_type_name(name)
+        {
+            return IrType::NamedGeneric(
+                format!("{library}::{public_name}"),
+                args.iter().map(|arg| self.lower_resolved_type(arg)).collect(),
+            );
+        }
         match ty {
             // Rust `!` is carried only for typechecking diverging interop calls; the call expression itself keeps its
             // concrete Rust spelling through lowering.
@@ -1084,6 +1099,68 @@ mod tests {
     use super::AstLowering;
     use crate::backend::ir::types::IrType;
     use crate::frontend::symbols::ResolvedType;
+    use crate::frontend::typechecker::canonical_public_library_type_name;
+
+    /// Regression for #892: checker-owned public-library keys lower to provider-qualified Rust nominal paths.
+    #[test]
+    fn lower_resolved_type_qualifies_canonical_public_library_identity_issue892() {
+        let lowering = AstLowering::new();
+        let lowered = lowering.lower_resolved_type(&ResolvedType::Named(canonical_public_library_type_name(
+            "widgets", "Widget",
+        )));
+
+        assert_eq!(lowered, IrType::Struct("widgets::Widget".to_string()));
+    }
+
+    /// Regression for #892: provider qualification survives generic nominal lowering and nested carrier arguments.
+    #[test]
+    fn lower_resolved_type_qualifies_generic_public_library_identity_issue892() {
+        let lowering = AstLowering::new();
+        let lowered = lowering.lower_resolved_type(&ResolvedType::Generic(
+            canonical_public_library_type_name("widgets", "Envelope"),
+            vec![ResolvedType::Named(canonical_public_library_type_name(
+                "widgets", "Widget",
+            ))],
+        ));
+
+        assert_eq!(
+            lowered,
+            IrType::NamedGeneric(
+                "widgets::Envelope".to_string(),
+                vec![IrType::Struct("widgets::Widget".to_string())]
+            )
+        );
+    }
+
+    /// Regression for #755/#892: provider-owned union members use provider-local names before wrapper identity hashing.
+    #[test]
+    fn pub_external_type_normalizes_canonical_union_members_issue892() {
+        let lowering = AstLowering::new();
+        let lowered = lowering.pub_external_type(
+            "widgets",
+            IrType::NamedGeneric(
+                crate::backend::ir::types::IR_UNION_TYPE_NAME.to_string(),
+                vec![
+                    IrType::Struct("widgets::Widget".to_string()),
+                    IrType::Struct("widgets::Fallback".to_string()),
+                ],
+            ),
+        );
+
+        assert_eq!(
+            lowered,
+            IrType::ExternalUnion {
+                library: "widgets".to_string(),
+                union: Box::new(IrType::NamedGeneric(
+                    crate::backend::ir::types::IR_UNION_TYPE_NAME.to_string(),
+                    vec![
+                        IrType::Struct("Widget".to_string()),
+                        IrType::Struct("Fallback".to_string())
+                    ]
+                ))
+            }
+        );
+    }
 
     #[test]
     fn lower_resolved_type_preserves_named_generic_args_for_nominal_types() {

--- a/src/backend/ir/types.rs
+++ b/src/backend/ir/types.rs
@@ -126,6 +126,50 @@ pub enum IrType {
 }
 
 impl IrType {
+    /// Remove one owning provider's qualification from nominal paths while preserving the complete type shape.
+    ///
+    /// Public-library expressions retain qualified names in consumer IR. Provider-owned signature and anonymous-union
+    /// metadata use names local to the compiled provider, so only the matching provider prefix may be removed when
+    /// comparing or hashing those boundary types.
+    pub(crate) fn provider_localized(&self, library: &str) -> Self {
+        let prefix = format!("{library}::");
+        let local_name = |name: &str| name.strip_prefix(&prefix).unwrap_or(name).to_string();
+        match self {
+            Self::Struct(name) => Self::Struct(local_name(name)),
+            Self::Enum(name) => Self::Enum(local_name(name)),
+            Self::Trait(name) => Self::Trait(local_name(name)),
+            Self::NamedGeneric(name, args) => Self::NamedGeneric(
+                local_name(name),
+                args.iter().map(|arg| arg.provider_localized(library)).collect(),
+            ),
+            Self::List(inner) => Self::List(Box::new(inner.provider_localized(library))),
+            Self::Dict(key, value) => Self::Dict(
+                Box::new(key.provider_localized(library)),
+                Box::new(value.provider_localized(library)),
+            ),
+            Self::Set(inner) => Self::Set(Box::new(inner.provider_localized(library))),
+            Self::Tuple(items) => Self::Tuple(items.iter().map(|item| item.provider_localized(library)).collect()),
+            Self::Option(inner) => Self::Option(Box::new(inner.provider_localized(library))),
+            Self::Result(ok, err) => Self::Result(
+                Box::new(ok.provider_localized(library)),
+                Box::new(err.provider_localized(library)),
+            ),
+            Self::Function { params, ret } => Self::Function {
+                params: params.iter().map(|param| param.provider_localized(library)).collect(),
+                ret: Box::new(ret.provider_localized(library)),
+            },
+            Self::Ref(inner) => Self::Ref(Box::new(inner.provider_localized(library))),
+            Self::RefMut(inner) => Self::RefMut(Box::new(inner.provider_localized(library))),
+            Self::TypeToken(inner) => Self::TypeToken(Box::new(inner.provider_localized(library))),
+            Self::ExternalUnion { library: owner, union } if owner == library => Self::ExternalUnion {
+                library: owner.clone(),
+                union: Box::new(union.provider_localized(library)),
+            },
+            Self::ExternalUnion { .. } => self.clone(),
+            other => other.clone(),
+        }
+    }
+
     /// Return whether this type mentions an unbound generic type parameter.
     pub fn contains_generic_parameter(&self) -> bool {
         match self {
@@ -355,9 +399,13 @@ impl IrType {
     /// Find the union variant index that can hold `member_ty`.
     pub fn union_variant_index_for_member(&self, member_ty: &IrType) -> Option<usize> {
         let members = self.union_members()?;
+        let member_ty = match self {
+            Self::ExternalUnion { library, .. } => member_ty.provider_localized(library),
+            _ => member_ty.clone(),
+        };
         members
             .iter()
-            .position(|member| union_member_type_matches(member, member_ty))
+            .position(|member| union_member_type_matches(member, &member_ty))
     }
 }
 
@@ -712,5 +760,40 @@ mod tests {
     fn test_incan_name_named_generic() {
         let ty = IrType::NamedGeneric("Json".to_string(), vec![IrType::Struct("User".to_string())]);
         assert_eq!(ty.incan_name(), "Json[User]");
+    }
+
+    /// Regression for #755/#892: external unions accept only members qualified by their own provider.
+    #[test]
+    fn external_union_member_matching_is_provider_aware_issue892() {
+        let union = IrType::ExternalUnion {
+            library: "widgets".to_string(),
+            union: Box::new(IrType::NamedGeneric(
+                IR_UNION_TYPE_NAME.to_string(),
+                vec![IrType::Struct("Widget".to_string())],
+            )),
+        };
+
+        assert_eq!(
+            union.union_variant_index_for_member(&IrType::Struct("widgets::Widget".to_string())),
+            Some(0)
+        );
+        assert_eq!(
+            union.union_variant_index_for_member(&IrType::Struct("other::Widget".to_string())),
+            None
+        );
+    }
+
+    /// Regression for #892: localizing one provider must not rewrite a union owned by another provider.
+    #[test]
+    fn provider_localization_preserves_foreign_external_union_issue892() {
+        let foreign_union = IrType::ExternalUnion {
+            library: "other".to_string(),
+            union: Box::new(IrType::NamedGeneric(
+                IR_UNION_TYPE_NAME.to_string(),
+                vec![IrType::Struct("widgets::Widget".to_string())],
+            )),
+        };
+
+        assert_eq!(foreign_union.provider_localized("widgets"), foreign_union);
     }
 }

--- a/src/frontend/typechecker/check_expr/mod.rs
+++ b/src/frontend/typechecker/check_expr/mod.rs
@@ -124,12 +124,8 @@ impl TypeChecker {
             return Some(kind);
         }
         if module_path.len() == 2 && module_path.first().is_some_and(|seg| seg == "pub") {
-            let entry = self.provider_plan.library_manifest_index().get(&module_path[1])?;
-            let crate::frontend::library_manifest_index::LibraryManifestIndexEntry::Loaded { manifest, .. } = entry
-            else {
-                return None;
-            };
-            return self.pub_library_function_symbol(manifest, member);
+            let kind = self.lookup_pub_library_symbol_member(&module_path[1], member)?;
+            return matches!(kind, SymbolKind::Function(_) | SymbolKind::FunctionOverloads(_)).then_some(kind);
         }
         None
     }

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -3,7 +3,7 @@
 //! This keeps stdlib import enforcement (RFC 022) separate from general declaration collection while preserving the
 //! existing behavior.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::frontend::api_metadata::{
     ApiDeclaration, class_export_from_api, enum_export_from_api, function_export_from_api,
@@ -22,7 +22,8 @@ use crate::frontend::testing_markers::{
 };
 use crate::frontend::typechecker::type_info::RustTraitImportInfo;
 use crate::frontend::typechecker::{
-    PartialProjectionInfo, PartialProjectionPreset, PartialProjectionTargetKind, TypeChecker,
+    PartialProjectionInfo, PartialProjectionPreset, PartialProjectionTargetKind, PublicLibraryTypeIdentity,
+    TypeChecker, canonical_public_library_type_name,
 };
 use crate::library_manifest::{
     AliasExport, ClassExport, ConstExport, EnumExport, EnumValueExport, EnumValueTypeExport, FieldExport,
@@ -1040,15 +1041,7 @@ impl TypeChecker {
         self.cache_transitive_pub_export_semantics(library, &manifest);
 
         let available_exports = Self::manifest_export_names(&manifest);
-        let mut imported_type_aliases: HashMap<String, String> = HashMap::new();
-        for item in items {
-            let local_name = item.alias.clone().unwrap_or_else(|| item.name.clone());
-            if let Some(export) = Self::find_manifest_export(&manifest, &item.name)
-                && Self::manifest_export_is_type(&export)
-            {
-                imported_type_aliases.insert(item.name.clone(), local_name);
-            }
-        }
+        let imported_type_aliases = self.public_library_type_import_remapping(library, &manifest);
 
         for item in items {
             let local_name = item.alias.clone().unwrap_or_else(|| item.name.clone());
@@ -1109,6 +1102,135 @@ impl TypeChecker {
         }
     }
 
+    /// Build the provider-aware type remapping shared by every import statement for one compiled library.
+    ///
+    /// The whole program's import table is available before declaration collection starts, so a callable imported in a
+    /// later statement can use a type alias declared in an earlier statement. Provider-owned signature types without a
+    /// local import receive an internal qualified spelling so identical short names from separate dependencies remain
+    /// distinct.
+    fn public_library_type_import_remapping(
+        &mut self,
+        library: &str,
+        manifest: &LibraryManifest,
+    ) -> HashMap<String, String> {
+        let mut local_names_by_public_export: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for (local_name, path) in &self.import_aliases {
+            let [root, dependency_key, public_name] = path.as_slice() else {
+                continue;
+            };
+            if root != "pub" || dependency_key != library || !self.manifest_public_name_is_type(manifest, public_name) {
+                continue;
+            }
+            local_names_by_public_export
+                .entry(public_name.clone())
+                .or_default()
+                .push(local_name.clone());
+        }
+        for local_names in local_names_by_public_export.values_mut() {
+            local_names.sort();
+            local_names.dedup();
+        }
+
+        let mut remapping = self.public_library_canonical_type_remapping(library, manifest);
+        for (public_name, local_names) in local_names_by_public_export {
+            if let Some(identity) = self.public_library_nominal_type_identity(library, manifest, &public_name) {
+                for local_name in &local_names {
+                    self.public_library_type_identities
+                        .insert(local_name.clone(), identity.clone());
+                }
+            }
+            if let Some(local_name) = local_names.into_iter().next() {
+                remapping.insert(public_name, local_name);
+            }
+        }
+        remapping
+    }
+
+    /// Build an import-scope-independent provider-qualified remapping for one compiled library.
+    ///
+    /// Qualified module access has no local `from` import whose alias can carry identity, so every nominal manifest
+    /// spelling is mapped to its checker-owned canonical key before the member's signature enters expression checking.
+    fn public_library_canonical_type_remapping(
+        &mut self,
+        library: &str,
+        manifest: &LibraryManifest,
+    ) -> HashMap<String, String> {
+        let mut remapping = HashMap::new();
+        let public_names = manifest
+            .contract_metadata
+            .identity_graph
+            .exports
+            .iter()
+            .map(|entry| entry.public_name.clone())
+            .collect::<Vec<_>>();
+        for public_name in public_names {
+            let Some(identity) = self.public_library_nominal_type_identity(library, manifest, &public_name) else {
+                continue;
+            };
+            let canonical_name = canonical_public_library_type_name(library, &public_name);
+            self.public_library_type_identities
+                .insert(canonical_name.clone(), identity);
+            remapping.insert(public_name, canonical_name);
+        }
+        remapping
+    }
+
+    /// Return whether one public manifest spelling resolves to a type-like import binding.
+    fn manifest_public_name_is_type(&self, manifest: &LibraryManifest, public_name: &str) -> bool {
+        let Some(export) = Self::find_manifest_export(manifest, public_name) else {
+            return false;
+        };
+        match export {
+            ManifestExportRef::Alias(alias) => self
+                .symbol_kind_from_manifest_alias(manifest, alias, &mut HashSet::new())
+                .is_some_and(|kind| matches!(kind, SymbolKind::Type(_) | SymbolKind::Trait(_))),
+            other => Self::manifest_export_is_type(&other),
+        }
+    }
+
+    /// Resolve one public spelling to nominal model/class/enum/newtype metadata.
+    fn manifest_nominal_type_info(&self, manifest: &LibraryManifest, public_name: &str) -> Option<TypeInfo> {
+        let export = Self::find_manifest_export(manifest, public_name)?;
+        let kind = match export {
+            ManifestExportRef::Alias(alias) => {
+                self.symbol_kind_from_manifest_alias(manifest, alias, &mut HashSet::new())?
+            }
+            ManifestExportRef::Model(export) => {
+                SymbolKind::Type(TypeInfo::Model(self.model_info_from_manifest(export)))
+            }
+            ManifestExportRef::Class(export) => {
+                SymbolKind::Type(TypeInfo::Class(self.class_info_from_manifest(export)))
+            }
+            ManifestExportRef::Enum(export) => SymbolKind::Type(TypeInfo::Enum(self.enum_info_from_manifest(export))),
+            ManifestExportRef::Newtype(export) => {
+                SymbolKind::Type(TypeInfo::Newtype(self.newtype_info_from_manifest(export)))
+            }
+            _ => return None,
+        };
+        match kind {
+            SymbolKind::Type(
+                info @ (TypeInfo::Model(_) | TypeInfo::Class(_) | TypeInfo::Enum(_) | TypeInfo::Newtype(_)),
+            ) => Some(info),
+            _ => None,
+        }
+    }
+
+    /// Resolve one public nominal type spelling to its dependency-qualified provider source identity.
+    fn public_library_nominal_type_identity(
+        &self,
+        library: &str,
+        manifest: &LibraryManifest,
+        public_name: &str,
+    ) -> Option<PublicLibraryTypeIdentity> {
+        self.manifest_nominal_type_info(manifest, public_name)?;
+        let entry = manifest
+            .contract_metadata
+            .identity_graph
+            .entry_for_public_name(public_name)?;
+        let source_path = entry.target_path().unwrap_or(entry.source_path.as_slice());
+        Some(PublicLibraryTypeIdentity::new(library, source_path))
+    }
+
     /// Return the missing public features for one known provider export that is inactive in this artifact projection.
     fn inactive_pub_export_features(manifest: &LibraryManifest, symbol: &str) -> Option<Vec<Vec<String>>> {
         let active = &manifest.contract_metadata.provider.active_features;
@@ -1164,29 +1286,19 @@ impl TypeChecker {
 
     /// Resolve one exported const/static value type from a loaded `pub::` library manifest.
     pub(in crate::frontend::typechecker) fn lookup_pub_library_constant_member(
-        &self,
+        &mut self,
         library: &str,
         member: &str,
     ) -> Option<VariableInfo> {
-        let entry = self.provider_plan.library_manifest_index().get(library)?;
-        let LibraryManifestIndexEntry::Loaded { manifest, .. } = entry else {
-            return None;
-        };
-        if let Some(export) = manifest.exports.consts.iter().find(|item| item.name == member) {
-            return Some(VariableInfo {
-                ty: resolved_type_from_manifest_type_ref(&export.ty),
-                is_mutable: false,
-                is_used: false,
-            });
-        }
-        if let Some(export) = manifest.exports.statics.iter().find(|item| item.name == member) {
-            return Some(VariableInfo {
-                ty: resolved_type_from_manifest_type_ref(&export.ty),
+        match self.lookup_pub_library_symbol_member(library, member)? {
+            SymbolKind::Variable(info) => Some(info),
+            SymbolKind::Static(info) => Some(VariableInfo {
+                ty: info.ty,
                 is_mutable: true,
-                is_used: false,
-            });
+                is_used: info.is_used,
+            }),
+            _ => None,
         }
-        None
     }
 
     /// Resolve one exported member from an imported `pub::` library as a symbol kind.
@@ -1195,52 +1307,59 @@ impl TypeChecker {
     /// a direct `from pub::lib import member` symbol. Alias exports are followed to their manifest target before the
     /// projected kind is returned.
     pub(in crate::frontend::typechecker) fn lookup_pub_library_symbol_member(
-        &self,
+        &mut self,
         library: &str,
         member: &str,
     ) -> Option<SymbolKind> {
-        let entry = self.provider_plan.library_manifest_index().get(library)?;
+        let entry = self.provider_plan.library_manifest_index().get(library)?.clone();
         let LibraryManifestIndexEntry::Loaded { manifest, .. } = entry else {
             return None;
         };
-        if let Some(kind) = self.pub_library_function_symbol(manifest, member) {
-            return Some(kind);
-        }
-        let export = Self::find_manifest_export(manifest, member)?;
-        Some(match export {
-            ManifestExportRef::Model(export) => {
-                SymbolKind::Type(TypeInfo::Model(self.model_info_from_manifest(export)))
+        self.cache_transitive_pub_export_semantics(library, &manifest);
+        let remapping = self.public_library_canonical_type_remapping(library, &manifest);
+        let mut kind = if let Some(kind) = self.pub_library_function_symbol(&manifest, member) {
+            kind
+        } else {
+            let export = Self::find_manifest_export(&manifest, member)?;
+            match export {
+                ManifestExportRef::Model(export) => {
+                    SymbolKind::Type(TypeInfo::Model(self.model_info_from_manifest(export)))
+                }
+                ManifestExportRef::Class(export) => {
+                    SymbolKind::Type(TypeInfo::Class(self.class_info_from_manifest(export)))
+                }
+                ManifestExportRef::Function(export) => SymbolKind::Function(self.function_info_from_manifest(export)),
+                ManifestExportRef::Partial(export) => SymbolKind::Function(self.partial_info_from_manifest(export)),
+                ManifestExportRef::Trait(export) => SymbolKind::Trait(self.trait_info_from_manifest(export)),
+                ManifestExportRef::Enum(export) => {
+                    SymbolKind::Type(TypeInfo::Enum(self.enum_info_from_manifest(export)))
+                }
+                ManifestExportRef::TypeAlias(_) => SymbolKind::Type(TypeInfo::TypeAlias),
+                ManifestExportRef::Newtype(export) => {
+                    SymbolKind::Type(TypeInfo::Newtype(self.newtype_info_from_manifest(export)))
+                }
+                ManifestExportRef::Const(export) => SymbolKind::Variable(VariableInfo {
+                    ty: resolved_type_from_manifest_type_ref(&export.ty),
+                    is_mutable: false,
+                    is_used: false,
+                }),
+                ManifestExportRef::Static(export) => SymbolKind::Static(StaticInfo {
+                    ty: resolved_type_from_manifest_type_ref(&export.ty),
+                    is_public: true,
+                    is_imported: true,
+                    is_used: false,
+                }),
+                ManifestExportRef::EnumVariant { enum_name, fields } => SymbolKind::Variant(VariantInfo {
+                    enum_name: enum_name.to_string(),
+                    fields: fields.iter().map(resolved_type_from_manifest_type_ref).collect(),
+                }),
+                ManifestExportRef::Alias(export) => {
+                    self.symbol_kind_from_manifest_alias(&manifest, export, &mut HashSet::new())?
+                }
             }
-            ManifestExportRef::Class(export) => {
-                SymbolKind::Type(TypeInfo::Class(self.class_info_from_manifest(export)))
-            }
-            ManifestExportRef::Function(export) => SymbolKind::Function(self.function_info_from_manifest(export)),
-            ManifestExportRef::Partial(export) => SymbolKind::Function(self.partial_info_from_manifest(export)),
-            ManifestExportRef::Trait(export) => SymbolKind::Trait(self.trait_info_from_manifest(export)),
-            ManifestExportRef::Enum(export) => SymbolKind::Type(TypeInfo::Enum(self.enum_info_from_manifest(export))),
-            ManifestExportRef::TypeAlias(_) => SymbolKind::Type(TypeInfo::TypeAlias),
-            ManifestExportRef::Newtype(export) => {
-                SymbolKind::Type(TypeInfo::Newtype(self.newtype_info_from_manifest(export)))
-            }
-            ManifestExportRef::Const(export) => SymbolKind::Variable(VariableInfo {
-                ty: resolved_type_from_manifest_type_ref(&export.ty),
-                is_mutable: false,
-                is_used: false,
-            }),
-            ManifestExportRef::Static(export) => SymbolKind::Static(StaticInfo {
-                ty: resolved_type_from_manifest_type_ref(&export.ty),
-                is_public: true,
-                is_imported: true,
-                is_used: false,
-            }),
-            ManifestExportRef::EnumVariant { enum_name, fields } => SymbolKind::Variant(VariantInfo {
-                enum_name: enum_name.to_string(),
-                fields: fields.iter().map(resolved_type_from_manifest_type_ref).collect(),
-            }),
-            ManifestExportRef::Alias(export) => {
-                return self.symbol_kind_from_manifest_alias(manifest, export, &mut HashSet::new());
-            }
-        })
+        };
+        self.remap_symbol_kind_with_import_aliases(&mut kind, &remapping);
+        Some(kind)
     }
 
     /// Seed internal semantic caches for one `pub::` library's exported types and traits.
@@ -1252,6 +1371,7 @@ impl TypeChecker {
         if !self.cached_pub_libraries.insert(library.to_string()) {
             return;
         }
+        let canonical_remapping = self.public_library_canonical_type_remapping(library, manifest);
 
         for model in &manifest.exports.models {
             let model_info = self.model_info_from_manifest(model);
@@ -1287,6 +1407,24 @@ impl TypeChecker {
                 .entry(trait_export.name.clone())
                 .or_default()
                 .push(trait_info);
+        }
+
+        let canonical_types = manifest
+            .contract_metadata
+            .identity_graph
+            .exports
+            .iter()
+            .filter_map(|identity| {
+                let info = self.manifest_nominal_type_info(manifest, &identity.public_name)?;
+                Some((canonical_public_library_type_name(library, &identity.public_name), info))
+            })
+            .collect::<Vec<_>>();
+        for (canonical_name, info) in canonical_types {
+            let mut kind = SymbolKind::Type(info);
+            self.remap_symbol_kind_with_import_aliases(&mut kind, &canonical_remapping);
+            if let SymbolKind::Type(info) = kind {
+                self.transitive_pub_types.entry(canonical_name).or_default().push(info);
+            }
         }
     }
 
@@ -1785,20 +1923,11 @@ impl TypeChecker {
                 Self::remap_resolved_type_with_import_aliases(&mut info.ty, imported_type_aliases);
             }
             SymbolKind::Function(info) => {
-                for param in &mut info.params {
-                    Self::remap_resolved_type_with_import_aliases(&mut param.ty, imported_type_aliases);
-                }
-                Self::remap_resolved_type_with_import_aliases(&mut info.return_type, imported_type_aliases);
+                Self::remap_function_info_with_import_aliases(info, imported_type_aliases);
             }
             SymbolKind::FunctionOverloads(overloads) => {
                 for overload in overloads {
-                    for param in &mut overload.info.params {
-                        Self::remap_resolved_type_with_import_aliases(&mut param.ty, imported_type_aliases);
-                    }
-                    Self::remap_resolved_type_with_import_aliases(
-                        &mut overload.info.return_type,
-                        imported_type_aliases,
-                    );
+                    Self::remap_function_info_with_import_aliases(&mut overload.info, imported_type_aliases);
                 }
             }
             SymbolKind::Type(ty_info) => match ty_info {
@@ -1808,6 +1937,7 @@ impl TypeChecker {
                     {
                         *extends = alias.clone();
                     }
+                    Self::remap_type_bounds_with_import_aliases(&mut info.trait_adoptions, imported_type_aliases);
                     for field in info.fields.values_mut() {
                         Self::remap_resolved_type_with_import_aliases(&mut field.ty, imported_type_aliases);
                     }
@@ -1815,13 +1945,16 @@ impl TypeChecker {
                         Self::remap_resolved_type_with_import_aliases(&mut property.return_type, imported_type_aliases);
                     }
                     for method in info.methods.values_mut() {
-                        for param in &mut method.params {
-                            Self::remap_resolved_type_with_import_aliases(&mut param.ty, imported_type_aliases);
+                        Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
+                    }
+                    for overloads in info.method_overloads.values_mut() {
+                        for method in overloads {
+                            Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
                         }
-                        Self::remap_resolved_type_with_import_aliases(&mut method.return_type, imported_type_aliases);
                     }
                 }
                 TypeInfo::Model(info) => {
+                    Self::remap_type_bounds_with_import_aliases(&mut info.trait_adoptions, imported_type_aliases);
                     for field in info.fields.values_mut() {
                         Self::remap_resolved_type_with_import_aliases(&mut field.ty, imported_type_aliases);
                     }
@@ -1829,29 +1962,52 @@ impl TypeChecker {
                         Self::remap_resolved_type_with_import_aliases(&mut property.return_type, imported_type_aliases);
                     }
                     for method in info.methods.values_mut() {
-                        for param in &mut method.params {
-                            Self::remap_resolved_type_with_import_aliases(&mut param.ty, imported_type_aliases);
+                        Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
+                    }
+                    for overloads in info.method_overloads.values_mut() {
+                        for method in overloads {
+                            Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
                         }
-                        Self::remap_resolved_type_with_import_aliases(&mut method.return_type, imported_type_aliases);
                     }
                 }
                 TypeInfo::Newtype(info) => {
                     Self::remap_resolved_type_with_import_aliases(&mut info.underlying, imported_type_aliases);
+                    Self::remap_type_bounds_with_import_aliases(&mut info.trait_adoptions, imported_type_aliases);
                     for method in info.methods.values_mut() {
-                        for param in &mut method.params {
-                            Self::remap_resolved_type_with_import_aliases(&mut param.ty, imported_type_aliases);
+                        Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
+                    }
+                    for overloads in info.method_overloads.values_mut() {
+                        for method in overloads {
+                            Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
                         }
-                        Self::remap_resolved_type_with_import_aliases(&mut method.return_type, imported_type_aliases);
                     }
                 }
-                TypeInfo::Enum(_) | TypeInfo::TypeAlias | TypeInfo::Builtin => {}
+                TypeInfo::Enum(info) => {
+                    Self::remap_type_bounds_with_import_aliases(&mut info.trait_adoptions, imported_type_aliases);
+                    for fields in info.variant_fields.values_mut() {
+                        for field in fields {
+                            Self::remap_resolved_type_with_import_aliases(field, imported_type_aliases);
+                        }
+                    }
+                    for method in info.methods.values_mut() {
+                        Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
+                    }
+                    for overloads in info.method_overloads.values_mut() {
+                        for method in overloads {
+                            Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
+                        }
+                    }
+                }
+                TypeInfo::TypeAlias | TypeInfo::Builtin => {}
             },
             SymbolKind::Trait(info) => {
-                for method in info.methods.values_mut() {
-                    for param in &mut method.params {
-                        Self::remap_resolved_type_with_import_aliases(&mut param.ty, imported_type_aliases);
+                for (_, type_args) in &mut info.supertraits {
+                    for type_arg in type_args {
+                        Self::remap_resolved_type_with_import_aliases(type_arg, imported_type_aliases);
                     }
-                    Self::remap_resolved_type_with_import_aliases(&mut method.return_type, imported_type_aliases);
+                }
+                for method in info.methods.values_mut() {
+                    Self::remap_method_info_with_import_aliases(method, imported_type_aliases);
                 }
                 for (_, ty) in &mut info.requires {
                     Self::remap_resolved_type_with_import_aliases(ty, imported_type_aliases);
@@ -1860,11 +2016,69 @@ impl TypeChecker {
                     Self::remap_resolved_type_with_import_aliases(&mut property.return_type, imported_type_aliases);
                 }
             }
-            SymbolKind::Module(_)
-            | SymbolKind::Variant(_)
-            | SymbolKind::Field(_)
-            | SymbolKind::Property(_)
-            | SymbolKind::RustItem(_) => {}
+            SymbolKind::Variant(info) => {
+                if let Some(alias) = imported_type_aliases.get(&info.enum_name) {
+                    info.enum_name = alias.clone();
+                }
+                for field in &mut info.fields {
+                    Self::remap_resolved_type_with_import_aliases(field, imported_type_aliases);
+                }
+            }
+            SymbolKind::Field(info) => {
+                Self::remap_resolved_type_with_import_aliases(&mut info.ty, imported_type_aliases);
+            }
+            SymbolKind::Property(info) => {
+                Self::remap_resolved_type_with_import_aliases(&mut info.return_type, imported_type_aliases);
+            }
+            SymbolKind::Module(_) | SymbolKind::RustItem(_) => {}
+        }
+    }
+
+    /// Rewrite all resolved carrier types in one imported function signature and its generic bounds.
+    fn remap_function_info_with_import_aliases(
+        info: &mut FunctionInfo,
+        imported_type_aliases: &HashMap<String, String>,
+    ) {
+        for param in &mut info.params {
+            Self::remap_resolved_type_with_import_aliases(&mut param.ty, imported_type_aliases);
+        }
+        Self::remap_resolved_type_with_import_aliases(&mut info.return_type, imported_type_aliases);
+        for bounds in info.type_param_bound_details.values_mut() {
+            Self::remap_type_bounds_with_import_aliases(bounds, imported_type_aliases);
+        }
+    }
+
+    /// Rewrite all resolved carrier types in one imported method signature and its generic or trait-target bounds.
+    fn remap_method_info_with_import_aliases(info: &mut MethodInfo, imported_type_aliases: &HashMap<String, String>) {
+        for param in &mut info.params {
+            Self::remap_resolved_type_with_import_aliases(&mut param.ty, imported_type_aliases);
+        }
+        Self::remap_resolved_type_with_import_aliases(&mut info.return_type, imported_type_aliases);
+        for bounds in info.type_param_bound_details.values_mut() {
+            Self::remap_type_bounds_with_import_aliases(bounds, imported_type_aliases);
+        }
+        if let Some(target) = info.trait_target.as_mut() {
+            Self::remap_type_bound_with_import_aliases(target, imported_type_aliases);
+        }
+    }
+
+    /// Rewrite resolved generic arguments carried by imported trait-bound metadata.
+    fn remap_type_bounds_with_import_aliases(
+        bounds: &mut [TypeBoundInfo],
+        imported_type_aliases: &HashMap<String, String>,
+    ) {
+        for bound in bounds {
+            Self::remap_type_bound_with_import_aliases(bound, imported_type_aliases);
+        }
+    }
+
+    /// Rewrite resolved generic arguments carried by one imported trait-bound entry.
+    fn remap_type_bound_with_import_aliases(
+        bound: &mut TypeBoundInfo,
+        imported_type_aliases: &HashMap<String, String>,
+    ) {
+        for type_arg in &mut bound.type_args {
+            Self::remap_resolved_type_with_import_aliases(type_arg, imported_type_aliases);
         }
     }
 

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -132,6 +132,44 @@ pub(crate) struct TypeAliasTarget {
     pub target: ResolvedType,
 }
 
+/// Canonical nominal identity for one type exported through a compiled public-library dependency.
+///
+/// Local aliases and provider-qualified internal signature spellings map to this value. The dependency key prevents
+/// same-named declarations from separate providers from unifying, while the provider-local source path lets multiple
+/// public spellings of one declaration compare as the same type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct PublicLibraryTypeIdentity {
+    dependency_key: String,
+    source_path: Vec<String>,
+}
+
+impl PublicLibraryTypeIdentity {
+    /// Build one provider-qualified identity from the active dependency key and manifest source path.
+    pub(crate) fn new(dependency_key: &str, source_path: &[String]) -> Self {
+        Self {
+            dependency_key: dependency_key.to_string(),
+            source_path: source_path.to_vec(),
+        }
+    }
+}
+
+const PUBLIC_LIBRARY_TYPE_PREFIX: &str = "pub::";
+
+/// Encode one provider-owned public type as an internal `ResolvedType` spelling without adding a new enum variant.
+///
+/// The encoded spelling remains source-unspellable because `pub::` is import syntax, but it preserves enough context
+/// for type compatibility and can be lowered to the provider-qualified Rust nominal path.
+pub(crate) fn canonical_public_library_type_name(dependency_key: &str, public_name: &str) -> String {
+    format!("{PUBLIC_LIBRARY_TYPE_PREFIX}{dependency_key}::{public_name}")
+}
+
+/// Decode an internal provider-qualified public type spelling into its dependency key and public export name.
+pub(crate) fn split_canonical_public_library_type_name(name: &str) -> Option<(&str, &str)> {
+    let remainder = name.strip_prefix(PUBLIC_LIBRARY_TYPE_PREFIX)?;
+    let (dependency_key, public_name) = remainder.split_once("::")?;
+    (!dependency_key.is_empty() && !public_name.is_empty()).then_some((dependency_key, public_name))
+}
+
 /// Declaration context that determines how `yield` expressions are interpreted.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum YieldContext {
@@ -251,6 +289,11 @@ pub struct TypeChecker {
     /// functions/methods can still participate in method lookup and trait compatibility even when the consumer did not
     /// explicitly import every referenced carrier type.
     pub(crate) transitive_pub_types: HashMap<String, Vec<TypeInfo>>,
+    /// Canonical nominal identities for local aliases and provider-qualified signature spellings from `pub::` imports.
+    ///
+    /// Identity is deliberately separate from [`ResolvedType`]: source diagnostics retain local spellings while
+    /// compatibility can still distinguish identical short names owned by separate dependencies.
+    pub(crate) public_library_type_identities: HashMap<String, PublicLibraryTypeIdentity>,
     /// Internal semantic trait cache for `pub::` exports referenced transitively by imported signatures.
     ///
     /// This keeps trait/supertrait compatibility available for imported function signatures without making those trait
@@ -383,6 +426,7 @@ impl TypeChecker {
             dependency_trait_rust_derive_paths: HashMap::new(),
             provider_plan: Arc::new(ProviderPlan::default()),
             transitive_pub_types: HashMap::new(),
+            public_library_type_identities: HashMap::new(),
             transitive_pub_traits: HashMap::new(),
             transitive_stdlib_stub_types: HashMap::new(),
             transitive_stdlib_stub_traits: HashMap::new(),
@@ -929,6 +973,47 @@ impl TypeChecker {
             .collect::<Vec<_>>()
             .join(", ");
         Some(format!("{base}<{rendered_args}>"))
+    }
+
+    /// Return the canonical public-library identity and generic arguments carried by one named type spelling.
+    fn public_library_type_identity_for_type<'a>(
+        &'a self,
+        ty: &'a ResolvedType,
+    ) -> Option<(&'a PublicLibraryTypeIdentity, &'a [ResolvedType])> {
+        match ty {
+            ResolvedType::Named(name) => self
+                .public_library_type_identities
+                .get(name)
+                .map(|identity| (identity, &[][..])),
+            ResolvedType::Generic(name, args) => self
+                .public_library_type_identities
+                .get(name)
+                .map(|identity| (identity, args.as_slice())),
+            _ => None,
+        }
+    }
+
+    /// Compare provider-qualified public-library identities before ordinary nominal spelling equality.
+    ///
+    /// Returning `None` leaves non-provider types on the ordinary compatibility path. When both sides carry compiled
+    /// provider identity, the dependency and source declaration must match and generic arguments are compared
+    /// recursively through the same compatibility rules.
+    fn public_library_type_identities_compatible(
+        &self,
+        actual: &ResolvedType,
+        expected: &ResolvedType,
+    ) -> Option<bool> {
+        let (actual_identity, actual_args) = self.public_library_type_identity_for_type(actual)?;
+        let (expected_identity, expected_args) = self.public_library_type_identity_for_type(expected)?;
+        if actual_identity != expected_identity || actual_args.len() != expected_args.len() {
+            return Some(false);
+        }
+        Some(
+            actual_args
+                .iter()
+                .zip(expected_args)
+                .all(|(actual_arg, expected_arg)| self.types_compatible(actual_arg, expected_arg)),
+        )
     }
 
     /// Return whether two Rust type identities describe the same boundary type.
@@ -3987,6 +4072,7 @@ impl TypeChecker {
         self.import_aliases = self.surface_context.import_aliases().clone();
         self.supertrait_closure.clear();
         self.transitive_pub_types.clear();
+        self.public_library_type_identities.clear();
         self.transitive_pub_traits.clear();
         self.cached_pub_libraries.clear();
         self.validate_alias_declarations(program);
@@ -4786,6 +4872,10 @@ impl TypeChecker {
         let expanded_expected = self.expand_type_aliases(expected.clone());
         if &expanded_actual != actual || &expanded_expected != expected {
             return self.types_compatible(&expanded_actual, &expanded_expected);
+        }
+
+        if let Some(matches) = self.public_library_type_identities_compatible(actual, expected) {
+            return matches;
         }
 
         if actual == expected {

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -1785,7 +1785,7 @@ class Child extends Parent:
 }
 
 fn library_index_with_mylib_exports() -> LibraryManifestIndex {
-    let manifest = LibraryManifest {
+    let mut manifest = LibraryManifest {
         name: "mylib".to_string(),
         version: "0.1.0".to_string(),
         incan_version: crate::version::INCAN_VERSION.to_string(),
@@ -1828,24 +1828,39 @@ fn library_index_with_mylib_exports() -> LibraryManifestIndex {
                 methods: Vec::new(),
             }],
             classes: Vec::new(),
-            functions: vec![FunctionExport {
-                name: "make_widget".to_string(),
-                emitted_name: None,
-                type_params: Vec::new(),
-                params: vec![ParamExport {
-                    name: "name".to_string(),
-                    ty: TypeRef::Named {
-                        name: "str".to_string(),
+            functions: vec![
+                FunctionExport {
+                    name: "make_widget".to_string(),
+                    emitted_name: None,
+                    type_params: Vec::new(),
+                    params: vec![ParamExport {
+                        name: "name".to_string(),
+                        ty: TypeRef::Named {
+                            name: "str".to_string(),
+                        },
+                        kind: ParamKindExport::Normal,
+                        has_default: false,
+                        default: None,
+                    }],
+                    return_type: TypeRef::Named {
+                        name: "Widget".to_string(),
                     },
-                    kind: ParamKindExport::Normal,
-                    has_default: false,
-                    default: None,
-                }],
-                return_type: TypeRef::Named {
-                    name: "Widget".to_string(),
+                    is_async: false,
                 },
-                is_async: false,
-            }],
+                FunctionExport {
+                    name: "collect_widgets".to_string(),
+                    emitted_name: None,
+                    type_params: Vec::new(),
+                    params: Vec::new(),
+                    return_type: TypeRef::Applied {
+                        name: "list".to_string(),
+                        args: vec![TypeRef::Named {
+                            name: "Widget".to_string(),
+                        }],
+                    },
+                    is_async: false,
+                },
+            ],
             traits: vec![TraitExport {
                 name: "Labelled".to_string(),
                 source_name: None,
@@ -1928,6 +1943,16 @@ fn library_index_with_mylib_exports() -> LibraryManifestIndex {
         contract_metadata: LibraryContractMetadata::default(),
         rust_abi: None,
     };
+    manifest.contract_metadata.identity_graph = LibraryIdentityGraph {
+        schema_version: LIBRARY_IDENTITY_GRAPH_SCHEMA_VERSION,
+        exports: vec![ExportIdentity {
+            public_name: "Widget".to_string(),
+            public_path: vec!["mylib".to_string(), "Widget".to_string()],
+            source_path: vec!["widgets".to_string(), "Widget".to_string()],
+            kind: ExportIdentityKind::Model,
+            projection: ExportIdentityProjection::Direct,
+        }],
+    };
 
     LibraryManifestIndex::from_entries(HashMap::from([(
         "mylib".to_string(),
@@ -1936,6 +1961,131 @@ fn library_index_with_mylib_exports() -> LibraryManifestIndex {
             metadata: LibraryArtifactMetadata::from_crate_root("mylib", "mylib", synthetic_artifact_root("mylib")),
         },
     )]))
+}
+
+/// Build two compiled-provider manifests that export distinct models and constructors under the same short names.
+fn library_index_with_colliding_pub_type_identities() -> LibraryManifestIndex {
+    let provider_manifest = |library: &str| {
+        let mut manifest = LibraryManifest::new(library, "0.1.0");
+        manifest.exports.models.push(ModelExport {
+            name: "Widget".to_string(),
+            type_params: Vec::new(),
+            traits: Vec::new(),
+            trait_adoptions: Vec::new(),
+            derives: Vec::new(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+        });
+        manifest.exports.models.push(ModelExport {
+            name: "Factory".to_string(),
+            type_params: Vec::new(),
+            traits: Vec::new(),
+            trait_adoptions: Vec::new(),
+            derives: Vec::new(),
+            fields: vec![FieldExport {
+                name: "widget".to_string(),
+                ty: TypeRef::Named {
+                    name: "Widget".to_string(),
+                },
+                visibility: FieldVisibilityExport::Public,
+                has_default: false,
+                default: None,
+                alias: None,
+                description: None,
+            }],
+            methods: Vec::new(),
+        });
+        manifest.exports.functions.push(FunctionExport {
+            name: "make_widget".to_string(),
+            emitted_name: None,
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: TypeRef::Named {
+                name: "Widget".to_string(),
+            },
+            is_async: false,
+        });
+        manifest.exports.functions.push(FunctionExport {
+            name: "make_factory".to_string(),
+            emitted_name: None,
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: TypeRef::Named {
+                name: "Factory".to_string(),
+            },
+            is_async: false,
+        });
+        manifest.exports.enums.push(EnumExport {
+            name: "Envelope".to_string(),
+            type_params: Vec::new(),
+            traits: Vec::new(),
+            trait_adoptions: Vec::new(),
+            value_type: None,
+            ordinal_type_identity: None,
+            variants: vec![EnumVariantExport {
+                name: "WithWidget".to_string(),
+                fields: vec![TypeRef::Named {
+                    name: "Widget".to_string(),
+                }],
+                value: None,
+            }],
+            variant_aliases: Vec::new(),
+            methods: Vec::new(),
+            derives: Vec::new(),
+        });
+        manifest.contract_metadata.identity_graph = LibraryIdentityGraph {
+            schema_version: LIBRARY_IDENTITY_GRAPH_SCHEMA_VERSION,
+            exports: vec![
+                ExportIdentity {
+                    public_name: "Widget".to_string(),
+                    public_path: vec![library.to_string(), "Widget".to_string()],
+                    source_path: vec!["widgets".to_string(), "Widget".to_string()],
+                    kind: ExportIdentityKind::Model,
+                    projection: ExportIdentityProjection::Direct,
+                },
+                ExportIdentity {
+                    public_name: "Envelope".to_string(),
+                    public_path: vec![library.to_string(), "Envelope".to_string()],
+                    source_path: vec!["widgets".to_string(), "Envelope".to_string()],
+                    kind: ExportIdentityKind::Enum,
+                    projection: ExportIdentityProjection::Direct,
+                },
+                ExportIdentity {
+                    public_name: "Factory".to_string(),
+                    public_path: vec![library.to_string(), "Factory".to_string()],
+                    source_path: vec!["widgets".to_string(), "Factory".to_string()],
+                    kind: ExportIdentityKind::Model,
+                    projection: ExportIdentityProjection::Direct,
+                },
+            ],
+        };
+        manifest
+    };
+
+    LibraryManifestIndex::from_entries(HashMap::from([
+        (
+            "alpha".to_string(),
+            LibraryManifestIndexEntry::Loaded {
+                manifest: Box::new(provider_manifest("alpha")),
+                metadata: LibraryArtifactMetadata::from_crate_root(
+                    "alpha",
+                    "alpha",
+                    synthetic_artifact_root("pub_identity_alpha"),
+                ),
+            },
+        ),
+        (
+            "beta".to_string(),
+            LibraryManifestIndexEntry::Loaded {
+                manifest: Box::new(provider_manifest("beta")),
+                metadata: LibraryArtifactMetadata::from_crate_root(
+                    "beta",
+                    "beta",
+                    synthetic_artifact_root("pub_identity_beta"),
+                ),
+            },
+        ),
+    ]))
 }
 
 fn library_index_with_private_class_field_issue883() -> LibraryManifestIndex {
@@ -15076,6 +15226,228 @@ def build() -> LibWidget:
 "#;
     let result = check_str_with_library_index(source, library_index_with_mylib_exports());
     assert!(result.is_ok(), "expected alias recovery to typecheck, got: {result:?}");
+}
+
+/// Regression for #892: callable signatures retain provider identity across separate import statements.
+#[test]
+fn test_pub_from_split_import_alias_preserves_provider_identity_issue892() {
+    let source = r#"
+from pub::mylib import Widget as LibWidget
+from pub::mylib import make_widget
+
+def build() -> LibWidget:
+  return make_widget("ok")
+"#;
+    let result = check_str_with_library_index(source, library_index_with_mylib_exports());
+    assert!(
+        result.is_ok(),
+        "expected split pub import alias to preserve identity, got: {result:?}"
+    );
+}
+
+/// Regression for #892: whole-program identity collection is independent of split-import declaration order.
+#[test]
+fn test_pub_from_reversed_split_import_alias_preserves_provider_identity_issue892() {
+    let source = r#"
+from pub::mylib import make_widget
+from pub::mylib import Widget as LibWidget
+
+def build() -> LibWidget:
+  return make_widget("ok")
+"#;
+    let result = check_str_with_library_index(source, library_index_with_mylib_exports());
+    assert!(
+        result.is_ok(),
+        "expected reversed split pub import alias to preserve identity, got: {result:?}"
+    );
+}
+
+/// Regression for #892: every local alias of one provider-owned type compares as the same nominal declaration.
+#[test]
+fn test_pub_from_multiple_aliases_share_provider_identity_issue892() {
+    let source = r#"
+from pub::mylib import Widget as FirstWidget
+from pub::mylib import Widget as SecondWidget
+from pub::mylib import make_widget
+
+def make_first() -> FirstWidget:
+  return make_widget("ok")
+
+def keep_identity(value: SecondWidget) -> FirstWidget:
+  return value
+"#;
+    let result = check_str_with_library_index(source, library_index_with_mylib_exports());
+    assert!(
+        result.is_ok(),
+        "expected aliases of one provider type to share identity, got: {result:?}"
+    );
+}
+
+/// Regression for #892: provider identity is compared recursively through generic type arguments.
+#[test]
+fn test_pub_from_split_alias_preserves_nested_generic_identity_issue892() {
+    let source = r#"
+from pub::mylib import Widget as LibWidget
+from pub::mylib import collect_widgets
+
+def collect() -> list[LibWidget]:
+  return collect_widgets()
+"#;
+    let result = check_str_with_library_index(source, library_index_with_mylib_exports());
+    assert!(
+        result.is_ok(),
+        "expected nested pub type identity to survive split imports, got: {result:?}"
+    );
+}
+
+/// Regression for #892: matching short names from separate dependencies remain nominally distinct.
+#[test]
+fn test_pub_from_same_short_name_different_providers_stay_distinct_issue892() -> Result<(), String> {
+    let source = r#"
+from pub::alpha import Widget as AlphaWidget, make_widget as make_alpha_widget
+from pub::beta import Widget as BetaWidget, make_widget as make_beta_widget
+
+def wrong_provider() -> BetaWidget:
+  return make_alpha_widget()
+"#;
+    let errors = check_str_with_library_index_err(
+        source,
+        library_index_with_colliding_pub_type_identities(),
+        "different provider identities must not unify",
+    )?;
+    if !errors.iter().any(|error| {
+        error
+            .message
+            .contains("Return type mismatch: expected 'BetaWidget', found 'AlphaWidget'")
+    }) {
+        return Err(format!("expected provider-qualified nominal mismatch, got: {errors:?}"));
+    }
+    Ok(())
+}
+
+/// Regression for #892: callable-only provider signatures remain qualified against an unaliased colliding type.
+#[test]
+fn test_pub_callable_only_same_short_name_different_providers_stays_distinct_issue892() -> Result<(), String> {
+    let source = r#"
+from pub::alpha import make_widget as make_alpha_widget
+from pub::beta import Widget
+
+def wrong_provider() -> Widget:
+  return make_alpha_widget()
+"#;
+    let errors = check_str_with_library_index_err(
+        source,
+        library_index_with_colliding_pub_type_identities(),
+        "callable-only provider identity must not unify with another provider's same-named type",
+    )?;
+    if !errors.iter().any(|error| {
+        error
+            .message
+            .starts_with("Return type mismatch: expected 'Widget', found '")
+    }) {
+        return Err(format!(
+            "expected callable-only provider-qualified mismatch, got: {errors:?}"
+        ));
+    }
+    Ok(())
+}
+
+/// Regression for #892: qualified module calls preserve provider identity instead of reverting to a short name.
+#[test]
+fn test_pub_qualified_callable_same_short_name_different_providers_stays_distinct_issue892() -> Result<(), String> {
+    let source = r#"
+import pub::alpha as alpha
+from pub::beta import Widget
+
+def wrong_provider() -> Widget:
+  return alpha.make_widget()
+"#;
+    let errors = check_str_with_library_index_err(
+        source,
+        library_index_with_colliding_pub_type_identities(),
+        "qualified provider callable identity must not unify with another provider's same-named type",
+    )?;
+    if !errors.iter().any(|error| {
+        error
+            .message
+            .starts_with("Return type mismatch: expected 'Widget', found '")
+    }) {
+        return Err(format!("expected qualified-call provider mismatch, got: {errors:?}"));
+    }
+    Ok(())
+}
+
+/// Regression for #892: enum variant payload metadata retains the provider identity of its manifest carrier types.
+#[test]
+fn test_pub_enum_variant_payload_same_short_name_different_providers_stays_distinct_issue892() -> Result<(), String> {
+    let source = r#"
+from pub::alpha import WithWidget
+from pub::beta import Widget
+"#;
+    let tokens = lexer::lex(source).map_err(|errors| format!("enum payload repro lex failed: {errors:?}"))?;
+    let ast = parser::parse(&tokens).map_err(|errors| format!("enum payload repro parse failed: {errors:?}"))?;
+    let mut checker = TypeChecker::new();
+    checker.set_library_manifest_index(library_index_with_colliding_pub_type_identities());
+    checker
+        .check_program(&ast)
+        .map_err(|errors| format!("enum payload imports should typecheck: {errors:?}"))?;
+    let payload_ty = match checker.lookup_symbol("WithWidget").map(|symbol| &symbol.kind) {
+        Some(SymbolKind::Variant(info)) => info
+            .fields
+            .first()
+            .cloned()
+            .ok_or("expected WithWidget payload metadata")?,
+        other => return Err(format!("expected imported WithWidget variant metadata, got: {other:?}")),
+    };
+    if checker.types_compatible(&payload_ty, &ResolvedType::Named("Widget".to_string())) {
+        return Err(format!(
+            "alpha variant payload must stay distinct from beta Widget, got payload {payload_ty}"
+        ));
+    }
+    Ok(())
+}
+
+/// Regression for #892: split enum aliases and variant imports retain one provider-owned enum identity.
+#[test]
+fn test_pub_split_enum_alias_and_variant_share_provider_identity_issue892() {
+    let source = r#"
+from pub::alpha import Envelope as ProviderEnvelope
+from pub::alpha import WithWidget
+from pub::alpha import make_widget
+
+def make_envelope() -> ProviderEnvelope:
+  return WithWidget(make_widget())
+"#;
+    let result = check_str_with_library_index(source, library_index_with_colliding_pub_type_identities());
+    assert!(
+        result.is_ok(),
+        "expected split enum alias and variant imports to share provider identity, got: {result:?}"
+    );
+}
+
+/// Regression for #892: transitive fields reached through qualified callables retain their provider identity.
+#[test]
+fn test_pub_transitive_field_same_short_name_different_providers_stays_distinct_issue892() -> Result<(), String> {
+    let source = r#"
+import pub::alpha as alpha
+from pub::beta import Widget
+
+def wrong_provider() -> Widget:
+  return alpha.make_factory().widget
+"#;
+    let errors = check_str_with_library_index_err(
+        source,
+        library_index_with_colliding_pub_type_identities(),
+        "transitive provider field identity must not unify with another provider's same-named type",
+    )?;
+    if !errors.iter().any(|error| {
+        error
+            .message
+            .starts_with("Return type mismatch: expected 'Widget', found '")
+    }) {
+        return Err(format!("expected transitive provider field mismatch, got: {errors:?}"));
+    }
+    Ok(())
 }
 
 #[test]

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -333,8 +333,8 @@
     {
       "path": "src/frontend/typechecker/collect/stdlib_imports.rs",
       "category": "stdlib import, checked API target paths, provider-bound roots, and extension-trait compatibility",
-      "expected_count": 10,
-      "expected_fingerprint": "0x6b541f0e7968ad59"
+      "expected_count": 11,
+      "expected_fingerprint": "0xe1b6f3637cf605f3"
     },
     {
       "path": "src/frontend/typechecker/const_eval.rs",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -13479,6 +13479,129 @@ pub def aggregate_default(expr: ColumnExpr, output_name: str = DEFAULT_LABEL) ->
         Ok(())
     }
 
+    /// Regression for #892: split aliases keep their provider identity in real library consumers and test batches.
+    #[test]
+    fn build_lib_consumer_preserves_split_pub_import_alias_identity_issue892() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let tmp = tempfile::tempdir()?;
+        let provider_root = tmp.path().join("proposal_provider");
+        std::fs::create_dir_all(provider_root.join("src"))?;
+        std::fs::write(
+            provider_root.join("incan.toml"),
+            "[project]\nname = \"proposal_provider\"\nversion = \"0.1.0\"\n",
+        )?;
+        std::fs::write(
+            provider_root.join("src/proposals.incn"),
+            r#"pub model ConsoleProposal:
+  pub title: str
+
+pub def make_console_proposal(title: str) -> ConsoleProposal:
+  return ConsoleProposal(title=title)
+"#,
+        )?;
+        std::fs::write(
+            provider_root.join("src/lib.incn"),
+            "pub from proposals import ConsoleProposal, make_console_proposal\n",
+        )?;
+
+        let provider_build = run_build_lib(&provider_root)?;
+        assert!(
+            provider_build.status.success(),
+            "expected #892 provider library build to succeed.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&provider_build.stdout),
+            String::from_utf8_lossy(&provider_build.stderr)
+        );
+        assert!(
+            provider_root.join("target/lib/proposal_provider.incnlib").is_file(),
+            "expected the provider's compiled .incnlib manifest"
+        );
+
+        let consumer_root = tmp.path().join("consumer");
+        std::fs::create_dir_all(consumer_root.join("src"))?;
+        std::fs::create_dir_all(consumer_root.join("tests"))?;
+        std::fs::write(
+            consumer_root.join("incan.toml"),
+            "[project]\nname = \"consumer\"\n\n[dependencies]\nproposals = { path = \"../proposal_provider\" }\n",
+        )?;
+        let main_path = consumer_root.join("src/main.incn");
+        std::fs::write(
+            &main_path,
+            r#"from pub::proposals import ConsoleProposal as ProviderConsoleProposal
+from pub::proposals import make_console_proposal
+
+def proposal() -> ProviderConsoleProposal:
+  return make_console_proposal("ready")
+
+def main() -> None:
+  println(proposal().title)
+"#,
+        )?;
+
+        let check_output = run_check(&main_path)?;
+        assert!(
+            check_output.status.success(),
+            "expected split pub import aliases to typecheck against the compiled library.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&check_output.stdout),
+            String::from_utf8_lossy(&check_output.stderr)
+        );
+
+        let out_dir = consumer_root.join("out");
+        let build_output = run_build(&main_path, &out_dir)?;
+        assert!(
+            build_output.status.success(),
+            "expected generated Rust for split pub import aliases to compile.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build_output.stdout),
+            String::from_utf8_lossy(&build_output.stderr)
+        );
+        let generated_main = std::fs::read_to_string(out_dir.join("src/main.rs"))?;
+        assert!(
+            generated_main.contains("proposals::ConsoleProposal"),
+            "expected generated Rust to retain the provider-qualified model path.\ngenerated main.rs:\n{generated_main}"
+        );
+
+        std::fs::write(
+            consumer_root.join("tests/test_split_alias.incn"),
+            r#"from pub::proposals import ConsoleProposal as SplitConsoleProposal
+from pub::proposals import make_console_proposal
+
+def make_split() -> SplitConsoleProposal:
+  return make_console_proposal("split")
+
+def test_split_pub_import_alias() -> None:
+  proposal: SplitConsoleProposal = make_split()
+  assert proposal.title == "split"
+"#,
+        )?;
+        std::fs::write(
+            consumer_root.join("tests/test_same_statement_alias.incn"),
+            r#"from pub::proposals import ConsoleProposal as SameStatementConsoleProposal, make_console_proposal
+
+def make_same_statement() -> SameStatementConsoleProposal:
+  return make_console_proposal("same")
+
+def test_same_statement_pub_import_alias() -> None:
+  proposal: SameStatementConsoleProposal = make_same_statement()
+  assert proposal.title == "same"
+"#,
+        )?;
+
+        let test_output = run_test(&consumer_root.join("tests"))?;
+        assert!(
+            test_output.status.success(),
+            "expected split and same-statement aliases to coexist in one compiled test batch.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&test_output.stdout),
+            String::from_utf8_lossy(&test_output.stderr)
+        );
+        let test_stdout = String::from_utf8_lossy(&test_output.stdout);
+        assert!(
+            test_stdout.contains("test_split_alias.incn::test_split_pub_import_alias")
+                && test_stdout.contains("test_same_statement_alias.incn::test_same_statement_pub_import_alias"),
+            "expected both #892 regression tests in the batch output.\nstdout:\n{test_stdout}"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn build_lib_consumer_preserves_private_class_field_visibility_issue883() -> Result<(), Box<dyn std::error::Error>>
     {

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -30,6 +30,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: Public types imported from compiled libraries now retain provider-qualified nominal identity across split imports, multiple local aliases, qualified module calls, nested generics, and generated test batches, without unifying same-named types from separate dependencies (#892).
 - **Compiler**: Generated Cargo packages now preserve the authored Incan project version and SPDX license for application and library builds, keeping library `Cargo.toml` versions aligned with their `.incnlib` manifests (#889).
 - **Compiler**: `std::io::stdout()` now retains its stable `Stdout` receiver type when sysroot metadata is unavailable, so fallible extension-trait calls such as crossterm's `ExecutableCommand.execute(...)` expose their native `Result` and support postfix `?` (#888).
 - **Compiler**: Class-field privacy now survives checked metadata and compiled package boundaries. Named construction through a compiled package uses an exact package-owned constructor bridge—including aliases, inherited fields, and provider-owned defaults—while later private member access receives an Incan diagnostic instead of a Rust privacy failure; older manifests without field visibility retain their compatible public behavior (#883).


### PR DESCRIPTION
## Summary

This PR fixes canonical nominal identity for public types imported from compiled `pub::` dependencies. Split imports, multiple local aliases, qualified member calls, nested generic signatures, enum payload metadata, and generated test batches now agree on the provider-owned declaration without unifying same-named types from different dependencies.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: A type alias imported in one statement now remains compatible with provider callables imported separately when their signatures refer to the provider's original export spelling. Distinct dependencies exporting the same short type name remain nominally separate.
- **Internals**: The typechecker records dependency-qualified source identity from format-3 manifest identity graphs, recursively remaps every signature carrier surface, and lowers checker-owned canonical names to provider-qualified Rust paths. Provider-owned anonymous-union comparison localizes only the owning provider and keeps foreign unions opaque.
- **Risks**: The change touches compiled-library type import, transitive metadata, qualified access, and anonymous-union ownership. Coverage includes same-statement controls, split/reversed imports, multiple aliases, provider collisions, nested generics, enum payloads, callable-only and transitive paths, real `.incnlib` consumers, and the existing #755 provider-union boundary.
- **Integration sequencing**: the branch is rebased onto merged #899 at `f8ba7fdaf`, advances the workspace to `0.5.0-dev.12`, and no longer carries the superseded #897 compatibility overlap.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- The final rebased branch passed all 16 focused #892 unit regressions and the real `.incnlib` provider/consumer/test-batch integration.
- The original reviewed branch passed exact Rust 1.93.0 provider consumers, the #755 dependency-owned anonymous-union boundary, and the complete pre-commit gate with 3,008/3,008 tests, clippy, cargo-deny, release smoke, examples, and benchmarks.
- `make fmt` and `git diff --check` passed after conflict resolution.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

- `workspaces/docs-site/docs/release_notes/0_5.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #892
