### PR TITLE
bugfix - stabilize rooted workspace locks (#906, #907, #908)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,6 +1485,7 @@ dependencies = [
  "incan_syntax",
  "incan_vocab",
  "insta",
+ "libc",
  "md-5",
  "miette",
  "prettyplease",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "blake2",
  "blake3",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,14 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "axum",
  "incan_core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,8 @@ wasmtime = { version = "45.0.3", default-features = false, features = ["cranelif
 wasmtime-wasi = { version = "45.0.3", default-features = false, features = ["p1"] }
 
 [dev-dependencies]
+# Unix process-group cleanup for bounded subprocess regression tests.
+libc = "0.2"
 # Runtime crate used by std.io generated-project offline smoke tests.
 byteorder = "1"
 # Runtime crate used by std.uuid generated-project offline smoke tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.15"
+version = "0.5.0-dev.16"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -57,7 +57,7 @@ use super::common::{
     resolve_project_root, resolve_source_root, typecheck_modules_with_import_graph, validate_output_dir,
 };
 use super::lock::{
-    GeneratedLibraryDependencyPreheatRequest, LockResolutionRequest, resolve_lock_context,
+    GeneratedLibraryDependencyPreheatRequest, LockResolution, LockResolutionRequest, resolve_lock_context,
     run_generated_library_dependency_preheat,
 };
 #[cfg(feature = "rust_inspect")]
@@ -1141,6 +1141,15 @@ pub(crate) fn build_file_report(
     }
 }
 
+/// Return whether an internal library artifact build must avoid canonical workspace lock resolution.
+///
+/// Ordinary dependency artifacts are prepared before their parent can finish the canonical workspace lock, so they
+/// must retain producer-local resolution. SDK artifacts are different: their publisher supplies an exact lock
+/// override that remains part of preparation.
+fn dependency_artifact_skips_canonical_lock(artifact_only: bool, sdk_provider_build: bool) -> bool {
+    artifact_only && !sdk_provider_build
+}
+
 /// Validate a library project and generate its Rust project without running Cargo.
 #[allow(clippy::too_many_arguments)] // Library preparation receives the same independent CLI selection axes.
 fn prepare_library_project(
@@ -1262,21 +1271,39 @@ fn prepare_library_project(
     let metadata_query_paths: Vec<String> = Vec::new();
 
     let lock_start = Instant::now();
-    let lock_resolution = resolve_lock_context(LockResolutionRequest {
-        project_root: &project_root,
-        project_name: project_name.as_str(),
-        entry_file: Some(&lib_entry),
-        manifest: Some(&manifest),
-        resolved: &resolved,
-        project_requirements: &project_requirements,
-        cargo_features: &cargo_features,
-        cargo_policy: &cargo_policy,
-        semantic: Some(&semantic),
-        package_features: Some(package_features),
-        sdk_profile_override,
-        #[cfg(feature = "rust_inspect")]
-        rust_inspect_query_paths: &metadata_query_paths,
-    })?;
+    let dependency_artifact_only = dependency_artifact_skips_canonical_lock(
+        env::var_os(INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV).is_some(),
+        env::var_os(SDK_PROVIDER_BUILD_ENV).is_some(),
+    );
+    let lock_resolution = if dependency_artifact_only {
+        // Dependency artifact preparation has no Cargo build to constrain with a lock payload. Resolving the
+        // canonical workspace lock here would traverse the consumer that requested this still-missing root artifact
+        // and recursively launch the same artifact-only child. Keep the already-resolved producer context intact;
+        // the parent command remains the sole owner of canonical lock generation and publication. SDK provider
+        // artifact builds are excluded because their parent supplies an exact Cargo.lock payload override.
+        LockResolution {
+            cargo_lock_payload: None,
+            cargo_package_name: project_name.clone(),
+            resolved,
+            project_requirements,
+        }
+    } else {
+        resolve_lock_context(LockResolutionRequest {
+            project_root: &project_root,
+            project_name: project_name.as_str(),
+            entry_file: Some(&lib_entry),
+            manifest: Some(&manifest),
+            resolved: &resolved,
+            project_requirements: &project_requirements,
+            cargo_features: &cargo_features,
+            cargo_policy: &cargo_policy,
+            semantic: Some(&semantic),
+            package_features: Some(package_features),
+            sdk_profile_override,
+            #[cfg(feature = "rust_inspect")]
+            rust_inspect_query_paths: &metadata_query_paths,
+        })?
+    };
     resolved = lock_resolution.resolved;
     project_requirements = lock_resolution.project_requirements;
     let lock_payload_for_typecheck = lock_resolution.cargo_lock_payload;
@@ -2573,6 +2600,13 @@ mod tests {
     use crate::lockfile::{IncanLock, compute_deps_fingerprint};
     use crate::manifest::ProjectManifest;
     use std::fs;
+
+    #[test]
+    fn dependency_artifact_only_build_skips_canonical_lock_issue908() {
+        assert!(dependency_artifact_skips_canonical_lock(true, false));
+        assert!(!dependency_artifact_skips_canonical_lock(true, true));
+        assert!(!dependency_artifact_skips_canonical_lock(false, false));
+    }
 
     #[test]
     fn classify_signature_mismatch_for_rust_extern_context() {

--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -117,6 +117,7 @@ pub fn lock_project(
         &cargo_features,
         package_features,
         sdk_profile_override,
+        None,
     )?
     .ok_or_else(|| CliError::failure("incan lock requires a FILE argument or at least one [project.scripts] entry"))?;
 
@@ -429,6 +430,7 @@ pub(crate) fn resolve_lock_context(request: LockResolutionRequest<'_>) -> CliRes
             cargo_features,
             package_features.unwrap_or(&default_package_features),
             sdk_profile_override,
+            None,
         )?
     } else {
         None
@@ -688,7 +690,17 @@ fn collect_workspace_lock_context(
     sdk_profile_override: Option<&str>,
 ) -> CliResult<WorkspaceLockContext> {
     let explicit_entry = entry_file.map(resolve_explicit_lock_entry).transpose()?;
-    let mut explicit_entry_was_selected = explicit_entry.is_none();
+    let explicit_entry_owner = explicit_entry
+        .as_deref()
+        .and_then(|entry| workspace.member_containing_path(entry));
+    if let Some(entry) = explicit_entry.as_deref()
+        && explicit_entry_owner.is_none()
+    {
+        return Err(CliError::failure(format!(
+            "lock entry {} is not contained by any selected workspace member",
+            entry.display()
+        )));
+    }
     let mut resolved = ResolvedDependencies {
         dependencies: Vec::new(),
         dev_dependencies: Vec::new(),
@@ -704,16 +716,16 @@ fn collect_workspace_lock_context(
             .effective_member_manifest(member)
             .map_err(|error| CliError::failure(error.to_string()))?;
         enforce_project_toolchain_constraint(&manifest)?;
-        let member_entry = explicit_entry.as_deref().filter(|path| path.starts_with(member.root()));
-        if member_entry.is_some() {
-            explicit_entry_was_selected = true;
-        }
+        let member_entry = explicit_entry
+            .as_deref()
+            .filter(|_| explicit_entry_owner.is_some_and(|owner| owner.root() == member.root()));
         let Some(member_context) = collect_project_lock_context(
             &manifest,
             member_entry,
             cargo_features,
             package_features,
             sdk_profile_override,
+            Some(workspace),
         )?
         else {
             continue;
@@ -727,15 +739,6 @@ fn collect_workspace_lock_context(
         rust_inspect_query_paths.extend(member_context.rust_inspect_query_paths);
     }
 
-    if !explicit_entry_was_selected {
-        let entry = explicit_entry.ok_or_else(|| {
-            CliError::failure("workspace lock selection lost the explicit entry path during resolution")
-        })?;
-        return Err(CliError::failure(format!(
-            "lock entry {} is not contained by any selected workspace member",
-            entry.display()
-        )));
-    }
     if !has_context {
         return Err(CliError::failure(
             "incan lock requires a FILE argument or at least one [project.scripts] entry across the workspace",
@@ -923,13 +926,17 @@ fn project_lock_entry_paths(manifest: &ProjectManifest, explicit_entry_file: Opt
     paths.into_iter().collect()
 }
 
-/// Collect the project-wide script and test dependency inputs used for both lock generation and freshness checks.
+/// Collect the project-wide script and owned test dependency inputs used for lock generation and freshness checks.
+///
+/// When `workspace` is present, descendant member tests are excluded so every test is resolved against the effective
+/// manifest of its deepest owning workspace member. Standalone projects retain unrestricted recursive discovery.
 fn collect_project_lock_context(
     manifest: &ProjectManifest,
     explicit_entry_file: Option<&Path>,
     cargo_features: &CargoFeatureSelection,
     package_features: &FeatureSelection,
     sdk_profile_override: Option<&str>,
+    workspace: Option<&WorkspaceGraph>,
 ) -> CliResult<Option<ProjectLockContext>> {
     let entry_paths = project_lock_entry_paths(manifest, explicit_entry_file);
     if entry_paths.is_empty() {
@@ -981,6 +988,7 @@ fn collect_project_lock_context(
 
     let test_inputs = collect_test_lock_inputs(
         manifest.project_root(),
+        workspace,
         Some(&library_imported_vocab),
         Some(&library_imported_dsl_surfaces),
         Some(&library_manifest_index),
@@ -1623,9 +1631,10 @@ pub(crate) fn generate_lockfile(
     Ok(lock)
 }
 
-/// Collect inline Rust crate imports and stdlib/provider requirements from test files for lock resolution.
+/// Collect inline Rust crate imports and stdlib/provider requirements from test files owned by this project.
 fn collect_test_lock_inputs(
     project_root: &Path,
+    workspace: Option<&WorkspaceGraph>,
     library_imported_vocab: Option<&parser::ImportedLibraryVocab>,
     library_imported_dsl_surfaces: Option<&parser::ImportedLibraryDslSurfaces>,
     library_manifest_index: Option<&LibraryManifestIndex>,
@@ -1634,7 +1643,7 @@ fn collect_test_lock_inputs(
     let mut inline_imports = Vec::new();
     let mut project_requirement_modules = Vec::new();
     let mut provider_module_groups = Vec::new();
-    let test_files = crate::cli::test_runner::discover_test_files(project_root);
+    let test_files = discover_project_test_files(project_root, workspace);
     let source_root = project_root.join("src");
 
     for file_path in test_files {
@@ -1698,6 +1707,20 @@ fn collect_test_lock_inputs(
         project_requirement_modules,
         provider_module_groups,
     })
+}
+
+/// Discover test files owned by one project, excluding descendant workspace members in rooted workspaces.
+fn discover_project_test_files(project_root: &Path, workspace: Option<&WorkspaceGraph>) -> Vec<PathBuf> {
+    crate::cli::test_runner::discover_test_files(project_root)
+        .into_iter()
+        .filter(|path| {
+            workspace.is_none_or(|graph| {
+                graph
+                    .member_containing_path(path)
+                    .is_some_and(|owner| owner.root() == project_root)
+            })
+        })
+        .collect()
 }
 
 /// Check whether any resolved dependency uses a git branch source, which is forbidden in strict
@@ -1844,7 +1867,7 @@ mod tests {
             "from internal import SessionContext\nfrom rust::tokio @ \"1\" import spawn\n",
         )?;
 
-        let inputs = collect_test_lock_inputs(project_root, None, None, None, &ProviderPlan::default())?;
+        let inputs = collect_test_lock_inputs(project_root, None, None, None, None, &ProviderPlan::default())?;
         let imports = inputs.inline_imports;
         let tokio = imports
             .iter()
@@ -1857,6 +1880,52 @@ mod tests {
 
         assert!(tokio.is_test_context);
         assert!(!datafusion.is_test_context);
+        Ok(())
+    }
+
+    #[test]
+    fn project_test_discovery_excludes_descendant_workspace_members() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let root = temp_dir.path();
+        let consumer_root = root.join("packages/consumer");
+        fs::create_dir_all(root.join("tests/nested"))?;
+        fs::create_dir_all(consumer_root.join("tests"))?;
+        fs::write(
+            root.join("incan.toml"),
+            r#"
+[project]
+name = "root"
+
+[workspace]
+members = ["packages/consumer"]
+"#,
+        )?;
+        fs::write(
+            consumer_root.join("incan.toml"),
+            r#"
+[project]
+name = "consumer"
+"#,
+        )?;
+        let root_test = root.join("tests/test_root.incn");
+        let nested_root_test = root.join("tests/nested/test_nested.incn");
+        let consumer_test = consumer_root.join("tests/test_consumer.incn");
+        fs::write(&root_test, "def test_root() -> None:\n    pass\n")?;
+        fs::write(&nested_root_test, "def test_nested() -> None:\n    pass\n")?;
+        fs::write(&consumer_test, "def test_consumer() -> None:\n    pass\n")?;
+
+        let workspace = WorkspaceGraph::load_from_root(root)?;
+        let root_files = discover_project_test_files(workspace.root(), Some(&workspace));
+        let consumer = workspace
+            .members()
+            .find(|member| member.name() == "consumer")
+            .ok_or("consumer workspace member should exist")?;
+        let consumer_files = discover_project_test_files(consumer.root(), Some(&workspace));
+        let mut expected_root_files = vec![fs::canonicalize(root_test)?, fs::canonicalize(nested_root_test)?];
+        expected_root_files.sort();
+
+        assert_eq!(root_files, expected_root_files);
+        assert_eq!(consumer_files, [fs::canonicalize(consumer_test)?]);
         Ok(())
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,7 +51,7 @@ use crate::workspace::{ResolvedWorkspaceScope, WorkspaceGraph, WorkspaceMember, 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use commands::build_report::{BuildReportFormat, BuildReportOptions, RustInspectionFormat};
 use commands::codegraph::CodegraphInspectionFormat;
-use commands::common::{CargoPolicy, CargoPolicyCliFlags};
+use commands::common::{CargoPolicy, CargoPolicyCliFlags, INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV};
 use commands::diagnostics::DiagnosticOutputFormat;
 use commands::lifecycle::{EnvOutputFormat, VersionBumpArg};
 use commands::provider_inspect::ProviderInspectionFormat;
@@ -1256,12 +1256,29 @@ impl BuildCommandRequest {
     }
 }
 
+/// Return whether this build should resolve and fan out an RFC 077 workspace scope.
+///
+/// Compiler-spawned artifact-only library builds target one dependency project even when that project also owns a
+/// workspace. Letting those children rediscover the default member scope can make the root package request its own
+/// still-missing artifact recursively. Ordinary library and executable builds retain workspace selection semantics.
+fn build_uses_workspace_scope(lib_mode: bool, artifact_only: bool) -> bool {
+    !lib_mode || !artifact_only
+}
+
 /// Fan out builds after resolving the exact RFC 077 member set, producing one aggregate report when JSON is requested.
+///
+/// Internal artifact-only library children bypass workspace selection because their current directory is the exact
+/// dependency project selected by the parent compiler process.
 fn execute_build(
     request: BuildCommandRequest,
     select_workspace: bool,
     member_selectors: Vec<String>,
 ) -> CliResult<ExitCode> {
+    let artifact_only = env::var_os(INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV).is_some();
+    if !build_uses_workspace_scope(request.lib_mode, artifact_only) {
+        return request.run_single();
+    }
+
     let Some(scope) = resolve_workspace_command_scope(select_workspace, &member_selectors)? else {
         return request.run_single();
     };
@@ -2016,6 +2033,13 @@ mod tests {
         assert!(file.is_none());
         assert!(lib_mode);
         Ok(())
+    }
+
+    #[test]
+    fn artifact_only_library_build_bypasses_workspace_scope_issue908() {
+        assert!(!build_uses_workspace_scope(true, true));
+        assert!(build_uses_workspace_scope(true, false));
+        assert!(build_uses_workspace_scope(false, true));
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -316,6 +316,10 @@ pub fn semantic_lock_state(
 }
 
 /// Assemble independently resolved member graphs into the one canonical workspace semantic lock state.
+///
+/// Member semantic paths are recorded relative to their owning member when possible. This boundary rebases every
+/// nested package and feature-edge coordinate into workspace-root coordinates so the canonical lock remains portable
+/// when the workspace is relocated.
 pub fn workspace_semantic_lock_state(
     workspace_root: &Path,
     members: impl IntoIterator<Item = (PathBuf, SemanticLockState)>,
@@ -329,11 +333,29 @@ pub fn workspace_semantic_lock_state(
                     member_root.display()
                 ));
             }
+            let packages = semantic
+                .packages
+                .into_iter()
+                .map(|mut package| {
+                    package.project_root =
+                        rebase_member_semantic_path(workspace_root, &member_root, &package.project_root);
+                    package
+                })
+                .collect();
+            let feature_edges = semantic
+                .feature_edges
+                .into_iter()
+                .map(|mut edge| {
+                    edge.from = rebase_member_semantic_path(workspace_root, &member_root, &edge.from);
+                    edge.to = rebase_member_semantic_path(workspace_root, &member_root, &edge.to);
+                    edge
+                })
+                .collect();
             Ok(LockedWorkspaceMember {
                 member_root: portable_project_path(workspace_root, &member_root),
                 sdk: semantic.sdk,
-                packages: semantic.packages,
-                feature_edges: semantic.feature_edges,
+                packages,
+                feature_edges,
                 providers: semantic.providers,
             })
         })
@@ -343,6 +365,21 @@ pub fn workspace_semantic_lock_state(
         workspace_members,
         ..SemanticLockState::default()
     })
+}
+
+/// Translate one member-local semantic coordinate into the canonical workspace coordinate space.
+///
+/// Absolute coordinates are retained as their original targets before portability is applied. Relative coordinates,
+/// including the empty member-root marker, are first resolved against the member root. Targets outside the workspace
+/// remain absolute because [`portable_project_path`] only strips paths contained by its project root.
+fn rebase_member_semantic_path(workspace_root: &Path, member_root: &Path, path: &str) -> String {
+    let member_path = Path::new(path);
+    let resolved = if member_path.is_absolute() {
+        member_path.to_path_buf()
+    } else {
+        member_root.join(member_path)
+    };
+    portable_project_path(workspace_root, &resolved)
 }
 
 /// Render one component-selection edge in the stable lockfile vocabulary.
@@ -732,6 +769,62 @@ mod tests {
     }
 
     #[test]
+    fn workspace_semantic_lock_state_rebases_member_paths_to_workspace_root() -> TestResult {
+        let fixture = tempfile::tempdir()?;
+        let workspace_root = fixture.path().join("root_lib");
+        let consumer_root = workspace_root.join("consumer");
+        let external = tempfile::tempdir()?;
+        fs::create_dir_all(&consumer_root)?;
+
+        let member_semantic = SemanticLockState {
+            packages: vec![
+                locked_package("consumer", ""),
+                locked_package("root_lib", &workspace_root.to_string_lossy()),
+                locked_package("external", &external.path().to_string_lossy()),
+            ],
+            feature_edges: vec![
+                locked_feature_edge("", "root_lib", &workspace_root.to_string_lossy()),
+                locked_feature_edge("", "external", &external.path().to_string_lossy()),
+            ],
+            ..SemanticLockState::default()
+        };
+
+        let state = workspace_semantic_lock_state(&workspace_root, [(consumer_root, member_semantic)])?;
+        assert_eq!(state.workspace_members.len(), 1);
+        let member = &state.workspace_members[0];
+        assert_eq!(member.member_root, "consumer");
+        assert_eq!(member.packages[0].project_root, "consumer");
+        assert_eq!(member.packages[1].project_root, "");
+        assert_eq!(
+            member.packages[2].project_root,
+            fs::canonicalize(external.path())?.to_string_lossy().replace('\\', "/")
+        );
+        assert_eq!(member.feature_edges[0].from, "consumer");
+        assert_eq!(member.feature_edges[0].to, "");
+        assert_eq!(
+            member.feature_edges[1].to,
+            fs::canonicalize(external.path())?.to_string_lossy().replace('\\', "/")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_semantic_fingerprint_is_stable_after_relocation() -> TestResult {
+        let first_fixture = tempfile::tempdir()?;
+        let second_fixture = tempfile::tempdir()?;
+        let first = relocated_workspace_semantic(first_fixture.path())?;
+        let second = relocated_workspace_semantic(second_fixture.path())?;
+
+        assert_eq!(first, second);
+        let selection = CargoFeatureSelection::default();
+        assert_eq!(
+            compute_resolved_fingerprint(&[], &[], &selection, None, &first),
+            compute_resolved_fingerprint(&[], &[], &selection, None, &second)
+        );
+        Ok(())
+    }
+
+    #[test]
     fn lockfile_round_trip() -> TestResult {
         let selection = CargoFeatureSelection {
             cargo_features: vec!["alpha".to_string()],
@@ -960,6 +1053,47 @@ lock = "payload"
         };
         let norm = sel.normalized();
         assert_eq!(norm.cargo_features, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    /// Build one minimal package-feature snapshot using the supplied member-local coordinate.
+    fn locked_package(package: &str, project_root: &str) -> LockedPackageFeatures {
+        LockedPackageFeatures {
+            package: package.to_string(),
+            project_root: project_root.to_string(),
+            active_features: BTreeSet::new(),
+            active_optional_dependencies: BTreeSet::new(),
+            dependency_features: BTreeMap::new(),
+            required_sdk_components: BTreeSet::new(),
+        }
+    }
+
+    /// Build one minimal feature edge using member-local source and target coordinates.
+    fn locked_feature_edge(from: &str, dependency_key: &str, to: &str) -> LockedFeatureEdge {
+        LockedFeatureEdge {
+            from: from.to_string(),
+            dependency_key: dependency_key.to_string(),
+            to: to.to_string(),
+            requested_features: BTreeSet::new(),
+            default_features: true,
+            optional: false,
+        }
+    }
+
+    /// Create the same rooted workspace semantic graph under an arbitrary filesystem location.
+    fn relocated_workspace_semantic(fixture_root: &Path) -> Result<SemanticLockState, Box<dyn std::error::Error>> {
+        let workspace_root = fixture_root.join("root_lib");
+        let consumer_root = workspace_root.join("consumer");
+        fs::create_dir_all(&consumer_root)?;
+        let member_semantic = SemanticLockState {
+            packages: vec![
+                locked_package("consumer", ""),
+                locked_package("root_lib", &workspace_root.to_string_lossy()),
+            ],
+            feature_edges: vec![locked_feature_edge("", "root_lib", &workspace_root.to_string_lossy())],
+            ..SemanticLockState::default()
+        };
+
+        workspace_semantic_lock_state(&workspace_root, [(consumer_root, member_semantic)]).map_err(|error| error.into())
     }
 
     fn sample_semantic_state() -> SemanticLockState {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -423,6 +423,15 @@ impl WorkspaceGraph {
         self.members.iter().find(|member| member.root == root)
     }
 
+    /// Return the workspace member that owns `path`, preferring the deepest matching member root.
+    ///
+    /// Rooted workspaces can contain a non-root member below the root project. In that topology, both member roots
+    /// are path prefixes, so callers must use the deepest match rather than allowing the root project to claim a
+    /// descendant member's entrypoint or test file.
+    pub(crate) fn member_containing_path(&self, path: &Path) -> Option<&WorkspaceMember> {
+        self.member_containing_index(path).map(|index| &self.members[index])
+    }
+
     /// Return the fully parsed manifest for one validated workspace member.
     pub fn member_manifest(&self, member: &WorkspaceMember) -> Option<&ProjectManifest> {
         self.member_manifests.get(member.root())
@@ -583,7 +592,7 @@ impl WorkspaceGraph {
         if current_dir == self.root {
             return Ok(self.root_scope());
         }
-        if let Some(index) = self.member_containing(&current_dir) {
+        if let Some(index) = self.member_containing_index(&current_dir) {
             return Ok(self.selection(WorkspaceScopeOrigin::CurrentMember, [index]));
         }
 
@@ -634,7 +643,7 @@ impl WorkspaceGraph {
     }
 
     /// Return the member containing a canonical invocation directory, preferring the deepest match defensively.
-    fn member_containing(&self, directory: &Path) -> Option<usize> {
+    fn member_containing_index(&self, directory: &Path) -> Option<usize> {
         self.members
             .iter()
             .enumerate()
@@ -1712,6 +1721,34 @@ default-members = ["zebra", "packages/alpha"]
         ))?;
         assert_eq!(all.origin(), WorkspaceScopeOrigin::Workspace);
         assert_eq!(all.member_names(), ["root", "alpha", "zebra"]);
+        Ok(())
+    }
+
+    #[test]
+    fn member_path_ownership_prefers_the_deepest_rooted_workspace_member() -> TestResult {
+        let root = tempfile::tempdir()?;
+        write_manifest(
+            root.path(),
+            r#"
+[project]
+name = "root"
+
+[workspace]
+members = ["packages/consumer"]
+"#,
+        )?;
+        write_project(root.path().join("packages/consumer"), "consumer")?;
+        let graph = WorkspaceGraph::load_from_root(root.path())?;
+
+        let root_owner = graph
+            .member_containing_path(&graph.root().join("tests/test_root.incn"))
+            .ok_or("root-owned path should resolve to a member")?;
+        let consumer_owner = graph
+            .member_containing_path(&graph.root().join("packages/consumer/tests/test_consumer.incn"))
+            .ok_or("consumer-owned path should resolve to a member")?;
+
+        assert_eq!(root_owner.name(), "root");
+        assert_eq!(consumer_owner.name(), "consumer");
         Ok(())
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -69,6 +69,35 @@ fn configured_incan_command(current_dir: &Path, args: &[&str]) -> Command {
     command
 }
 
+/// Run one Unix CLI probe in its own process group so recursive subprocess regressions can be terminated together.
+#[cfg(unix)]
+fn run_incan_with_timeout(
+    current_dir: &Path,
+    args: &[&str],
+    timeout: std::time::Duration,
+) -> Result<(Output, bool), Box<dyn std::error::Error>> {
+    use std::os::unix::process::CommandExt;
+
+    let mut command = configured_incan_command(current_dir, args);
+    command.process_group(0).stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    let started = std::time::Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            return Ok((child.wait_with_output()?, false));
+        }
+        if started.elapsed() >= timeout {
+            let process_group = format!("-{}", child.id());
+            let killed_group = Command::new("kill").args(["-TERM", process_group.as_str()]).status()?;
+            if !killed_group.success() {
+                child.kill()?;
+            }
+            return Ok((child.wait_with_output()?, true));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+}
+
 #[cfg(unix)]
 fn run_incan_with_os_env(
     current_dir: &Path,
@@ -1220,6 +1249,89 @@ def test_workspace_rust_dependency_is_available() -> None:
         &test_output,
         "rooted workspace selected-member test with an inherited Rust dependency",
     );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn rooted_workspace_missing_root_artifact_is_prepared_once_issue908() -> Result<(), Box<dyn std::error::Error>> {
+    let root = tempfile::tempdir()?;
+    fs::create_dir_all(root.path().join("src"))?;
+    fs::write(
+        root.path().join("incan.toml"),
+        r#"[project]
+name = "root_lib"
+version = "0.1.0"
+
+[project.scripts]
+library = "src/lib.incn"
+"#,
+    )?;
+    fs::write(
+        root.path().join("src/lib.incn"),
+        "pub def answer() -> int:\n  return 42\n",
+    )?;
+
+    let warmup = run_incan(root.path(), &["build", "--lib"])?;
+    assert_success(&warmup, "standalone SDK and library artifact warmup");
+    fs::remove_dir_all(root.path().join("target/lib"))?;
+    fs::remove_file(root.path().join("incan.lock"))?;
+
+    fs::write(
+        root.path().join("incan.toml"),
+        r#"[project]
+name = "root_lib"
+version = "0.1.0"
+
+[project.scripts]
+library = "src/lib.incn"
+
+[workspace]
+members = ["consumer"]
+default-members = ["root_lib", "consumer"]
+
+[workspace.dependencies]
+root_lib = { path = "." }
+"#,
+    )?;
+    let consumer = root.path().join("consumer");
+    fs::create_dir_all(consumer.join("src"))?;
+    fs::write(
+        consumer.join("incan.toml"),
+        r#"[project]
+name = "consumer"
+version = "0.1.0"
+
+[project.scripts]
+main = "src/main.incn"
+
+[dependencies]
+root_lib = { workspace = true }
+"#,
+    )?;
+    fs::write(
+        consumer.join("src/main.incn"),
+        "from pub::root_lib import answer\n\n\ndef main() -> None:\n  println(answer())\n",
+    )?;
+
+    let (output, timed_out) = run_incan_with_timeout(root.path(), &["lock"], std::time::Duration::from_secs(60))?;
+    assert!(
+        !timed_out,
+        "rooted workspace lock exceeded its bounded artifact-preparation window\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_success(&output, "rooted workspace lock with a missing root artifact");
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(
+        stderr
+            .matches("Preparing missing pub::root_lib dependency artifact")
+            .count(),
+        1,
+        "root dependency preparation should launch exactly one artifact-only child:\n{stderr}"
+    );
+    assert!(root.path().join("target/lib/root_lib.incnlib").is_file());
+    assert!(root.path().join("incan.lock").is_file());
     Ok(())
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -79,7 +79,11 @@ fn run_incan_with_timeout(
     use std::os::unix::process::CommandExt;
 
     let mut command = configured_incan_command(current_dir, args);
-    command.process_group(0).stdout(Stdio::piped()).stderr(Stdio::piped());
+    command
+        .process_group(0)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("INCAN_LOCK_PREHEAT", "1");
     let mut child = command.spawn()?;
     let started = std::time::Instant::now();
     loop {
@@ -87,14 +91,55 @@ fn run_incan_with_timeout(
             return Ok((child.wait_with_output()?, false));
         }
         if started.elapsed() >= timeout {
-            let process_group = format!("-{}", child.id());
-            let killed_group = Command::new("kill").args(["-TERM", process_group.as_str()]).status()?;
-            if !killed_group.success() {
-                child.kill()?;
+            // TERM is best-effort because the group can disappear between the timeout check and this signal. The
+            // group-wide KILL below is the authoritative cleanup before any output pipe is reaped.
+            let _ = signal_process_group(child.id(), libc::SIGTERM);
+            let grace_started = std::time::Instant::now();
+            while grace_started.elapsed() < std::time::Duration::from_secs(2) {
+                std::thread::sleep(std::time::Duration::from_millis(25));
             }
-            return Ok((child.wait_with_output()?, true));
+            // Always address the full group with SIGKILL after the grace window. The group may contain a descendant
+            // that retained the output pipes after the leader exited or ignored SIGTERM.
+            if let Err(error) = signal_process_group(child.id(), libc::SIGKILL) {
+                let leader_kill = child.kill();
+                let leader_wait = child.wait();
+                if let Err(kill_error) = leader_kill {
+                    return Err(std::io::Error::other(format!(
+                        "process-group SIGKILL failed ({error}); leader kill also failed ({kill_error})"
+                    ))
+                    .into());
+                }
+                leader_wait?;
+                return Err(error.into());
+            }
+            let kill_started = std::time::Instant::now();
+            while kill_started.elapsed() < std::time::Duration::from_secs(2) {
+                if child.try_wait()?.is_some() {
+                    return Ok((child.wait_with_output()?, true));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            return Err("timed-out Incan process group did not exit after SIGKILL".into());
         }
         std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+}
+
+/// Send one signal to the complete Unix process group owned by a bounded CLI probe.
+#[cfg(unix)]
+fn signal_process_group(child_id: u32, signal: libc::c_int) -> std::io::Result<()> {
+    let process_group = i32::try_from(child_id).map_err(|error| std::io::Error::other(error.to_string()))?;
+    // SAFETY: The child was spawned with its PID as its process-group ID, and negating that validated positive ID
+    // targets only the task-owned group. `signal` is one of libc's SIGTERM/SIGKILL constants supplied above.
+    let result = unsafe { libc::kill(-process_group, signal) };
+    if result == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
     }
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -993,6 +993,236 @@ itoa = "1"
     Ok(())
 }
 
+#[test]
+fn rooted_workspace_semantic_lock_is_relocation_stable_issue906() -> Result<(), Box<dyn std::error::Error>> {
+    fn create_locked_workspace(
+        root: &Path,
+        prebuilt_artifact: &Path,
+    ) -> Result<incan::lockfile::IncanLock, Box<dyn std::error::Error>> {
+        fs::create_dir_all(root.join("src"))?;
+        fs::write(
+            root.join("incan.toml"),
+            r#"[project]
+name = "root_lib"
+version = "0.1.0"
+
+[project.scripts]
+library = "src/lib.incn"
+
+[workspace]
+members = ["consumer"]
+default-members = ["root_lib", "consumer"]
+
+[workspace.dependencies]
+root_lib = { path = "." }
+"#,
+        )?;
+        fs::write(root.join("src/lib.incn"), "pub def answer() -> int:\n  return 42\n")?;
+        let artifact = root.join("target/lib");
+        fs::create_dir_all(artifact.join("src"))?;
+        for relative in ["Cargo.toml", "Cargo.lock", "root_lib.incnlib", "src/lib.rs"] {
+            fs::copy(prebuilt_artifact.join(relative), artifact.join(relative))?;
+        }
+        let consumer = root.join("consumer");
+        fs::create_dir_all(consumer.join("src"))?;
+        fs::write(
+            consumer.join("incan.toml"),
+            r#"[project]
+name = "consumer"
+version = "0.1.0"
+
+[project.scripts]
+main = "src/main.incn"
+
+[dependencies]
+root_lib = { workspace = true }
+"#,
+        )?;
+        fs::write(
+            consumer.join("src/main.incn"),
+            "from pub::root_lib import answer\n\n\ndef main() -> None:\n  println(answer())\n",
+        )?;
+
+        let lock_output = run_incan(root, &["lock"])?;
+        assert_success(&lock_output, "rooted workspace lock generation");
+        Ok(incan::lockfile::IncanLock::load(&root.join("incan.lock"))?)
+    }
+
+    let temp = tempfile::tempdir()?;
+    let producer = temp.path().join("prebuilt/root_lib");
+    fs::create_dir_all(producer.join("src"))?;
+    fs::write(
+        producer.join("incan.toml"),
+        r#"[project]
+name = "root_lib"
+version = "0.1.0"
+
+[project.scripts]
+library = "src/lib.incn"
+"#,
+    )?;
+    fs::write(producer.join("src/lib.incn"), "pub def answer() -> int:\n  return 42\n")?;
+    let library_output = run_incan(&producer, &["build", "--lib"])?;
+    assert_success(
+        &library_output,
+        "standalone root library build before workspace activation",
+    );
+
+    let first = create_locked_workspace(&temp.path().join("first/root_lib"), &producer.join("target/lib"))?;
+    let second = create_locked_workspace(&temp.path().join("relocated/root_lib"), &producer.join("target/lib"))?;
+
+    assert_eq!(first.semantic, second.semantic);
+    assert_eq!(first.deps_fingerprint, second.deps_fingerprint);
+    let consumer = first
+        .semantic
+        .workspace_members
+        .iter()
+        .find(|member| member.member_root == "consumer")
+        .ok_or("consumer semantic graph missing")?;
+    assert!(
+        consumer
+            .packages
+            .iter()
+            .any(|package| package.package == "root_lib" && package.project_root.is_empty()),
+        "the root package should use the workspace-root coordinate"
+    );
+    assert!(
+        consumer
+            .packages
+            .iter()
+            .any(|package| package.package == "consumer" && package.project_root == "consumer"),
+        "the selected member package should use its workspace-relative coordinate"
+    );
+    assert!(
+        consumer
+            .feature_edges
+            .iter()
+            .any(|edge| edge.from == "consumer" && edge.to.is_empty()),
+        "the member-to-root dependency edge should be workspace-relative"
+    );
+    Ok(())
+}
+
+#[test]
+fn rooted_workspace_member_build_uses_direct_rust_dependencies_issue907() -> Result<(), Box<dyn std::error::Error>> {
+    let root = tempfile::tempdir()?;
+    fs::create_dir_all(root.path().join("src"))?;
+    fs::write(
+        root.path().join("incan.toml"),
+        r#"[project]
+name = "root_lib"
+version = "0.1.0"
+
+[workspace]
+members = ["consumer"]
+default-members = ["consumer"]
+"#,
+    )?;
+    fs::write(
+        root.path().join("src/lib.incn"),
+        "pub def root_marker() -> None:\n  pass\n",
+    )?;
+
+    let consumer = root.path().join("consumer");
+    fs::create_dir_all(consumer.join("src"))?;
+    fs::write(
+        consumer.join("incan.toml"),
+        r#"[project]
+name = "consumer"
+version = "0.1.0"
+
+[project.scripts]
+main = "src/main.incn"
+
+[rust-dependencies]
+itoa = "1"
+"#,
+    )?;
+    fs::write(
+        consumer.join("src/main.incn"),
+        "from rust::itoa import Buffer\n\n\ndef main() -> None:\n  println(\"direct dependency\")\n",
+    )?;
+
+    let output = run_incan(&consumer, &["build", "--no-locked"])?;
+    assert_success(&output, "rooted workspace member build with a direct Rust dependency");
+    Ok(())
+}
+
+#[test]
+fn rooted_workspace_member_test_uses_inherited_rust_dependencies_issue907() -> Result<(), Box<dyn std::error::Error>> {
+    let root = tempfile::tempdir()?;
+    fs::create_dir_all(root.path().join("src"))?;
+    fs::write(
+        root.path().join("incan.toml"),
+        r#"[project]
+name = "root_lib"
+version = "0.1.0"
+
+[workspace]
+members = ["consumer"]
+default-members = ["consumer"]
+
+[workspace.rust-dependencies]
+itoa = "1"
+"#,
+    )?;
+    fs::write(
+        root.path().join("src/lib.incn"),
+        "pub def root_marker() -> None:\n  pass\n",
+    )?;
+
+    let consumer = root.path().join("consumer");
+    fs::create_dir_all(consumer.join("src"))?;
+    fs::create_dir_all(consumer.join("tests"))?;
+    fs::write(
+        consumer.join("incan.toml"),
+        r#"[project]
+name = "consumer"
+version = "0.1.0"
+
+[project.scripts]
+main = "src/main.incn"
+
+[rust-dependencies]
+itoa = { workspace = true }
+"#,
+    )?;
+    fs::write(consumer.join("src/main.incn"), "def main() -> None:\n  pass\n")?;
+    fs::write(
+        consumer.join("tests/test_workspace_rust_dependency.incn"),
+        r#"from rust::itoa import Buffer
+from std.testing import test
+
+
+@test
+def test_workspace_rust_dependency_is_available() -> None:
+    assert True
+"#,
+    )?;
+
+    let lock_output = run_incan(root.path(), &["lock"])?;
+    assert_success(
+        &lock_output,
+        "rooted workspace lock with a member-owned test dependency",
+    );
+    let test_output = run_incan(
+        root.path(),
+        &[
+            "test",
+            "--member",
+            "consumer",
+            "--locked",
+            "--fail-on-empty",
+            "tests/test_workspace_rust_dependency.incn",
+        ],
+    )?;
+    assert_success(
+        &test_output,
+        "rooted workspace selected-member test with an inherited Rust dependency",
+    );
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn workspace_lock_concurrent_publishers_leave_one_parseable_root_lock() -> Result<(), Box<dyn std::error::Error>> {

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -30,6 +30,9 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Workspaces**: Root library dependency preparation now targets exactly that project and leaves canonical lock publication to its parent command, preventing fresh rooted workspaces from recursively spawning `incan build --lib` until the machine is exhausted (#908).
+- **Workspaces**: Rooted-workspace entrypoints and tests now resolve through their deepest owning member, so selected member builds retain both direct and inherited Rust dependency versions (#907).
+- **Workspaces**: Canonical workspace locks now rebase nested package roots and feature edges into workspace-relative coordinates, keeping cross-member semantic state and fingerprints portable across checkout locations (#906).
 - **Compiler**: Batched test modules now keep transitive dependency imports out of each other's local scopes, so separate test files can legitimately import the same public package symbols while true duplicate bindings inside one module remain rejected (#898).
 - **Compiler**: Public types imported from compiled libraries now retain provider-qualified nominal identity across split imports, multiple local aliases, qualified module calls, nested generics, and generated test batches, without unifying same-named types from separate dependencies (#892).
 - **Compiler**: Generated Cargo packages now preserve the authored Incan project version and SPDX license for application and library builds, keeping library `Cargo.toml` versions aligned with their `.incnlib` manifests (#889).


### PR DESCRIPTION
## Summary

Fix three rooted-workspace failures that blocked safe library consumption:

- stop missing root-library artifact preparation from recursively spawning `incan build --lib` processes;
- preserve the selected member's effective Rust dependencies and test ownership under a rooted workspace;
- serialize member semantic-graph paths relative to the canonical workspace root so lock state and fingerprints remain relocation-stable.

Fixes #908.
Fixes #907.
Fixes #906.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: rooted workspaces can preheat a missing root library once, selected-member builds/tests retain direct or inherited Rust dependencies, and canonical locks no longer embed relocatable member paths as absolute host paths.
- **Internals**: artifact-only dependency builds bypass workspace fanout and canonical-lock publication; lock ownership is assigned to the deepest member; nested semantic paths are rebased into workspace-root coordinates.
- **Risks**: workspace project ownership, internal library preparation, and semantic-lock path rebasing are changed. Dedicated rooted-workspace unit and CLI regressions cover all three paths, including a bounded process-group timeout for the resource-exhaustion case.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed twice on the final branch; the final pass ran 3,051/3,051 tests, Clippy, cargo-deny, 60 examples, and 9 benchmark builds.
- `cargo test --test cli_integration rooted_workspace_missing_root_artifact_is_prepared_once_issue908 -- --nocapture --test-threads=1` passed with preheat forced on and bounded process-group cleanup.
- Rust 1.93.0 focused unit tests passed for semantic path rebasing, deepest member ownership, descendant test filtering, and artifact-only build guards.
- `cargo +1.93.0 test --test cli_integration rooted_workspace_ -- --nocapture --test-threads=1` passed 4/4 rooted-workspace regressions.
- `cargo +nightly fmt --all` and `git diff --check` passed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): v0.5 release notes include the three bug fixes.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
