### PR TITLE
bugfix - rebind compiled SDK provider caches (#911)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "blake2",
  "blake3",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -1528,14 +1528,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "axum",
  "incan_core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.17"
+version = "0.5.0-dev.18"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/backend/project/cargo_toml.rs
+++ b/src/backend/project/cargo_toml.rs
@@ -226,6 +226,7 @@ impl ProjectGenerator {
     pub(super) fn generate_cargo_toml(&self) -> io::Result<String> {
         let edition = self.rust_edition.as_deref().unwrap_or("2021").to_string();
         let package_name = self.cargo_package_name().to_string();
+        let (dependencies, dev_dependencies) = self.dependencies_with_sdk_rebindings()?;
 
         // ---- Resolve toolchain-owned support crates for generated Rust projects ----
         let stdlib_path = toolchain_crate_path(INCAN_STDLIB_CRATE_NAME);
@@ -241,7 +242,7 @@ impl ProjectGenerator {
         // authoritative for generated projects.
         let mut stdlib_features = self.stdlib_features.clone();
         stdlib_features.extend(
-            self.dependencies
+            dependencies
                 .iter()
                 .filter(|dependency| rendered_dependency_key(dependency) == INCAN_STDLIB_CRATE_NAME)
                 .flat_map(|dependency| dependency.features.iter().cloned()),
@@ -268,7 +269,7 @@ impl ProjectGenerator {
 
         // Add resolved user dependencies
         let mut optional_features = Vec::new();
-        for spec in &self.dependencies {
+        for spec in &dependencies {
             let dependency_key = rendered_dependency_key(spec);
             if added_crates.contains(&dependency_key) {
                 continue;
@@ -282,9 +283,9 @@ impl ProjectGenerator {
         }
 
         // ---- Build dev-dependencies table ----
-        let dev_deps = if self.include_dev_dependencies && !self.dev_dependencies.is_empty() {
+        let dev_deps = if self.include_dev_dependencies && !dev_dependencies.is_empty() {
             let mut dev = toml::Table::new();
-            for spec in &self.dev_dependencies {
+            for spec in &dev_dependencies {
                 let dependency_key = rendered_dependency_key(spec);
                 if added_crates.contains(&dependency_key) {
                     continue;

--- a/src/backend/project/generator.rs
+++ b/src/backend/project/generator.rs
@@ -14,8 +14,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::compiled_sdk::CompiledSdkModules;
-use crate::manifest::DependencySpec;
-use crate::provider::{ProviderPlan, SDK_PROVIDER_BUILD_ENV};
+use crate::library_manifest::{LibraryManifest, ProviderDependencyKind, digest_provider_artifact};
+use crate::manifest::{DependencySource, DependencySpec};
+use crate::provider::{ProviderPlan, SDK_PROVIDER_BUILD_ENV, SdkDependencyRebinding};
 use incan_core::lang::{rust_keywords, stdlib};
 use sha2::{Digest as _, Sha256};
 use toml_edit::{DocumentMut, Item, value};
@@ -59,6 +60,80 @@ pub(super) fn is_sdk_provider_build() -> bool {
     std::env::var_os(SDK_PROVIDER_BUILD_ENV).is_some()
 }
 
+/// Normalize an existing artifact coordinate for stable generated-dependency replacement.
+fn normalize_artifact_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Render a filesystem-safe prefix for one deterministic rebound artifact directory.
+fn sanitize_artifact_name(name: &str) -> String {
+    let normalized = name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    if normalized.is_empty() {
+        "compiled-library".to_string()
+    } else {
+        normalized
+    }
+}
+
+/// Copy one generated provider artifact without carrying its mutable nested Cargo target directory.
+fn copy_compiled_artifact_tree(source: &Path, destination: &Path) -> io::Result<()> {
+    fs::create_dir_all(destination)?;
+    let mut entries = fs::read_dir(source)?.collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            if entry.file_name() == "target" {
+                continue;
+            }
+            copy_compiled_artifact_tree(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &destination_path)?;
+        } else {
+            return Err(io::Error::other(format!(
+                "compiled library artifact contains unsupported filesystem entry {}",
+                source_path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Compute a portable path from one generated artifact root to an active SDK provider crate.
+fn relative_artifact_path(from: &Path, to: &Path) -> String {
+    let from = normalize_artifact_path(from);
+    let to = normalize_artifact_path(to);
+    let from_components = from.components().collect::<Vec<_>>();
+    let to_components = to.components().collect::<Vec<_>>();
+    let common = from_components
+        .iter()
+        .zip(&to_components)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut relative = PathBuf::new();
+    for _ in common..from_components.len() {
+        relative.push("..");
+    }
+    for component in &to_components[common..] {
+        relative.push(component.as_os_str());
+    }
+    if relative.as_os_str().is_empty() {
+        relative.push(".");
+    }
+    relative.to_string_lossy().replace('\\', "/")
+}
+
 /// Project generator for creating runnable Rust projects from Incan code.
 pub struct ProjectGenerator {
     /// Output directory for the generated project
@@ -95,6 +170,8 @@ pub struct ProjectGenerator {
     pub(super) compiled_sdk_modules: CompiledSdkModules,
     /// Top-level `std.*` modules grouped by the generated Rust crate that supplies each compiled SDK provider.
     pub(super) compiled_provider_modules: BTreeMap<String, BTreeSet<String>>,
+    /// Equivalent active SDK paths used to project immutable compiled-library Cargo artifacts into this build.
+    pub(super) sdk_dependency_rebindings: Vec<SdkDependencyRebinding>,
 }
 
 /// Cargo profile used for `incan run`.
@@ -127,6 +204,7 @@ impl ProjectGenerator {
             run_profile: RunProfile::Debug,
             compiled_sdk_modules: CompiledSdkModules::default(),
             compiled_provider_modules: BTreeMap::new(),
+            sdk_dependency_rebindings: Vec::new(),
         }
     }
 
@@ -223,6 +301,7 @@ impl ProjectGenerator {
     pub(crate) fn set_provider_plan(&mut self, plan: &ProviderPlan) {
         self.compiled_provider_modules.clear();
         self.compiled_sdk_modules = CompiledSdkModules::from_provider_plan(plan);
+        self.sdk_dependency_rebindings = plan.sdk_dependency_rebindings().to_vec();
         for provider in plan.sdk_link_roots() {
             let Some(artifact) = provider.artifact.as_ref() else {
                 continue;
@@ -239,6 +318,133 @@ impl ProjectGenerator {
                 }
             }
         }
+    }
+
+    /// Materialize project-owned views of compiled libraries whose private SDK paths belong to an older cache root.
+    ///
+    /// Neither the published library artifact nor either SDK cache generation is mutated. The generated consumer
+    /// instead links a deterministic shadow containing the same Rust source and public manifest with only its private
+    /// SDK Cargo path and relocatable descriptor projected onto the logically equivalent active inventory artifact.
+    pub(super) fn dependencies_with_sdk_rebindings(&self) -> io::Result<(Vec<DependencySpec>, Vec<DependencySpec>)> {
+        if self.sdk_dependency_rebindings.is_empty() {
+            return Ok((self.dependencies.clone(), self.dev_dependencies.clone()));
+        }
+        let mut by_artifact = BTreeMap::<PathBuf, Vec<&SdkDependencyRebinding>>::new();
+        for rebinding in &self.sdk_dependency_rebindings {
+            by_artifact
+                .entry(normalize_artifact_path(&rebinding.containing_artifact.crate_root))
+                .or_default()
+                .push(rebinding);
+        }
+        let mut projected = BTreeMap::new();
+        for (artifact_root, rebindings) in by_artifact {
+            let shadow_root = self.materialize_sdk_rebound_artifact(&artifact_root, &rebindings)?;
+            projected.insert(artifact_root, shadow_root);
+        }
+        let redirect = |dependencies: &[DependencySpec]| {
+            dependencies
+                .iter()
+                .cloned()
+                .map(|mut dependency| {
+                    if let DependencySource::Path { path } = &mut dependency.source
+                        && let Some(shadow) = projected.get(&normalize_artifact_path(path))
+                    {
+                        *path = shadow.clone();
+                    }
+                    dependency
+                })
+                .collect()
+        };
+        Ok((redirect(&self.dependencies), redirect(&self.dev_dependencies)))
+    }
+
+    /// Copy one immutable compiled artifact and rewrite only checked private SDK implementation coordinates.
+    fn materialize_sdk_rebound_artifact(
+        &self,
+        artifact_root: &Path,
+        rebindings: &[&SdkDependencyRebinding],
+    ) -> io::Result<PathBuf> {
+        let artifact_digest = digest_provider_artifact(artifact_root).map_err(io::Error::other)?;
+        let mut hasher = Sha256::new();
+        hasher.update(artifact_digest.as_bytes());
+        for rebinding in rebindings {
+            hasher.update(b"\0");
+            hasher.update(rebinding.provider_name.as_bytes());
+            hasher.update(b"\0");
+            hasher.update(rebinding.active_crate_root.to_string_lossy().as_bytes());
+        }
+        let shadow_id = hex::encode(&hasher.finalize()[..12]);
+        let shadow_parent = self
+            .output_dir
+            .parent()
+            .unwrap_or(self.output_dir.as_path())
+            .join(".incan-sdk-rebound");
+        let artifact_name = rebindings
+            .first()
+            .map(|rebinding| rebinding.containing_artifact.manifest_name.as_str())
+            .unwrap_or("compiled-library");
+        let shadow_root = shadow_parent.join(format!("{}-{shadow_id}", sanitize_artifact_name(artifact_name)));
+        copy_compiled_artifact_tree(artifact_root, &shadow_root)?;
+
+        let cargo_manifest_path = shadow_root.join("Cargo.toml");
+        let cargo_source = fs::read_to_string(&cargo_manifest_path)?;
+        let mut cargo_document = cargo_source
+            .parse::<DocumentMut>()
+            .map_err(|error| io::Error::other(format!("failed to parse rebound Cargo manifest: {error}")))?;
+        let dependencies = cargo_document
+            .get_mut("dependencies")
+            .and_then(Item::as_table_like_mut)
+            .ok_or_else(|| io::Error::other("compiled library Cargo manifest has no dependencies table"))?;
+        for rebinding in rebindings {
+            let dependency = dependencies
+                .get_mut(&rebinding.dependency_key)
+                .and_then(Item::as_table_like_mut)
+                .ok_or_else(|| {
+                    io::Error::other(format!(
+                        "compiled library Cargo manifest has no path dependency `{}` for private SDK provider `{}`",
+                        rebinding.dependency_key, rebinding.provider_name
+                    ))
+                })?;
+            let relative = relative_artifact_path(&shadow_root, &rebinding.active_crate_root);
+            dependency.insert("path", value(relative));
+        }
+        fs::write(&cargo_manifest_path, cargo_document.to_string())?;
+
+        let manifest_relative = rebindings
+            .first()
+            .and_then(|rebinding| {
+                rebinding
+                    .containing_artifact
+                    .manifest_path
+                    .strip_prefix(&rebinding.containing_artifact.crate_root)
+                    .ok()
+            })
+            .ok_or_else(|| io::Error::other("compiled library manifest is outside its artifact root"))?;
+        let rebound_manifest_path = shadow_root.join(manifest_relative);
+        let mut library_manifest = LibraryManifest::read_from_path(&rebound_manifest_path).map_err(io::Error::other)?;
+        for rebinding in rebindings {
+            let descriptor = library_manifest
+                .contract_metadata
+                .provider
+                .provider_dependencies
+                .iter_mut()
+                .find(|dependency| {
+                    dependency.kind == ProviderDependencyKind::PrivateImplementation
+                        && dependency.dependency_key == rebinding.dependency_key
+                        && dependency.provider_name == rebinding.provider_name
+                })
+                .ok_or_else(|| {
+                    io::Error::other(format!(
+                        "compiled library manifest has no private SDK dependency `{}`",
+                        rebinding.provider_name
+                    ))
+                })?;
+            descriptor.relative_artifact_path = relative_artifact_path(&shadow_root, &rebinding.active_crate_root);
+        }
+        library_manifest
+            .write_to_path(&rebound_manifest_path)
+            .map_err(io::Error::other)?;
+        Ok(shadow_root)
     }
 
     /// Return the generated Rust project directory.
@@ -862,8 +1068,123 @@ impl ProjectGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::frontend::library_manifest_index::LibraryArtifactMetadata;
+    use crate::library_manifest::{ProviderDependencyMetadata, ProviderModuleClaim};
     use crate::manifest::DependencySource;
+    use crate::provider::SdkDependencyRebinding;
     use std::collections::HashMap;
+    use std::process::Command;
+
+    #[test]
+    fn generated_consumer_rebinds_absent_private_sdk_cache_root_issue911() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        let library_artifact = workspace.path().join("root-lib");
+        let absent_sdk_artifact = workspace.path().join("sdk-cache-a/stdlib-codecs");
+        let active_sdk_artifact = workspace.path().join("sdk-cache-b/stdlib-codecs");
+        let generated = workspace.path().join("generated/consumer");
+        fs::create_dir_all(library_artifact.join("src"))?;
+        fs::create_dir_all(active_sdk_artifact.join("src"))?;
+        fs::write(
+            library_artifact.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"root_lib\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[workspace]\n\n[dependencies.incan_issue911_codecs]\npath = {:?}\ndefault-features = false\n",
+                absent_sdk_artifact.to_string_lossy()
+            ),
+        )?;
+        fs::write(
+            library_artifact.join("src/lib.rs"),
+            "pub fn root_value() -> u8 { incan_issue911_codecs::value() }\n",
+        )?;
+        fs::write(
+            active_sdk_artifact.join("Cargo.toml"),
+            "[package]\nname = \"incan_issue911_codecs\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n",
+        )?;
+        fs::write(active_sdk_artifact.join("src/lib.rs"), "pub fn value() -> u8 { 7 }\n")?;
+        let digest = format!("sha256:{}", "a".repeat(64));
+        let mut manifest = LibraryManifest::new("root_lib", "0.1.0");
+        manifest.contract_metadata.provider.namespace_claims = vec![ProviderModuleClaim {
+            module_path: vec!["root".to_string()],
+            required_features: BTreeSet::new(),
+        }];
+        manifest
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .push(ProviderDependencyMetadata {
+                kind: ProviderDependencyKind::PrivateImplementation,
+                dependency_key: "incan_issue911_codecs".to_string(),
+                provider_name: "incan_issue911_codecs".to_string(),
+                provider_version: "0.5.0".to_string(),
+                artifact_digest: digest,
+                relative_artifact_path: relative_artifact_path(&library_artifact, &absent_sdk_artifact),
+                requested_features: BTreeSet::new(),
+                default_features: false,
+                optional: false,
+            });
+        let manifest_path = library_artifact.join("root_lib.incnlib");
+        manifest.write_to_path(&manifest_path)?;
+        let containing_artifact = LibraryArtifactMetadata::from_manifest_path(
+            "root_lib",
+            "root_lib",
+            manifest_path,
+            library_artifact.clone(),
+        );
+        let mut generator = ProjectGenerator::new(&generated, "issue911_consumer", true);
+        generator.set_dependencies(vec![
+            DependencySpec {
+                crate_name: "root_lib".to_string(),
+                version: None,
+                features: Vec::new(),
+                default_features: true,
+                source: DependencySource::Path {
+                    path: library_artifact.clone(),
+                },
+                optional: false,
+                package: None,
+            },
+            DependencySpec {
+                crate_name: "incan_issue911_codecs".to_string(),
+                version: None,
+                features: Vec::new(),
+                default_features: false,
+                source: DependencySource::Path {
+                    path: active_sdk_artifact.clone(),
+                },
+                optional: false,
+                package: None,
+            },
+        ]);
+        generator.sdk_dependency_rebindings = vec![SdkDependencyRebinding {
+            containing_artifact,
+            source_crate_root: absent_sdk_artifact.clone(),
+            provider_name: "incan_issue911_codecs".to_string(),
+            dependency_key: "incan_issue911_codecs".to_string(),
+            active_crate_root: active_sdk_artifact,
+        }];
+        generator.generate("fn main() { assert_eq!(root_lib::root_value(), incan_issue911_codecs::value()); }")?;
+
+        assert!(
+            !absent_sdk_artifact.exists(),
+            "logical rebinding must not recreate the historical SDK cache root"
+        );
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let output = Command::new(cargo)
+            .arg("check")
+            .arg("--offline")
+            .arg("--manifest-path")
+            .arg(generated.join("Cargo.toml"))
+            .env("CARGO_TARGET_DIR", workspace.path().join("cargo-target"))
+            .output()?;
+        if !output.status.success() {
+            return Err(format!(
+                "rebound generated Cargo graph failed:\n{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+            .into());
+        }
+        Ok(())
+    }
 
     #[test]
     fn test_is_stdlib_path() {

--- a/src/backend/project/generator.rs
+++ b/src/backend/project/generator.rs
@@ -208,6 +208,8 @@ pub struct ProjectGenerator {
     pub(super) compiled_provider_modules: BTreeMap<String, BTreeSet<String>>,
     /// Equivalent active SDK paths used to project immutable compiled-library Cargo artifacts into this build.
     pub(super) sdk_dependency_rebindings: Vec<SdkDependencyRebinding>,
+    /// Path-backed dependencies proven to come from the active SDK/toolchain rather than an ordinary project source.
+    pub(super) sdk_path_dependencies: Vec<DependencySpec>,
     /// Complete compiled-artifact closure that must be copied so projected child paths propagate to every ancestor.
     pub(super) sdk_artifact_projections: Vec<SdkArtifactProjection>,
 }
@@ -243,6 +245,7 @@ impl ProjectGenerator {
             compiled_sdk_modules: CompiledSdkModules::default(),
             compiled_provider_modules: BTreeMap::new(),
             sdk_dependency_rebindings: Vec::new(),
+            sdk_path_dependencies: Vec::new(),
             sdk_artifact_projections: Vec::new(),
         }
     }
@@ -342,6 +345,16 @@ impl ProjectGenerator {
         self.compiled_sdk_modules = CompiledSdkModules::from_provider_plan(plan);
         self.sdk_dependency_rebindings = plan.sdk_dependency_rebindings().to_vec();
         self.sdk_artifact_projections = plan.sdk_artifact_projections().to_vec();
+        self.set_sdk_path_dependencies(
+            plan.active_sdk_records()
+                .filter_map(|provider| {
+                    provider
+                        .artifact
+                        .as_ref()
+                        .map(LibraryArtifactMetadata::to_dependency_spec)
+                })
+                .collect(),
+        );
         for provider in plan.sdk_link_roots() {
             let Some(artifact) = provider.artifact.as_ref() else {
                 continue;
@@ -363,6 +376,35 @@ impl ProjectGenerator {
     /// Configure immutable compiled-library SDK projections for helper Cargo workspaces that do not retain a plan.
     pub(crate) fn set_sdk_dependency_rebindings(&mut self, rebindings: Vec<SdkDependencyRebinding>) {
         self.sdk_dependency_rebindings = rebindings;
+    }
+
+    /// Configure active path-backed SDK/toolchain dependencies for helper workspaces that do not retain a plan.
+    pub(crate) fn set_sdk_path_dependencies(&mut self, dependencies: Vec<DependencySpec>) {
+        self.sdk_path_dependencies.extend(
+            dependencies
+                .into_iter()
+                .filter(|dependency| matches!(dependency.source, DependencySource::Path { .. }))
+                .map(DependencySpec::normalized),
+        );
+        self.sdk_path_dependencies.sort_by(|left, right| {
+            (
+                &left.crate_name,
+                left.package.as_deref(),
+                match &left.source {
+                    DependencySource::Path { path } => Some(path),
+                    DependencySource::Registry | DependencySource::Git { .. } => None,
+                },
+            )
+                .cmp(&(
+                    &right.crate_name,
+                    right.package.as_deref(),
+                    match &right.source {
+                        DependencySource::Path { path } => Some(path),
+                        DependencySource::Registry | DependencySource::Git { .. } => None,
+                    },
+                ))
+        });
+        self.sdk_path_dependencies.dedup();
     }
 
     /// Configure the complete compiled-artifact closure for helper workspaces that do not retain a provider plan.
@@ -416,7 +458,7 @@ impl ProjectGenerator {
             .unwrap_or(self.output_dir.as_path())
             .join(".incan-sdk-rebound");
         let mut projection_identity = Sha256::new();
-        projection_identity.update(b"incan-sdk-artifact-projection/v2\0");
+        projection_identity.update(b"incan-sdk-artifact-projection/v4\0");
         let mut rebindings = self.sdk_dependency_rebindings.iter().collect::<Vec<_>>();
         rebindings.sort_by(|left, right| {
             (
@@ -441,13 +483,37 @@ impl ProjectGenerator {
             projection_identity.update(active_digest.as_bytes());
             projection_identity.update(b"\0");
         }
+        let mut sdk_path_dependencies = self.sdk_path_dependencies.iter().collect::<Vec<_>>();
+        sdk_path_dependencies.sort_by(|left, right| {
+            (&left.crate_name, left.package.as_deref()).cmp(&(&right.crate_name, right.package.as_deref()))
+        });
+        for dependency in sdk_path_dependencies {
+            let DependencySource::Path { path } = &dependency.source else {
+                continue;
+            };
+            projection_identity.update(dependency.crate_name.as_bytes());
+            projection_identity.update(b"\0");
+            projection_identity.update(
+                dependency
+                    .package
+                    .as_deref()
+                    .unwrap_or(&dependency.crate_name)
+                    .as_bytes(),
+            );
+            projection_identity.update(b"\0");
+            projection_identity.update(path.as_os_str().as_encoded_bytes());
+            projection_identity.update(b"\0");
+            let active_digest = digest_provider_artifact(path).map_err(io::Error::other)?;
+            projection_identity.update(active_digest.as_bytes());
+            projection_identity.update(b"\0");
+        }
         let projection_identity = projection_identity.finalize();
         let mut projected = BTreeMap::new();
         for projection in &self.sdk_artifact_projections {
             let artifact_root = normalize_artifact_path(&projection.artifact.crate_root);
             let artifact_digest = digest_provider_artifact(&artifact_root).map_err(io::Error::other)?;
             let mut hasher = Sha256::new();
-            hasher.update(b"incan-sdk-artifact-shadow/v2\0");
+            hasher.update(b"incan-sdk-artifact-shadow/v4\0");
             hasher.update(artifact_digest.as_bytes());
             hasher.update(b"\0");
             hasher.update(projection_identity.as_slice());
@@ -511,7 +577,9 @@ impl ProjectGenerator {
         lock.lock()?;
         let ready_marker = shadow_root.join(".incan-sdk-rebound-ready");
         let integrity_marker = shadow_parent.join(format!(".{shadow_name}.integrity"));
-        let shadow_is_valid = ready_marker.is_file()
+        let shadow_is_valid = fs::read_to_string(&ready_marker)
+            .ok()
+            .is_some_and(|marker| marker.trim() == "v4")
             && fs::read_to_string(&integrity_marker)
                 .ok()
                 .zip(digest_provider_artifact(shadow_root).ok())
@@ -550,97 +618,172 @@ impl ProjectGenerator {
                                 && rebinding.provider_name == descriptor.provider_name
                         })
                         .map(|rebinding| rebinding.active_crate_root.clone())
+                        .unwrap_or_else(|| source_root.clone())
                 } else {
-                    projected.get(&source_root).map(|(_, shadow)| shadow.clone())
+                    projected
+                        .get(&source_root)
+                        .map(|(_, shadow)| shadow.clone())
+                        .unwrap_or_else(|| source_root.clone())
                 };
-                if let Some(target_root) = target_root {
-                    edges.push(ProjectedArtifactEdge {
-                        dependency_key: descriptor.dependency_key.clone(),
-                        provider_name: descriptor.provider_name.clone(),
-                        source_root,
-                        target_root,
-                        kind: descriptor.kind,
-                        default_features: descriptor.default_features,
-                        optional: descriptor.optional,
-                    });
-                }
+                edges.push(ProjectedArtifactEdge {
+                    dependency_key: descriptor.dependency_key.clone(),
+                    provider_name: descriptor.provider_name.clone(),
+                    source_root,
+                    target_root,
+                    kind: descriptor.kind,
+                    default_features: descriptor.default_features,
+                    optional: descriptor.optional,
+                });
             }
 
-            let cargo_manifest_path = staging_root.join("Cargo.toml");
+            let cargo_relative = artifact
+                .cargo_toml_path
+                .strip_prefix(&artifact.crate_root)
+                .map_err(|_| io::Error::other("compiled Cargo manifest is outside its artifact root"))?;
+            let cargo_manifest_path = staging_root.join(cargo_relative);
             let cargo_source = fs::read_to_string(&cargo_manifest_path)?;
             let mut cargo_document = cargo_source
                 .parse::<DocumentMut>()
                 .map_err(|error| io::Error::other(format!("failed to parse rebound Cargo manifest: {error}")))?;
-            let dependencies = cargo_document
-                .get_mut("dependencies")
-                .and_then(Item::as_table_like_mut)
-                .ok_or_else(|| io::Error::other("compiled library Cargo manifest has no dependencies table"))?;
-            for edge in &edges {
-                let dependency = dependencies
-                    .get_mut(&edge.dependency_key)
-                    .and_then(Item::as_table_like_mut)
-                    .ok_or_else(|| {
-                        io::Error::other(format!(
-                            "compiled library Cargo manifest has no path dependency `{}` for private SDK provider `{}`",
-                            edge.dependency_key, edge.provider_name
-                        ))
-                    })?;
-                if ["git", "registry", "branch", "tag", "rev"]
-                    .iter()
-                    .any(|key| dependency.contains_key(key))
-                {
-                    return Err(io::Error::other(format!(
-                        "compiled library Cargo dependency `{}` for private SDK provider `{}` is not an exclusive path dependency",
-                        edge.dependency_key, edge.provider_name
-                    )));
-                }
-                let authored_path = dependency.get("path").and_then(Item::as_str).ok_or_else(|| {
-                    io::Error::other(format!(
-                        "compiled library Cargo dependency `{}` for private SDK provider `{}` has no path source",
-                        edge.dependency_key, edge.provider_name
-                    ))
-                })?;
-                let frozen_path = if Path::new(authored_path).is_absolute() {
-                    PathBuf::from(authored_path)
-                } else {
-                    artifact_root.join(authored_path)
+            let original_cargo_dir = artifact
+                .cargo_toml_path
+                .parent()
+                .ok_or_else(|| io::Error::other("compiled library Cargo manifest has no parent directory"))?;
+            let projected_cargo_manifest = shadow_root.join(cargo_relative);
+            let projected_cargo_dir = projected_cargo_manifest
+                .parent()
+                .ok_or_else(|| io::Error::other("projected Cargo manifest has no parent directory"))?;
+            let mut matched_edges = BTreeSet::new();
+            for table_name in ["dependencies", "dev-dependencies"] {
+                let Some(dependencies) = cargo_document.get_mut(table_name).and_then(Item::as_table_like_mut) else {
+                    continue;
                 };
-                if normalize_artifact_path(&frozen_path) != edge.source_root {
-                    return Err(io::Error::other(format!(
-                        "compiled library Cargo dependency `{}` points to `{}`, but its checked .incnlib descriptor freezes `{}`",
-                        edge.dependency_key,
-                        frozen_path.display(),
-                        edge.source_root.display()
-                    )));
+                for (dependency_key, dependency_item) in dependencies.iter_mut() {
+                    let dependency_key = dependency_key.get();
+                    let Some(dependency) = dependency_item.as_table_like_mut() else {
+                        continue;
+                    };
+                    let Some(authored_path) = dependency.get("path").and_then(Item::as_str) else {
+                        continue;
+                    };
+                    if ["git", "registry", "branch", "tag", "rev"]
+                        .iter()
+                        .any(|key| dependency.contains_key(key))
+                    {
+                        return Err(io::Error::other(format!(
+                            "compiled library Cargo dependency `{dependency_key}` is not an exclusive path dependency"
+                        )));
+                    }
+                    let frozen_path = if Path::new(authored_path).is_absolute() {
+                        PathBuf::from(authored_path)
+                    } else {
+                        original_cargo_dir.join(authored_path)
+                    };
+                    let frozen_path = normalize_artifact_path(&frozen_path);
+                    let cargo_package = dependency
+                        .get("package")
+                        .and_then(Item::as_str)
+                        .unwrap_or(dependency_key)
+                        .to_string();
+                    let edge = (table_name == "dependencies")
+                        .then(|| {
+                            edges
+                                .iter()
+                                .enumerate()
+                                .find(|(_, edge)| edge.dependency_key == dependency_key)
+                        })
+                        .flatten();
+                    if let Some((edge_index, edge)) = edge {
+                        matched_edges.insert(edge_index);
+                        if frozen_path != edge.source_root {
+                            return Err(io::Error::other(format!(
+                                "compiled library Cargo dependency `{}` points to `{}`, but its checked .incnlib descriptor freezes `{}`",
+                                dependency_key,
+                                frozen_path.display(),
+                                edge.source_root.display()
+                            )));
+                        }
+                        if cargo_package != edge.provider_name {
+                            return Err(io::Error::other(format!(
+                                "compiled library Cargo dependency `{}` names package `{cargo_package}`, but its checked .incnlib descriptor names `{}`",
+                                dependency_key, edge.provider_name
+                            )));
+                        }
+                        let cargo_optional = dependency.get("optional").and_then(Item::as_bool).unwrap_or(false);
+                        let cargo_default_features = dependency
+                            .get("default-features")
+                            .and_then(Item::as_bool)
+                            .unwrap_or(true);
+                        let flags_match = if edge.kind == ProviderDependencyKind::PublicPackage {
+                            cargo_optional == edge.optional && cargo_default_features == edge.default_features
+                        } else {
+                            !cargo_optional
+                                && match dependency.get("default-features") {
+                                    None => true,
+                                    Some(authored) => authored.as_bool() == Some(edge.default_features),
+                                }
+                        };
+                        if !flags_match {
+                            return Err(io::Error::other(format!(
+                                "compiled library Cargo dependency `{}` optional/default feature flags disagree with its checked .incnlib descriptor",
+                                dependency_key,
+                            )));
+                        }
+                        if edge.kind == ProviderDependencyKind::PrivateImplementation
+                            && dependency.get("default-features").is_none()
+                        {
+                            // v0.5 development artifacts recorded the checked private value in `.incnlib` but
+                            // omitted it from Cargo.toml. The checked descriptor is authoritative; normalize the
+                            // copied shadow while new producers emit the key explicitly.
+                            dependency.insert("default-features", value(edge.default_features));
+                        }
+                    }
+                    let trusted_sdk_targets = self
+                        .sdk_path_dependencies
+                        .iter()
+                        .filter(|resolved| {
+                            resolved.crate_name == dependency_key
+                                && resolved.package.as_deref().unwrap_or(resolved.crate_name.as_str())
+                                    == cargo_package.as_str()
+                        })
+                        .filter_map(|resolved| match &resolved.source {
+                            DependencySource::Path { path } => Some(normalize_artifact_path(path)),
+                            DependencySource::Registry | DependencySource::Git { .. } => None,
+                        })
+                        .collect::<BTreeSet<_>>();
+                    if trusted_sdk_targets.len() > 1 {
+                        return Err(io::Error::other(format!(
+                            "compiled library Cargo dependency `{dependency_key}` has multiple active SDK path targets"
+                        )));
+                    }
+                    let trusted_sdk_target = trusted_sdk_targets.into_iter().next().filter(|target| {
+                        self.sdk_dependency_rebindings.iter().any(|rebinding| {
+                            relative_artifact_path(&rebinding.source_crate_root, &frozen_path)
+                                == relative_artifact_path(&rebinding.active_crate_root, target)
+                        })
+                    });
+                    let target_root = if let Some((_, edge)) = edge {
+                        edge.target_root.clone()
+                    } else if let Some(target) = trusted_sdk_target {
+                        target
+                    } else if let Ok(relative) = frozen_path.strip_prefix(&artifact_root) {
+                        shadow_root.join(relative)
+                    } else {
+                        frozen_path
+                    };
+                    let relative = relative_artifact_path(projected_cargo_dir, &target_root);
+                    dependency.insert("path", value(relative));
                 }
-                let cargo_package = dependency
-                    .get("package")
-                    .and_then(Item::as_str)
-                    .unwrap_or(edge.dependency_key.as_str());
-                if cargo_package != edge.provider_name {
-                    return Err(io::Error::other(format!(
-                        "compiled library Cargo dependency `{}` names package `{cargo_package}`, but its checked .incnlib descriptor names `{}`",
-                        edge.dependency_key, edge.provider_name
-                    )));
-                }
-                let cargo_optional = dependency.get("optional").and_then(Item::as_bool).unwrap_or(false);
-                let cargo_default_features = dependency
-                    .get("default-features")
-                    .and_then(Item::as_bool)
-                    .unwrap_or(true);
-                let flags_match = if edge.kind == ProviderDependencyKind::PublicPackage {
-                    cargo_optional == edge.optional && cargo_default_features == edge.default_features
-                } else {
-                    !cargo_optional && dependency.get("default-features").and_then(Item::as_bool) != Some(true)
-                };
-                if !flags_match {
-                    return Err(io::Error::other(format!(
-                        "compiled library Cargo dependency `{}` optional/default feature flags disagree with its checked .incnlib descriptor",
-                        edge.dependency_key,
-                    )));
-                }
-                let relative = relative_artifact_path(&staging_root, &edge.target_root);
-                dependency.insert("path", value(relative));
+            }
+            if let Some(edge) = edges
+                .iter()
+                .enumerate()
+                .find_map(|(index, edge)| (!matched_edges.contains(&index)).then_some(edge))
+            {
+                return Err(io::Error::other(format!(
+                    "compiled library Cargo manifest has no path dependency `{}` for checked provider `{}`",
+                    edge.dependency_key, edge.provider_name
+                )));
             }
             fs::write(&cargo_manifest_path, cargo_document.to_string())?;
 
@@ -676,13 +819,13 @@ impl ProjectGenerator {
                         edge.provider_name, descriptor.artifact_digest
                     )));
                 }
-                descriptor.relative_artifact_path = relative_artifact_path(&staging_root, &edge.target_root);
+                descriptor.relative_artifact_path = relative_artifact_path(shadow_root, &edge.target_root);
                 descriptor.artifact_digest = digest;
             }
             library_manifest
                 .write_to_path(&rebound_manifest_path)
                 .map_err(io::Error::other)?;
-            fs::write(staging_root.join(".incan-sdk-rebound-ready"), "v2\n")?;
+            fs::write(staging_root.join(".incan-sdk-rebound-ready"), "v4\n")?;
             Ok(())
         })();
         if let Err(error) = projection {
@@ -1330,26 +1473,74 @@ mod tests {
         let workspace = tempfile::tempdir()?;
         let library_artifact = workspace.path().join("root-lib");
         let absent_sdk_artifact = workspace.path().join("sdk-cache-a/stdlib-codecs");
+        let absent_sdk_core = workspace.path().join("sdk-cache-a/stdlib-core");
+        let absent_sdk_testing = workspace.path().join("sdk-cache-a/stdlib-testing");
         let active_sdk_artifact = workspace.path().join("sdk-cache-b/stdlib-codecs");
-        let generated = workspace.path().join("generated/consumer");
+        let active_sdk_core = workspace.path().join("sdk-cache-b/stdlib-core");
+        let active_sdk_testing = workspace.path().join("sdk-cache-b/stdlib-testing");
+        let active_sdk_external_decoy = workspace.path().join("sdk-cache-b/stdlib-external");
+        let frozen_external = workspace.path().join("ordinary-external");
+        let internal_support = library_artifact.join("support");
+        let internal_dev_support = library_artifact.join("dev-support");
+        let generated = workspace
+            .path()
+            .join("Users/danny/Development/encero/tmp/hees/target/incan_lock");
         fs::create_dir_all(library_artifact.join("src"))?;
-        fs::create_dir_all(active_sdk_artifact.join("src"))?;
+        for active in [
+            &active_sdk_artifact,
+            &active_sdk_core,
+            &active_sdk_testing,
+            &active_sdk_external_decoy,
+            &frozen_external,
+            &internal_support,
+            &internal_dev_support,
+        ] {
+            fs::create_dir_all(active.join("src"))?;
+        }
         fs::write(
             library_artifact.join("Cargo.toml"),
             format!(
-                "[package]\nname = \"root_lib\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[workspace]\n\n[dependencies.incan_issue911_codecs]\npath = {:?}\ndefault-features = false\n",
-                absent_sdk_artifact.to_string_lossy()
+                "[package]\nname = \"root_lib\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[workspace]\n\n[dependencies.incan_issue911_codecs]\npath = {:?}\ndefault-features = false\n\n[dependencies.incan_issue911_core]\npath = {:?}\n\n[dependencies.incan_issue911_testing]\npath = {:?}\n\n[dependencies.incan_issue911_external]\npath = {:?}\n\n[dependencies.incan_issue911_support]\npath = \"support\"\n\n[dev-dependencies.incan_issue911_dev_support]\npath = \"dev-support\"\n",
+                relative_artifact_path(&library_artifact, &absent_sdk_artifact),
+                relative_artifact_path(&library_artifact, &absent_sdk_core),
+                relative_artifact_path(&library_artifact, &absent_sdk_testing),
+                relative_artifact_path(&library_artifact, &frozen_external)
             ),
         )?;
         fs::write(
             library_artifact.join("src/lib.rs"),
-            "pub fn root_value() -> u8 { incan_issue911_codecs::value() }\n",
+            "pub fn root_value() -> u8 { incan_issue911_codecs::value() + incan_issue911_core::value() + incan_issue911_testing::value() + incan_issue911_external::value() + incan_issue911_support::value() }\n",
         )?;
         fs::write(
             active_sdk_artifact.join("Cargo.toml"),
             "[package]\nname = \"incan_issue911_codecs\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n",
         )?;
         fs::write(active_sdk_artifact.join("src/lib.rs"), "pub fn value() -> u8 { 7 }\n")?;
+        fs::write(
+            active_sdk_core.join("Cargo.toml"),
+            "[package]\nname = \"incan_issue911_core\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n",
+        )?;
+        fs::write(active_sdk_core.join("src/lib.rs"), "pub fn value() -> u8 { 8 }\n")?;
+        fs::write(
+            active_sdk_testing.join("Cargo.toml"),
+            "[package]\nname = \"incan_issue911_testing\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n",
+        )?;
+        fs::write(active_sdk_testing.join("src/lib.rs"), "pub fn value() -> u8 { 9 }\n")?;
+        for (artifact, package, value) in [
+            (&active_sdk_external_decoy, "incan_issue911_external", 99),
+            (&frozen_external, "incan_issue911_external", 10),
+            (&internal_support, "incan_issue911_support", 5),
+            (&internal_dev_support, "incan_issue911_dev_support", 6),
+        ] {
+            fs::write(
+                artifact.join("Cargo.toml"),
+                format!("[package]\nname = \"{package}\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n"),
+            )?;
+            fs::write(
+                artifact.join("src/lib.rs"),
+                format!("pub fn value() -> u8 {{ {value} }}\n"),
+            )?;
+        }
         let digest = digest_provider_artifact(&active_sdk_artifact)?;
         let mut manifest = LibraryManifest::new("root_lib", "0.1.0");
         manifest.contract_metadata.provider.namespace_claims = vec![ProviderModuleClaim {
@@ -1403,17 +1594,127 @@ mod tests {
                 optional: false,
                 package: None,
             },
+            DependencySpec {
+                crate_name: "incan_issue911_core".to_string(),
+                version: None,
+                features: Vec::new(),
+                default_features: true,
+                source: DependencySource::Path {
+                    path: active_sdk_core.clone(),
+                },
+                optional: false,
+                package: None,
+            },
+            DependencySpec {
+                crate_name: "incan_issue911_testing".to_string(),
+                version: None,
+                features: Vec::new(),
+                default_features: true,
+                source: DependencySource::Path {
+                    path: active_sdk_testing.clone(),
+                },
+                optional: false,
+                package: None,
+            },
         ]);
         generator.sdk_dependency_rebindings = vec![SdkDependencyRebinding {
             containing_artifact: containing_artifact.clone(),
             source_crate_root: absent_sdk_artifact.clone(),
             provider_name: "incan_issue911_codecs".to_string(),
             dependency_key: "incan_issue911_codecs".to_string(),
-            active_crate_root: active_sdk_artifact,
+            active_crate_root: active_sdk_artifact.clone(),
         }];
+        generator.set_sdk_path_dependencies(vec![
+            DependencySpec {
+                crate_name: "incan_issue911_core".to_string(),
+                version: None,
+                features: Vec::new(),
+                default_features: true,
+                source: DependencySource::Path {
+                    path: active_sdk_core.clone(),
+                },
+                optional: false,
+                package: None,
+            },
+            DependencySpec {
+                crate_name: "incan_issue911_testing".to_string(),
+                version: None,
+                features: Vec::new(),
+                default_features: true,
+                source: DependencySource::Path {
+                    path: active_sdk_testing.clone(),
+                },
+                optional: false,
+                package: None,
+            },
+            DependencySpec {
+                crate_name: "incan_issue911_external".to_string(),
+                version: None,
+                features: Vec::new(),
+                default_features: true,
+                source: DependencySource::Path {
+                    path: active_sdk_external_decoy.clone(),
+                },
+                optional: false,
+                package: None,
+            },
+        ]);
         generator.sdk_artifact_projections = vec![SdkArtifactProjection {
             artifact: containing_artifact,
         }];
+
+        let original_sdk_paths = generator.sdk_path_dependencies.clone();
+        let original_shadow = generator
+            .sdk_projection_shadow_roots()?
+            .into_values()
+            .next()
+            .ok_or("missing original SDK shadow")?
+            .1;
+        let alternate_core = workspace.path().join("sdk-cache-c/stdlib-core");
+        fs::create_dir_all(alternate_core.join("src"))?;
+        fs::write(
+            alternate_core.join("Cargo.toml"),
+            "[package]\nname = \"incan_issue911_core\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n",
+        )?;
+        fs::write(alternate_core.join("src/lib.rs"), "pub fn value() -> u8 { 8 }\n")?;
+        generator
+            .sdk_path_dependencies
+            .retain(|dependency| dependency.crate_name != "incan_issue911_core");
+        generator.set_sdk_path_dependencies(vec![DependencySpec {
+            crate_name: "incan_issue911_core".to_string(),
+            version: None,
+            features: Vec::new(),
+            default_features: true,
+            source: DependencySource::Path { path: alternate_core },
+            optional: false,
+            package: None,
+        }]);
+        let changed_shadow = generator
+            .sdk_projection_shadow_roots()?
+            .into_values()
+            .next()
+            .ok_or("missing changed SDK shadow")?
+            .1;
+        assert_ne!(
+            original_shadow, changed_shadow,
+            "active SDK path targets must participate in shadow identity"
+        );
+        generator.sdk_path_dependencies = original_sdk_paths;
+
+        copy_compiled_artifact_tree(&library_artifact, &original_shadow)?;
+        fs::write(original_shadow.join(".incan-sdk-rebound-ready"), "v3\n")?;
+        let stale_digest = digest_provider_artifact(&original_shadow)?;
+        let shadow_name = original_shadow
+            .file_name()
+            .ok_or("missing SDK shadow name")?
+            .to_string_lossy();
+        fs::write(
+            original_shadow
+                .parent()
+                .ok_or("missing SDK shadow parent")?
+                .join(format!(".{shadow_name}.integrity")),
+            format!("{stale_digest}\n"),
+        )?;
         let (left_projection, right_projection) = std::thread::scope(|scope| {
             let left = scope.spawn(|| generator.effective_dependencies());
             let right = scope.spawn(|| generator.effective_dependencies());
@@ -1430,16 +1731,76 @@ mod tests {
                 return Err("projected root dependency is not path-backed".into());
             }
         };
+        assert_eq!(
+            fs::read_to_string(projected_root.join(".incan-sdk-rebound-ready"))?,
+            "v4\n"
+        );
         fs::write(projected_root.join("src/lib.rs"), "pub fn corrupt() {}\n")?;
         let repaired_projection = generator.effective_dependencies()?;
         assert_eq!(repaired_projection, left_projection);
         assert!(fs::read_to_string(projected_root.join("src/lib.rs"))?.contains("root_value"));
-        generator.generate("fn main() { assert_eq!(root_lib::root_value(), incan_issue911_codecs::value()); }")?;
+        generator.generate("fn main() { assert_eq!(root_lib::root_value(), 39); }")?;
+
+        let rebound_cargo = fs::read_to_string(projected_root.join("Cargo.toml"))?.parse::<DocumentMut>()?;
+        let rebound_dependencies = rebound_cargo
+            .get("dependencies")
+            .and_then(Item::as_table_like)
+            .ok_or("projected Cargo manifest has no dependencies")?;
+        for (dependency_key, expected_root) in [
+            ("incan_issue911_codecs", &active_sdk_artifact),
+            ("incan_issue911_core", &active_sdk_core),
+            ("incan_issue911_testing", &active_sdk_testing),
+        ] {
+            let relative = rebound_dependencies
+                .get(dependency_key)
+                .and_then(Item::as_table_like)
+                .and_then(|dependency| dependency.get("path"))
+                .and_then(Item::as_str)
+                .ok_or("projected Cargo dependency has no path")?;
+            assert_eq!(
+                fs::canonicalize(projected_root.join(relative))?,
+                fs::canonicalize(expected_root)?,
+                "projected Cargo dependency `{dependency_key}` must resolve from the shadow manifest directory"
+            );
+        }
+        for (dependency_key, expected_root) in [
+            ("incan_issue911_external", frozen_external.as_path()),
+            ("incan_issue911_support", projected_root.join("support").as_path()),
+        ] {
+            let relative = rebound_dependencies
+                .get(dependency_key)
+                .and_then(Item::as_table_like)
+                .and_then(|dependency| dependency.get("path"))
+                .and_then(Item::as_str)
+                .ok_or("projected Cargo dependency has no path")?;
+            assert_eq!(
+                fs::canonicalize(projected_root.join(relative))?,
+                fs::canonicalize(expected_root)?,
+                "projected Cargo dependency `{dependency_key}` must preserve its intended source"
+            );
+        }
+        let rebound_dev_dependencies = rebound_cargo
+            .get("dev-dependencies")
+            .and_then(Item::as_table_like)
+            .ok_or("projected Cargo manifest has no dev dependencies")?;
+        let relative = rebound_dev_dependencies
+            .get("incan_issue911_dev_support")
+            .and_then(Item::as_table_like)
+            .and_then(|dependency| dependency.get("path"))
+            .and_then(Item::as_str)
+            .ok_or("projected dev Cargo dependency has no path")?;
+        assert_eq!(
+            fs::canonicalize(projected_root.join(relative))?,
+            fs::canonicalize(projected_root.join("dev-support"))?,
+            "projected dev Cargo dependency must remain inside the copied shadow"
+        );
 
         assert!(
             !absent_sdk_artifact.exists(),
             "logical rebinding must not recreate the historical SDK cache root"
         );
+        assert!(!absent_sdk_core.exists());
+        assert!(!absent_sdk_testing.exists());
         let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
         let output = Command::new(cargo)
             .arg("check")
@@ -1665,13 +2026,13 @@ mod tests {
             version: None,
             features: Vec::new(),
             default_features: true,
-            source: DependencySource::Path { path: artifact },
+            source: DependencySource::Path { path: artifact.clone() },
             optional: false,
             package: None,
         }]);
         generator.sdk_dependency_rebindings = vec![SdkDependencyRebinding {
             containing_artifact: metadata.clone(),
-            source_crate_root: descriptor_source,
+            source_crate_root: descriptor_source.clone(),
             provider_name: "incan_issue911_runtime".to_string(),
             dependency_key: "incan_issue911_runtime".to_string(),
             active_crate_root: active,
@@ -1685,6 +2046,47 @@ mod tests {
 
         assert!(error.to_string().contains("checked .incnlib descriptor freezes"));
         assert!(!cargo_source.exists());
+
+        fs::write(
+            artifact.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"issue911_source_mismatch\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies.incan_issue911_runtime]\npath = {:?}\n",
+                descriptor_source.to_string_lossy()
+            ),
+        )?;
+        generator.generate("fn main() {}")?;
+        let projected = generator.effective_dependencies()?;
+        let projected_root = match &projected[0].source {
+            DependencySource::Path { path } => path,
+            DependencySource::Registry | DependencySource::Git { .. } => {
+                return Err("projected dependency is not path-backed".into());
+            }
+        };
+        let cargo = fs::read_to_string(projected_root.join("Cargo.toml"))?.parse::<DocumentMut>()?;
+        assert_eq!(
+            cargo
+                .get("dependencies")
+                .and_then(Item::as_table_like)
+                .and_then(|dependencies| dependencies.get("incan_issue911_runtime"))
+                .and_then(Item::as_table_like)
+                .and_then(|dependency| dependency.get("default-features"))
+                .and_then(Item::as_bool),
+            Some(false),
+            "legacy private SDK edges must be normalized to their checked feature contract"
+        );
+
+        fs::write(
+            artifact.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"issue911_source_mismatch\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies.incan_issue911_runtime]\npath = {:?}\ndefault-features = \"false\"\n",
+                descriptor_source.to_string_lossy()
+            ),
+        )?;
+        let error = generator
+            .generate("fn main() {}")
+            .err()
+            .ok_or("expected malformed Cargo/default-feature descriptor mismatch")?;
+        assert!(error.to_string().contains("optional/default feature flags disagree"));
         Ok(())
     }
 

--- a/src/backend/project/generator.rs
+++ b/src/backend/project/generator.rs
@@ -14,15 +14,27 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::compiled_sdk::CompiledSdkModules;
+use crate::frontend::library_manifest_index::LibraryArtifactMetadata;
 use crate::library_manifest::{LibraryManifest, ProviderDependencyKind, digest_provider_artifact};
 use crate::manifest::{DependencySource, DependencySpec};
-use crate::provider::{ProviderPlan, SDK_PROVIDER_BUILD_ENV, SdkDependencyRebinding};
+use crate::provider::{ProviderPlan, SDK_PROVIDER_BUILD_ENV, SdkArtifactProjection, SdkDependencyRebinding};
 use incan_core::lang::{rust_keywords, stdlib};
 use sha2::{Digest as _, Sha256};
 use toml_edit::{DocumentMut, Item, value};
 
 const MOD_INSERT_MARKER: &str = "// __INCAN_INSERT_MODS__";
 pub(crate) const GENERATED_CARGO_TARGET_DIR_ENV: &str = "INCAN_GENERATED_CARGO_TARGET_DIR";
+
+/// One checked dependency edge and its effective projected artifact root.
+struct ProjectedArtifactEdge {
+    dependency_key: String,
+    provider_name: String,
+    source_root: PathBuf,
+    target_root: PathBuf,
+    kind: ProviderDependencyKind,
+    default_features: bool,
+    optional: bool,
+}
 
 // ============================================================================
 // RFC 023: Stdlib module naming
@@ -60,9 +72,33 @@ pub(super) fn is_sdk_provider_build() -> bool {
     std::env::var_os(SDK_PROVIDER_BUILD_ENV).is_some()
 }
 
-/// Normalize an existing artifact coordinate for stable generated-dependency replacement.
+/// Normalize an artifact coordinate through its nearest existing ancestor so absent cache tails remain comparable.
 fn normalize_artifact_path(path: &Path) -> PathBuf {
-    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|current| current.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    let mut cursor = absolute.as_path();
+    let mut tail = Vec::new();
+    loop {
+        if let Ok(mut canonical) = fs::canonicalize(cursor) {
+            for component in tail.iter().rev() {
+                canonical.push(component);
+            }
+            return canonical;
+        }
+        let Some(name) = cursor.file_name() else {
+            return absolute;
+        };
+        tail.push(name.to_os_string());
+        let Some(parent) = cursor.parent() else {
+            return absolute;
+        };
+        cursor = parent;
+    }
 }
 
 /// Render a filesystem-safe prefix for one deterministic rebound artifact directory.
@@ -172,6 +208,8 @@ pub struct ProjectGenerator {
     pub(super) compiled_provider_modules: BTreeMap<String, BTreeSet<String>>,
     /// Equivalent active SDK paths used to project immutable compiled-library Cargo artifacts into this build.
     pub(super) sdk_dependency_rebindings: Vec<SdkDependencyRebinding>,
+    /// Complete compiled-artifact closure that must be copied so projected child paths propagate to every ancestor.
+    pub(super) sdk_artifact_projections: Vec<SdkArtifactProjection>,
 }
 
 /// Cargo profile used for `incan run`.
@@ -205,6 +243,7 @@ impl ProjectGenerator {
             compiled_sdk_modules: CompiledSdkModules::default(),
             compiled_provider_modules: BTreeMap::new(),
             sdk_dependency_rebindings: Vec::new(),
+            sdk_artifact_projections: Vec::new(),
         }
     }
 
@@ -302,6 +341,7 @@ impl ProjectGenerator {
         self.compiled_provider_modules.clear();
         self.compiled_sdk_modules = CompiledSdkModules::from_provider_plan(plan);
         self.sdk_dependency_rebindings = plan.sdk_dependency_rebindings().to_vec();
+        self.sdk_artifact_projections = plan.sdk_artifact_projections().to_vec();
         for provider in plan.sdk_link_roots() {
             let Some(artifact) = provider.artifact.as_ref() else {
                 continue;
@@ -320,26 +360,30 @@ impl ProjectGenerator {
         }
     }
 
+    /// Configure immutable compiled-library SDK projections for helper Cargo workspaces that do not retain a plan.
+    pub(crate) fn set_sdk_dependency_rebindings(&mut self, rebindings: Vec<SdkDependencyRebinding>) {
+        self.sdk_dependency_rebindings = rebindings;
+    }
+
+    /// Configure the complete compiled-artifact closure for helper workspaces that do not retain a provider plan.
+    pub(crate) fn set_sdk_artifact_projections(&mut self, projections: Vec<SdkArtifactProjection>) {
+        self.sdk_artifact_projections = projections;
+    }
+
     /// Materialize project-owned views of compiled libraries whose private SDK paths belong to an older cache root.
     ///
     /// Neither the published library artifact nor either SDK cache generation is mutated. The generated consumer
     /// instead links a deterministic shadow containing the same Rust source and public manifest with only its private
     /// SDK Cargo path and relocatable descriptor projected onto the logically equivalent active inventory artifact.
     pub(super) fn dependencies_with_sdk_rebindings(&self) -> io::Result<(Vec<DependencySpec>, Vec<DependencySpec>)> {
-        if self.sdk_dependency_rebindings.is_empty() {
+        if self.sdk_artifact_projections.is_empty() {
             return Ok((self.dependencies.clone(), self.dev_dependencies.clone()));
         }
-        let mut by_artifact = BTreeMap::<PathBuf, Vec<&SdkDependencyRebinding>>::new();
-        for rebinding in &self.sdk_dependency_rebindings {
-            by_artifact
-                .entry(normalize_artifact_path(&rebinding.containing_artifact.crate_root))
-                .or_default()
-                .push(rebinding);
-        }
-        let mut projected = BTreeMap::new();
-        for (artifact_root, rebindings) in by_artifact {
-            let shadow_root = self.materialize_sdk_rebound_artifact(&artifact_root, &rebindings)?;
-            projected.insert(artifact_root, shadow_root);
+        let projected = self.sdk_projection_shadow_roots()?;
+        let mut materialized = BTreeSet::new();
+        let mut visiting = BTreeSet::new();
+        for artifact_root in projected.keys() {
+            self.materialize_sdk_rebound_artifact(artifact_root, &projected, &mut visiting, &mut materialized)?;
         }
         let redirect = |dependencies: &[DependencySpec]| {
             dependencies
@@ -347,7 +391,7 @@ impl ProjectGenerator {
                 .cloned()
                 .map(|mut dependency| {
                     if let DependencySource::Path { path } = &mut dependency.source
-                        && let Some(shadow) = projected.get(&normalize_artifact_path(path))
+                        && let Some((_, shadow)) = projected.get(&normalize_artifact_path(path))
                     {
                         *path = shadow.clone();
                     }
@@ -358,93 +402,299 @@ impl ProjectGenerator {
         Ok((redirect(&self.dependencies), redirect(&self.dev_dependencies)))
     }
 
-    /// Copy one immutable compiled artifact and rewrite only checked private SDK implementation coordinates.
-    fn materialize_sdk_rebound_artifact(
-        &self,
-        artifact_root: &Path,
-        rebindings: &[&SdkDependencyRebinding],
-    ) -> io::Result<PathBuf> {
-        let artifact_digest = digest_provider_artifact(artifact_root).map_err(io::Error::other)?;
-        let mut hasher = Sha256::new();
-        hasher.update(artifact_digest.as_bytes());
-        for rebinding in rebindings {
-            hasher.update(b"\0");
-            hasher.update(rebinding.provider_name.as_bytes());
-            hasher.update(b"\0");
-            hasher.update(rebinding.active_crate_root.to_string_lossy().as_bytes());
-        }
-        let shadow_id = hex::encode(&hasher.finalize()[..12]);
+    /// Return the exact normal dependency specifications used by generated Cargo metadata after SDK projection.
+    pub(crate) fn effective_dependencies(&self) -> io::Result<Vec<DependencySpec>> {
+        self.dependencies_with_sdk_rebindings()
+            .map(|(dependencies, _)| dependencies)
+    }
+
+    /// Assign deterministic consumer-owned shadow roots to the complete compiled-artifact projection closure.
+    fn sdk_projection_shadow_roots(&self) -> io::Result<BTreeMap<PathBuf, (LibraryArtifactMetadata, PathBuf)>> {
         let shadow_parent = self
             .output_dir
             .parent()
             .unwrap_or(self.output_dir.as_path())
             .join(".incan-sdk-rebound");
-        let artifact_name = rebindings
-            .first()
-            .map(|rebinding| rebinding.containing_artifact.manifest_name.as_str())
-            .unwrap_or("compiled-library");
-        let shadow_root = shadow_parent.join(format!("{}-{shadow_id}", sanitize_artifact_name(artifact_name)));
-        copy_compiled_artifact_tree(artifact_root, &shadow_root)?;
-
-        let cargo_manifest_path = shadow_root.join("Cargo.toml");
-        let cargo_source = fs::read_to_string(&cargo_manifest_path)?;
-        let mut cargo_document = cargo_source
-            .parse::<DocumentMut>()
-            .map_err(|error| io::Error::other(format!("failed to parse rebound Cargo manifest: {error}")))?;
-        let dependencies = cargo_document
-            .get_mut("dependencies")
-            .and_then(Item::as_table_like_mut)
-            .ok_or_else(|| io::Error::other("compiled library Cargo manifest has no dependencies table"))?;
+        let mut projection_identity = Sha256::new();
+        projection_identity.update(b"incan-sdk-artifact-projection/v2\0");
+        let mut rebindings = self.sdk_dependency_rebindings.iter().collect::<Vec<_>>();
+        rebindings.sort_by(|left, right| {
+            (
+                &left.containing_artifact.crate_root,
+                &left.dependency_key,
+                &left.active_crate_root,
+            )
+                .cmp(&(
+                    &right.containing_artifact.crate_root,
+                    &right.dependency_key,
+                    &right.active_crate_root,
+                ))
+        });
         for rebinding in rebindings {
-            let dependency = dependencies
-                .get_mut(&rebinding.dependency_key)
-                .and_then(Item::as_table_like_mut)
-                .ok_or_else(|| {
-                    io::Error::other(format!(
-                        "compiled library Cargo manifest has no path dependency `{}` for private SDK provider `{}`",
-                        rebinding.dependency_key, rebinding.provider_name
-                    ))
-                })?;
-            let relative = relative_artifact_path(&shadow_root, &rebinding.active_crate_root);
-            dependency.insert("path", value(relative));
+            projection_identity.update(rebinding.containing_artifact.crate_root.as_os_str().as_encoded_bytes());
+            projection_identity.update(b"\0");
+            projection_identity.update(rebinding.dependency_key.as_bytes());
+            projection_identity.update(b"\0");
+            projection_identity.update(rebinding.active_crate_root.as_os_str().as_encoded_bytes());
+            projection_identity.update(b"\0");
+            let active_digest = digest_provider_artifact(&rebinding.active_crate_root).map_err(io::Error::other)?;
+            projection_identity.update(active_digest.as_bytes());
+            projection_identity.update(b"\0");
         }
-        fs::write(&cargo_manifest_path, cargo_document.to_string())?;
+        let projection_identity = projection_identity.finalize();
+        let mut projected = BTreeMap::new();
+        for projection in &self.sdk_artifact_projections {
+            let artifact_root = normalize_artifact_path(&projection.artifact.crate_root);
+            let artifact_digest = digest_provider_artifact(&artifact_root).map_err(io::Error::other)?;
+            let mut hasher = Sha256::new();
+            hasher.update(b"incan-sdk-artifact-shadow/v2\0");
+            hasher.update(artifact_digest.as_bytes());
+            hasher.update(b"\0");
+            hasher.update(projection_identity.as_slice());
+            let shadow_id = hex::encode(&hasher.finalize()[..12]);
+            let shadow_root = shadow_parent.join(format!(
+                "{}-{shadow_id}",
+                sanitize_artifact_name(&projection.artifact.manifest_name)
+            ));
+            projected.insert(artifact_root, (projection.artifact.clone(), shadow_root));
+        }
+        Ok(projected)
+    }
 
-        let manifest_relative = rebindings
-            .first()
-            .and_then(|rebinding| {
-                rebinding
-                    .containing_artifact
-                    .manifest_path
-                    .strip_prefix(&rebinding.containing_artifact.crate_root)
-                    .ok()
-            })
-            .ok_or_else(|| io::Error::other("compiled library manifest is outside its artifact root"))?;
-        let rebound_manifest_path = shadow_root.join(manifest_relative);
-        let mut library_manifest = LibraryManifest::read_from_path(&rebound_manifest_path).map_err(io::Error::other)?;
-        for rebinding in rebindings {
-            let descriptor = library_manifest
-                .contract_metadata
-                .provider
-                .provider_dependencies
-                .iter_mut()
-                .find(|dependency| {
-                    dependency.kind == ProviderDependencyKind::PrivateImplementation
-                        && dependency.dependency_key == rebinding.dependency_key
-                        && dependency.provider_name == rebinding.provider_name
-                })
-                .ok_or_else(|| {
-                    io::Error::other(format!(
-                        "compiled library manifest has no private SDK dependency `{}`",
-                        rebinding.provider_name
-                    ))
-                })?;
-            descriptor.relative_artifact_path = relative_artifact_path(&shadow_root, &rebinding.active_crate_root);
+    /// Copy one immutable compiled artifact after recursively materializing every projected public child.
+    fn materialize_sdk_rebound_artifact(
+        &self,
+        artifact_root: &Path,
+        projected: &BTreeMap<PathBuf, (LibraryArtifactMetadata, PathBuf)>,
+        visiting: &mut BTreeSet<PathBuf>,
+        materialized: &mut BTreeSet<PathBuf>,
+    ) -> io::Result<PathBuf> {
+        let artifact_root = normalize_artifact_path(artifact_root);
+        let Some((artifact, shadow_root)) = projected.get(&artifact_root) else {
+            return Err(io::Error::other(format!(
+                "compiled artifact {} is absent from the SDK projection closure",
+                artifact_root.display()
+            )));
+        };
+        if materialized.contains(&artifact_root) {
+            return Ok(shadow_root.clone());
         }
-        library_manifest
-            .write_to_path(&rebound_manifest_path)
+        if !visiting.insert(artifact_root.clone()) {
+            return Err(io::Error::other("compiled SDK projection graph contains a cycle"));
+        }
+        let original_manifest = LibraryManifest::read_from_path(&artifact.manifest_path).map_err(io::Error::other)?;
+        for dependency in &original_manifest.contract_metadata.provider.provider_dependencies {
+            if dependency.kind != ProviderDependencyKind::PublicPackage {
+                continue;
+            }
+            let child_root = normalize_artifact_path(&artifact_root.join(&dependency.relative_artifact_path));
+            if projected.contains_key(&child_root) {
+                self.materialize_sdk_rebound_artifact(&child_root, projected, visiting, materialized)?;
+            }
+        }
+
+        let shadow_parent = shadow_root
+            .parent()
+            .ok_or_else(|| io::Error::other("SDK projection shadow has no parent directory"))?;
+        fs::create_dir_all(shadow_parent)?;
+        let shadow_name = shadow_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| io::Error::other("SDK projection shadow has no valid file name"))?;
+        let lock_path = shadow_parent.join(format!(".{shadow_name}.lock"));
+        let lock = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        lock.lock()?;
+        let ready_marker = shadow_root.join(".incan-sdk-rebound-ready");
+        let integrity_marker = shadow_parent.join(format!(".{shadow_name}.integrity"));
+        let shadow_is_valid = ready_marker.is_file()
+            && fs::read_to_string(&integrity_marker)
+                .ok()
+                .zip(digest_provider_artifact(shadow_root).ok())
+                .is_some_and(|(expected, actual)| expected.trim() == actual);
+        if shadow_is_valid {
+            visiting.remove(&artifact_root);
+            materialized.insert(artifact_root);
+            return Ok(shadow_root.clone());
+        }
+        if integrity_marker.exists() {
+            fs::remove_file(&integrity_marker)?;
+        }
+        if shadow_root.exists() {
+            fs::remove_dir_all(shadow_root)?;
+        }
+        let elapsed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
             .map_err(io::Error::other)?;
-        Ok(shadow_root)
+        let staging_root = shadow_parent.join(format!(
+            ".{shadow_name}-staging-{}-{}",
+            std::process::id(),
+            elapsed.as_nanos()
+        ));
+        let projection = (|| -> io::Result<()> {
+            copy_compiled_artifact_tree(&artifact_root, &staging_root)?;
+
+            let mut edges = Vec::new();
+            for descriptor in &original_manifest.contract_metadata.provider.provider_dependencies {
+                let source_root = normalize_artifact_path(&artifact_root.join(&descriptor.relative_artifact_path));
+                let target_root = if descriptor.kind == ProviderDependencyKind::PrivateImplementation {
+                    self.sdk_dependency_rebindings
+                        .iter()
+                        .find(|rebinding| {
+                            normalize_artifact_path(&rebinding.containing_artifact.crate_root) == artifact_root
+                                && rebinding.dependency_key == descriptor.dependency_key
+                                && rebinding.provider_name == descriptor.provider_name
+                        })
+                        .map(|rebinding| rebinding.active_crate_root.clone())
+                } else {
+                    projected.get(&source_root).map(|(_, shadow)| shadow.clone())
+                };
+                if let Some(target_root) = target_root {
+                    edges.push(ProjectedArtifactEdge {
+                        dependency_key: descriptor.dependency_key.clone(),
+                        provider_name: descriptor.provider_name.clone(),
+                        source_root,
+                        target_root,
+                        kind: descriptor.kind,
+                        default_features: descriptor.default_features,
+                        optional: descriptor.optional,
+                    });
+                }
+            }
+
+            let cargo_manifest_path = staging_root.join("Cargo.toml");
+            let cargo_source = fs::read_to_string(&cargo_manifest_path)?;
+            let mut cargo_document = cargo_source
+                .parse::<DocumentMut>()
+                .map_err(|error| io::Error::other(format!("failed to parse rebound Cargo manifest: {error}")))?;
+            let dependencies = cargo_document
+                .get_mut("dependencies")
+                .and_then(Item::as_table_like_mut)
+                .ok_or_else(|| io::Error::other("compiled library Cargo manifest has no dependencies table"))?;
+            for edge in &edges {
+                let dependency = dependencies
+                    .get_mut(&edge.dependency_key)
+                    .and_then(Item::as_table_like_mut)
+                    .ok_or_else(|| {
+                        io::Error::other(format!(
+                            "compiled library Cargo manifest has no path dependency `{}` for private SDK provider `{}`",
+                            edge.dependency_key, edge.provider_name
+                        ))
+                    })?;
+                if ["git", "registry", "branch", "tag", "rev"]
+                    .iter()
+                    .any(|key| dependency.contains_key(key))
+                {
+                    return Err(io::Error::other(format!(
+                        "compiled library Cargo dependency `{}` for private SDK provider `{}` is not an exclusive path dependency",
+                        edge.dependency_key, edge.provider_name
+                    )));
+                }
+                let authored_path = dependency.get("path").and_then(Item::as_str).ok_or_else(|| {
+                    io::Error::other(format!(
+                        "compiled library Cargo dependency `{}` for private SDK provider `{}` has no path source",
+                        edge.dependency_key, edge.provider_name
+                    ))
+                })?;
+                let frozen_path = if Path::new(authored_path).is_absolute() {
+                    PathBuf::from(authored_path)
+                } else {
+                    artifact_root.join(authored_path)
+                };
+                if normalize_artifact_path(&frozen_path) != edge.source_root {
+                    return Err(io::Error::other(format!(
+                        "compiled library Cargo dependency `{}` points to `{}`, but its checked .incnlib descriptor freezes `{}`",
+                        edge.dependency_key,
+                        frozen_path.display(),
+                        edge.source_root.display()
+                    )));
+                }
+                let cargo_package = dependency
+                    .get("package")
+                    .and_then(Item::as_str)
+                    .unwrap_or(edge.dependency_key.as_str());
+                if cargo_package != edge.provider_name {
+                    return Err(io::Error::other(format!(
+                        "compiled library Cargo dependency `{}` names package `{cargo_package}`, but its checked .incnlib descriptor names `{}`",
+                        edge.dependency_key, edge.provider_name
+                    )));
+                }
+                let cargo_optional = dependency.get("optional").and_then(Item::as_bool).unwrap_or(false);
+                let cargo_default_features = dependency
+                    .get("default-features")
+                    .and_then(Item::as_bool)
+                    .unwrap_or(true);
+                let flags_match = if edge.kind == ProviderDependencyKind::PublicPackage {
+                    cargo_optional == edge.optional && cargo_default_features == edge.default_features
+                } else {
+                    !cargo_optional && dependency.get("default-features").and_then(Item::as_bool) != Some(true)
+                };
+                if !flags_match {
+                    return Err(io::Error::other(format!(
+                        "compiled library Cargo dependency `{}` optional/default feature flags disagree with its checked .incnlib descriptor",
+                        edge.dependency_key,
+                    )));
+                }
+                let relative = relative_artifact_path(&staging_root, &edge.target_root);
+                dependency.insert("path", value(relative));
+            }
+            fs::write(&cargo_manifest_path, cargo_document.to_string())?;
+
+            let manifest_relative = artifact
+                .manifest_path
+                .strip_prefix(&artifact.crate_root)
+                .ok()
+                .ok_or_else(|| io::Error::other("compiled library manifest is outside its artifact root"))?;
+            let rebound_manifest_path = staging_root.join(manifest_relative);
+            let mut library_manifest =
+                LibraryManifest::read_from_path(&rebound_manifest_path).map_err(io::Error::other)?;
+            for edge in &edges {
+                let descriptor = library_manifest
+                    .contract_metadata
+                    .provider
+                    .provider_dependencies
+                    .iter_mut()
+                    .find(|dependency| {
+                        dependency.kind == edge.kind
+                            && dependency.dependency_key == edge.dependency_key
+                            && dependency.provider_name == edge.provider_name
+                    })
+                    .ok_or_else(|| {
+                        io::Error::other(format!(
+                            "compiled library manifest has no checked dependency `{}`",
+                            edge.provider_name
+                        ))
+                    })?;
+                let digest = digest_provider_artifact(&edge.target_root).map_err(io::Error::other)?;
+                if edge.kind == ProviderDependencyKind::PrivateImplementation && digest != descriptor.artifact_digest {
+                    return Err(io::Error::other(format!(
+                        "active SDK provider `{}` has digest `{digest}`, but the checked dependency freezes `{}`",
+                        edge.provider_name, descriptor.artifact_digest
+                    )));
+                }
+                descriptor.relative_artifact_path = relative_artifact_path(&staging_root, &edge.target_root);
+                descriptor.artifact_digest = digest;
+            }
+            library_manifest
+                .write_to_path(&rebound_manifest_path)
+                .map_err(io::Error::other)?;
+            fs::write(staging_root.join(".incan-sdk-rebound-ready"), "v2\n")?;
+            Ok(())
+        })();
+        if let Err(error) = projection {
+            let _ = fs::remove_dir_all(&staging_root);
+            return Err(error);
+        }
+        fs::rename(&staging_root, shadow_root)?;
+        let projected_digest = digest_provider_artifact(shadow_root).map_err(io::Error::other)?;
+        fs::write(&integrity_marker, format!("{projected_digest}\n"))?;
+        visiting.remove(&artifact_root);
+        materialized.insert(artifact_root);
+        Ok(shadow_root.clone())
     }
 
     /// Return the generated Rust project directory.
@@ -1071,7 +1321,7 @@ mod tests {
     use crate::frontend::library_manifest_index::LibraryArtifactMetadata;
     use crate::library_manifest::{ProviderDependencyMetadata, ProviderModuleClaim};
     use crate::manifest::DependencySource;
-    use crate::provider::SdkDependencyRebinding;
+    use crate::provider::{SdkArtifactProjection, SdkDependencyRebinding};
     use std::collections::HashMap;
     use std::process::Command;
 
@@ -1100,7 +1350,7 @@ mod tests {
             "[package]\nname = \"incan_issue911_codecs\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n",
         )?;
         fs::write(active_sdk_artifact.join("src/lib.rs"), "pub fn value() -> u8 { 7 }\n")?;
-        let digest = format!("sha256:{}", "a".repeat(64));
+        let digest = digest_provider_artifact(&active_sdk_artifact)?;
         let mut manifest = LibraryManifest::new("root_lib", "0.1.0");
         manifest.contract_metadata.provider.namespace_claims = vec![ProviderModuleClaim {
             module_path: vec!["root".to_string()],
@@ -1155,12 +1405,35 @@ mod tests {
             },
         ]);
         generator.sdk_dependency_rebindings = vec![SdkDependencyRebinding {
-            containing_artifact,
+            containing_artifact: containing_artifact.clone(),
             source_crate_root: absent_sdk_artifact.clone(),
             provider_name: "incan_issue911_codecs".to_string(),
             dependency_key: "incan_issue911_codecs".to_string(),
             active_crate_root: active_sdk_artifact,
         }];
+        generator.sdk_artifact_projections = vec![SdkArtifactProjection {
+            artifact: containing_artifact,
+        }];
+        let (left_projection, right_projection) = std::thread::scope(|scope| {
+            let left = scope.spawn(|| generator.effective_dependencies());
+            let right = scope.spawn(|| generator.effective_dependencies());
+            match (left.join(), right.join()) {
+                (Ok(left), Ok(right)) => Ok((left?, right?)),
+                _ => Err(io::Error::other("concurrent SDK projection worker panicked")),
+            }
+        })?;
+        assert_eq!(left_projection, right_projection);
+        let projected_root = left_projection.first().ok_or("missing projected root dependency")?;
+        let projected_root = match &projected_root.source {
+            DependencySource::Path { path } => path,
+            DependencySource::Registry | DependencySource::Git { .. } => {
+                return Err("projected root dependency is not path-backed".into());
+            }
+        };
+        fs::write(projected_root.join("src/lib.rs"), "pub fn corrupt() {}\n")?;
+        let repaired_projection = generator.effective_dependencies()?;
+        assert_eq!(repaired_projection, left_projection);
+        assert!(fs::read_to_string(projected_root.join("src/lib.rs"))?.contains("root_value"));
         generator.generate("fn main() { assert_eq!(root_lib::root_value(), incan_issue911_codecs::value()); }")?;
 
         assert!(
@@ -1183,6 +1456,235 @@ mod tests {
             )
             .into());
         }
+        Ok(())
+    }
+
+    #[test]
+    fn nested_compiled_artifacts_propagate_sdk_projection_issue911() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        let root_artifact = workspace.path().join("root-lib");
+        let child_artifact = workspace.path().join("child-lib");
+        let absent_sdk_artifact = workspace.path().join("sdk-cache-a/runtime");
+        let active_sdk_artifact = workspace.path().join("sdk-cache-b/runtime");
+        let generated = workspace.path().join("generated/consumer");
+        for artifact in [&root_artifact, &child_artifact, &active_sdk_artifact] {
+            fs::create_dir_all(artifact.join("src"))?;
+        }
+        fs::write(
+            active_sdk_artifact.join("Cargo.toml"),
+            "[package]\nname = \"incan_issue911_runtime\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n",
+        )?;
+        fs::write(active_sdk_artifact.join("src/lib.rs"), "pub fn value() -> u8 { 11 }\n")?;
+        let sdk_digest = digest_provider_artifact(&active_sdk_artifact)?;
+
+        fs::write(
+            child_artifact.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"issue911_child\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[workspace]\n\n[dependencies.incan_issue911_runtime]\npath = {:?}\ndefault-features = false\n",
+                absent_sdk_artifact.to_string_lossy()
+            ),
+        )?;
+        fs::write(
+            child_artifact.join("src/lib.rs"),
+            "pub fn child_value() -> u8 { incan_issue911_runtime::value() }\n",
+        )?;
+        let mut child_manifest = LibraryManifest::new("issue911_child", "0.1.0");
+        child_manifest
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .push(ProviderDependencyMetadata {
+                kind: ProviderDependencyKind::PrivateImplementation,
+                dependency_key: "incan_issue911_runtime".to_string(),
+                provider_name: "incan_issue911_runtime".to_string(),
+                provider_version: "0.5.0".to_string(),
+                artifact_digest: sdk_digest,
+                relative_artifact_path: relative_artifact_path(&child_artifact, &absent_sdk_artifact),
+                requested_features: BTreeSet::new(),
+                default_features: false,
+                optional: false,
+            });
+        let child_manifest_path = child_artifact.join("issue911_child.incnlib");
+        child_manifest.write_to_path(&child_manifest_path)?;
+        let child_digest = digest_provider_artifact(&child_artifact)?;
+
+        fs::write(
+            root_artifact.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"issue911_root\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[workspace]\n\n[features]\ndefault = [\"issue911_child\"]\n\n[dependencies.issue911_child]\npath = {:?}\ndefault-features = true\noptional = true\n",
+                child_artifact.to_string_lossy()
+            ),
+        )?;
+        fs::write(
+            root_artifact.join("src/lib.rs"),
+            "pub fn root_value() -> u8 { issue911_child::child_value() }\n",
+        )?;
+        let mut root_manifest = LibraryManifest::new("issue911_root", "0.1.0");
+        root_manifest
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .push(ProviderDependencyMetadata {
+                kind: ProviderDependencyKind::PublicPackage,
+                dependency_key: "issue911_child".to_string(),
+                provider_name: "issue911_child".to_string(),
+                provider_version: "0.1.0".to_string(),
+                artifact_digest: child_digest,
+                relative_artifact_path: relative_artifact_path(&root_artifact, &child_artifact),
+                requested_features: BTreeSet::new(),
+                default_features: true,
+                optional: true,
+            });
+        let root_manifest_path = root_artifact.join("issue911_root.incnlib");
+        root_manifest.write_to_path(&root_manifest_path)?;
+        let root_metadata = LibraryArtifactMetadata::from_manifest_path(
+            "issue911_root",
+            "issue911_root",
+            root_manifest_path,
+            root_artifact.clone(),
+        );
+        let child_metadata = LibraryArtifactMetadata::from_manifest_path(
+            "issue911_child",
+            "issue911_child",
+            child_manifest_path,
+            child_artifact.clone(),
+        );
+
+        let mut generator = ProjectGenerator::new(&generated, "issue911_nested_consumer", true);
+        generator.set_dependencies(vec![DependencySpec {
+            crate_name: "issue911_root".to_string(),
+            version: None,
+            features: Vec::new(),
+            default_features: true,
+            source: DependencySource::Path {
+                path: root_artifact.clone(),
+            },
+            optional: false,
+            package: None,
+        }]);
+        generator.sdk_dependency_rebindings = vec![SdkDependencyRebinding {
+            containing_artifact: child_metadata.clone(),
+            source_crate_root: absent_sdk_artifact.clone(),
+            provider_name: "incan_issue911_runtime".to_string(),
+            dependency_key: "incan_issue911_runtime".to_string(),
+            active_crate_root: active_sdk_artifact,
+        }];
+        generator.sdk_artifact_projections = vec![
+            SdkArtifactProjection {
+                artifact: root_metadata,
+            },
+            SdkArtifactProjection {
+                artifact: child_metadata,
+            },
+        ];
+        generator.generate("fn main() { assert_eq!(issue911_root::root_value(), 11); }")?;
+
+        let effective = generator.effective_dependencies()?;
+        let root_shadow = match &effective[0].source {
+            DependencySource::Path { path } => path,
+            DependencySource::Registry | DependencySource::Git { .. } => {
+                return Err("projected root dependency is not path-backed".into());
+            }
+        };
+        let rebound_root = LibraryManifest::read_from_path(&root_shadow.join("issue911_root.incnlib"))?;
+        let rebound_child = &rebound_root.contract_metadata.provider.provider_dependencies[0];
+        let child_shadow = root_shadow.join(&rebound_child.relative_artifact_path);
+        assert_eq!(rebound_child.artifact_digest, digest_provider_artifact(&child_shadow)?);
+        assert!(child_shadow.join(".incan-sdk-rebound-ready").is_file());
+        assert!(!absent_sdk_artifact.exists());
+
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let output = Command::new(cargo)
+            .arg("check")
+            .arg("--offline")
+            .arg("--manifest-path")
+            .arg(generated.join("Cargo.toml"))
+            .env("CARGO_TARGET_DIR", workspace.path().join("cargo-target"))
+            .output()?;
+        if !output.status.success() {
+            return Err(format!(
+                "nested rebound Cargo graph failed:\n{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn sdk_projection_rejects_cargo_source_mismatch_before_cargo_issue911() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        let artifact = workspace.path().join("library");
+        let descriptor_source = workspace.path().join("sdk-cache-a/runtime");
+        let cargo_source = workspace.path().join("untrusted/runtime");
+        let active = workspace.path().join("sdk-cache-b/runtime");
+        for root in [&artifact, &active] {
+            fs::create_dir_all(root.join("src"))?;
+        }
+        fs::write(
+            artifact.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"issue911_source_mismatch\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies.incan_issue911_runtime]\npath = {:?}\n",
+                cargo_source.to_string_lossy()
+            ),
+        )?;
+        fs::write(artifact.join("src/lib.rs"), "pub fn value() {}\n")?;
+        fs::write(
+            active.join("Cargo.toml"),
+            "[package]\nname = \"incan_issue911_runtime\"\nversion = \"0.5.0\"\nedition = \"2024\"\n",
+        )?;
+        fs::write(active.join("src/lib.rs"), "pub fn value() {}\n")?;
+        let mut manifest = LibraryManifest::new("issue911_source_mismatch", "0.1.0");
+        manifest
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .push(ProviderDependencyMetadata {
+                kind: ProviderDependencyKind::PrivateImplementation,
+                dependency_key: "incan_issue911_runtime".to_string(),
+                provider_name: "incan_issue911_runtime".to_string(),
+                provider_version: "0.5.0".to_string(),
+                artifact_digest: digest_provider_artifact(&active)?,
+                relative_artifact_path: relative_artifact_path(&artifact, &descriptor_source),
+                requested_features: BTreeSet::new(),
+                default_features: false,
+                optional: false,
+            });
+        let manifest_path = artifact.join("issue911_source_mismatch.incnlib");
+        manifest.write_to_path(&manifest_path)?;
+        let metadata = LibraryArtifactMetadata::from_manifest_path(
+            "issue911_source_mismatch",
+            "issue911_source_mismatch",
+            manifest_path,
+            artifact.clone(),
+        );
+        let mut generator = ProjectGenerator::new(workspace.path().join("generated"), "consumer", true);
+        generator.set_dependencies(vec![DependencySpec {
+            crate_name: "issue911_source_mismatch".to_string(),
+            version: None,
+            features: Vec::new(),
+            default_features: true,
+            source: DependencySource::Path { path: artifact },
+            optional: false,
+            package: None,
+        }]);
+        generator.sdk_dependency_rebindings = vec![SdkDependencyRebinding {
+            containing_artifact: metadata.clone(),
+            source_crate_root: descriptor_source,
+            provider_name: "incan_issue911_runtime".to_string(),
+            dependency_key: "incan_issue911_runtime".to_string(),
+            active_crate_root: active,
+        }];
+        generator.sdk_artifact_projections = vec![SdkArtifactProjection { artifact: metadata }];
+
+        let error = generator
+            .generate("fn main() {}")
+            .err()
+            .ok_or("expected Cargo/source descriptor mismatch")?;
+
+        assert!(error.to_string().contains("checked .incnlib descriptor freezes"));
+        assert!(!cargo_source.exists());
         Ok(())
     }
 

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -33,8 +33,8 @@ use crate::frontend::{diagnostics, typechecker};
 use crate::library_manifest::LibraryRustAbi;
 use crate::library_manifest::{
     CompiledProviderMetadata, LibraryManifest, ProviderCargoDependency, ProviderCargoDependencySource,
-    ProviderDependencyMetadata, ProviderFactKind, ProviderFactRequirement, ProviderImplementationFacet,
-    ProviderModuleClaim, digest_provider_artifact,
+    ProviderDependencyKind, ProviderDependencyMetadata, ProviderFactKind, ProviderFactRequirement,
+    ProviderImplementationFacet, ProviderModuleClaim, digest_provider_artifact,
 };
 use crate::lockfile::{CargoFeatureSelection, semantic_lock_state};
 use crate::manifest::{DependencySource, DependencySpec, ProjectManifest};
@@ -1672,6 +1672,13 @@ fn prepare_library_project(
             .generate_nested(&main_code, &rust_modules)
             .map_err(|e| CliError::failure(format!("Error generating project: {e}")))?;
     }
+    synchronize_projected_provider_dependencies(
+        &mut library_manifest,
+        &out_dir,
+        &generator.effective_dependencies().map_err(|error| {
+            CliError::failure(format!("failed to resolve projected provider dependencies: {error}"))
+        })?,
+    )?;
     record_timing(&mut timings_ms, "library_generate_rust", codegen_start);
     record_timing(&mut timings_ms, "library_prepare_total", prepare_start);
 
@@ -1693,6 +1700,47 @@ fn prepare_library_project(
         timings_ms,
         report: report_draft,
     })
+}
+
+/// Synchronize newly published public dependency metadata with the exact projected paths rendered into Cargo.toml.
+fn synchronize_projected_provider_dependencies(
+    library_manifest: &mut LibraryManifest,
+    artifact_root: &Path,
+    dependencies: &[DependencySpec],
+) -> CliResult<()> {
+    for descriptor in library_manifest
+        .contract_metadata
+        .provider
+        .provider_dependencies
+        .iter_mut()
+        .filter(|dependency| dependency.kind == ProviderDependencyKind::PublicPackage)
+    {
+        let Some(dependency) = dependencies
+            .iter()
+            .find(|dependency| dependency.crate_name == descriptor.dependency_key)
+        else {
+            continue;
+        };
+        let cargo_package = dependency.package.as_deref().unwrap_or(dependency.crate_name.as_str());
+        if cargo_package != descriptor.provider_name {
+            return Err(CliError::failure(format!(
+                "projected Cargo dependency `{}` names package `{cargo_package}`, but its checked provider edge names `{}`",
+                descriptor.dependency_key, descriptor.provider_name
+            )));
+        }
+        let DependencySource::Path { path } = &dependency.source else {
+            continue;
+        };
+        descriptor.relative_artifact_path = relative_provider_artifact_path(artifact_root, path)?;
+        descriptor.artifact_digest = digest_provider_artifact(path).map_err(|error| {
+            CliError::failure(format!(
+                "failed to hash projected provider dependency `{}` artifact {}: {error}",
+                descriptor.dependency_key,
+                path.display()
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 /// Build transport-stable provider facts from the checked physical artifact projection.
@@ -2675,6 +2723,57 @@ mod tests {
         assert!(dependency_artifact_skips_canonical_lock(true, false));
         assert!(!dependency_artifact_skips_canonical_lock(true, true));
         assert!(!dependency_artifact_skips_canonical_lock(false, false));
+    }
+
+    #[test]
+    fn emitted_library_metadata_tracks_projected_dependency_issue911() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        let artifact_root = workspace.path().join("published");
+        let projected_root = workspace.path().join("projected");
+        fs::create_dir_all(&artifact_root)?;
+        fs::create_dir_all(projected_root.join("src"))?;
+        fs::write(
+            projected_root.join("Cargo.toml"),
+            "[package]\nname = \"projected_provider\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )?;
+        fs::write(projected_root.join("src/lib.rs"), "pub fn marker() {}\n")?;
+        let mut manifest = LibraryManifest::new("published", "0.1.0");
+        manifest
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .push(ProviderDependencyMetadata {
+                kind: ProviderDependencyKind::PublicPackage,
+                dependency_key: "provider_alias".to_string(),
+                provider_name: "projected_provider".to_string(),
+                provider_version: "0.1.0".to_string(),
+                artifact_digest: "sha256:stale".to_string(),
+                relative_artifact_path: "../stale".to_string(),
+                requested_features: BTreeSet::new(),
+                default_features: false,
+                optional: false,
+            });
+        let dependencies = vec![DependencySpec {
+            crate_name: "provider_alias".to_string(),
+            version: None,
+            features: Vec::new(),
+            default_features: false,
+            source: DependencySource::Path {
+                path: projected_root.clone(),
+            },
+            optional: false,
+            package: Some("projected_provider".to_string()),
+        }];
+
+        synchronize_projected_provider_dependencies(&mut manifest, &artifact_root, &dependencies)?;
+
+        let descriptor = &manifest.contract_metadata.provider.provider_dependencies[0];
+        assert_eq!(descriptor.artifact_digest, digest_provider_artifact(&projected_root)?);
+        assert_eq!(
+            fs::canonicalize(artifact_root.join(&descriptor.relative_artifact_path))?,
+            fs::canonicalize(projected_root)?
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -877,6 +877,7 @@ fn prepare_project_with_options(
         generator.set_package_metadata(project.version.clone(), project.license.clone());
     }
     generator.set_provider_plan(&provider_plan);
+    generator.set_sdk_path_dependencies(project_requirements.sdk_path_dependencies.clone());
     generator.set_cargo_target_dir_override(options.generated_cargo_target_dir.map(Path::to_path_buf));
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
     generator.set_include_dev_dependencies(false);
@@ -1595,6 +1596,7 @@ fn prepare_library_project(
     generator.set_package_name(Some(project_name.clone()));
     generator.set_package_metadata(Some(project_version.clone()), project_license);
     generator.set_provider_plan(&provider_plan);
+    generator.set_sdk_path_dependencies(project_requirements.sdk_path_dependencies.clone());
     generator.set_cargo_target_dir_override(generated_cargo_target_dir.map(Path::to_path_buf));
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
     generator.set_include_dev_dependencies(lock_payload_for_typecheck.is_some());

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -179,6 +179,8 @@ pub(crate) struct ProjectRequirements {
     pub dependencies: Vec<DependencySpec>,
     /// Immutable compiled-library projections that replace obsolete physical SDK cache coordinates.
     pub sdk_dependency_rebindings: Vec<SdkDependencyRebinding>,
+    /// Path dependencies proven to be owned by the active SDK/toolchain rather than an ordinary project source.
+    pub sdk_path_dependencies: Vec<DependencySpec>,
     /// Complete compiled-artifact closure whose transitive coordinates must be projected together.
     pub sdk_artifact_projections: Vec<SdkArtifactProjection>,
 }
@@ -1157,6 +1159,30 @@ fn extend_requirements_with_selected_sdk_providers(
     provider_plan: &ProviderPlan,
     sdk_providers: &BTreeSet<String>,
 ) -> CliResult<()> {
+    // Projection helpers do not retain the ProviderPlan. Preserve the complete active SDK path catalog separately
+    // from the minimal set of providers linked directly into this generated crate: a copied compiled artifact can
+    // still carry a non-descriptor Cargo edge to an active provider supplied transitively or unused by this consumer.
+    for provider in provider_plan.active_sdk_records() {
+        if let Some(artifact) = provider.artifact.as_ref() {
+            merge_requirement_dependency(
+                &mut requirements.sdk_path_dependencies,
+                artifact.to_dependency_spec(),
+                format!("active SDK provider `{}`", provider.identity.name),
+            )?;
+        }
+        for requirement in provider_plan.selected_backend_requirements(provider) {
+            let BackendImplementationRequirement::CargoDependency { dependency } = requirement else {
+                continue;
+            };
+            if matches!(dependency.source, ProviderCargoDependencySource::Toolchain { .. }) {
+                merge_requirement_dependency(
+                    &mut requirements.sdk_path_dependencies,
+                    provider_cargo_dependency_spec(&dependency),
+                    format!("active SDK provider `{}` toolchain dependency", provider.identity.name),
+                )?;
+            }
+        }
+    }
     for provider in provider_plan.active_records() {
         if matches!(provider.authority, crate::provider::NamespaceAuthority::SdkReserved)
             && !sdk_providers.contains(&provider.identity.stable_key())
@@ -1166,16 +1192,30 @@ fn extend_requirements_with_selected_sdk_providers(
         let Some(artifact) = provider.artifact.as_ref() else {
             continue;
         };
+        let mut provider_dependency = artifact.to_dependency_spec();
+        if matches!(provider.authority, crate::provider::NamespaceAuthority::SdkReserved) {
+            // Checked private SDK edges freeze an exact feature projection and never inherit the provider crate's
+            // conventional Cargo defaults. Emit that contract explicitly so future artifacts need no legacy repair.
+            provider_dependency.default_features = false;
+        }
         merge_requirement_dependency(
             &mut requirements.dependencies,
-            artifact.to_dependency_spec(),
+            provider_dependency,
             format!("compiled provider `{}`", provider.identity.name),
         )?;
         for requirement in provider_plan.selected_backend_requirements(provider) {
             if let BackendImplementationRequirement::CargoDependency { dependency } = requirement {
+                let dependency_spec = provider_cargo_dependency_spec(&dependency);
+                if matches!(dependency.source, ProviderCargoDependencySource::Toolchain { .. }) {
+                    merge_requirement_dependency(
+                        &mut requirements.sdk_path_dependencies,
+                        dependency_spec.clone(),
+                        format!("compiled provider `{}` toolchain dependency", provider.identity.name),
+                    )?;
+                }
                 merge_requirement_dependency(
                     &mut requirements.dependencies,
-                    provider_cargo_dependency_spec(&dependency),
+                    dependency_spec,
                     format!("compiled provider `{}` implementation facet", provider.identity.name),
                 )?;
             }
@@ -2082,6 +2122,7 @@ pub(crate) fn collect_project_requirements(
         stdlib_features: stdlib_features.into_iter().collect(),
         dependencies: Vec::new(),
         sdk_dependency_rebindings: Vec::new(),
+        sdk_path_dependencies: Vec::new(),
         sdk_artifact_projections: Vec::new(),
     };
     let workspace_root = stdlib_extra_crate_workspace_root();
@@ -2091,6 +2132,13 @@ pub(crate) fn collect_project_requirements(
         };
         for dep in namespace.extra_crate_deps {
             let spec = dependency_spec_from_stdlib_dep(dep, &workspace_root);
+            if matches!(spec.source, DependencySource::Path { .. }) {
+                merge_requirement_dependency(
+                    &mut requirements.sdk_path_dependencies,
+                    spec.clone(),
+                    format!("stdlib namespace `std.{namespace_name}` toolchain path"),
+                )?;
+            }
             merge_requirement_dependency(
                 &mut requirements.dependencies,
                 spec,
@@ -2102,6 +2150,13 @@ pub(crate) fn collect_project_requirements(
     let needs_serde_runtime = needs_legacy_serde_runtime || stdlib_namespaces.contains("serde");
     if needs_serde_runtime {
         let serde = dependency_spec_from_stdlib_extra_crate("serde")?;
+        if matches!(serde.source, DependencySource::Path { .. }) {
+            merge_requirement_dependency(
+                &mut requirements.sdk_path_dependencies,
+                serde.clone(),
+                "std.serde toolchain path".to_string(),
+            )?;
+        }
         merge_requirement_dependency(
             &mut requirements.dependencies,
             serde,
@@ -2298,6 +2353,14 @@ pub(crate) fn merge_project_requirements(
     let mut sdk_dependency_rebindings = current.sdk_dependency_rebindings.clone();
     sdk_dependency_rebindings.extend(extra.sdk_dependency_rebindings.iter().cloned());
     normalize_sdk_dependency_rebindings(&mut sdk_dependency_rebindings);
+    let mut sdk_path_dependencies = current.sdk_path_dependencies.clone();
+    for candidate in &extra.sdk_path_dependencies {
+        merge_requirement_dependency(
+            &mut sdk_path_dependencies,
+            candidate.clone(),
+            "merged SDK/toolchain path context".to_string(),
+        )?;
+    }
     let mut sdk_artifact_projections = current.sdk_artifact_projections.clone();
     sdk_artifact_projections.extend(extra.sdk_artifact_projections.iter().cloned());
     normalize_sdk_artifact_projections(&mut sdk_artifact_projections);
@@ -2306,6 +2369,7 @@ pub(crate) fn merge_project_requirements(
         stdlib_features,
         dependencies,
         sdk_dependency_rebindings,
+        sdk_path_dependencies,
         sdk_artifact_projections,
     })
 }
@@ -2431,11 +2495,12 @@ fn rust_inspect_workspace_fingerprint(
     resolved: &ResolvedDependencies,
     stdlib_features: &[String],
     sdk_dependency_rebindings: &[SdkDependencyRebinding],
+    sdk_path_dependencies: &[DependencySpec],
     sdk_artifact_projections: &[SdkArtifactProjection],
     cargo_lock_payload: Option<&str>,
 ) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"incan_rust_inspect_workspace/1\0");
+    hasher.update(b"incan_rust_inspect_workspace/2\0");
     hasher.update(project_name.as_bytes());
     hasher.update(b"\0");
     hasher.update(cargo_package_name.as_bytes());
@@ -2491,6 +2556,23 @@ fn rust_inspect_workspace_fingerprint(
             Err(error) => hasher.update(error.to_string().as_bytes()),
         }
         hasher.update(b"\0");
+    }
+    hasher.update(b"|\0");
+
+    let mut sdk_paths = sdk_path_dependencies.to_vec();
+    sdk_paths.sort_by(|left, right| {
+        (&left.crate_name, left.package.as_deref()).cmp(&(&right.crate_name, right.package.as_deref()))
+    });
+    hasher.update(b"sdk_path_dependencies\0");
+    for dependency in &sdk_paths {
+        hash_dependency_spec_for_rust_inspect(&mut hasher, dependency);
+        if let DependencySource::Path { path } = &dependency.source {
+            match digest_provider_artifact(path) {
+                Ok(digest) => hasher.update(digest.as_bytes()),
+                Err(error) => hasher.update(error.to_string().as_bytes()),
+            }
+            hasher.update(b"\0");
+        }
     }
     hasher.update(b"|\0");
 
@@ -2786,6 +2868,7 @@ pub(crate) fn ensure_rust_inspect_workspace_with_cargo_package_name(
         resolved,
         &project_requirements.stdlib_features,
         &project_requirements.sdk_dependency_rebindings,
+        &project_requirements.sdk_path_dependencies,
         &project_requirements.sdk_artifact_projections,
         cargo_lock_payload.as_deref(),
     );
@@ -2814,6 +2897,7 @@ pub(crate) fn ensure_rust_inspect_workspace_with_cargo_package_name(
     generator.set_include_dev_dependencies(true);
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
     generator.set_sdk_dependency_rebindings(project_requirements.sdk_dependency_rebindings.clone());
+    generator.set_sdk_path_dependencies(project_requirements.sdk_path_dependencies.clone());
     generator.set_sdk_artifact_projections(project_requirements.sdk_artifact_projections.clone());
     generator.set_rust_edition(rust_edition);
     generator.set_cargo_lock_payload(cargo_lock_payload);
@@ -5478,6 +5562,7 @@ pub def main() -> int:
             &resolved,
             &requirements.stdlib_features,
             &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_path_dependencies,
             &requirements.sdk_artifact_projections,
             Some("lock-bytes"),
         );
@@ -5488,6 +5573,7 @@ pub def main() -> int:
             &resolved,
             &requirements.stdlib_features,
             &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_path_dependencies,
             &requirements.sdk_artifact_projections,
             Some("lock-bytes"),
         );
@@ -5498,6 +5584,7 @@ pub def main() -> int:
             &resolved,
             &requirements.stdlib_features,
             &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_path_dependencies,
             &requirements.sdk_artifact_projections,
             Some("lock-bytes"),
         );
@@ -5521,6 +5608,7 @@ pub def main() -> int:
             &resolved,
             &requirements.stdlib_features,
             &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_path_dependencies,
             &requirements.sdk_artifact_projections,
             Some("lock-a"),
         );
@@ -5531,6 +5619,7 @@ pub def main() -> int:
             &resolved,
             &requirements.stdlib_features,
             &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_path_dependencies,
             &requirements.sdk_artifact_projections,
             Some("lock-b"),
         );
@@ -5566,6 +5655,7 @@ pub def main() -> int:
             &resolved,
             &requirements.stdlib_features,
             &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_path_dependencies,
             &requirements.sdk_artifact_projections,
             None,
         );
@@ -5577,11 +5667,78 @@ pub def main() -> int:
             &resolved,
             &requirements.stdlib_features,
             &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_path_dependencies,
             &requirements.sdk_artifact_projections,
             None,
         );
 
         assert_ne!(before, after);
+        Ok(())
+    }
+
+    #[test]
+    fn helper_requirements_keep_unused_active_sdk_path_targets_issue911() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        let artifact = workspace.path().join("unused-sdk-provider");
+        let record = crate::provider::ProviderRecord {
+            identity: crate::provider::ProviderIdentity {
+                name: "incan_issue911_unused_sdk".to_string(),
+                version: "0.5.0".to_string(),
+                digest: "sha256:issue911-unused".to_string(),
+                feature_projection: BTreeSet::new(),
+            },
+            provenance: crate::provider::ProviderProvenance::Sdk {
+                sdk_identity: "incan@0.5.0".to_string(),
+                component_id: "issue911-unused".to_string(),
+                inventory_path: None,
+            },
+            authority: crate::provider::NamespaceAuthority::SdkReserved,
+            namespace_claims: BTreeSet::from([vec!["std".to_string(), "issue911_unused".to_string()]]),
+            available: true,
+            enabled: true,
+            manifest: Some(Arc::new(LibraryManifest::new("incan_issue911_unused_sdk", "0.5.0"))),
+            artifact: Some(LibraryArtifactMetadata::from_crate_root(
+                "incan_issue911_unused_sdk",
+                "incan_issue911_unused_sdk",
+                &artifact,
+            )),
+            implementation_facets: Vec::new(),
+        };
+        let plan = ProviderPlan::new(
+            crate::frontend::library_manifest_index::LibraryManifestIndex::default(),
+            vec![record.clone()],
+            std::iter::empty(),
+        )?;
+        assert!(
+            plan.sdk_link_roots().is_empty(),
+            "unused SDK provider must not become a direct link root"
+        );
+
+        let mut requirements = ProjectRequirements::default();
+        extend_requirements_with_provider_plan(&mut requirements, &plan)?;
+
+        assert!(
+            requirements.dependencies.is_empty(),
+            "unused provider must not be linked directly"
+        );
+        assert_eq!(requirements.sdk_path_dependencies.len(), 1);
+        assert!(matches!(
+            &requirements.sdk_path_dependencies[0].source,
+            DependencySource::Path { path } if path == &artifact
+        ));
+
+        let used_plan = ProviderPlan::new(
+            crate::frontend::library_manifest_index::LibraryManifestIndex::default(),
+            vec![record],
+            [vec!["std".to_string(), "issue911_unused".to_string()]],
+        )?;
+        let mut used_requirements = ProjectRequirements::default();
+        extend_requirements_with_provider_plan(&mut used_requirements, &used_plan)?;
+        assert_eq!(used_requirements.dependencies.len(), 1);
+        assert!(
+            !used_requirements.dependencies[0].default_features,
+            "new direct SDK edges must render explicit default-features = false"
+        );
         Ok(())
     }
 

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -50,8 +50,8 @@ use crate::project_lifecycle::toolchain::ToolchainConstraintSet;
 use crate::provider::{
     BackendImplementationRequirement, FeatureSelection, PackageFeatureGraph, PackageFeaturePlan,
     ProviderModuleResolution, ProviderPlan, ProviderProvenance, ResolvedSdkComponents, SDK_INVENTORY_FILE,
-    SDK_PROVIDER_BUILD_ENV, SDK_SOURCE_CATALOG_FILE, SdkComponent, SdkComponentSelection, SdkInventory,
-    SdkProviderDescriptor, SdkResolutionError, SdkSourceCatalog,
+    SDK_PROVIDER_BUILD_ENV, SDK_SOURCE_CATALOG_FILE, SdkArtifactProjection, SdkComponent, SdkComponentSelection,
+    SdkDependencyRebinding, SdkInventory, SdkProviderDescriptor, SdkResolutionError, SdkSourceCatalog,
 };
 #[cfg(feature = "rust_inspect")]
 use crate::rust_inspect::{Inspector, InspectorConfig};
@@ -177,6 +177,10 @@ pub(crate) struct ProjectRequirements {
     pub stdlib_features: Vec<String>,
     /// Required Cargo dependencies contributed by stdlib namespaces and provider manifests.
     pub dependencies: Vec<DependencySpec>,
+    /// Immutable compiled-library projections that replace obsolete physical SDK cache coordinates.
+    pub sdk_dependency_rebindings: Vec<SdkDependencyRebinding>,
+    /// Complete compiled-artifact closure whose transitive coordinates must be projected together.
+    pub sdk_artifact_projections: Vec<SdkArtifactProjection>,
 }
 
 /// Select the Incan CLI executable that prepares SDK provider artifacts.
@@ -1199,9 +1203,44 @@ fn extend_requirements_with_selected_sdk_providers(
             dependency.features.dedup();
         }
     }
+    requirements
+        .sdk_dependency_rebindings
+        .extend_from_slice(provider_plan.sdk_dependency_rebindings());
+    normalize_sdk_dependency_rebindings(&mut requirements.sdk_dependency_rebindings);
+    requirements
+        .sdk_artifact_projections
+        .extend_from_slice(provider_plan.sdk_artifact_projections());
+    normalize_sdk_artifact_projections(&mut requirements.sdk_artifact_projections);
     requirements.stdlib_features.sort();
     requirements.stdlib_features.dedup();
     Ok(())
+}
+
+/// Sort and de-duplicate physical SDK projections independently of module-group traversal order.
+fn normalize_sdk_dependency_rebindings(rebindings: &mut Vec<SdkDependencyRebinding>) {
+    rebindings.sort_by(|left, right| {
+        (
+            &left.containing_artifact.crate_root,
+            &left.provider_name,
+            &left.dependency_key,
+            &left.source_crate_root,
+            &left.active_crate_root,
+        )
+            .cmp(&(
+                &right.containing_artifact.crate_root,
+                &right.provider_name,
+                &right.dependency_key,
+                &right.source_crate_root,
+                &right.active_crate_root,
+            ))
+    });
+    rebindings.dedup();
+}
+
+/// Sort and de-duplicate projected artifacts by their immutable compiled crate root.
+fn normalize_sdk_artifact_projections(projections: &mut Vec<SdkArtifactProjection>) {
+    projections.sort_by(|left, right| left.artifact.crate_root.cmp(&right.artifact.crate_root));
+    projections.dedup_by(|left, right| left.artifact.crate_root == right.artifact.crate_root);
 }
 
 /// Translate relocatable provider-owned Cargo metadata at the final Rust-backend boundary.
@@ -1458,9 +1497,12 @@ impl CompilationSession {
             .map(|manifest| manifest.project_root().to_path_buf())
             .unwrap_or(inferred_project_root);
         let source_root = resolve_source_root(&project_root, manifest.as_ref());
+        let sdk_inventory = prepare_or_discover_sdk_inventory()?;
         let package_feature_plan = manifest
             .as_ref()
-            .map(|manifest| PackageFeaturePlan::resolve(manifest, feature_selection))
+            .map(|manifest| {
+                PackageFeaturePlan::resolve_with_sdk_inventory(manifest, feature_selection, sdk_inventory.as_deref())
+            })
             .transpose()
             .map_err(|error| CliError::failure(error.to_string()))?;
         let root_feature_state = package_feature_plan
@@ -1509,7 +1551,6 @@ impl CompilationSession {
         // legacy monolithic stdlib. Besides losing component-aware diagnostics, that made a transient SDK profile
         // fail during collection and allowed the lock projection to drift before execution prepared the artifacts.
         // Publication is content-addressed and reused; parser-only mode still avoids preparing ordinary dependencies.
-        let sdk_inventory = prepare_or_discover_sdk_inventory()?;
         validate_component_inventory_selection(manifest.as_ref(), sdk_profile_override, sdk_inventory.as_deref())?;
         let sdk_selection =
             SdkComponentSelection::from_manifest_with_profile_override(manifest.as_ref(), sdk_profile_override);
@@ -2040,6 +2081,8 @@ pub(crate) fn collect_project_requirements(
     let mut requirements = ProjectRequirements {
         stdlib_features: stdlib_features.into_iter().collect(),
         dependencies: Vec::new(),
+        sdk_dependency_rebindings: Vec::new(),
+        sdk_artifact_projections: Vec::new(),
     };
     let workspace_root = stdlib_extra_crate_workspace_root();
     for namespace_name in &stdlib_namespaces {
@@ -2252,10 +2295,18 @@ pub(crate) fn merge_project_requirements(
         dependencies.push(candidate.clone());
     }
     dependencies.sort_by(|left, right| left.crate_name.cmp(&right.crate_name));
+    let mut sdk_dependency_rebindings = current.sdk_dependency_rebindings.clone();
+    sdk_dependency_rebindings.extend(extra.sdk_dependency_rebindings.iter().cloned());
+    normalize_sdk_dependency_rebindings(&mut sdk_dependency_rebindings);
+    let mut sdk_artifact_projections = current.sdk_artifact_projections.clone();
+    sdk_artifact_projections.extend(extra.sdk_artifact_projections.iter().cloned());
+    normalize_sdk_artifact_projections(&mut sdk_artifact_projections);
 
     Ok(ProjectRequirements {
         stdlib_features,
         dependencies,
+        sdk_dependency_rebindings,
+        sdk_artifact_projections,
     })
 }
 
@@ -2372,12 +2423,15 @@ fn hash_dependency_spec_for_rust_inspect(hasher: &mut Sha256, spec: &DependencyS
 
 /// Stable fingerprint for inputs that define one generated rust-inspect Cargo workspace.
 #[cfg(feature = "rust_inspect")]
+#[allow(clippy::too_many_arguments)]
 fn rust_inspect_workspace_fingerprint(
     project_name: &str,
     cargo_package_name: &str,
     rust_edition: Option<&str>,
     resolved: &ResolvedDependencies,
     stdlib_features: &[String],
+    sdk_dependency_rebindings: &[SdkDependencyRebinding],
+    sdk_artifact_projections: &[SdkArtifactProjection],
     cargo_lock_payload: Option<&str>,
 ) -> String {
     let mut hasher = Sha256::new();
@@ -2400,6 +2454,42 @@ fn rust_inspect_workspace_fingerprint(
     let stdlib = normalized_stdlib_features_for_rust_inspect_fingerprint(stdlib_features);
     for f in &stdlib {
         hasher.update(f.as_bytes());
+        hasher.update(b"\0");
+    }
+    hasher.update(b"|\0");
+
+    let mut projections = sdk_artifact_projections.to_vec();
+    normalize_sdk_artifact_projections(&mut projections);
+    hasher.update(b"sdk_artifact_projections\0");
+    for projection in projections {
+        hasher.update(projection.artifact.crate_root.as_os_str().as_encoded_bytes());
+        hasher.update(b"\0");
+        match digest_provider_artifact(&projection.artifact.crate_root) {
+            Ok(digest) => hasher.update(digest.as_bytes()),
+            Err(error) => hasher.update(error.to_string().as_bytes()),
+        }
+        hasher.update(b"\0");
+    }
+    hasher.update(b"|\0");
+
+    let mut rebindings = sdk_dependency_rebindings.to_vec();
+    normalize_sdk_dependency_rebindings(&mut rebindings);
+    hasher.update(b"sdk_dependency_rebindings\0");
+    for rebinding in rebindings {
+        hasher.update(rebinding.containing_artifact.crate_root.as_os_str().as_encoded_bytes());
+        hasher.update(b"\0");
+        hasher.update(rebinding.provider_name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(rebinding.dependency_key.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(rebinding.source_crate_root.as_os_str().as_encoded_bytes());
+        hasher.update(b"\0");
+        hasher.update(rebinding.active_crate_root.as_os_str().as_encoded_bytes());
+        hasher.update(b"\0");
+        match digest_provider_artifact(&rebinding.active_crate_root) {
+            Ok(digest) => hasher.update(digest.as_bytes()),
+            Err(error) => hasher.update(error.to_string().as_bytes()),
+        }
         hasher.update(b"\0");
     }
     hasher.update(b"|\0");
@@ -2695,6 +2785,8 @@ pub(crate) fn ensure_rust_inspect_workspace_with_cargo_package_name(
         rust_edition.as_deref(),
         resolved,
         &project_requirements.stdlib_features,
+        &project_requirements.sdk_dependency_rebindings,
+        &project_requirements.sdk_artifact_projections,
         cargo_lock_payload.as_deref(),
     );
     let rust_inspect_manifest_dir = rust_inspect_workspace_dir(project_root, project_name, &fingerprint);
@@ -2707,7 +2799,11 @@ pub(crate) fn ensure_rust_inspect_workspace_with_cargo_package_name(
         Err(_) => false,
     };
 
-    if cargo_toml_path.is_file() && main_rs_path.is_file() && fingerprint_matches {
+    if cargo_toml_path.is_file()
+        && main_rs_path.is_file()
+        && fingerprint_matches
+        && project_requirements.sdk_artifact_projections.is_empty()
+    {
         return Ok(rust_inspect_manifest_dir);
     }
 
@@ -2717,6 +2813,8 @@ pub(crate) fn ensure_rust_inspect_workspace_with_cargo_package_name(
     generator.set_dev_dependencies(resolved.dev_dependencies.clone());
     generator.set_include_dev_dependencies(true);
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
+    generator.set_sdk_dependency_rebindings(project_requirements.sdk_dependency_rebindings.clone());
+    generator.set_sdk_artifact_projections(project_requirements.sdk_artifact_projections.clone());
     generator.set_rust_edition(rust_edition);
     generator.set_cargo_lock_payload(cargo_lock_payload);
     let mut referenced_crates = std::collections::BTreeSet::new();
@@ -5379,6 +5477,8 @@ pub def main() -> int:
             Some("2021"),
             &resolved,
             &requirements.stdlib_features,
+            &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_artifact_projections,
             Some("lock-bytes"),
         );
         let fp_b = super::rust_inspect_workspace_fingerprint(
@@ -5387,6 +5487,8 @@ pub def main() -> int:
             Some("2021"),
             &resolved,
             &requirements.stdlib_features,
+            &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_artifact_projections,
             Some("lock-bytes"),
         );
         let workspace_fp = super::rust_inspect_workspace_fingerprint(
@@ -5395,6 +5497,8 @@ pub def main() -> int:
             Some("2021"),
             &resolved,
             &requirements.stdlib_features,
+            &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_artifact_projections,
             Some("lock-bytes"),
         );
         assert_eq!(fp_a, fp_b);
@@ -5416,6 +5520,8 @@ pub def main() -> int:
             None,
             &resolved,
             &requirements.stdlib_features,
+            &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_artifact_projections,
             Some("lock-a"),
         );
         let fp_two = super::rust_inspect_workspace_fingerprint(
@@ -5424,9 +5530,185 @@ pub def main() -> int:
             None,
             &resolved,
             &requirements.stdlib_features,
+            &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_artifact_projections,
             Some("lock-b"),
         );
         assert_ne!(fp_one, fp_two);
+    }
+
+    #[cfg(feature = "rust_inspect")]
+    #[test]
+    fn rust_inspect_fingerprint_tracks_same_path_projection_rebuild_issue911() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let workspace = tempfile::tempdir()?;
+        let artifact = workspace.path().join("compiled");
+        fs::create_dir_all(artifact.join("src"))?;
+        fs::write(
+            artifact.join("Cargo.toml"),
+            "[package]\nname = \"issue911_compiled\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )?;
+        fs::write(artifact.join("src/lib.rs"), "pub fn value() -> u8 { 1 }\n")?;
+        let requirements = ProjectRequirements {
+            sdk_artifact_projections: vec![SdkArtifactProjection {
+                artifact: LibraryArtifactMetadata::from_crate_root("issue911_compiled", "issue911_compiled", &artifact),
+            }],
+            ..ProjectRequirements::default()
+        };
+        let resolved = ResolvedDependencies {
+            dependencies: Vec::new(),
+            dev_dependencies: Vec::new(),
+        };
+        let before = super::rust_inspect_workspace_fingerprint(
+            "probe",
+            "probe",
+            None,
+            &resolved,
+            &requirements.stdlib_features,
+            &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_artifact_projections,
+            None,
+        );
+        fs::write(artifact.join("src/lib.rs"), "pub fn value() -> u8 { 2 }\n")?;
+        let after = super::rust_inspect_workspace_fingerprint(
+            "probe",
+            "probe",
+            None,
+            &resolved,
+            &requirements.stdlib_features,
+            &requirements.sdk_dependency_rebindings,
+            &requirements.sdk_artifact_projections,
+            None,
+        );
+
+        assert_ne!(before, after);
+        Ok(())
+    }
+
+    #[cfg(feature = "rust_inspect")]
+    #[test]
+    fn rust_inspect_helper_materializes_sdk_projection_issue911() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        let artifact = workspace.path().join("compiled");
+        let absent_sdk = workspace.path().join("sdk-cache-a/runtime");
+        let active_sdk = workspace.path().join("sdk-cache-b/runtime");
+        for root in [&artifact, &active_sdk] {
+            fs::create_dir_all(root.join("src"))?;
+        }
+        fs::write(
+            artifact.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"issue911_compiled\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[workspace]\n\n[dependencies.issue911_runtime]\npath = {:?}\ndefault-features = false\n",
+                absent_sdk.to_string_lossy()
+            ),
+        )?;
+        fs::write(
+            artifact.join("src/lib.rs"),
+            "pub fn value() -> u8 { issue911_runtime::value() }\n",
+        )?;
+        fs::write(
+            active_sdk.join("Cargo.toml"),
+            "[package]\nname = \"issue911_runtime\"\nversion = \"0.5.0\"\nedition = \"2024\"\n\n[workspace]\n",
+        )?;
+        fs::write(active_sdk.join("src/lib.rs"), "pub fn value() -> u8 { 3 }\n")?;
+        let mut manifest = LibraryManifest::new("issue911_compiled", "0.1.0");
+        manifest.contract_metadata.provider.provider_dependencies.push(
+            crate::library_manifest::ProviderDependencyMetadata {
+                kind: crate::library_manifest::ProviderDependencyKind::PrivateImplementation,
+                dependency_key: "issue911_runtime".to_string(),
+                provider_name: "issue911_runtime".to_string(),
+                provider_version: "0.5.0".to_string(),
+                artifact_digest: digest_provider_artifact(&active_sdk)?,
+                relative_artifact_path: "../sdk-cache-a/runtime".to_string(),
+                requested_features: BTreeSet::new(),
+                default_features: false,
+                optional: false,
+            },
+        );
+        let manifest_path = artifact.join("issue911_compiled.incnlib");
+        manifest.write_to_path(&manifest_path)?;
+        let metadata = LibraryArtifactMetadata::from_manifest_path(
+            "issue911_compiled",
+            "issue911_compiled",
+            manifest_path,
+            artifact.clone(),
+        );
+        let requirements = ProjectRequirements {
+            sdk_dependency_rebindings: vec![SdkDependencyRebinding {
+                containing_artifact: metadata.clone(),
+                source_crate_root: absent_sdk.clone(),
+                provider_name: "issue911_runtime".to_string(),
+                dependency_key: "issue911_runtime".to_string(),
+                active_crate_root: active_sdk,
+            }],
+            sdk_artifact_projections: vec![SdkArtifactProjection { artifact: metadata }],
+            ..ProjectRequirements::default()
+        };
+        let resolved = ResolvedDependencies {
+            dependencies: vec![DependencySpec {
+                crate_name: "issue911_compiled".to_string(),
+                version: None,
+                features: Vec::new(),
+                default_features: true,
+                source: DependencySource::Path { path: artifact },
+                optional: false,
+                package: None,
+            }],
+            dev_dependencies: Vec::new(),
+        };
+
+        let generated = ensure_rust_inspect_workspace_with_cargo_package_name(
+            workspace.path(),
+            "issue911_probe",
+            "issue911_probe",
+            Some("2024".to_string()),
+            &resolved,
+            &requirements,
+            None,
+        )?;
+
+        let cargo_manifest = fs::read_to_string(generated.join("Cargo.toml"))?;
+        assert!(cargo_manifest.contains(".incan-sdk-rebound"));
+        assert!(!cargo_manifest.contains(absent_sdk.to_string_lossy().as_ref()));
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let output = Command::new(cargo)
+            .arg("check")
+            .arg("--offline")
+            .arg("--manifest-path")
+            .arg(generated.join("Cargo.toml"))
+            .env("CARGO_TARGET_DIR", workspace.path().join("cargo-target"))
+            .output()?;
+        if !output.status.success() {
+            return Err(format!(
+                "rust-inspect projected Cargo graph failed:\n{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+            .into());
+        }
+        let projection_parent = generated
+            .parent()
+            .ok_or("rust-inspect workspace has no parent")?
+            .join(".incan-sdk-rebound");
+        let shadow_root = fs::read_dir(&projection_parent)?
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| path.is_dir())
+            .ok_or("missing rust-inspect projected artifact")?;
+        fs::write(shadow_root.join("src/lib.rs"), "pub fn corrupt() {}\n")?;
+        let regenerated = ensure_rust_inspect_workspace_with_cargo_package_name(
+            workspace.path(),
+            "issue911_probe",
+            "issue911_probe",
+            Some("2024".to_string()),
+            &resolved,
+            &requirements,
+            None,
+        )?;
+        assert_eq!(generated, regenerated);
+        assert!(fs::read_to_string(shadow_root.join("src/lib.rs"))?.contains("value"));
+        assert!(!absent_sdk.exists());
+        Ok(())
     }
 
     #[cfg(feature = "rust_inspect")]

--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -889,6 +889,23 @@ fn merge_workspace_project_requirements(
             ))
     });
     sdk_dependency_rebindings.dedup();
+    let mut sdk_path_dependencies = current.sdk_path_dependencies.clone();
+    for candidate in &extra.sdk_path_dependencies {
+        if let Some(existing) = sdk_path_dependencies
+            .iter()
+            .find(|dependency| dependency.crate_name == candidate.crate_name)
+        {
+            if existing != candidate {
+                return Err(CliError::failure(format!(
+                    "SDK/toolchain path dependency `{}` conflicts between workspace requirement contexts",
+                    candidate.crate_name
+                )));
+            }
+        } else {
+            sdk_path_dependencies.push(candidate.clone());
+        }
+    }
+    sdk_path_dependencies.sort_by(|left, right| left.crate_name.cmp(&right.crate_name));
     let mut sdk_artifact_projections = current.sdk_artifact_projections.clone();
     sdk_artifact_projections.extend(extra.sdk_artifact_projections.iter().cloned());
     sdk_artifact_projections.sort_by(|left, right| left.artifact.crate_root.cmp(&right.artifact.crate_root));
@@ -897,6 +914,7 @@ fn merge_workspace_project_requirements(
         stdlib_features,
         dependencies,
         sdk_dependency_rebindings,
+        sdk_path_dependencies,
         sdk_artifact_projections,
     })
 }
@@ -1534,6 +1552,7 @@ fn materialize_dependency_preheat_workspace(
     generator.set_rust_edition(rust_edition);
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
     generator.set_sdk_dependency_rebindings(project_requirements.sdk_dependency_rebindings.clone());
+    generator.set_sdk_path_dependencies(project_requirements.sdk_path_dependencies.clone());
     generator.set_sdk_artifact_projections(project_requirements.sdk_artifact_projections.clone());
     generator.set_cargo_lock_payload(Some(cargo_lock_payload.to_string()));
     generator
@@ -1602,6 +1621,7 @@ pub(crate) fn generate_lockfile(
     generator.set_rust_edition(rust_edition);
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
     generator.set_sdk_dependency_rebindings(project_requirements.sdk_dependency_rebindings.clone());
+    generator.set_sdk_path_dependencies(project_requirements.sdk_path_dependencies.clone());
     generator.set_sdk_artifact_projections(project_requirements.sdk_artifact_projections.clone());
 
     let rust_code = "fn main() {}";
@@ -1786,6 +1806,7 @@ mod tests {
             stdlib_features: Vec::new(),
             dependencies: Vec::new(),
             sdk_dependency_rebindings: Vec::new(),
+            sdk_path_dependencies: Vec::new(),
             sdk_artifact_projections: Vec::new(),
         }
     }

--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -870,9 +870,34 @@ fn merge_workspace_project_requirements(
         }
     }
     dependencies.sort_by(|left, right| left.crate_name.cmp(&right.crate_name));
+    let mut sdk_dependency_rebindings = current.sdk_dependency_rebindings.clone();
+    sdk_dependency_rebindings.extend(extra.sdk_dependency_rebindings.iter().cloned());
+    sdk_dependency_rebindings.sort_by(|left, right| {
+        (
+            &left.containing_artifact.crate_root,
+            &left.provider_name,
+            &left.dependency_key,
+            &left.source_crate_root,
+            &left.active_crate_root,
+        )
+            .cmp(&(
+                &right.containing_artifact.crate_root,
+                &right.provider_name,
+                &right.dependency_key,
+                &right.source_crate_root,
+                &right.active_crate_root,
+            ))
+    });
+    sdk_dependency_rebindings.dedup();
+    let mut sdk_artifact_projections = current.sdk_artifact_projections.clone();
+    sdk_artifact_projections.extend(extra.sdk_artifact_projections.iter().cloned());
+    sdk_artifact_projections.sort_by(|left, right| left.artifact.crate_root.cmp(&right.artifact.crate_root));
+    sdk_artifact_projections.dedup_by(|left, right| left.artifact.crate_root == right.artifact.crate_root);
     Ok(ProjectRequirements {
         stdlib_features,
         dependencies,
+        sdk_dependency_rebindings,
+        sdk_artifact_projections,
     })
 }
 
@@ -943,8 +968,10 @@ fn collect_project_lock_context(
         return Ok(None);
     }
 
-    let package_feature_plan = PackageFeaturePlan::resolve(manifest, package_features)
-        .map_err(|error| CliError::failure(error.to_string()))?;
+    let sdk_inventory = prepare_or_discover_sdk_inventory()?;
+    let package_feature_plan =
+        PackageFeaturePlan::resolve_with_sdk_inventory(manifest, package_features, sdk_inventory.as_deref())
+            .map_err(|error| CliError::failure(error.to_string()))?;
     let active_dependencies = package_feature_plan
         .root_package()
         .map(|package| package.active_dependencies.clone())
@@ -968,7 +995,6 @@ fn collect_project_lock_context(
         provider_module_groups.push(entry_modules);
     }
 
-    let sdk_inventory = prepare_or_discover_sdk_inventory()?;
     let sdk_selection =
         SdkComponentSelection::from_manifest_with_profile_override(Some(manifest), sdk_profile_override);
     let sdk_components = sdk_inventory
@@ -1507,6 +1533,8 @@ fn materialize_dependency_preheat_workspace(
     generator.set_include_dev_dependencies(true);
     generator.set_rust_edition(rust_edition);
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
+    generator.set_sdk_dependency_rebindings(project_requirements.sdk_dependency_rebindings.clone());
+    generator.set_sdk_artifact_projections(project_requirements.sdk_artifact_projections.clone());
     generator.set_cargo_lock_payload(Some(cargo_lock_payload.to_string()));
     generator
         .generate("pub fn __incan_dependency_preheat() {}")
@@ -1573,6 +1601,8 @@ pub(crate) fn generate_lockfile(
     generator.set_include_dev_dependencies(true);
     generator.set_rust_edition(rust_edition);
     generator.set_stdlib_features(project_requirements.stdlib_features.clone());
+    generator.set_sdk_dependency_rebindings(project_requirements.sdk_dependency_rebindings.clone());
+    generator.set_sdk_artifact_projections(project_requirements.sdk_artifact_projections.clone());
 
     let rust_code = "fn main() {}";
     generator
@@ -1755,6 +1785,8 @@ mod tests {
         ProjectRequirements {
             stdlib_features: Vec::new(),
             dependencies: Vec::new(),
+            sdk_dependency_rebindings: Vec::new(),
+            sdk_artifact_projections: Vec::new(),
         }
     }
 

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -4208,6 +4208,8 @@ mod tests {
         let current = ProjectRequirements {
             stdlib_features: vec!["json".to_string()],
             dependencies: vec![test_requirement_dependency("serde", &["derive"])],
+            sdk_dependency_rebindings: Vec::new(),
+            sdk_artifact_projections: Vec::new(),
         };
         let lock_entry = ProjectRequirements {
             stdlib_features: vec!["async".to_string(), "json".to_string()],
@@ -4215,6 +4217,8 @@ mod tests {
                 test_requirement_dependency("serde", &["derive"]),
                 test_requirement_dependency("tokio", &["macros"]),
             ],
+            sdk_dependency_rebindings: Vec::new(),
+            sdk_artifact_projections: Vec::new(),
         };
 
         let merged = match merge_lock_project_requirements(&current, &lock_entry) {
@@ -4238,10 +4242,14 @@ mod tests {
         let current = ProjectRequirements {
             stdlib_features: Vec::new(),
             dependencies: vec![test_requirement_dependency("tokio", &["time"])],
+            sdk_dependency_rebindings: Vec::new(),
+            sdk_artifact_projections: Vec::new(),
         };
         let lock_entry = ProjectRequirements {
             stdlib_features: Vec::new(),
             dependencies: vec![test_requirement_dependency("tokio", &["macros"])],
+            sdk_dependency_rebindings: Vec::new(),
+            sdk_artifact_projections: Vec::new(),
         };
 
         let error = match merge_lock_project_requirements(&current, &lock_entry) {

--- a/src/cli/test_runner/execution.rs
+++ b/src/cli/test_runner/execution.rs
@@ -3517,6 +3517,7 @@ pub(super) fn run_file_tests_batch(
 
     let mut generator = ProjectGenerator::new(&temp_dir, &runner_crate_name, false);
     generator.set_provider_plan(&prepared.provider_plan);
+    generator.set_sdk_path_dependencies(prepared.project_requirements.sdk_path_dependencies.clone());
     generator.set_package_name(Some(prepared.cargo_package_name.clone()));
     generator.set_stdlib_features(test_runner_stdlib_features_for_batch(
         &prepared.project_requirements.stdlib_features,
@@ -4209,6 +4210,7 @@ mod tests {
             stdlib_features: vec!["json".to_string()],
             dependencies: vec![test_requirement_dependency("serde", &["derive"])],
             sdk_dependency_rebindings: Vec::new(),
+            sdk_path_dependencies: Vec::new(),
             sdk_artifact_projections: Vec::new(),
         };
         let lock_entry = ProjectRequirements {
@@ -4218,6 +4220,7 @@ mod tests {
                 test_requirement_dependency("tokio", &["macros"]),
             ],
             sdk_dependency_rebindings: Vec::new(),
+            sdk_path_dependencies: Vec::new(),
             sdk_artifact_projections: Vec::new(),
         };
 
@@ -4243,12 +4246,14 @@ mod tests {
             stdlib_features: Vec::new(),
             dependencies: vec![test_requirement_dependency("tokio", &["time"])],
             sdk_dependency_rebindings: Vec::new(),
+            sdk_path_dependencies: Vec::new(),
             sdk_artifact_projections: Vec::new(),
         };
         let lock_entry = ProjectRequirements {
             stdlib_features: Vec::new(),
             dependencies: vec![test_requirement_dependency("tokio", &["macros"])],
             sdk_dependency_rebindings: Vec::new(),
+            sdk_path_dependencies: Vec::new(),
             sdk_artifact_projections: Vec::new(),
         };
 

--- a/src/provider/features.rs
+++ b/src/provider/features.rs
@@ -16,6 +16,8 @@ use crate::library_manifest::{
 };
 use crate::manifest::{ExpandedProjectFeature, MANIFEST_FILENAME, ProjectFeatureDefinition, ProjectManifest};
 
+use super::SdkInventory;
+
 /// Root feature selection supplied by the project manifest and current command.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FeatureSelection {
@@ -271,6 +273,19 @@ impl PackageFeaturePlan {
         root_manifest: &ProjectManifest,
         root_selection: &FeatureSelection,
     ) -> Result<Self, PackageFeaturePlanError> {
+        Self::resolve_with_sdk_inventory(root_manifest, root_selection, None)
+    }
+
+    /// Resolve package features while rebasing frozen private SDK dependencies onto the active inventory.
+    ///
+    /// Private implementation paths in compiled artifacts are physical coordinates, not semantic package identities.
+    /// Feature planning must therefore select an equivalent current SDK artifact before attempting filesystem access;
+    /// an older content-addressed cache generation may already have been collected.
+    pub fn resolve_with_sdk_inventory(
+        root_manifest: &ProjectManifest,
+        root_selection: &FeatureSelection,
+        sdk_inventory: Option<&SdkInventory>,
+    ) -> Result<Self, PackageFeaturePlanError> {
         let root = normalize_project_root(root_manifest.project_root());
         let mut manifests = BTreeMap::from([(root.clone(), root_manifest.clone())]);
         let mut compiled_packages = BTreeMap::<PathBuf, CompiledFeaturePackage>::new();
@@ -402,10 +417,21 @@ impl PackageFeaturePlan {
                 );
 
                 for dependency in dependencies {
-                    let dependency_artifact_root = compiled_package
+                    let frozen_artifact_root = compiled_package
                         .artifact
                         .crate_root
                         .join(&dependency.relative_artifact_path);
+                    let dependency_artifact_root = if dependency.kind == ProviderDependencyKind::PrivateImplementation {
+                        active_sdk_dependency_root(
+                            sdk_inventory,
+                            &package_name,
+                            artifact_path,
+                            dependency,
+                            &frozen_artifact_root,
+                        )?
+                    } else {
+                        frozen_artifact_root
+                    };
                     let entry =
                         load_provider_dependency_artifact(&dependency.dependency_key, &dependency_artifact_root);
                     let (dependency_manifest, dependency_artifact) = match entry {
@@ -604,6 +630,67 @@ impl PackageFeaturePlan {
     }
 }
 
+/// Select an active-inventory crate root for one frozen private SDK edge before reading its historical cache path.
+fn active_sdk_dependency_root(
+    inventory: Option<&SdkInventory>,
+    package_name: &str,
+    package_manifest_path: &Path,
+    dependency: &ProviderDependencyMetadata,
+    frozen_artifact_root: &Path,
+) -> Result<PathBuf, PackageFeaturePlanError> {
+    let Some(inventory) = inventory else {
+        return Ok(frozen_artifact_root.to_path_buf());
+    };
+    let candidates = inventory
+        .components
+        .values()
+        .flat_map(|component| component.providers.iter())
+        .filter(|provider| provider.name == dependency.provider_name)
+        .collect::<Vec<_>>();
+    let exact = candidates
+        .iter()
+        .copied()
+        .filter(|provider| {
+            provider.version == dependency.provider_version && provider.digest == dependency.artifact_digest
+        })
+        .collect::<Vec<_>>();
+    if dependency.default_features || dependency.optional || exact.len() != 1 {
+        let active = if candidates.is_empty() {
+            "missing from the active SDK inventory".to_string()
+        } else {
+            candidates
+                .iter()
+                .map(|provider| format!("{}@{}#{}", provider.name, provider.version, provider.digest))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        return Err(PackageFeaturePlanError::ProviderDependencyArtifact {
+            package: package_name.to_string(),
+            dependency: dependency.dependency_key.clone(),
+            path: package_manifest_path.to_path_buf(),
+            message: format!(
+                "private SDK provider `{}` froze {}@{}#{}, but the active SDK provides {active}; rebuild the compiled library with the active Incan SDK",
+                dependency.provider_name,
+                dependency.provider_name,
+                dependency.provider_version,
+                dependency.artifact_digest
+            ),
+        });
+    }
+    let provider = exact[0];
+    provider.crate_root.clone().ok_or_else(|| {
+        PackageFeaturePlanError::ProviderDependencyArtifact {
+            package: package_name.to_string(),
+            dependency: dependency.dependency_key.clone(),
+            path: package_manifest_path.to_path_buf(),
+            message: format!(
+                "equivalent private SDK provider `{}` is unavailable in the active SDK installation; install the required component or rebuild with an available SDK profile",
+                dependency.provider_name
+            ),
+        }
+    })
+}
+
 /// Validate a resolved transitive artifact against the exact identity frozen by its parent provider.
 fn validate_provider_dependency_descriptor(
     package_name: &str,
@@ -620,6 +707,14 @@ fn validate_provider_dependency_descriptor(
         Some(format!(
             "expected provider version `{}`, found `{}`",
             descriptor.provider_version, manifest.version
+        ))
+    } else if descriptor.kind == ProviderDependencyKind::PrivateImplementation
+        && manifest.contract_metadata.provider.active_features != descriptor.requested_features
+    {
+        Some(format!(
+            "expected private SDK feature projection [{}], found [{}]",
+            render_features(&descriptor.requested_features),
+            render_features(&manifest.contract_metadata.provider.active_features)
         ))
     } else {
         None
@@ -1464,6 +1559,81 @@ serializer = { path = "../serializer", optional = true, default-features = false
             .err()
             .ok_or("corrupt transitive provider artifact should fail integrity validation")?;
         assert!(error.to_string().contains("expected artifact digest"));
+        Ok(())
+    }
+
+    #[test]
+    fn package_feature_plan_rebinds_private_sdk_before_reading_absent_cache_issue911() -> TestResult {
+        let workspace = tempfile::tempdir()?;
+        let reporting_root = workspace.path().join("reporting");
+        let reporting_artifact = reporting_root.join("target/lib");
+        let absent_sdk = workspace.path().join("sdk-cache-a/runtime");
+        let active_sdk = workspace.path().join("sdk-cache-b/runtime");
+        write_test_provider_artifact(&reporting_artifact, "reporting")?;
+        write_test_provider_artifact(&active_sdk, "incan_issue911_runtime")?;
+
+        let active_manifest_path = active_sdk.join("incan_issue911_runtime.incnlib");
+        LibraryManifest::new("incan_issue911_runtime", "0.5.0").write_to_path(&active_manifest_path)?;
+        let active_digest = digest_provider_artifact(&active_sdk)?;
+        let mut reporting = LibraryManifest::new("reporting", "0.5.0");
+        reporting
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .push(ProviderDependencyMetadata {
+                kind: ProviderDependencyKind::PrivateImplementation,
+                dependency_key: "incan_issue911_runtime".to_string(),
+                provider_name: "incan_issue911_runtime".to_string(),
+                provider_version: "0.5.0".to_string(),
+                artifact_digest: active_digest.clone(),
+                relative_artifact_path: "../../../sdk-cache-a/runtime".to_string(),
+                requested_features: BTreeSet::new(),
+                default_features: false,
+                optional: false,
+            });
+        reporting.write_to_path(&reporting_artifact.join("reporting.incnlib"))?;
+
+        let consumer_root = workspace.path().join("consumer");
+        fs::create_dir_all(&consumer_root)?;
+        fs::write(
+            consumer_root.join(MANIFEST_FILENAME),
+            "[project]\nname = \"consumer\"\n\n[dependencies]\nreporting = { path = \"../reporting\" }\n",
+        )?;
+        let inventory = SdkInventory {
+            root: workspace.path().join("sdk-cache-b"),
+            sdk_id: "incan".to_string(),
+            sdk_version: "0.5.0".to_string(),
+            compiler_requirement: ">=0.5.0-dev.16,<0.6.0".to_string(),
+            components: BTreeMap::from([(
+                "runtime".to_string(),
+                crate::provider::SdkComponent {
+                    id: "runtime".to_string(),
+                    version: "0.5.0".to_string(),
+                    mandatory: true,
+                    available: true,
+                    dependencies: BTreeSet::new(),
+                    providers: vec![crate::provider::SdkProviderDescriptor {
+                        name: "incan_issue911_runtime".to_string(),
+                        version: "0.5.0".to_string(),
+                        digest: active_digest,
+                        namespace_claims: BTreeSet::new(),
+                        manifest_path: Some(active_manifest_path),
+                        crate_root: Some(active_sdk),
+                    }],
+                },
+            )]),
+            profiles: BTreeMap::new(),
+        };
+        let consumer = ProjectManifest::discover(&consumer_root)?.ok_or("missing consumer manifest")?;
+
+        let plan =
+            PackageFeaturePlan::resolve_with_sdk_inventory(&consumer, &FeatureSelection::default(), Some(&inventory))?;
+
+        assert!(plan.packages().any(|package| package.package_name == "reporting"));
+        assert!(
+            !absent_sdk.exists(),
+            "feature planning must not reopen the stale cache root"
+        );
         Ok(())
     }
 

--- a/src/provider/plan.rs
+++ b/src/provider/plan.rs
@@ -269,6 +269,13 @@ pub(crate) struct SdkDependencyRebinding {
     pub active_crate_root: PathBuf,
 }
 
+/// One compiled artifact that must be copied into the consumer-owned SDK projection graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SdkArtifactProjection {
+    /// Immutable compiled artifact whose dependency coordinates require projection.
+    pub artifact: LibraryArtifactMetadata,
+}
+
 /// Immutable provider catalog and active module projection shared by every compiler stage.
 #[derive(Debug, Clone, Default)]
 pub struct ProviderPlan {
@@ -277,6 +284,7 @@ pub struct ProviderPlan {
     module_catalog: BTreeMap<Vec<String>, String>,
     used_module_paths: BTreeSet<Vec<String>>,
     sdk_dependency_rebindings: Vec<SdkDependencyRebinding>,
+    sdk_artifact_projections: Vec<SdkArtifactProjection>,
     /// Reserved namespace roots owned by the one SDK component currently being compiled from source.
     ///
     /// This bootstrap-only grant disappears once the checked provider manifest is published and must never be
@@ -323,7 +331,8 @@ impl ProviderPlan {
             }
             indexed_records.insert(key, record);
         }
-        let sdk_dependency_rebindings = resolve_sdk_dependency_rebindings(&indexed_records)?;
+        let (sdk_dependency_rebindings, sdk_artifact_projections) =
+            resolve_sdk_dependency_rebindings(&indexed_records)?;
 
         Ok(Self {
             library_manifest_index,
@@ -331,6 +340,7 @@ impl ProviderPlan {
             module_catalog,
             used_module_paths: used_module_paths.into_iter().collect(),
             sdk_dependency_rebindings,
+            sdk_artifact_projections,
             bootstrap_sdk_namespace_roots: BTreeSet::new(),
         })
     }
@@ -343,6 +353,11 @@ impl ProviderPlan {
     /// Return artifact projections needed to replace stale physical SDK cache paths without mutating either artifact.
     pub(crate) fn sdk_dependency_rebindings(&self) -> &[SdkDependencyRebinding] {
         &self.sdk_dependency_rebindings
+    }
+
+    /// Return every compiled artifact whose private or transitive dependency coordinates require projection.
+    pub(crate) fn sdk_artifact_projections(&self) -> &[SdkArtifactProjection] {
+        &self.sdk_artifact_projections
     }
 
     /// Build one provider plan from ordinary dependency artifacts and the active SDK catalog.
@@ -398,6 +413,7 @@ impl ProviderPlan {
             module_catalog,
             used_module_paths: BTreeSet::new(),
             sdk_dependency_rebindings: Vec::new(),
+            sdk_artifact_projections: Vec::new(),
             bootstrap_sdk_namespace_roots: BTreeSet::new(),
         }
     }
@@ -463,6 +479,7 @@ impl ProviderPlan {
             module_catalog: namespace_claims.into_iter().map(|claim| (claim, key.clone())).collect(),
             used_module_paths: BTreeSet::new(),
             sdk_dependency_rebindings: Vec::new(),
+            sdk_artifact_projections: Vec::new(),
             bootstrap_sdk_namespace_roots: BTreeSet::new(),
         }
     }
@@ -680,16 +697,19 @@ impl ProviderPlan {
 /// have been collected. Only an enabled, available active SDK record with the exact identity can replace that path.
 fn resolve_sdk_dependency_rebindings(
     records: &BTreeMap<String, ProviderRecord>,
-) -> Result<Vec<SdkDependencyRebinding>, ProviderPlanError> {
+) -> Result<(Vec<SdkDependencyRebinding>, Vec<SdkArtifactProjection>), ProviderPlanError> {
     let sdk_records = records
         .values()
         .filter(|record| matches!(record.authority, NamespaceAuthority::SdkReserved))
         .collect::<Vec<_>>();
     if sdk_records.is_empty() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     }
 
     let mut rebindings = Vec::new();
+    let mut projected = BTreeMap::<PathBuf, LibraryArtifactMetadata>::new();
+    let mut visited = BTreeSet::new();
+    let mut visiting = BTreeSet::new();
     for library in records
         .values()
         .filter(|record| matches!(record.authority, NamespaceAuthority::ProjectDependency { .. }))
@@ -698,56 +718,16 @@ fn resolve_sdk_dependency_rebindings(
         else {
             continue;
         };
-        for dependency in manifest
-            .contract_metadata
-            .provider
-            .provider_dependencies
-            .iter()
-            .filter(|dependency| dependency.kind == ProviderDependencyKind::PrivateImplementation)
-        {
-            let candidates = sdk_records
-                .iter()
-                .copied()
-                .filter(|record| record.identity.name == dependency.provider_name)
-                .collect::<Vec<_>>();
-            let exact = candidates.iter().copied().find(|record| {
-                record.identity.version == dependency.provider_version
-                    && record.identity.digest == dependency.artifact_digest
-                    && record.identity.feature_projection == dependency.requested_features
-                    && record.enabled
-                    && record.available
-                    && record.artifact.is_some()
-            });
-            let Some(active) = exact else {
-                return Err(incompatible_compiled_sdk_dependency(
-                    library,
-                    containing_artifact,
-                    dependency,
-                    &candidates,
-                ));
-            };
-            let Some(active_artifact) = active.artifact.as_ref() else {
-                return Err(incompatible_compiled_sdk_dependency(
-                    library,
-                    containing_artifact,
-                    dependency,
-                    &candidates,
-                ));
-            };
-            let source_crate_root =
-                normalize_artifact_root(&containing_artifact.crate_root.join(&dependency.relative_artifact_path));
-            let active_crate_root = normalize_artifact_root(&active_artifact.crate_root);
-            if source_crate_root == active_crate_root {
-                continue;
-            }
-            rebindings.push(SdkDependencyRebinding {
-                containing_artifact: containing_artifact.clone(),
-                source_crate_root,
-                provider_name: dependency.provider_name.clone(),
-                dependency_key: dependency.dependency_key.clone(),
-                active_crate_root,
-            });
-        }
+        resolve_sdk_artifact_projection(
+            &library.identity.name,
+            manifest,
+            containing_artifact,
+            &sdk_records,
+            &mut visiting,
+            &mut visited,
+            &mut rebindings,
+            &mut projected,
+        )?;
     }
     rebindings.sort_by(|left, right| {
         (
@@ -766,12 +746,161 @@ fn resolve_sdk_dependency_rebindings(
             ))
     });
     rebindings.dedup();
-    Ok(rebindings)
+    let projections = projected
+        .into_values()
+        .map(|artifact| SdkArtifactProjection { artifact })
+        .collect();
+    Ok((rebindings, projections))
+}
+
+/// Traverse one compiled provider graph and mark every ancestor that must point at a projected child artifact.
+#[allow(clippy::too_many_arguments)]
+fn resolve_sdk_artifact_projection(
+    library_name: &str,
+    manifest: &LibraryManifest,
+    artifact: &LibraryArtifactMetadata,
+    sdk_records: &[&ProviderRecord],
+    visiting: &mut BTreeSet<PathBuf>,
+    visited: &mut BTreeSet<PathBuf>,
+    rebindings: &mut Vec<SdkDependencyRebinding>,
+    projected: &mut BTreeMap<PathBuf, LibraryArtifactMetadata>,
+) -> Result<bool, ProviderPlanError> {
+    let artifact_root = normalize_artifact_root(&artifact.crate_root);
+    if visited.contains(&artifact_root) {
+        return Ok(projected.contains_key(&artifact_root));
+    }
+    if !visiting.insert(artifact_root.clone()) {
+        return Err(ProviderPlanError::ManifestLoad {
+            provider: library_name.to_string(),
+            path: artifact.manifest_path.clone(),
+            message: "compiled provider dependency graph contains a cycle".to_string(),
+        });
+    }
+
+    let mut requires_projection = false;
+    for dependency in &manifest.contract_metadata.provider.provider_dependencies {
+        if dependency.kind == ProviderDependencyKind::PrivateImplementation {
+            let candidates = sdk_records
+                .iter()
+                .copied()
+                .filter(|record| record.identity.name == dependency.provider_name)
+                .collect::<Vec<_>>();
+            let exact = candidates
+                .iter()
+                .copied()
+                .filter(|record| {
+                    record.identity.version == dependency.provider_version
+                        && record.identity.digest == dependency.artifact_digest
+                        && record.identity.feature_projection == dependency.requested_features
+                        && record.enabled
+                        && record.available
+                        && record.artifact.is_some()
+                })
+                .collect::<Vec<_>>();
+            if dependency.default_features || dependency.optional || exact.len() != 1 {
+                return Err(incompatible_compiled_sdk_dependency(
+                    library_name,
+                    artifact,
+                    dependency,
+                    &candidates,
+                ));
+            }
+            let Some(active_artifact) = exact[0].artifact.as_ref() else {
+                return Err(incompatible_compiled_sdk_dependency(
+                    library_name,
+                    artifact,
+                    dependency,
+                    &candidates,
+                ));
+            };
+            let source_crate_root =
+                normalize_artifact_root(&artifact.crate_root.join(&dependency.relative_artifact_path));
+            let active_crate_root = normalize_artifact_root(&active_artifact.crate_root);
+            if source_crate_root != active_crate_root {
+                rebindings.push(SdkDependencyRebinding {
+                    containing_artifact: artifact.clone(),
+                    source_crate_root,
+                    provider_name: dependency.provider_name.clone(),
+                    dependency_key: dependency.dependency_key.clone(),
+                    active_crate_root,
+                });
+                requires_projection = true;
+            }
+            continue;
+        }
+
+        let dependency_root = artifact.crate_root.join(&dependency.relative_artifact_path);
+        let loaded = load_provider_dependency_artifact(&dependency.dependency_key, &dependency_root);
+        let (dependency_manifest, dependency_artifact) = match loaded {
+            LibraryManifestIndexEntry::Loaded { manifest, metadata } => (manifest, metadata),
+            LibraryManifestIndexEntry::Failed(failure) => {
+                return Err(ProviderPlanError::ManifestLoad {
+                    provider: dependency.provider_name.clone(),
+                    path: failure.path,
+                    message: failure.message,
+                });
+            }
+        };
+        validate_transitive_provider_dependency(dependency, &dependency_manifest, &dependency_artifact)?;
+        if resolve_sdk_artifact_projection(
+            &dependency.provider_name,
+            &dependency_manifest,
+            &dependency_artifact,
+            sdk_records,
+            visiting,
+            visited,
+            rebindings,
+            projected,
+        )? {
+            requires_projection = true;
+        }
+    }
+
+    visiting.remove(&artifact_root);
+    visited.insert(artifact_root.clone());
+    if requires_projection {
+        projected.insert(artifact_root, artifact.clone());
+    }
+    Ok(requires_projection)
+}
+
+/// Validate the stable identity on one public compiled-provider edge before traversing it.
+fn validate_transitive_provider_dependency(
+    descriptor: &ProviderDependencyMetadata,
+    manifest: &LibraryManifest,
+    artifact: &LibraryArtifactMetadata,
+) -> Result<(), ProviderPlanError> {
+    if manifest.name != descriptor.provider_name || manifest.version != descriptor.provider_version {
+        return Err(ProviderPlanError::ManifestLoad {
+            provider: descriptor.provider_name.clone(),
+            path: artifact.manifest_path.clone(),
+            message: format!(
+                "expected {}@{}, found {}@{}",
+                descriptor.provider_name, descriptor.provider_version, manifest.name, manifest.version
+            ),
+        });
+    }
+    let digest = digest_provider_artifact(&artifact.crate_root).map_err(|error| ProviderPlanError::ManifestLoad {
+        provider: descriptor.provider_name.clone(),
+        path: artifact.crate_root.clone(),
+        message: error.to_string(),
+    })?;
+    if digest != descriptor.artifact_digest {
+        return Err(ProviderPlanError::ManifestLoad {
+            provider: descriptor.provider_name.clone(),
+            path: artifact.crate_root.clone(),
+            message: format!(
+                "expected artifact digest `{}`, found `{digest}`",
+                descriptor.artifact_digest
+            ),
+        });
+    }
+    Ok(())
 }
 
 /// Preserve a targeted pre-Cargo diagnostic when an active SDK cannot satisfy one frozen private implementation edge.
 fn incompatible_compiled_sdk_dependency(
-    library: &ProviderRecord,
+    library_name: &str,
     artifact: &LibraryArtifactMetadata,
     dependency: &ProviderDependencyMetadata,
     candidates: &[&ProviderRecord],
@@ -795,7 +924,7 @@ fn incompatible_compiled_sdk_dependency(
             .join(", ")
     };
     ProviderPlanError::IncompatibleCompiledSdkDependency {
-        library: library.identity.name.clone(),
+        library: library_name.to_string(),
         manifest_path: artifact.manifest_path.clone(),
         provider: dependency.provider_name.clone(),
         frozen_identity: provider_dependency_stable_identity(dependency),
@@ -1577,6 +1706,104 @@ mod tests {
             std::fs::canonicalize(active_sdk_artifact)?
         );
         assert_eq!(rebindings[0].provider_name, "incan_stdlib_codecs");
+        assert_eq!(plan.sdk_artifact_projections().len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn transitive_private_sdk_rebinding_projects_every_compiled_ancestor_issue911() -> TestResult {
+        let workspace = tempfile::tempdir()?;
+        let root_artifact = workspace.path().join("root");
+        let child_artifact = workspace.path().join("child");
+        let active_sdk_artifact = workspace.path().join("active-sdk/runtime");
+        let absent_sdk_artifact = workspace.path().join("old-sdk/runtime");
+        for artifact in [&root_artifact, &child_artifact, &active_sdk_artifact] {
+            std::fs::create_dir_all(artifact.join("src"))?;
+            std::fs::write(
+                artifact.join("Cargo.toml"),
+                "[package]\nname = \"placeholder\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+            )?;
+            std::fs::write(artifact.join("src/lib.rs"), "pub fn marker() {}\n")?;
+        }
+        std::fs::write(
+            child_artifact.join("Cargo.toml"),
+            "[package]\nname = \"child\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )?;
+        let sdk_digest = digest_provider_artifact(&active_sdk_artifact)?;
+        let mut child_manifest = LibraryManifest::new("child", "0.1.0");
+        child_manifest
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .push(ProviderDependencyMetadata {
+                kind: ProviderDependencyKind::PrivateImplementation,
+                dependency_key: "incan_stdlib_codecs".to_string(),
+                provider_name: "incan_stdlib_codecs".to_string(),
+                provider_version: "0.5.0".to_string(),
+                artifact_digest: sdk_digest.clone(),
+                relative_artifact_path: "../old-sdk/runtime".to_string(),
+                requested_features: BTreeSet::new(),
+                default_features: false,
+                optional: false,
+            });
+        let child_manifest_path = child_artifact.join("child.incnlib");
+        child_manifest.write_to_path(&child_manifest_path)?;
+        let child_digest = digest_provider_artifact(&child_artifact)?;
+        let mut root_manifest = LibraryManifest::new("root", "0.1.0");
+        root_manifest
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .push(ProviderDependencyMetadata {
+                kind: ProviderDependencyKind::PublicPackage,
+                dependency_key: "child".to_string(),
+                provider_name: "child".to_string(),
+                provider_version: "0.1.0".to_string(),
+                artifact_digest: child_digest,
+                relative_artifact_path: "../child".to_string(),
+                requested_features: BTreeSet::new(),
+                default_features: false,
+                optional: false,
+            });
+        let root_record = ProviderRecord {
+            identity: ProviderIdentity {
+                name: "root".to_string(),
+                version: "0.1.0".to_string(),
+                digest: digest_provider_artifact(&root_artifact)?,
+                feature_projection: BTreeSet::new(),
+            },
+            provenance: ProviderProvenance::ProjectDependency {
+                dependency_key: "root".to_string(),
+                manifest_path: root_artifact.join("root.incnlib"),
+            },
+            authority: NamespaceAuthority::ProjectDependency {
+                dependency_key: "root".to_string(),
+            },
+            namespace_claims: BTreeSet::new(),
+            available: true,
+            enabled: true,
+            manifest: Some(Arc::new(root_manifest)),
+            artifact: Some(LibraryArtifactMetadata::from_crate_root("root", "root", &root_artifact)),
+            implementation_facets: Vec::new(),
+        };
+        let plan = ProviderPlan::new(
+            LibraryManifestIndex::default(),
+            vec![
+                root_record,
+                active_sdk_record(&active_sdk_artifact, &sdk_digest, BTreeSet::new()),
+            ],
+            [],
+        )?;
+
+        assert_eq!(plan.sdk_dependency_rebindings().len(), 1);
+        assert_eq!(plan.sdk_artifact_projections().len(), 2);
+        assert!(plan.sdk_artifact_projections().iter().any(|projection| {
+            normalize_artifact_root(&projection.artifact.crate_root) == normalize_artifact_root(&root_artifact)
+        }));
+        assert!(plan.sdk_artifact_projections().iter().any(|projection| {
+            normalize_artifact_root(&projection.artifact.crate_root) == normalize_artifact_root(&child_artifact)
+        }));
+        assert!(!absent_sdk_artifact.exists());
         Ok(())
     }
 

--- a/src/provider/plan.rs
+++ b/src/provider/plan.rs
@@ -11,8 +11,8 @@ use crate::frontend::library_manifest_index::{
     load_provider_dependency_artifact,
 };
 use crate::library_manifest::{
-    LibraryManifest, LibraryManifestError, ProviderCargoDependency, ProviderImplementationFacet,
-    digest_provider_artifact,
+    LibraryManifest, LibraryManifestError, ProviderCargoDependency, ProviderDependencyKind, ProviderDependencyMetadata,
+    ProviderImplementationFacet, digest_provider_artifact,
 };
 
 use super::features::feature_value_location;
@@ -236,6 +236,37 @@ pub enum ProviderPlanError {
         /// SDK component that must be selected explicitly.
         component: String,
     },
+    /// A compiled library freezes a private SDK implementation that is not equivalent to the active SDK artifact.
+    #[error(
+        "compiled library `{library}` at {manifest_path} has incompatible private SDK provider `{provider}`: frozen identity `{frozen_identity}`, active SDK identity `{active_identity}`; rebuild the compiled library with the active Incan SDK"
+    )]
+    IncompatibleCompiledSdkDependency {
+        /// Compiled library that froze the private implementation edge.
+        library: String,
+        /// Checked library manifest carrying the stale edge.
+        manifest_path: PathBuf,
+        /// SDK provider package name.
+        provider: String,
+        /// Stable name, version, digest, and feature projection frozen by the library.
+        frozen_identity: String,
+        /// Matching provider identities advertised by the active SDK, or an explicit absence marker.
+        active_identity: String,
+    },
+}
+
+/// One compiled-library dependency that must be projected through the active equivalent SDK artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SdkDependencyRebinding {
+    /// Compiled library crate whose Cargo manifest freezes the old SDK path.
+    pub containing_artifact: LibraryArtifactMetadata,
+    /// Historical provider crate root recorded relative to the containing artifact; it may no longer exist.
+    pub source_crate_root: PathBuf,
+    /// Logical Cargo provider package name.
+    pub provider_name: String,
+    /// Cargo dependency key frozen in the containing generated manifest.
+    pub dependency_key: String,
+    /// Active inventory-owned provider crate root with equivalent semantic identity.
+    pub active_crate_root: PathBuf,
 }
 
 /// Immutable provider catalog and active module projection shared by every compiler stage.
@@ -245,6 +276,7 @@ pub struct ProviderPlan {
     records: BTreeMap<String, ProviderRecord>,
     module_catalog: BTreeMap<Vec<String>, String>,
     used_module_paths: BTreeSet<Vec<String>>,
+    sdk_dependency_rebindings: Vec<SdkDependencyRebinding>,
     /// Reserved namespace roots owned by the one SDK component currently being compiled from source.
     ///
     /// This bootstrap-only grant disappears once the checked provider manifest is published and must never be
@@ -291,12 +323,14 @@ impl ProviderPlan {
             }
             indexed_records.insert(key, record);
         }
+        let sdk_dependency_rebindings = resolve_sdk_dependency_rebindings(&indexed_records)?;
 
         Ok(Self {
             library_manifest_index,
             records: indexed_records,
             module_catalog,
             used_module_paths: used_module_paths.into_iter().collect(),
+            sdk_dependency_rebindings,
             bootstrap_sdk_namespace_roots: BTreeSet::new(),
         })
     }
@@ -304,6 +338,11 @@ impl ProviderPlan {
     /// Return the consumer-side dependency manifest index normalized into this plan.
     pub fn library_manifest_index(&self) -> &LibraryManifestIndex {
         &self.library_manifest_index
+    }
+
+    /// Return artifact projections needed to replace stale physical SDK cache paths without mutating either artifact.
+    pub(crate) fn sdk_dependency_rebindings(&self) -> &[SdkDependencyRebinding] {
+        &self.sdk_dependency_rebindings
     }
 
     /// Build one provider plan from ordinary dependency artifacts and the active SDK catalog.
@@ -358,6 +397,7 @@ impl ProviderPlan {
             records: BTreeMap::from([(key, record)]),
             module_catalog,
             used_module_paths: BTreeSet::new(),
+            sdk_dependency_rebindings: Vec::new(),
             bootstrap_sdk_namespace_roots: BTreeSet::new(),
         }
     }
@@ -422,6 +462,7 @@ impl ProviderPlan {
             records: BTreeMap::from([(key.clone(), record)]),
             module_catalog: namespace_claims.into_iter().map(|claim| (claim, key.clone())).collect(),
             used_module_paths: BTreeSet::new(),
+            sdk_dependency_rebindings: Vec::new(),
             bootstrap_sdk_namespace_roots: BTreeSet::new(),
         }
     }
@@ -629,6 +670,156 @@ impl ProviderPlan {
         }
         Ok(())
     }
+}
+
+/// Resolve historical private SDK edges in ordinary compiled libraries against the active inventory by logical
+/// identity.
+///
+/// The checked `.incnlib` descriptor is authoritative for the frozen name, version, digest, and feature projection;
+/// the old physical cache root is deliberately not read because content-addressed provider generations may already
+/// have been collected. Only an enabled, available active SDK record with the exact identity can replace that path.
+fn resolve_sdk_dependency_rebindings(
+    records: &BTreeMap<String, ProviderRecord>,
+) -> Result<Vec<SdkDependencyRebinding>, ProviderPlanError> {
+    let sdk_records = records
+        .values()
+        .filter(|record| matches!(record.authority, NamespaceAuthority::SdkReserved))
+        .collect::<Vec<_>>();
+    if sdk_records.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut rebindings = Vec::new();
+    for library in records
+        .values()
+        .filter(|record| matches!(record.authority, NamespaceAuthority::ProjectDependency { .. }))
+    {
+        let (Some(manifest), Some(containing_artifact)) = (library.manifest.as_deref(), library.artifact.as_ref())
+        else {
+            continue;
+        };
+        for dependency in manifest
+            .contract_metadata
+            .provider
+            .provider_dependencies
+            .iter()
+            .filter(|dependency| dependency.kind == ProviderDependencyKind::PrivateImplementation)
+        {
+            let candidates = sdk_records
+                .iter()
+                .copied()
+                .filter(|record| record.identity.name == dependency.provider_name)
+                .collect::<Vec<_>>();
+            let exact = candidates.iter().copied().find(|record| {
+                record.identity.version == dependency.provider_version
+                    && record.identity.digest == dependency.artifact_digest
+                    && record.identity.feature_projection == dependency.requested_features
+                    && record.enabled
+                    && record.available
+                    && record.artifact.is_some()
+            });
+            let Some(active) = exact else {
+                return Err(incompatible_compiled_sdk_dependency(
+                    library,
+                    containing_artifact,
+                    dependency,
+                    &candidates,
+                ));
+            };
+            let Some(active_artifact) = active.artifact.as_ref() else {
+                return Err(incompatible_compiled_sdk_dependency(
+                    library,
+                    containing_artifact,
+                    dependency,
+                    &candidates,
+                ));
+            };
+            let source_crate_root =
+                normalize_artifact_root(&containing_artifact.crate_root.join(&dependency.relative_artifact_path));
+            let active_crate_root = normalize_artifact_root(&active_artifact.crate_root);
+            if source_crate_root == active_crate_root {
+                continue;
+            }
+            rebindings.push(SdkDependencyRebinding {
+                containing_artifact: containing_artifact.clone(),
+                source_crate_root,
+                provider_name: dependency.provider_name.clone(),
+                dependency_key: dependency.dependency_key.clone(),
+                active_crate_root,
+            });
+        }
+    }
+    rebindings.sort_by(|left, right| {
+        (
+            &left.containing_artifact.crate_root,
+            &left.provider_name,
+            &left.dependency_key,
+            &left.source_crate_root,
+            &left.active_crate_root,
+        )
+            .cmp(&(
+                &right.containing_artifact.crate_root,
+                &right.provider_name,
+                &right.dependency_key,
+                &right.source_crate_root,
+                &right.active_crate_root,
+            ))
+    });
+    rebindings.dedup();
+    Ok(rebindings)
+}
+
+/// Preserve a targeted pre-Cargo diagnostic when an active SDK cannot satisfy one frozen private implementation edge.
+fn incompatible_compiled_sdk_dependency(
+    library: &ProviderRecord,
+    artifact: &LibraryArtifactMetadata,
+    dependency: &ProviderDependencyMetadata,
+    candidates: &[&ProviderRecord],
+) -> ProviderPlanError {
+    let active_identity = if candidates.is_empty() {
+        "<missing from active SDK inventory>".to_string()
+    } else {
+        candidates
+            .iter()
+            .map(|candidate| {
+                let availability = if !candidate.enabled {
+                    "disabled"
+                } else if !candidate.available || candidate.artifact.is_none() {
+                    "unavailable"
+                } else {
+                    "available"
+                };
+                format!("{} ({availability})", candidate.identity.stable_key())
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    ProviderPlanError::IncompatibleCompiledSdkDependency {
+        library: library.identity.name.clone(),
+        manifest_path: artifact.manifest_path.clone(),
+        provider: dependency.provider_name.clone(),
+        frozen_identity: provider_dependency_stable_identity(dependency),
+        active_identity,
+    }
+}
+
+/// Render the same stable identity dimensions used by active SDK provider records.
+fn provider_dependency_stable_identity(dependency: &ProviderDependencyMetadata) -> String {
+    let features = dependency
+        .requested_features
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{}@{}#{}[{}]",
+        dependency.provider_name, dependency.provider_version, dependency.artifact_digest, features
+    )
+}
+
+/// Canonicalize an artifact root when it exists while retaining an absent historical cache coordinate verbatim.
+fn normalize_artifact_root(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Render one concise provider provenance chain for human diagnostics.
@@ -1356,6 +1547,139 @@ mod tests {
         );
         assert!(matches!(result, Err(ProviderPlanError::InventoryMismatch { .. })));
         Ok(())
+    }
+
+    #[test]
+    fn equivalent_private_sdk_dependency_rebinds_to_active_inventory_root_issue911() -> TestResult {
+        let workspace = tempfile::tempdir()?;
+        let library_artifact = workspace.path().join("library/target/lib");
+        let frozen_sdk_artifact = library_artifact.join("private/stdlib-codecs");
+        let active_sdk_artifact = workspace.path().join("active-sdk/stdlib-codecs");
+        std::fs::create_dir_all(&active_sdk_artifact)?;
+        let digest = format!("sha256:{}", "a".repeat(64));
+        let features = BTreeSet::from(["json".to_string()]);
+        let records = vec![
+            compiled_library_record(&library_artifact, &digest, features.clone()),
+            active_sdk_record(&active_sdk_artifact, &digest, features),
+        ];
+
+        let plan = ProviderPlan::new(LibraryManifestIndex::default(), records, [])?;
+        let rebindings = plan.sdk_dependency_rebindings();
+
+        assert_eq!(rebindings.len(), 1);
+        assert_eq!(rebindings[0].source_crate_root, frozen_sdk_artifact);
+        assert!(
+            !rebindings[0].source_crate_root.exists(),
+            "the historical cache root must not be required for logical rebinding"
+        );
+        assert_eq!(
+            rebindings[0].active_crate_root,
+            std::fs::canonicalize(active_sdk_artifact)?
+        );
+        assert_eq!(rebindings[0].provider_name, "incan_stdlib_codecs");
+        Ok(())
+    }
+
+    #[test]
+    fn incompatible_private_sdk_dependency_fails_before_cargo_issue911() -> TestResult {
+        let workspace = tempfile::tempdir()?;
+        let library_artifact = workspace.path().join("library/target/lib");
+        let frozen_sdk_artifact = library_artifact.join("private/stdlib-codecs");
+        let active_sdk_artifact = workspace.path().join("active-sdk/stdlib-codecs");
+        std::fs::create_dir_all(&frozen_sdk_artifact)?;
+        std::fs::create_dir_all(&active_sdk_artifact)?;
+        let frozen_digest = format!("sha256:{}", "a".repeat(64));
+        let active_digest = format!("sha256:{}", "b".repeat(64));
+        let features = BTreeSet::from(["json".to_string()]);
+        let records = vec![
+            compiled_library_record(&library_artifact, &frozen_digest, features.clone()),
+            active_sdk_record(&active_sdk_artifact, &active_digest, features),
+        ];
+
+        let error = ProviderPlan::new(LibraryManifestIndex::default(), records, [])
+            .err()
+            .ok_or("expected incompatible compiled SDK dependency")?;
+
+        assert!(matches!(
+            error,
+            ProviderPlanError::IncompatibleCompiledSdkDependency { .. }
+        ));
+        assert!(error.to_string().contains("incan_stdlib_codecs"));
+        assert!(error.to_string().contains("rebuild the compiled library"));
+        Ok(())
+    }
+
+    fn compiled_library_record(
+        artifact_root: &Path,
+        sdk_digest: &str,
+        sdk_features: BTreeSet<String>,
+    ) -> ProviderRecord {
+        let mut manifest = LibraryManifest::new("root_lib", "0.1.0");
+        manifest.contract_metadata.provider.provider_dependencies.push(
+            crate::library_manifest::ProviderDependencyMetadata {
+                kind: crate::library_manifest::ProviderDependencyKind::PrivateImplementation,
+                dependency_key: "incan_stdlib_codecs".to_string(),
+                provider_name: "incan_stdlib_codecs".to_string(),
+                provider_version: "0.5.0".to_string(),
+                artifact_digest: sdk_digest.to_string(),
+                relative_artifact_path: "private/stdlib-codecs".to_string(),
+                requested_features: sdk_features,
+                default_features: false,
+                optional: false,
+            },
+        );
+        ProviderRecord {
+            identity: ProviderIdentity {
+                name: "root_lib".to_string(),
+                version: "0.1.0".to_string(),
+                digest: format!("sha256:{}", "c".repeat(64)),
+                feature_projection: BTreeSet::new(),
+            },
+            provenance: ProviderProvenance::ProjectDependency {
+                dependency_key: "root_lib".to_string(),
+                manifest_path: artifact_root.join("root_lib.incnlib"),
+            },
+            authority: NamespaceAuthority::ProjectDependency {
+                dependency_key: "root_lib".to_string(),
+            },
+            namespace_claims: BTreeSet::new(),
+            available: true,
+            enabled: true,
+            manifest: Some(Arc::new(manifest)),
+            artifact: Some(LibraryArtifactMetadata::from_crate_root(
+                "root_lib",
+                "root_lib",
+                artifact_root,
+            )),
+            implementation_facets: Vec::new(),
+        }
+    }
+
+    fn active_sdk_record(artifact_root: &Path, digest: &str, feature_projection: BTreeSet<String>) -> ProviderRecord {
+        ProviderRecord {
+            identity: ProviderIdentity {
+                name: "incan_stdlib_codecs".to_string(),
+                version: "0.5.0".to_string(),
+                digest: digest.to_string(),
+                feature_projection,
+            },
+            provenance: ProviderProvenance::Sdk {
+                sdk_identity: "incan@0.5.0".to_string(),
+                component_id: "stdlib-codecs".to_string(),
+                inventory_path: None,
+            },
+            authority: NamespaceAuthority::SdkReserved,
+            namespace_claims: BTreeSet::new(),
+            available: true,
+            enabled: true,
+            manifest: Some(Arc::new(LibraryManifest::new("incan_stdlib_codecs", "0.5.0"))),
+            artifact: Some(LibraryArtifactMetadata::from_crate_root(
+                "incan_stdlib_codecs",
+                "incan_stdlib_codecs",
+                artifact_root,
+            )),
+            implementation_facets: Vec::new(),
+        }
     }
 
     fn record(

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -31,6 +31,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **SDK providers**: Compiled library artifacts now rebind SDK path dependencies to the active content-addressed provider cache, including copied support crates, so semantically identical components cannot enter one Cargo graph through conflicting cache roots (#911).
 - **Workspaces**: Rooted workspace library artifacts now retain the selected project's identity across Cargo package, Cargo library, and `.incnlib` metadata, while removing self-dependencies even with explicit output overrides so external consumers can compile the published package (#909).
 - **Workspaces**: Root library dependency preparation now targets exactly that project and leaves canonical lock publication to its parent command, preventing fresh rooted workspaces from recursively spawning `incan build --lib` until the machine is exhausted (#908).
 - **Workspaces**: Rooted-workspace entrypoints and tests now resolve through their deepest owning member, so selected member builds retain both direct and inherited Rust dependency versions (#907).


### PR DESCRIPTION
## Summary

Fix SDK provider cache collisions when compiled Incan libraries outlive or move away from the SDK cache root that originally produced them.

Compiled public libraries now project equivalent private SDK dependencies into a consumer-owned shadow artifact, rebind Cargo and `.incnlib` metadata to the active cache root, and reject semantically incompatible providers before invoking Cargo. Relative Cargo paths are rebased from the original artifact root to the shadow root, including deep rooted-workspace layouts and nested public-library graphs.

Closes #911.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: compiled libraries remain consumable after the equivalent SDK provider moves to a different immutable cache root; stale absolute or relative paths no longer produce Cargo package collisions or missing-path failures.
- **Internals**: provider planning validates logical package identity and Cargo feature/source contracts, then materializes versioned, atomic, consumer-owned shadow artifacts. Shadow identity includes all effective path projections, nested libraries are projected child-first, and v4 shadows normalize the narrowly validated legacy omission of `default-features = false`.
- **Risks**: dependency metadata projection affects lock, build, Rust inspection, and test-runner preparation. The implementation keeps original artifacts immutable, topology-gates SDK rebinding, preserves unrelated external paths, rejects ambiguous/incompatible providers, and invalidates shadows produced by older algorithms.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit`: 3,068/3,068 tests passed, Clippy passed, cargo-deny passed, release build passed, assertion canary passed, 60 examples checked / 35 run / 0 failed / 0 timed out, and 9/9 benchmark builds passed.
- Focused #911 suite: 11/11 passed on stable and Rust 1.93.0.
- Exact offline acceptance: built a library against SDK cache A, copied the semantically identical SDK artifact to active cache B, removed A entirely, then ran `incan lock` from a fresh consumer with no target. Cargo compiled SDK crates only from B; the projected Cargo manifest and `.incnlib` both referenced B, and no staging residue remained.
- Regression coverage includes deep shadow paths, absent old cache roots, nested libraries, stale shadow invalidation, concurrent materialization, legacy `default-features` normalization, incompatible-provider rejection, and preservation of unrelated external/internal paths.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): v0.5 release notes

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
