### PR TITLE
bugfix - preserve rooted library Cargo identity (#909)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "blake2",
  "blake3",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -1528,14 +1528,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "axum",
  "incan_core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.16"
+version = "0.5.0-dev.17"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -37,7 +37,7 @@ use crate::library_manifest::{
     ProviderModuleClaim, digest_provider_artifact,
 };
 use crate::lockfile::{CargoFeatureSelection, semantic_lock_state};
-use crate::manifest::ProjectManifest;
+use crate::manifest::{DependencySource, DependencySpec, ProjectManifest};
 use crate::provider::{
     FeatureSelection, PackageFeatureGraph, PackageFeaturePlan, ProviderPlan, SDK_PROVIDER_BUILD_ENV,
 };
@@ -135,7 +135,7 @@ struct InlineCommandProject {
 struct PreparedLibraryProject {
     generator: ProjectGenerator,
     project_root: PathBuf,
-    cargo_package_name: String,
+    lock_cargo_package_name: String,
     rust_edition: Option<String>,
     out_dir: PathBuf,
     manifest_path: PathBuf,
@@ -1169,6 +1169,23 @@ fn dependency_artifact_skips_canonical_lock(artifact_only: bool, sdk_provider_bu
     artifact_only && !sdk_provider_build
 }
 
+/// Remove path dependencies that point back to the generated library crate itself.
+///
+/// A rooted workspace lock includes the root library as a dependency of its consumers. That aggregate dependency is
+/// valid for the synthetic lock/preheat package, but the selected root library artifact cannot depend on its own
+/// `target/lib` crate after adopting the producer's Cargo package identity.
+fn remove_generated_library_self_dependencies(resolved: &mut ResolvedDependencies, out_dir: &Path) {
+    let canonical_out_dir = fs::canonicalize(out_dir).unwrap_or_else(|_| out_dir.to_path_buf());
+    let points_to_generated_crate = |spec: &DependencySpec| match &spec.source {
+        DependencySource::Path { path } => fs::canonicalize(path).unwrap_or_else(|_| path.clone()) == canonical_out_dir,
+        DependencySource::Registry | DependencySource::Git { .. } => false,
+    };
+    resolved.dependencies.retain(|spec| !points_to_generated_crate(spec));
+    resolved
+        .dev_dependencies
+        .retain(|spec| !points_to_generated_crate(spec));
+}
+
 /// Validate a library project and generate its Rust project without running Cargo.
 #[allow(clippy::too_many_arguments)] // Library preparation receives the same independent CLI selection axes.
 fn prepare_library_project(
@@ -1326,7 +1343,7 @@ fn prepare_library_project(
     resolved = lock_resolution.resolved;
     project_requirements = lock_resolution.project_requirements;
     let lock_payload_for_typecheck = lock_resolution.cargo_lock_payload;
-    let cargo_package_name = lock_resolution.cargo_package_name;
+    let lock_cargo_package_name = lock_resolution.cargo_package_name;
     record_timing(&mut timings_ms, "library_resolve_lock_payload", lock_start);
     let should_preheat_library_dependencies = lock_payload_for_typecheck.is_some()
         && (!resolved.dependencies.is_empty() || !project_requirements.stdlib_features.is_empty());
@@ -1337,7 +1354,7 @@ fn prepare_library_project(
         let rust_inspect_manifest_dir = prepare_rust_inspect_workspace(RustInspectWorkspaceRequest {
             project_root: &project_root,
             project_name: project_name.as_str(),
-            cargo_package_name: &cargo_package_name,
+            cargo_package_name: &lock_cargo_package_name,
             rust_edition: manifest.build.as_ref().and_then(|build| build.rust_edition.clone()),
             resolved: &resolved,
             project_requirements: &project_requirements,
@@ -1568,7 +1585,10 @@ fn prepare_library_project(
         codegen.add_module_with_path_segments(&module.name, &module.ast, module.path_segments.clone());
     }
     let mut generator = ProjectGenerator::new(&out_dir, project_name.as_str(), false);
-    generator.set_package_name(Some(cargo_package_name.clone()));
+    // Canonical workspace locking uses a synthetic package name so every member resolves one shared Cargo graph.
+    // A published library artifact instead has an identity contract across Cargo.toml, `[lib]`, and `.incnlib`, so
+    // its generated Cargo package must retain the selected producer project's name.
+    generator.set_package_name(Some(project_name.clone()));
     generator.set_package_metadata(Some(project_version.clone()), project_license);
     generator.set_provider_plan(&provider_plan);
     generator.set_cargo_target_dir_override(generated_cargo_target_dir.map(Path::to_path_buf));
@@ -1580,10 +1600,11 @@ fn prepare_library_project(
     codegen.set_rust_inspect_manifest_dir(rust_inspect_manifest_dir.clone());
     generator.set_cargo_lock_payload(lock_payload_for_typecheck);
     generator.set_cargo_policy_flags(cargo_command_flags(&cargo_policy, &cargo_features));
-    let rust_dependencies = resolved.dependencies.clone();
-    let rust_dev_dependencies = resolved.dev_dependencies.clone();
     let resolved_dependencies_for_preheat = resolved.clone();
     let project_requirements_for_preheat = project_requirements.clone();
+    remove_generated_library_self_dependencies(&mut resolved, &out_dir);
+    let rust_dependencies = resolved.dependencies.clone();
+    let rust_dev_dependencies = resolved.dev_dependencies.clone();
     let report_draft = BuildReportDraft {
         mode: BuildReportMode::Library,
         profile: "release".to_string(),
@@ -1653,7 +1674,7 @@ fn prepare_library_project(
     Ok(PreparedLibraryProject {
         generator,
         project_root,
-        cargo_package_name,
+        lock_cargo_package_name,
         rust_edition,
         out_dir,
         manifest_path,
@@ -2395,7 +2416,7 @@ pub(crate) fn build_library_report(
         run_generated_library_dependency_preheat(GeneratedLibraryDependencyPreheatRequest {
             project_root: &prepared.project_root,
             lock_dir: &prepared.project_root.join("target").join("incan_lock"),
-            project_name: &prepared.cargo_package_name,
+            project_name: &prepared.lock_cargo_package_name,
             rust_edition: prepared.rust_edition.clone(),
             resolved: &prepared.resolved_dependencies,
             project_requirements: &prepared.project_requirements,

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -1169,15 +1169,19 @@ fn dependency_artifact_skips_canonical_lock(artifact_only: bool, sdk_provider_bu
     artifact_only && !sdk_provider_build
 }
 
-/// Remove path dependencies that point back to the generated library crate itself.
+/// Remove path dependencies that point back to the selected project's generated library crate.
 ///
 /// A rooted workspace lock includes the root library as a dependency of its consumers. That aggregate dependency is
 /// valid for the synthetic lock/preheat package, but the selected root library artifact cannot depend on its own
-/// `target/lib` crate after adopting the producer's Cargo package identity.
-fn remove_generated_library_self_dependencies(resolved: &mut ResolvedDependencies, out_dir: &Path) {
-    let canonical_out_dir = fs::canonicalize(out_dir).unwrap_or_else(|_| out_dir.to_path_buf());
+/// canonical `target/lib` crate after adopting the producer's Cargo package identity. This comparison deliberately
+/// uses the project-owned artifact path rather than a command-specific output override.
+fn remove_generated_library_self_dependencies(resolved: &mut ResolvedDependencies, project_root: &Path) {
+    let artifact_root = project_root.join("target/lib");
+    let canonical_artifact_root = fs::canonicalize(&artifact_root).unwrap_or(artifact_root);
     let points_to_generated_crate = |spec: &DependencySpec| match &spec.source {
-        DependencySource::Path { path } => fs::canonicalize(path).unwrap_or_else(|_| path.clone()) == canonical_out_dir,
+        DependencySource::Path { path } => {
+            fs::canonicalize(path).unwrap_or_else(|_| path.clone()) == canonical_artifact_root
+        }
         DependencySource::Registry | DependencySource::Git { .. } => false,
     };
     resolved.dependencies.retain(|spec| !points_to_generated_crate(spec));
@@ -1602,7 +1606,7 @@ fn prepare_library_project(
     generator.set_cargo_policy_flags(cargo_command_flags(&cargo_policy, &cargo_features));
     let resolved_dependencies_for_preheat = resolved.clone();
     let project_requirements_for_preheat = project_requirements.clone();
-    remove_generated_library_self_dependencies(&mut resolved, &out_dir);
+    remove_generated_library_self_dependencies(&mut resolved, &project_root);
     let rust_dependencies = resolved.dependencies.clone();
     let rust_dev_dependencies = resolved.dev_dependencies.clone();
     let report_draft = BuildReportDraft {
@@ -2671,6 +2675,38 @@ mod tests {
         assert!(dependency_artifact_skips_canonical_lock(true, false));
         assert!(!dependency_artifact_skips_canonical_lock(true, true));
         assert!(!dependency_artifact_skips_canonical_lock(false, false));
+    }
+
+    #[test]
+    fn rooted_library_removes_selected_project_self_dependency_issue909() -> Result<(), Box<dyn std::error::Error>> {
+        let project_root = tempfile::tempdir()?;
+        let artifact_root = project_root.path().join("target/lib");
+        let external_root = project_root.path().join("external/artifact");
+        fs::create_dir_all(&artifact_root)?;
+        fs::create_dir_all(&external_root)?;
+        let path_dependency = |crate_name: &str, path: PathBuf| DependencySpec {
+            crate_name: crate_name.to_string(),
+            version: None,
+            features: Vec::new(),
+            default_features: true,
+            source: DependencySource::Path { path },
+            optional: false,
+            package: None,
+        };
+        let mut resolved = ResolvedDependencies {
+            dependencies: vec![
+                path_dependency("root_lib", artifact_root.clone()),
+                path_dependency("external", external_root),
+            ],
+            dev_dependencies: vec![path_dependency("root_lib_dev_alias", artifact_root)],
+        };
+
+        remove_generated_library_self_dependencies(&mut resolved, project_root.path());
+
+        assert_eq!(resolved.dependencies.len(), 1);
+        assert_eq!(resolved.dependencies[0].crate_name, "external");
+        assert!(resolved.dev_dependencies.is_empty());
+        Ok(())
     }
 
     #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1382,6 +1382,108 @@ root_lib = { workspace = true }
 
 #[cfg(unix)]
 #[test]
+fn rooted_workspace_library_artifact_uses_selected_project_identity_issue909() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = tempfile::tempdir()?;
+    fs::create_dir_all(root.path().join("src"))?;
+    fs::write(
+        root.path().join("incan.toml"),
+        r#"[project]
+name = "root_lib"
+version = "0.1.0"
+
+[project.scripts]
+library = "src/lib.incn"
+"#,
+    )?;
+    fs::write(
+        root.path().join("src/lib.incn"),
+        "pub def answer() -> int:\n  return 42\n",
+    )?;
+
+    let warmup = run_incan(root.path(), &["build", "--lib"])?;
+    assert_success(&warmup, "standalone SDK and library artifact warmup");
+    fs::remove_dir_all(root.path().join("target/lib"))?;
+    fs::remove_file(root.path().join("incan.lock"))?;
+
+    fs::write(
+        root.path().join("incan.toml"),
+        r#"[project]
+name = "root_lib"
+version = "0.1.0"
+
+[project.scripts]
+library = "src/lib.incn"
+
+[workspace]
+members = ["consumer"]
+default-members = ["root_lib", "consumer"]
+
+[workspace.dependencies]
+root_lib = { path = "." }
+"#,
+    )?;
+    let consumer = root.path().join("consumer");
+    fs::create_dir_all(consumer.join("src"))?;
+    fs::write(
+        consumer.join("incan.toml"),
+        r#"[project]
+name = "consumer"
+version = "0.1.0"
+
+[project.scripts]
+main = "src/main.incn"
+
+[dependencies]
+root_lib = { workspace = true }
+"#,
+    )?;
+    fs::write(
+        consumer.join("src/main.incn"),
+        "from pub::root_lib import answer\n\n\ndef main() -> None:\n  println(answer())\n",
+    )?;
+
+    let (lock_output, timed_out) = run_incan_with_timeout(root.path(), &["lock"], std::time::Duration::from_secs(60))?;
+    assert!(
+        !timed_out,
+        "rooted workspace lock exceeded its bounded artifact-preparation window\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&lock_output.stdout),
+        String::from_utf8_lossy(&lock_output.stderr)
+    );
+    assert_success(&lock_output, "fresh rooted workspace lock generation");
+
+    // The first lock prepares the previously missing root artifact, which currently changes the semantic fingerprint.
+    // Refresh once so this regression reaches the independent library package-identity boundary from #909.
+    let lock_refresh = run_incan(root.path(), &["lock"])?;
+    assert_success(
+        &lock_refresh,
+        "rooted workspace lock refresh after artifact preparation",
+    );
+
+    let library_output = run_incan(root.path(), &["build", "--lib", "--member", "root_lib", "--locked"])?;
+    assert_success(&library_output, "selected rooted library build");
+
+    let cargo_toml: toml::Value = toml::from_str(&fs::read_to_string(root.path().join("target/lib/Cargo.toml"))?)?;
+    assert_eq!(cargo_toml["package"]["name"].as_str(), Some("root_lib"));
+    assert_eq!(cargo_toml["lib"]["name"].as_str(), Some("root_lib"));
+    assert!(
+        cargo_toml["dependencies"].get("root_lib").is_none(),
+        "the rooted library artifact must not depend on its own generated crate"
+    );
+    assert!(root.path().join("target/lib/root_lib.incnlib").is_file());
+
+    let consumer_lock_refresh = run_incan(root.path(), &["lock"])?;
+    assert_success(
+        &consumer_lock_refresh,
+        "rooted workspace lock refresh after selected library rebuild",
+    );
+    let consumer_output = run_incan(&consumer, &["run", "src/main.incn", "--locked"])?;
+    assert_success(&consumer_output, "consumer of the freshly rebuilt root library");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
 fn workspace_lock_concurrent_publishers_leave_one_parseable_root_lock() -> Result<(), Box<dyn std::error::Error>> {
     let root = tempfile::tempdir()?;
     fs::write(

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -31,6 +31,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Workspaces**: Rooted workspace library artifacts now retain the selected project's identity across Cargo package, Cargo library, and `.incnlib` metadata, while removing self-dependencies even with explicit output overrides so external consumers can compile the published package (#909).
 - **Workspaces**: Root library dependency preparation now targets exactly that project and leaves canonical lock publication to its parent command, preventing fresh rooted workspaces from recursively spawning `incan build --lib` until the machine is exhausted (#908).
 - **Workspaces**: Rooted-workspace entrypoints and tests now resolve through their deepest owning member, so selected member builds retain both direct and inherited Rust dependency versions (#907).
 - **Workspaces**: Canonical workspace locks now rebase nested package roots and feature edges into workspace-relative coordinates, keeping cross-member semantic state and fingerprints portable across checkout locations (#906).


### PR DESCRIPTION
## Summary

Fix rooted workspace library artifacts so the selected Incan project identity is used consistently by Cargo `[package]`, Cargo `[lib]`, and `.incnlib` metadata instead of leaking the synthetic canonical-lock name `incan_workspace`.

The generated library also removes its workspace-aggregate self-dependency, including when the caller selects an explicit output directory, so external consumers can resolve and compile the fresh artifact.

Fixes #909.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan build --lib --member <root-project> --locked` emits a Cargo package that external `pub::<project>` consumers accept.
- **Internals**: canonical lock/preheat generation retains `incan_workspace`, while ordinary library artifact generation uses the selected project name and filters the canonical `target/lib` self edge independently of output overrides.
- **Risks**: library lock/preheat identity and published artifact identity now intentionally diverge. The end-to-end regression proves fresh rooted lock/build, metadata agreement, no self path dependency, and locked consumer execution.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Final rebased `make pre-commit`: 3,057/3,057 tests, Clippy, cargo-deny, 60 examples, 9 benchmark builds, release smoke, and assertion canary all passed.
- Stable focused #909 end-to-end: 1/1 passed.
- Rust 1.93.0 focused #909 end-to-end: 1/1 passed.
- `cargo check --workspace --all-targets`, nightly formatting, changed-Rust rustdoc, and `git diff --check` passed.
- Independent review found an explicit-output self-dependency overfit; the correction and unit regression were applied and re-reviewed clean.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): v0.5 release notes include the #909 fix.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
