### PR TITLE
bugfix - isolate dependency imports in test batches (#898)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "blake2",
  "blake3",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.12"
+version = "0.5.0-dev.13"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/frontend/symbols.rs
+++ b/src/frontend/symbols.rs
@@ -85,14 +85,17 @@ pub struct SymbolTable {
     symbols: Vec<Symbol>,
     scopes: Vec<Scope>,
     current_scope: usize,
+    current_scope_binding_transaction: Option<HashMap<String, Option<SymbolId>>>,
 }
 
 impl SymbolTable {
+    /// Create a root module scope populated with the language's builtin symbols.
     pub fn new() -> Self {
         let mut table = Self {
             symbols: Vec::new(),
             scopes: vec![Scope::new(None, ScopeKind::Module)],
             current_scope: 0,
+            current_scope_binding_transaction: None,
         };
 
         // Add builtin types
@@ -274,6 +277,7 @@ impl SymbolTable {
 
     /// Define a new symbol in the current scope
     pub fn define(&mut self, mut symbol: Symbol) -> SymbolId {
+        self.record_current_scope_binding_before_change(&symbol.name);
         symbol.scope = self.current_scope;
         let id = self.symbols.len();
         self.scopes[self.current_scope].symbols.insert(symbol.name.clone(), id);
@@ -286,6 +290,7 @@ impl SymbolTable {
     /// Enum variants need to remain available to whole-table consumers such as match exhaustiveness and qualified
     /// pattern resolution, but a variant named like an imported type must not steal the bare identifier from that type.
     pub fn define_preserving_existing_binding(&mut self, mut symbol: Symbol) -> SymbolId {
+        self.record_current_scope_binding_before_change(&symbol.name);
         symbol.scope = self.current_scope;
         let id = self.symbols.len();
         self.scopes[self.current_scope]
@@ -315,6 +320,36 @@ impl SymbolTable {
     /// Look up a symbol only in the current scope (no parent lookup)
     pub fn lookup_local(&self, name: &str) -> Option<SymbolId> {
         self.scopes[self.current_scope].symbols.get(name).copied()
+    }
+
+    /// Start recording the previous value of each current-scope binding changed by subsequent definitions.
+    pub(crate) fn begin_current_scope_binding_transaction(&mut self) {
+        debug_assert!(self.current_scope_binding_transaction.is_none());
+        self.current_scope_binding_transaction = Some(HashMap::new());
+    }
+
+    /// Finish the active binding transaction and return only the names it touched.
+    pub(crate) fn finish_current_scope_binding_transaction(&mut self) -> HashMap<String, Option<SymbolId>> {
+        self.current_scope_binding_transaction.take().unwrap_or_default()
+    }
+
+    /// Record one binding before its first change in the active transaction.
+    fn record_current_scope_binding_before_change(&mut self, name: &str) {
+        let previous = self.scopes[self.current_scope].symbols.get(name).copied();
+        if let Some(transaction) = &mut self.current_scope_binding_transaction {
+            transaction.entry(name.to_string()).or_insert(previous);
+        }
+    }
+
+    /// Restore or remove one name binding in the current scope without deleting historical symbol metadata.
+    pub(crate) fn restore_current_scope_binding(&mut self, name: &str, binding: Option<SymbolId>) {
+        if let Some(symbol_id) = binding {
+            self.scopes[self.current_scope]
+                .symbols
+                .insert(name.to_string(), symbol_id);
+        } else {
+            self.scopes[self.current_scope].symbols.remove(name);
+        }
     }
 
     /// Get a symbol by ID

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -1851,6 +1851,7 @@ impl TypeChecker {
             ManifestExportRef::TypeAlias(export) => {
                 let mut target = resolved_type_from_manifest_type_ref(&export.target);
                 Self::remap_resolved_type_with_import_aliases(&mut target, imported_type_aliases);
+                self.record_dependency_import_type_alias_before_change(&local_name);
                 self.type_aliases.insert(
                     local_name.clone(),
                     crate::frontend::typechecker::TypeAliasTarget {

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -247,6 +247,8 @@ pub struct TypeChecker {
     pub(crate) current_module_function_symbols: HashMap<String, SymbolId>,
     /// Transparent source type aliases, keyed by their local type name.
     pub(crate) type_aliases: HashMap<String, TypeAliasTarget>,
+    /// Previous type-alias bindings changed while dependency imports are collected transactionally.
+    dependency_import_type_alias_transaction: Option<HashMap<String, Option<TypeAliasTarget>>>,
     /// Declaration-order index for each local static binding.
     pub(crate) static_decl_positions: HashMap<String, usize>,
     /// Const evaluation state machine.
@@ -313,6 +315,8 @@ pub struct TypeChecker {
     /// Tracks which `pub::` libraries have already seeded the internal transitive semantic caches for this checker
     /// run.
     pub(crate) cached_pub_libraries: HashSet<String>,
+    /// Whether a manual [`Self::import_module`] call prepared dependency-only semantics for the next program check.
+    dependency_semantics_pending: bool,
     /// Module path for the program being checked (if known).
     pub(crate) current_module_path: Option<Vec<String>>,
     /// Source import aliases with declaration origins known from the dependency import graph.
@@ -412,6 +416,7 @@ impl TypeChecker {
             local_function_decls: HashMap::new(),
             current_module_function_symbols: HashMap::new(),
             type_aliases: HashMap::new(),
+            dependency_import_type_alias_transaction: None,
             static_decl_positions: HashMap::new(),
             const_eval_state: HashMap::new(),
             const_eval_cache: HashMap::new(),
@@ -431,6 +436,7 @@ impl TypeChecker {
             transitive_stdlib_stub_types: HashMap::new(),
             transitive_stdlib_stub_traits: HashMap::new(),
             cached_pub_libraries: HashSet::new(),
+            dependency_semantics_pending: false,
             current_module_path: None,
             source_import_targets: HashMap::new(),
             declared_crate_names: None,
@@ -4051,6 +4057,22 @@ impl TypeChecker {
     /// For multi-module projects, call [`import_module`](Self::import_module) first to populate dependency symbols,
     /// or use [`check_with_imports`](Self::check_with_imports) to import dependencies first.
     pub fn check_program(&mut self, program: &Program) -> Result<(), Vec<CompileError>> {
+        let preserve_dependency_semantics = std::mem::take(&mut self.dependency_semantics_pending);
+        self.check_program_internal(program, preserve_dependency_semantics)
+    }
+
+    /// Check one program while retaining semantic-only type metadata collected from its dependency imports.
+    fn check_program_with_dependency_semantics(&mut self, program: &Program) -> Result<(), Vec<CompileError>> {
+        self.dependency_semantics_pending = false;
+        self.check_program_internal(program, true)
+    }
+
+    /// Shared program checker with explicit control over dependency-only semantic caches.
+    fn check_program_internal(
+        &mut self,
+        program: &Program,
+        preserve_dependency_semantics: bool,
+    ) -> Result<(), Vec<CompileError>> {
         // Reset per-run caches.
         self.const_decls.clear();
         self.static_decls.clear();
@@ -4071,10 +4093,12 @@ impl TypeChecker {
         self.surface_context = SurfaceContext::from_program(program);
         self.import_aliases = self.surface_context.import_aliases().clone();
         self.supertrait_closure.clear();
-        self.transitive_pub_types.clear();
-        self.public_library_type_identities.clear();
-        self.transitive_pub_traits.clear();
-        self.cached_pub_libraries.clear();
+        if !preserve_dependency_semantics {
+            self.transitive_pub_types.clear();
+            self.public_library_type_identities.clear();
+            self.transitive_pub_traits.clear();
+            self.cached_pub_libraries.clear();
+        }
         self.validate_alias_declarations(program);
 
         // `check_with_imports` / `import_module` can queue supertrait bounds while collecting dependency ASTs.
@@ -4150,6 +4174,17 @@ impl TypeChecker {
         self.surface_context = SurfaceContext::from_program(module_ast);
         self.import_aliases = self.surface_context.import_aliases().clone();
 
+        // Imports are lexical rather than exported, but public declaration signatures may depend on their exact type
+        // metadata. Collect them temporarily, then restore only the names they introduced after the public surface has
+        // been cached.
+        self.begin_dependency_import_binding_transaction();
+        for decl in &module_ast.declarations {
+            if matches!(decl.node, Declaration::Import(_)) {
+                self.collect_declaration(decl);
+            }
+        }
+        let (imported_symbol_bindings, imported_type_alias_bindings) =
+            self.finish_dependency_import_binding_transaction();
         // Collect only public declarations from the imported module.
         for decl in &module_ast.declarations {
             if is_public_decl(decl) && !matches!(decl.node, Declaration::Alias(_) | Declaration::Partial(_)) {
@@ -4170,6 +4205,28 @@ impl TypeChecker {
         self.register_dependency_derivable_metadata(_module_name, module_ast);
         self.cache_dependency_direct_member_symbols(_module_name, module_ast, true);
         self.cache_dependency_member_symbols(_module_name, module_ast, true);
+        let owned_names = module_ast
+            .declarations
+            .iter()
+            .filter(|decl| is_public_decl(decl))
+            .filter_map(declaration_name)
+            .collect::<HashSet<_>>();
+        let owned_type_alias_names = module_ast
+            .declarations
+            .iter()
+            .filter(|decl| is_public_decl(decl))
+            .filter_map(|decl| match &decl.node {
+                Declaration::TypeAlias(alias) => Some(alias.name.as_str()),
+                _ => None,
+            })
+            .collect::<HashSet<_>>();
+        self.restore_dependency_import_bindings(
+            imported_symbol_bindings,
+            imported_type_alias_bindings,
+            &owned_names,
+            &owned_type_alias_names,
+        );
+        self.dependency_semantics_pending = true;
         self.surface_context = previous_surface_context;
         self.import_aliases = previous_import_aliases;
         self.current_module_function_symbols = previous_module_function_symbols;
@@ -4186,8 +4243,22 @@ impl TypeChecker {
         self.surface_context = SurfaceContext::from_program(module_ast);
         self.import_aliases = self.surface_context.import_aliases().clone();
 
+        // Dependency imports must be available while its declarations are collected so public signatures retain exact
+        // provider-owned type metadata. They still belong only to the dependency's lexical scope, so remember which
+        // root bindings they introduce and restore those names before the consumer program is collected.
+        self.begin_dependency_import_binding_transaction();
         for decl in &module_ast.declarations {
-            if !matches!(decl.node, Declaration::Alias(_) | Declaration::Partial(_)) {
+            if matches!(decl.node, Declaration::Import(_)) {
+                self.collect_declaration(decl);
+            }
+        }
+        let (imported_symbol_bindings, imported_type_alias_bindings) =
+            self.finish_dependency_import_binding_transaction();
+        for decl in &module_ast.declarations {
+            if !matches!(
+                decl.node,
+                Declaration::Import(_) | Declaration::Alias(_) | Declaration::Partial(_)
+            ) {
                 self.collect_declaration(decl);
             }
         }
@@ -4205,9 +4276,83 @@ impl TypeChecker {
         self.register_dependency_derivable_metadata(_module_name, module_ast);
         self.cache_dependency_direct_member_symbols(_module_name, module_ast, false);
         self.cache_dependency_member_symbols(_module_name, module_ast, false);
+        let owned_names = module_ast
+            .declarations
+            .iter()
+            .filter_map(declaration_name)
+            .collect::<HashSet<_>>();
+        let owned_type_alias_names = module_ast
+            .declarations
+            .iter()
+            .filter_map(|decl| match &decl.node {
+                Declaration::TypeAlias(alias) => Some(alias.name.as_str()),
+                _ => None,
+            })
+            .collect::<HashSet<_>>();
+        self.restore_dependency_import_bindings(
+            imported_symbol_bindings,
+            imported_type_alias_bindings,
+            &owned_names,
+            &owned_type_alias_names,
+        );
+        self.dependency_semantics_pending = true;
         self.surface_context = previous_surface_context;
         self.import_aliases = previous_import_aliases;
         self.current_module_function_symbols = previous_module_function_symbols;
+    }
+
+    /// Start a narrow transaction for source-visible bindings mutated while dependency imports are collected.
+    fn begin_dependency_import_binding_transaction(&mut self) {
+        self.symbols.begin_current_scope_binding_transaction();
+        debug_assert!(self.dependency_import_type_alias_transaction.is_none());
+        self.dependency_import_type_alias_transaction = Some(HashMap::new());
+    }
+
+    /// Finish the dependency import transaction and return the previous values of only the bindings it changed.
+    fn finish_dependency_import_binding_transaction(
+        &mut self,
+    ) -> (
+        HashMap<String, Option<SymbolId>>,
+        HashMap<String, Option<TypeAliasTarget>>,
+    ) {
+        (
+            self.symbols.finish_current_scope_binding_transaction(),
+            self.dependency_import_type_alias_transaction.take().unwrap_or_default(),
+        )
+    }
+
+    /// Record one type-alias binding before a dependency import changes it.
+    fn record_dependency_import_type_alias_before_change(&mut self, name: &str) {
+        let previous = self.type_aliases.get(name).cloned();
+        if let Some(transaction) = &mut self.dependency_import_type_alias_transaction {
+            transaction.entry(name.to_string()).or_insert(previous);
+        }
+    }
+
+    /// Remove dependency-lexical imports from the consumer scope while retaining dependency-owned declarations.
+    fn restore_dependency_import_bindings(
+        &mut self,
+        imported_symbol_bindings: HashMap<String, Option<SymbolId>>,
+        imported_type_alias_bindings: HashMap<String, Option<TypeAliasTarget>>,
+        owned_names: &HashSet<&str>,
+        owned_type_alias_names: &HashSet<&str>,
+    ) {
+        for (name, previous_binding) in imported_symbol_bindings {
+            if owned_names.contains(name.as_str()) {
+                continue;
+            }
+            self.symbols.restore_current_scope_binding(&name, previous_binding);
+        }
+        for (name, previous_alias) in imported_type_alias_bindings {
+            if owned_type_alias_names.contains(name.as_str()) {
+                continue;
+            }
+            if let Some(previous_alias) = previous_alias {
+                self.type_aliases.insert(name, previous_alias);
+            } else {
+                self.type_aliases.remove(&name);
+            }
+        }
     }
 
     /// Rebuild exact dependency-member caches after all dependency modules have been collected.
@@ -4635,6 +4780,11 @@ impl TypeChecker {
         program: &Program,
         dependencies: &[(&str, &Program)],
     ) -> Result<(), Vec<CompileError>> {
+        self.dependency_semantics_pending = false;
+        self.transitive_pub_types.clear();
+        self.public_library_type_identities.clear();
+        self.transitive_pub_traits.clear();
+        self.cached_pub_libraries.clear();
         self.dependency_exports.clear();
         self.dependency_member_symbols.clear();
         self.dependency_member_partial_projections.clear();
@@ -4662,7 +4812,7 @@ impl TypeChecker {
         self.refresh_dependency_member_symbols(dependencies, true);
 
         // Then check the main program
-        self.check_program(program)
+        self.check_program_with_dependency_semantics(program)
     }
 
     /// Check a program with dependencies, but allow importing private items.
@@ -4674,6 +4824,11 @@ impl TypeChecker {
         program: &Program,
         dependencies: &[(&str, &Program)],
     ) -> Result<(), Vec<CompileError>> {
+        self.dependency_semantics_pending = false;
+        self.transitive_pub_types.clear();
+        self.public_library_type_identities.clear();
+        self.transitive_pub_traits.clear();
+        self.cached_pub_libraries.clear();
         // Skip populating dependency exports so visibility checks are bypassed.
         self.dependency_exports.clear();
         self.dependency_member_symbols.clear();
@@ -4692,7 +4847,7 @@ impl TypeChecker {
             self.import_module_all(dep_ast, name);
         }
         self.refresh_dependency_member_symbols(dependencies, false);
-        self.check_program(program)
+        self.check_program_with_dependency_semantics(program)
     }
 
     // ========================================================================

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -15451,6 +15451,91 @@ def wrong_provider() -> Widget:
 }
 
 #[test]
+fn test_dependency_import_does_not_leak_pub_bindings_into_consumer_issue898() {
+    let dependency = parse_program(
+        r#"
+from pub::mylib import Widget, make_widget
+
+pub def bridge() -> Widget:
+  return make_widget("ok")
+"#,
+        "#898 dependency",
+    );
+    let consumer = parse_program(
+        r#"
+from pub::mylib import Widget, make_widget
+from bridge import bridge
+
+def build() -> Widget:
+  _ = make_widget("direct")
+  return bridge()
+"#,
+        "#898 consumer",
+    );
+    let mut public_checker = TypeChecker::new();
+    public_checker.set_library_manifest_index(library_index_with_mylib_exports());
+    public_checker.import_module(&dependency, "bridge");
+
+    let public_result = public_checker.check_program(&consumer);
+
+    assert!(
+        public_result.is_ok(),
+        "public dependency-local bindings must not collide with explicit consumer imports, got: {:?}",
+        public_result.err()
+    );
+
+    let mut private_checker = TypeChecker::new();
+    private_checker.set_library_manifest_index(library_index_with_mylib_exports());
+    let private_result = private_checker.check_with_imports_allow_private(&consumer, &[("bridge", &dependency)]);
+
+    assert!(
+        private_result.is_ok(),
+        "private dependency-local bindings must not collide with explicit consumer imports, got: {:?}",
+        private_result.err()
+    );
+}
+
+#[test]
+fn test_dependency_import_does_not_leak_pub_type_alias_into_consumer_issue898() {
+    let dependency = parse_program(
+        r#"
+from pub::mylib import WidgetAlias, make_widget
+
+pub def bridge() -> WidgetAlias:
+  return make_widget("ok")
+"#,
+        "#898 alias dependency",
+    );
+    let consumer = parse_program(
+        r#"
+from pub::mylib import WidgetAlias
+from bridge import bridge
+
+def build() -> WidgetAlias:
+  return bridge()
+"#,
+        "#898 alias consumer",
+    );
+    let mut checker = TypeChecker::new();
+    checker.set_library_manifest_index(library_index_with_mylib_exports());
+    checker.import_module(&dependency, "bridge");
+
+    assert!(
+        !checker.type_aliases.contains_key("WidgetAlias"),
+        "the dependency's imported type alias must be removed before checking the consumer"
+    );
+    assert!(
+        checker.symbols.lookup("WidgetAlias").is_none(),
+        "the dependency's imported type-alias symbol must be removed before checking the consumer"
+    );
+
+    assert!(
+        checker.check_program(&consumer).is_ok(),
+        "the consumer must be able to import the same alias explicitly after the dependency transaction"
+    );
+}
+
+#[test]
 fn test_pub_import_module_alias_resolves_manifest_exports() {
     let source = r#"
 import pub::mylib as lib

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11262,6 +11262,99 @@ def test_absolute_crate_public_types() -> None:
     }
 
     #[test]
+    fn test_batch_keeps_transitive_pub_imports_out_of_later_test_scope_issue898()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let producer_root = tmp.path().join("probe_lib_provider");
+        std::fs::create_dir_all(producer_root.join("src"))?;
+        std::fs::write(
+            producer_root.join("incan.toml"),
+            "[project]\nname = \"probe_lib\"\nversion = \"0.1.0\"\n",
+        )?;
+        std::fs::write(
+            producer_root.join("src/lib.incn"),
+            r#"pub model Record:
+  pub value: int
+
+pub def marker() -> int:
+  return 7
+"#,
+        )?;
+
+        let producer_build = run_build_lib(&producer_root)?;
+        assert!(
+            producer_build.status.success(),
+            "expected #898 provider library build to succeed.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&producer_build.stdout),
+            String::from_utf8_lossy(&producer_build.stderr),
+        );
+
+        let consumer_root = tmp.path().join("consumer");
+        std::fs::create_dir_all(consumer_root.join("src"))?;
+        std::fs::create_dir_all(consumer_root.join("tests"))?;
+        std::fs::write(
+            consumer_root.join("incan.toml"),
+            "[project]\nname = \"pub_import_batch\"\nversion = \"0.1.0\"\n\n[dependencies]\nprobe_lib = { path = \"../probe_lib_provider\" }\n",
+        )?;
+        std::fs::write(
+            consumer_root.join("src/bridge.incn"),
+            r#"from pub::probe_lib import Record, marker
+
+pub def bridged() -> int:
+  _ = Record(value=marker())
+  return marker()
+
+pub def bridged_record() -> Record:
+  return Record(value=marker())
+"#,
+        )?;
+        std::fs::write(
+            consumer_root.join("tests/aaa_indirect_test.incn"),
+            r#"from crate.bridge import bridged, bridged_record
+
+def test_indirect_import() -> None:
+  assert bridged() == 7
+  assert bridged_record().value == 7
+"#,
+        )?;
+        std::fs::write(
+            consumer_root.join("tests/zzz_direct_test.incn"),
+            r#"from pub::probe_lib import Record, marker
+from crate.bridge import bridged, bridged_record
+
+def test_direct_import() -> None:
+  record: Record = bridged_record()
+  assert record.value == 7
+  assert marker() == 7
+  assert bridged() == 7
+"#,
+        )?;
+
+        let batch = run_test(&consumer_root.join("tests"))?;
+        let stdout = String::from_utf8_lossy(&batch.stdout);
+        let stderr = String::from_utf8_lossy(&batch.stderr);
+        assert!(
+            batch.status.success(),
+            "expected #898 indirect/direct public-import test batch to pass.\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr,
+        );
+        assert!(
+            stdout.contains("test_indirect_import") && stdout.contains("test_direct_import"),
+            "expected both #898 regression tests to run.\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr,
+        );
+        assert!(
+            !stderr.contains("already in scope"),
+            "transitive dependency imports must not leak into a later test module.\nstderr:\n{}",
+            stderr,
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn boundary_parity_preserves_dependency_owned_union_helpers_through_facade()
     -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -30,6 +30,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: Batched test modules now keep transitive dependency imports out of each other's local scopes, so separate test files can legitimately import the same public package symbols while true duplicate bindings inside one module remain rejected (#898).
 - **Compiler**: Public types imported from compiled libraries now retain provider-qualified nominal identity across split imports, multiple local aliases, qualified module calls, nested generics, and generated test batches, without unifying same-named types from separate dependencies (#892).
 - **Compiler**: Generated Cargo packages now preserve the authored Incan project version and SPDX license for application and library builds, keeping library `Cargo.toml` versions aligned with their `.incnlib` manifests (#889).
 - **Compiler**: `std::io::stdout()` now retains its stable `Stdout` receiver type when sysroot metadata is unavailable, so fallible extension-trait calls such as crossterm's `ExecutableCommand.execute(...)` expose their native `Result` and support postfix `?` (#888).


### PR DESCRIPTION
## Summary

Fixes batched `incan test` compilation leaking dependency-local public-package imports from one module into the next module's source scope. Separate test files can now import the same public symbols without false duplicate-binding diagnostics, while genuine duplicate imports inside one module remain rejected.

Closes #898.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: batched test files retain independent import scopes, including the indirect-then-direct public package import ordering from the minimized report.
- **Internals**: dependency imports are collected in a narrow transaction so dependency-owned signatures retain exact provider metadata. Only touched symbol and transparent type-alias bindings are restored before consumer collection; semantic-only transitive type, trait, and provider-identity caches remain available for imported signatures.
- **Integration sequencing**: the branch is rebased onto merged #900 at `fdb77ec88`, advances the workspace to `0.5.0-dev.13`, and composes #898's cache transaction with #892's provider-qualified identity state. New batch runs clear provider identity at their boundary while active dependency transactions preserve it.
- **Risks**: dependency import collection is shared by public and internal/private multi-module checking. Regressions cover both paths, explicit consumer re-imports, provider-owned model fields and identity, and the existing same-module collision control.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- The final branch passed all 16 #892 provider-identity unit regressions, both #898 binding/type-alias isolation units, and the real producer `.incnlib` plus two-file consumer test-batch regression.
- The original reviewed branch passed exact Rust 1.93.0 focused coverage, the same-module duplicate-import control, and the complete pre-commit gate with 2,994/2,994 tests, clippy, cargo-deny, release build, examples, and benchmarks.
- `make fmt` and `git diff --check` passed after conflict resolution.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

- Incan 0.5 release notes.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
