### PR TITLE
bugfix - stabilize Rust ABI trait fingerprints (#924)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "blake2",
  "blake3",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "serde",
  "serde_json",
@@ -1528,14 +1528,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "axum",
  "incan_core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.20"
+version = "0.5.0-dev.21"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/rust_inspect/src/extractor.rs
+++ b/crates/rust_inspect/src/extractor.rs
@@ -1,6 +1,6 @@
 //! Map rust-analyzer `hir` definitions into [`incan_core::interop::RustItemMetadata`].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use incan_core::interop::{
     RustFieldInfo, RustFunctionSig, RustImplementedTrait, RustItemKind, RustItemMetadata, RustMethodSig,
@@ -714,13 +714,38 @@ fn collect_inherent_methods(ty: Type<'_>, db: &RootDatabase, dt: DisplayTarget) 
     by_name.into_values().collect()
 }
 
-/// Collect non-blanket trait impls that rust-analyzer can associate directly with `ty`.
-fn collect_implemented_traits(ty: Type<'_>, db: &RootDatabase) -> Vec<RustImplementedTrait> {
+/// Collect the queried surface crate and every transitive crate dependency that can define its Rust API traits.
+fn crate_dependency_closure(surface_crate: Crate, db: &RootDatabase) -> HashSet<Crate> {
+    let mut closure = HashSet::new();
+    let mut pending = vec![surface_crate];
+    while let Some(krate) = pending.pop() {
+        if !closure.insert(krate) {
+            continue;
+        }
+        pending.extend(krate.dependencies(db).into_iter().map(|dependency| dependency.krate));
+    }
+    closure
+}
+
+/// Collect non-blanket trait impls whose traits belong to the queried Rust surface dependency closure.
+///
+/// `Impl::all_for_type` scans the entire loaded rust-analyzer graph. Rust's orphan rules allow a downstream crate to
+/// define its own trait and implement it for an imported type, but that trait is not part of the queried crate's API.
+/// Restricting the trait's defining crate preserves intrinsic dependency traits while excluding ambient downstream
+/// impls whose presence varies with workspace, cache, and host-platform graph shape.
+fn collect_implemented_traits(
+    ty: Type<'_>,
+    authorized_trait_crates: &HashSet<Crate>,
+    db: &RootDatabase,
+) -> Vec<RustImplementedTrait> {
     let mut traits = BTreeMap::new();
     for impl_def in Impl::all_for_type(db, ty) {
         let Some(trait_def) = impl_def.trait_(db) else {
             continue;
         };
+        if !authorized_trait_crates.contains(&trait_def.module(db).krate(db)) {
+            continue;
+        }
         let path = canonical_module_def_path(ModuleDef::Trait(trait_def), db)
             .unwrap_or_else(|| trait_def.name(db).as_str().to_owned());
         traits.insert(path.clone(), RustImplementedTrait { path });
@@ -974,6 +999,7 @@ fn extract_rust_item_inner(
     let krate =
         find_crate(workspace, crate_name).ok_or_else(|| RustMetadataError::CrateNotFound(crate_name.to_owned()))?;
     let dt = DisplayTarget::from_crate(db, krate.base());
+    let authorized_trait_crates = crate_dependency_closure(krate, db);
     let def = resolve_module_def(db, krate, &segments)?;
     let vis = map_visibility(def.visibility(db));
     let kind = match def {
@@ -985,7 +1011,7 @@ fn extract_rust_item_inner(
                 alias_target: None,
                 metadata_completeness: Default::default(),
                 methods: collect_inherent_methods(ty.clone(), db, dt),
-                implemented_traits: collect_implemented_traits(ty.clone(), db),
+                implemented_traits: collect_implemented_traits(ty.clone(), &authorized_trait_crates, db),
                 fields: collect_public_fields(ty.clone(), db, dt, crate_name),
                 variants: match adt {
                     Adt::Enum(enum_) => collect_enum_variant_payloads(enum_, ty, db, dt, crate_name),
@@ -999,7 +1025,7 @@ fn extract_rust_item_inner(
                 alias_target: None,
                 metadata_completeness: Default::default(),
                 methods: collect_inherent_methods(ty.clone(), db, dt),
-                implemented_traits: collect_implemented_traits(ty.clone(), db),
+                implemented_traits: collect_implemented_traits(ty.clone(), &authorized_trait_crates, db),
                 fields: collect_public_fields(ty, db, dt, crate_name),
                 variants: Vec::new(),
             })
@@ -1017,7 +1043,7 @@ fn extract_rust_item_inner(
                 alias_target: source_type_alias_target_display(a, db).or_else(|| Some(format_ty(&ty, db, dt))),
                 metadata_completeness: Default::default(),
                 methods: collect_inherent_methods(ty.clone(), db, dt),
-                implemented_traits: collect_implemented_traits(ty.clone(), db),
+                implemented_traits: collect_implemented_traits(ty.clone(), &authorized_trait_crates, db),
                 fields: collect_public_fields(ty, db, dt, crate_name),
                 variants: Vec::new(),
             })
@@ -1085,6 +1111,90 @@ impl Labelled for Thing {}
                 .any(|implemented| implemented.path == "demo_trait_probe::Labelled"),
             "expected direct Labelled impl in metadata, got {:?}",
             info.implemented_traits
+        );
+        Ok(())
+    }
+
+    /// Proves ambient downstream impl crates cannot change ADT or alias metadata for an upstream Rust surface.
+    #[test]
+    fn type_metadata_ignores_traits_from_loaded_downstream_crates() -> Result<(), Box<dyn std::error::Error>> {
+        // ---- Fixture: upstream API plus an unrelated loaded downstream impl ----
+        let tmp = tempfile::tempdir()?;
+        let trait_api = tmp.path().join("trait-api");
+        let surface_api = tmp.path().join("surface-api");
+        let downstream_api = tmp.path().join("downstream-api");
+        let clean_probe = tmp.path().join("clean-probe");
+        let polluted_probe = tmp.path().join("polluted-probe");
+        for root in [&trait_api, &surface_api, &downstream_api, &clean_probe, &polluted_probe] {
+            fs::create_dir_all(root.join("src"))?;
+        }
+
+        fs::write(
+            trait_api.join("Cargo.toml"),
+            "[package]\nname = \"trait_api\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )?;
+        fs::write(trait_api.join("src/lib.rs"), "pub trait Intrinsic {}\n")?;
+        fs::write(
+            surface_api.join("Cargo.toml"),
+            "[package]\nname = \"surface_api\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\ntrait_api = { path = \"../trait-api\" }\n",
+        )?;
+        fs::write(
+            surface_api.join("src/lib.rs"),
+            "pub struct Thing;\npub type ThingAlias = Thing;\n\nimpl trait_api::Intrinsic for Thing {}\n",
+        )?;
+        fs::write(
+            downstream_api.join("Cargo.toml"),
+            "[package]\nname = \"downstream_api\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nsurface_api = { path = \"../surface-api\" }\n",
+        )?;
+        fs::write(
+            downstream_api.join("src/lib.rs"),
+            "pub trait Ambient {}\n\nimpl Ambient for surface_api::Thing {}\n",
+        )?;
+        fs::write(
+            clean_probe.join("Cargo.toml"),
+            "[package]\nname = \"clean_probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nsurface_api = { path = \"../surface-api\" }\n",
+        )?;
+        fs::write(clean_probe.join("src/lib.rs"), "pub fn load_surface() {}\n")?;
+        fs::write(
+            polluted_probe.join("Cargo.toml"),
+            "[package]\nname = \"polluted_probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nsurface_api = { path = \"../surface-api\" }\ndownstream_api = { path = \"../downstream-api\" }\n",
+        )?;
+        fs::write(polluted_probe.join("src/lib.rs"), "pub fn load_graph() {}\n")?;
+
+        // ---- Extraction: compare the same surface under clean and polluted graphs ----
+        let clean_workspace = RustWorkspace::load(&clean_probe, &|_| ())?;
+        let clean = extract_rust_item(&clean_workspace, "surface_api::Thing")?;
+        let polluted_workspace = RustWorkspace::load(&polluted_probe, &|_| ())?;
+        let polluted = extract_rust_item(&polluted_workspace, "surface_api::Thing")?;
+        let RustItemKind::Type(info) = &polluted.kind else {
+            return Err(std::io::Error::other("expected type metadata").into());
+        };
+
+        // ---- Contract: retain intrinsic traits and reject ambient downstream traits ----
+        assert!(
+            info.implemented_traits
+                .iter()
+                .any(|implemented| implemented.path == "trait_api::Intrinsic"),
+            "expected intrinsic dependency trait in metadata, got {:?}",
+            info.implemented_traits
+        );
+        assert!(
+            info.implemented_traits
+                .iter()
+                .all(|implemented| implemented.path != "downstream_api::Ambient"),
+            "downstream-only trait leaked into metadata: {:?}",
+            info.implemented_traits
+        );
+        assert_eq!(
+            clean, polluted,
+            "loaded downstream crates must not change surface metadata"
+        );
+
+        let clean_alias = extract_rust_item(&clean_workspace, "surface_api::ThingAlias")?;
+        let polluted_alias = extract_rust_item(&polluted_workspace, "surface_api::ThingAlias")?;
+        assert_eq!(
+            clean_alias, polluted_alias,
+            "loaded downstream crates must not change type-alias metadata"
         );
         Ok(())
     }

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -3152,6 +3152,85 @@ impl ChildId {
         Ok(())
     }
 
+    /// Proves complete published ABI extraction is independent of unrelated downstream impl crates in the graph.
+    #[cfg(feature = "rust_inspect")]
+    #[test]
+    fn library_rust_abi_ignores_loaded_downstream_trait_impls_issue924() -> Result<(), Box<dyn std::error::Error>> {
+        // ---- Fixture: clean and downstream-loaded views of one Rust surface ----
+        let workspace = tempfile::tempdir()?;
+        let trait_api = workspace.path().join("trait-api");
+        let surface_api = workspace.path().join("surface-api");
+        let downstream_api = workspace.path().join("downstream-api");
+        let clean_probe = workspace.path().join("clean-probe");
+        let polluted_probe = workspace.path().join("polluted-probe");
+        for root in [&trait_api, &surface_api, &downstream_api, &clean_probe, &polluted_probe] {
+            fs::create_dir_all(root.join("src"))?;
+        }
+        fs::write(
+            trait_api.join("Cargo.toml"),
+            "[package]\nname = \"abi_trait_api\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )?;
+        fs::write(trait_api.join("src/lib.rs"), "pub trait Intrinsic {}\n")?;
+        fs::write(
+            surface_api.join("Cargo.toml"),
+            "[package]\nname = \"abi_surface_api\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nabi_trait_api = { path = \"../trait-api\" }\n",
+        )?;
+        fs::write(
+            surface_api.join("src/lib.rs"),
+            "pub struct Thing;\n\nimpl abi_trait_api::Intrinsic for Thing {}\n",
+        )?;
+        fs::write(
+            downstream_api.join("Cargo.toml"),
+            "[package]\nname = \"abi_downstream_api\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nabi_surface_api = { path = \"../surface-api\" }\n",
+        )?;
+        fs::write(
+            downstream_api.join("src/lib.rs"),
+            "pub trait Ambient {}\n\nimpl Ambient for abi_surface_api::Thing {}\n",
+        )?;
+        fs::write(
+            clean_probe.join("Cargo.toml"),
+            "[package]\nname = \"abi_clean_probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nabi_surface_api = { path = \"../surface-api\" }\n",
+        )?;
+        fs::write(clean_probe.join("src/lib.rs"), "pub fn load_surface() {}\n")?;
+        fs::write(
+            polluted_probe.join("Cargo.toml"),
+            "[package]\nname = \"abi_polluted_probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nabi_surface_api = { path = \"../surface-api\" }\nabi_downstream_api = { path = \"../downstream-api\" }\n",
+        )?;
+        fs::write(polluted_probe.join("src/lib.rs"), "pub fn load_graph() {}\n")?;
+
+        // ---- Publication: complete ABI must converge across both loaded graphs ----
+        let query_paths = vec!["abi_surface_api::Thing".to_string()];
+        let clean = collect_library_rust_abi(&clean_probe, &query_paths)?.ok_or("expected clean library Rust ABI")?;
+        let polluted =
+            collect_library_rust_abi(&polluted_probe, &query_paths)?.ok_or("expected polluted library Rust ABI")?;
+
+        assert_eq!(
+            clean, polluted,
+            "published library ABI must not depend on unrelated downstream impl crates"
+        );
+
+        // ---- Contract: preserve intrinsic traits and exclude downstream-only traits ----
+        let thing = polluted
+            .get("abi_surface_api::Thing")
+            .ok_or("expected Thing ABI item")?;
+        let incan_core::interop::RustItemKind::Type(thing_type) = &thing.kind else {
+            return Err("expected Thing ABI type metadata".into());
+        };
+        assert!(
+            thing_type
+                .implemented_traits
+                .iter()
+                .any(|implemented| implemented.path == "abi_trait_api::Intrinsic")
+        );
+        assert!(
+            thing_type
+                .implemented_traits
+                .iter()
+                .all(|implemented| implemented.path != "abi_downstream_api::Ambient")
+        );
+        Ok(())
+    }
+
     #[test]
     fn library_entrypoint_precondition_fails_when_missing() -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -34,6 +34,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: Published Rust ABI metadata now excludes traits introduced only by unrelated downstream crates in the loaded inspection graph, keeping SDK provider identities and workspace dependency fingerprints stable across cache state and host platforms (#924).
 - **Tooling**: Canonical lock publication now keeps its persistent cross-process guard under ignored compiler target state instead of leaving `.incan.lock.incan.lock` in the project root (#912).
 - **SDK providers**: Official stdlib component packages now preserve their source-owned Apache-2.0 license in generated Cargo metadata, so downstream dependency audits no longer classify synthesized provider crates as unlicensed (#920).
 - **Stdlib**: Cold SDK preparation now copies borrowed regex matches and capture names into owned `std.regex` values instead of calling an unavailable `&str.to_string()` method (#918).


### PR DESCRIPTION
## Summary

Fixes published Rust ABI metadata so unrelated downstream trait implementations cannot change SDK provider identities or workspace dependency fingerprints across cache and host graph shapes.

`rust-analyzer` exposes every loaded impl for a type. The extractor now authorizes traits only when their defining crate belongs to the queried surface crate's transitive dependency closure. This preserves intrinsic traits while excluding traits introduced solely by unrelated downstream crates.

Closes #924.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: identical source and dependency resolution now produce stable SDK provider identities and workspace `deps-fingerprint` values even when unrelated Rust crates are loaded.
- **Internals**: Rust ABI trait extraction computes the queried crate's transitive crate-dependency closure once per query and filters `Impl::all_for_type` results by the trait's defining crate.
- **Risks**: traits defined only in downstream consumer crates no longer appear in an upstream library's published ABI. Dependency-owned traits remain covered by focused regressions.
- **Release identity**: allocates `0.5.0-dev.21` after merged PR #866 allocated dev.20.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Final dev.21 stable extractor regression: 1/1 passed.
- Final dev.21 stable complete-library ABI publication regression: 1/1 passed.
- Rust 1.93.0, isolated target: both focused regressions passed 1/1.
- Final dev.21 `make fmt`, changed-rustdoc gate, `git diff --check`, and `make lint-fast-ci`: passed.
- Production-equivalent pre-rebase candidate `make pre-commit`: 3,120/3,120 tests passed; Clippy, cargo-deny, assertion canary, web/nested builds, 60 examples, and 9 benchmark builds passed.
- Fresh detached Hees `fb3bbb1` checkout with an empty provider home and `CARGO_NET_OFFLINE=true`: `incan lock` -> locked `hees_ai` library build -> unchanged relock -> second locked build all passed.
- The final Hees lock remained byte-identical across relock: `2da325e386468ff40e36751021121cada6048d2b690cb1a50ad0a13660a58914`; dependency fingerprint `sha256:4809c452bfbd6a67ea53861ce09d3ed9a73ac5d4c4f9ded01357cd1dc1a999e5`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): v0.5 release notes

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
