### PR TITLE
fix - stabilize provider lock identity across platforms (#931)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "blake2",
  "blake3",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "serde",
  "serde_json",
@@ -1528,14 +1528,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "axum",
  "incan_core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.21"
+version = "0.5.0-dev.22"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -39,7 +39,7 @@ use crate::library_manifest::LibraryRustAbi;
 use crate::library_manifest::{
     CompiledProviderMetadata, LibraryManifest, ProviderCargoDependency, ProviderCargoDependencySource,
     ProviderDependencyKind, ProviderDependencyMetadata, ProviderFactKind, ProviderFactRequirement,
-    ProviderImplementationFacet, ProviderModuleClaim, digest_provider_artifact,
+    ProviderImplementationFacet, ProviderModuleClaim, digest_provider_artifact, digest_provider_source_inputs,
 };
 use crate::lockfile::{CargoFeatureSelection, semantic_lock_state};
 use crate::manifest::{DependencySource, DependencySpec, ProjectManifest};
@@ -1914,7 +1914,30 @@ fn compiled_provider_metadata(
     let provider_dependencies =
         compiled_provider_dependencies(feature_plan, library_manifest_index, provider_plan, artifact_root)?;
     let implementation_facets = provider_implementation_facets(&namespace_claims);
+    let semantic_source_inputs = modules
+        .iter()
+        .filter(|module| !module_is_owned_by_dependency_provider(provider_plan, &module.path_segments))
+        .map(|module| {
+            let label = if module.path_segments.is_empty() {
+                "<root>".to_string()
+            } else {
+                module.path_segments.join(".")
+            };
+            (label, module.file_path.clone())
+        })
+        .collect::<Vec<_>>();
+    let trusted_source_roots = crate::toolchain_layout::find_stdlib_source_dir()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let semantic_source_digest = digest_provider_source_inputs(
+        manifest.project_root(),
+        manifest.path(),
+        &semantic_source_inputs,
+        &trusted_source_roots,
+    )
+    .map_err(|error| CliError::failure(format!("failed to fingerprint authored provider inputs: {error}")))?;
     Ok(CompiledProviderMetadata {
+        semantic_source_digest: Some(semantic_source_digest),
         namespace_claims,
         public_features,
         active_features: root_features.active_features.clone(),

--- a/src/library_manifest/artifact.rs
+++ b/src/library_manifest/artifact.rs
@@ -24,6 +24,12 @@ pub enum ProviderArtifactDigestError {
     /// Published provider artifacts may not depend on symlinks or other special filesystem entries.
     #[error("provider artifact path {path} is not a regular file or directory")]
     UnsupportedEntry { path: PathBuf },
+    /// An authored provider input is missing or is not a regular file.
+    #[error("provider source input {path} is not a regular file")]
+    InvalidSourceInput { path: PathBuf },
+    /// An authored source resolved outside both its package and compiler-owned shared source roots.
+    #[error("provider source input {path} is outside its package and trusted toolchain source roots")]
+    OutsideSourceRoots { path: PathBuf },
     /// A checked delivery coordinate could not be normalized into the semantic identity projection.
     #[error("failed to normalize provider artifact path {path}: {message}")]
     Normalization { path: PathBuf, message: String },
@@ -43,6 +49,96 @@ pub fn digest_provider_artifact(root: &Path) -> Result<String, ProviderArtifactD
     let mut hasher = Sha256::new();
     hasher.update(b"incan-provider-artifact-v1\0");
     hash_directory(root, root, &mut hasher)?;
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+/// Hash the authored manifest and logically named Incan source modules that define one compiled provider's semantics.
+///
+/// The resulting identity deliberately precedes generated Rust and host-derived ABI extraction. Canonical locks use
+/// it to compare equivalent native builds, while [`digest_provider_artifact`] remains the byte-exact integrity check
+/// for each physical artifact. Logical module labels keep shared toolchain source outside the package directory
+/// relocation-stable without excluding it from the semantic identity.
+pub(crate) fn digest_provider_source_inputs(
+    project_root: &Path,
+    manifest_path: &Path,
+    source_inputs: &[(String, PathBuf)],
+    trusted_source_roots: &[PathBuf],
+) -> Result<String, ProviderArtifactDigestError> {
+    if !project_root.is_dir() {
+        return Err(ProviderArtifactDigestError::InvalidRoot {
+            path: project_root.to_path_buf(),
+        });
+    }
+    let resolve = |path: &Path| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            project_root.join(path)
+        }
+    };
+    let canonical_project_root = fs::canonicalize(project_root).map_err(|source| ProviderArtifactDigestError::Io {
+        path: project_root.to_path_buf(),
+        source,
+    })?;
+    let mut allowed_source_roots = vec![canonical_project_root.clone()];
+    for root in trusted_source_roots {
+        if !root.is_dir() {
+            return Err(ProviderArtifactDigestError::InvalidRoot { path: root.clone() });
+        }
+        let canonical = fs::canonicalize(root).map_err(|source| ProviderArtifactDigestError::Io {
+            path: root.clone(),
+            source,
+        })?;
+        if !allowed_source_roots.contains(&canonical) {
+            allowed_source_roots.push(canonical);
+        }
+    }
+    let canonical_source_file = |path: PathBuf| {
+        let metadata = fs::symlink_metadata(&path).map_err(|source| {
+            if source.kind() == std::io::ErrorKind::NotFound {
+                ProviderArtifactDigestError::InvalidSourceInput { path: path.clone() }
+            } else {
+                ProviderArtifactDigestError::Io {
+                    path: path.clone(),
+                    source,
+                }
+            }
+        })?;
+        if !metadata.file_type().is_file() {
+            return Err(ProviderArtifactDigestError::InvalidSourceInput { path });
+        }
+        fs::canonicalize(&path).map_err(|source| ProviderArtifactDigestError::Io { path, source })
+    };
+    let manifest_path = canonical_source_file(resolve(manifest_path))?;
+    let manifest_label = manifest_path
+        .strip_prefix(&canonical_project_root)
+        .map_err(|_| ProviderArtifactDigestError::OutsideRoot {
+            path: manifest_path.clone(),
+            root: canonical_project_root.clone(),
+        })?
+        .to_string_lossy()
+        .replace('\\', "/");
+    let mut inputs = BTreeMap::from([(format!("manifest:{manifest_label}"), manifest_path)]);
+    for (module_label, path) in source_inputs {
+        let path = canonical_source_file(resolve(path))?;
+        if !allowed_source_roots.iter().any(|root| path.starts_with(root)) {
+            return Err(ProviderArtifactDigestError::OutsideSourceRoots { path });
+        }
+        let label = format!("module:{module_label}");
+        if module_label.is_empty() || inputs.insert(label.clone(), path.clone()).is_some() {
+            return Err(ProviderArtifactDigestError::Normalization {
+                path,
+                message: format!("provider source input has invalid or duplicate logical label `{label}`"),
+            });
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"incan-provider-source-inputs-v1\0");
+    for (relative, path) in inputs {
+        let bytes = fs::read(&path).map_err(|source| ProviderArtifactDigestError::Io { path, source })?;
+        hash_named_bytes(&mut hasher, &relative, &bytes);
+    }
     Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
 }
 
@@ -510,12 +606,12 @@ fn hash_named_bytes(hasher: &mut Sha256, name: &str, bytes: &[u8]) {
     hasher.update([0xff]);
 }
 
-/// Hash one generated provider artifact while excluding checked provider delivery coordinates from its lock identity.
+/// Hash one generated provider artifact through its source-owned semantic lock projection.
 ///
 /// The ordinary artifact digest remains the byte-exact integrity contract frozen into compiled provider edges. This
-/// projection is narrower: it is used only for semantic lock identity, where an equivalent provider graph rebuilt
-/// beneath another compiler-owned cache root must remain the same provider. Only paths already paired with an exact
-/// provider name, version, artifact digest, and feature projection in the checked `.incnlib` metadata are normalized.
+/// projection is narrower: new artifacts bind authored source inputs to their normalized checked contract and Cargo
+/// requirements, so equivalent providers rebuilt beneath another cache root or on another host remain the same.
+/// Legacy artifacts without an authored source digest retain the v1 byte-derived projection for compatibility.
 #[cfg(test)]
 fn digest_provider_semantic_artifact(
     root: &Path,
@@ -708,6 +804,16 @@ fn digest_provider_semantic_artifact_inner(
             expected_artifact_root: Some(dependency.artifact_root.clone()),
         });
     }
+    let has_semantic_source_digest = normalized_manifest
+        .contract_metadata
+        .provider
+        .semantic_source_digest
+        .is_some();
+    if has_semantic_source_digest {
+        // Rust ABI extraction is required physical consumer metadata, but its host analyzer graph is not the authored
+        // provider identity. The source digest plus normalized contract and Cargo requirements own that identity.
+        normalized_manifest.rust_abi = None;
+    }
     let normalized_manifest_bytes = serde_json::to_vec(&RawLibraryManifest::from_semantic(&normalized_manifest))
         .map_err(|error| ProviderArtifactDigestError::Normalization {
             path: manifest_path.to_path_buf(),
@@ -724,15 +830,22 @@ fn digest_provider_semantic_artifact_inner(
         &toolchain_dependencies,
     )?;
 
-    let normalization = SemanticArtifactNormalization {
-        manifest_path,
-        cargo_toml_path,
-        normalized_manifest_bytes: &normalized_manifest_bytes,
-        normalized_cargo_bytes: &normalized_cargo_bytes,
-    };
     let mut hasher = Sha256::new();
-    hasher.update(b"incan-provider-semantic-artifact-v1\0");
-    hash_directory_with_normalization(root, root, &mut hasher, Some(&normalization), false)?;
+    if let Some(source_digest) = &normalized_manifest.contract_metadata.provider.semantic_source_digest {
+        hasher.update(b"incan-provider-semantic-artifact-v2\0");
+        hash_named_bytes(&mut hasher, "authored-source", source_digest.as_bytes());
+        hash_named_bytes(&mut hasher, "provider-manifest", &normalized_manifest_bytes);
+        hash_named_bytes(&mut hasher, "Cargo.toml", &normalized_cargo_bytes);
+    } else {
+        let normalization = SemanticArtifactNormalization {
+            manifest_path,
+            cargo_toml_path,
+            normalized_manifest_bytes: &normalized_manifest_bytes,
+            normalized_cargo_bytes: &normalized_cargo_bytes,
+        };
+        hasher.update(b"incan-provider-semantic-artifact-v1\0");
+        hash_directory_with_normalization(root, root, &mut hasher, Some(&normalization), false)?;
+    }
     context.visiting.remove(&normalized_root);
     let digest = format!("sha256:{}", hex::encode(hasher.finalize()));
     context.resolved_artifacts.insert(normalized_root, digest.clone());
@@ -1013,6 +1126,186 @@ mod tests {
         fs::create_dir_all(artifact.path().join("target/debug"))?;
         fs::write(artifact.path().join("target/debug/cache"), "mutable")?;
         assert_eq!(source_changed, digest_provider_artifact(artifact.path())?);
+        Ok(())
+    }
+
+    #[test]
+    fn authored_provider_source_digest_is_relocation_stable_and_tracks_inputs_issue931() -> TestResult {
+        let first = tempfile::tempdir()?;
+        let second = tempfile::tempdir()?;
+        for workspace in [first.path(), second.path()] {
+            let root = workspace.join("component");
+            fs::create_dir_all(root.join("src"))?;
+            fs::create_dir_all(workspace.join("shared"))?;
+            fs::write(
+                root.join("incan.toml"),
+                "[project]\nname = \"provider\"\nversion = \"0.1.0\"\n",
+            )?;
+            fs::write(root.join("src/lib.incn"), "pub def value() -> int:\n    return 1\n")?;
+            fs::write(
+                workspace.join("shared/item.incn"),
+                "pub const LABEL: str = \"stable\"\n",
+            )?;
+        }
+        let source_inputs = |workspace: &Path| {
+            vec![
+                ("<root>".to_string(), workspace.join("component/src/lib.incn")),
+                ("shared.item".to_string(), workspace.join("shared/item.incn")),
+            ]
+        };
+        let first_root = first.path().join("component");
+        let second_root = second.path().join("component");
+        let first_digest = digest_provider_source_inputs(
+            &first_root,
+            &first_root.join("incan.toml"),
+            &source_inputs(first.path()),
+            &[first.path().join("shared")],
+        )?;
+        let second_digest = digest_provider_source_inputs(
+            &second_root,
+            &second_root.join("incan.toml"),
+            &source_inputs(second.path()),
+            &[second.path().join("shared")],
+        )?;
+        assert_eq!(first_digest, second_digest);
+
+        fs::write(
+            second.path().join("shared/item.incn"),
+            "pub const LABEL: str = \"changed\"\n",
+        )?;
+        assert_ne!(
+            first_digest,
+            digest_provider_source_inputs(
+                &second_root,
+                &second_root.join("incan.toml"),
+                &source_inputs(second.path()),
+                &[second.path().join("shared")],
+            )?
+        );
+
+        let outside = second.path().join("untrusted.incn");
+        fs::write(&outside, "pub const LABEL: str = \"outside\"\n")?;
+        let error = digest_provider_source_inputs(
+            &second_root,
+            &second_root.join("incan.toml"),
+            &[("outside".to_string(), outside)],
+            &[],
+        )
+        .err()
+        .ok_or("expected untrusted outside-root source input to fail")?;
+        assert!(matches!(error, ProviderArtifactDigestError::OutsideSourceRoots { .. }));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authored_provider_source_digest_rejects_symlink_inputs_issue931() -> TestResult {
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir()?;
+        let root = workspace.path().join("component");
+        fs::create_dir_all(root.join("src"))?;
+        fs::write(root.join("incan.toml"), "[project]\nname = \"provider\"\n")?;
+        fs::write(root.join("src/real.incn"), "pub const LABEL: str = \"real\"\n")?;
+        symlink(root.join("src/real.incn"), root.join("src/link.incn"))?;
+
+        let error = digest_provider_source_inputs(
+            &root,
+            &root.join("incan.toml"),
+            &[("link".to_string(), root.join("src/link.incn"))],
+            &[],
+        )
+        .err()
+        .ok_or("expected symlinked provider source input to fail")?;
+        assert!(matches!(error, ProviderArtifactDigestError::InvalidSourceInput { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_digest_uses_authored_inputs_not_host_generated_outputs_issue931() -> TestResult {
+        let first = tempfile::tempdir()?;
+        let second = tempfile::tempdir()?;
+        let make_artifact = |root: &Path, generated: &str, host_abi: bool, user_path: &str| -> TestResult {
+            fs::create_dir_all(root.join("src"))?;
+            fs::write(root.join("src/lib.rs"), generated)?;
+            fs::write(
+                root.join("Cargo.toml"),
+                format!(
+                    "[package]\nname = \"provider\"\nversion = \"0.1.0\"\n\n[dependencies.user_path]\npath = \"{user_path}\"\n"
+                ),
+            )?;
+            let mut manifest = LibraryManifest::new("provider", "0.1.0");
+            manifest.contract_metadata.provider.semantic_source_digest = Some(format!("sha256:{}", "a".repeat(64)));
+            if host_abi {
+                manifest.rust_abi = Some(super::super::LibraryRustAbi {
+                    schema_version: super::super::RUST_ABI_SCHEMA_VERSION,
+                    items: Vec::new(),
+                });
+            }
+            manifest.write_to_path(&root.join("provider.incnlib"))?;
+            Ok(())
+        };
+        make_artifact(
+            first.path(),
+            "pub fn platform_value() -> &'static str { \"macos\" }\n",
+            false,
+            "../user-dependency",
+        )?;
+        make_artifact(
+            second.path(),
+            "pub fn platform_value() -> &'static str { \"linux\" }\n",
+            true,
+            "../user-dependency",
+        )?;
+        let semantic = |root: &Path| -> Result<String, Box<dyn std::error::Error>> {
+            let manifest = LibraryManifest::read_from_path(&root.join("provider.incnlib"))?;
+            Ok(digest_provider_semantic_artifact(
+                root,
+                &root.join("provider.incnlib"),
+                &root.join("Cargo.toml"),
+                &manifest,
+            )?)
+        };
+
+        assert_ne!(
+            digest_provider_artifact(first.path())?,
+            digest_provider_artifact(second.path())?
+        );
+        let stable = semantic(first.path())?;
+        assert_eq!(stable, semantic(second.path())?);
+
+        let mut changed_source = LibraryManifest::read_from_path(&second.path().join("provider.incnlib"))?;
+        changed_source.contract_metadata.provider.semantic_source_digest = Some(format!("sha256:{}", "b".repeat(64)));
+        changed_source.write_to_path(&second.path().join("provider.incnlib"))?;
+        assert_ne!(stable, semantic(second.path())?);
+
+        changed_source.contract_metadata.provider.semantic_source_digest = Some(format!("sha256:{}", "a".repeat(64)));
+        changed_source
+            .contract_metadata
+            .provider
+            .namespace_claims
+            .push(super::super::ProviderModuleClaim {
+                module_path: vec!["changed_contract".to_string()],
+                required_features: BTreeSet::new(),
+            });
+        changed_source.write_to_path(&second.path().join("provider.incnlib"))?;
+        assert_ne!(stable, semantic(second.path())?);
+
+        changed_source.contract_metadata.provider.namespace_claims.clear();
+        changed_source.contract_metadata.provider.public_features.insert(
+            "changed_feature".to_string(),
+            super::super::ProviderFeatureMetadata::default(),
+        );
+        changed_source.write_to_path(&second.path().join("provider.incnlib"))?;
+        assert_ne!(stable, semantic(second.path())?);
+
+        changed_source.contract_metadata.provider.public_features.clear();
+        changed_source.write_to_path(&second.path().join("provider.incnlib"))?;
+        fs::write(
+            second.path().join("Cargo.toml"),
+            "[package]\nname = \"provider\"\nversion = \"0.1.0\"\n\n[dependencies.user_path]\npath = \"../different-user-dependency\"\n",
+        )?;
+        assert_ne!(stable, semantic(second.path())?);
         Ok(())
     }
 

--- a/src/library_manifest/mod.rs
+++ b/src/library_manifest/mod.rs
@@ -18,7 +18,7 @@ use incan_vocab::{
 pub use artifact::{ProviderArtifactDigestError, digest_provider_artifact};
 pub(crate) use artifact::{
     ProviderSemanticToolchainDependency, digest_provider_semantic_artifact_with_context_and_cache,
-    digest_toolchain_source_tree_with_cache,
+    digest_provider_source_inputs, digest_toolchain_source_tree_with_cache,
 };
 pub use model::*;
 pub use type_refs::resolved_type_from_manifest_type_ref;

--- a/src/library_manifest/model.rs
+++ b/src/library_manifest/model.rs
@@ -189,6 +189,12 @@ pub struct CompiledProviderMetadata {
     /// Version of this provider metadata payload.
     #[serde(default = "default_compiled_provider_metadata_schema_version")]
     pub schema_version: u32,
+    /// Stable digest of the provider's authored manifest and Incan source inputs.
+    ///
+    /// Physical generated Rust and extracted host ABI metadata remain protected by the artifact digest, while this
+    /// source-owned identity lets canonical locks compare equivalent native provider builds across platforms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_source_digest: Option<String>,
     /// Provider-local module claims before the consumer's authorized namespace prefix is applied.
     #[serde(default)]
     pub namespace_claims: Vec<ProviderModuleClaim>,
@@ -216,6 +222,7 @@ impl Default for CompiledProviderMetadata {
     fn default() -> Self {
         Self {
             schema_version: COMPILED_PROVIDER_METADATA_SCHEMA_VERSION,
+            semantic_source_digest: None,
             namespace_claims: Vec::new(),
             public_features: BTreeMap::new(),
             active_features: BTreeSet::new(),
@@ -230,7 +237,8 @@ impl Default for CompiledProviderMetadata {
 impl CompiledProviderMetadata {
     /// Return whether the manifest has no provider facts beyond the default schema discriminator.
     pub fn is_empty(&self) -> bool {
-        self.namespace_claims.is_empty()
+        self.semantic_source_digest.is_none()
+            && self.namespace_claims.is_empty()
             && self.public_features.is_empty()
             && self.active_features.is_empty()
             && self.provider_dependencies.is_empty()

--- a/src/library_manifest/tests.rs
+++ b/src/library_manifest/tests.rs
@@ -1336,6 +1336,7 @@ fn manifest_reader_rejects_unknown_manifest_format() -> Result<(), Box<dyn std::
 fn compiled_provider_metadata_roundtrips_feature_and_facet_facts() -> Result<(), Box<dyn std::error::Error>> {
     let mut manifest = LibraryManifest::new("reporting", "0.5.0");
     manifest.contract_metadata.provider = CompiledProviderMetadata {
+        semantic_source_digest: Some(format!("sha256:{}", "b".repeat(64))),
         namespace_claims: vec![ProviderModuleClaim {
             module_path: vec!["reports".to_string()],
             required_features: BTreeSet::new(),
@@ -1387,6 +1388,20 @@ fn compiled_provider_metadata_roundtrips_feature_and_facet_facts() -> Result<(),
     let loaded = LibraryManifest::read_from_path(&path)?;
 
     assert_eq!(loaded.contract_metadata.provider, manifest.contract_metadata.provider);
+    Ok(())
+}
+
+#[test]
+fn compiled_provider_metadata_rejects_invalid_semantic_source_digest() -> Result<(), Box<dyn std::error::Error>> {
+    let mut manifest = LibraryManifest::new("reporting", "0.5.0");
+    manifest.contract_metadata.provider.semantic_source_digest = Some("sha256:not-a-digest".to_string());
+    let dir = tempfile::tempdir()?;
+    let error = manifest
+        .write_to_path(&dir.path().join("reporting.incnlib"))
+        .err()
+        .ok_or("expected invalid provider semantic source digest to fail")?;
+
+    assert!(matches!(error, LibraryManifestError::Invalid(message) if message.contains("provider semantic source")));
     Ok(())
 }
 

--- a/src/library_manifest/validation.rs
+++ b/src/library_manifest/validation.rs
@@ -149,6 +149,9 @@ fn validate_compiled_provider_metadata(metadata: &CompiledProviderMetadata) -> R
             metadata.schema_version, COMPILED_PROVIDER_METADATA_SCHEMA_VERSION
         )));
     }
+    if let Some(digest) = &metadata.semantic_source_digest {
+        validate_sha256_digest("provider semantic source", digest)?;
+    }
     for feature in metadata.public_features.keys() {
         validate_provider_identifier("public feature", feature)?;
     }
@@ -290,14 +293,19 @@ fn validate_compiled_provider_metadata(metadata: &CompiledProviderMetadata) -> R
 
 /// Validate the exact SHA-256 identity emitted by the compiled-provider artifact hasher.
 fn validate_provider_artifact_digest(dependency_key: &str, digest: &str) -> Result<(), LibraryManifestError> {
+    validate_sha256_digest(&format!("provider dependency `{dependency_key}` artifact"), digest)
+}
+
+/// Validate one exact SHA-256 identity with a caller-owned diagnostic label.
+fn validate_sha256_digest(label: &str, digest: &str) -> Result<(), LibraryManifestError> {
     let Some(hex) = digest.strip_prefix("sha256:") else {
         return Err(LibraryManifestError::Invalid(format!(
-            "provider dependency `{dependency_key}` artifact digest must start with `sha256:`"
+            "{label} digest must start with `sha256:`"
         )));
     };
     if hex.len() != 64 || !hex.chars().all(|character| character.is_ascii_hexdigit()) {
         return Err(LibraryManifestError::Invalid(format!(
-            "provider dependency `{dependency_key}` artifact digest must contain 64 hexadecimal characters"
+            "{label} digest must contain 64 hexadecimal characters"
         )));
     }
     Ok(())

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1404,6 +1404,16 @@ mod tests {
     fn production_toolchain_semantic_fixture(
         checkout: &Path,
     ) -> Result<ProductionToolchainSemanticFixture, Box<dyn std::error::Error>> {
+        production_toolchain_semantic_fixture_with_native_output(checkout, "pub fn support() {}\n", false, 'a')
+    }
+
+    /// Build one SDK fixture whose physical provider output can vary independently of its authored semantic input.
+    fn production_toolchain_semantic_fixture_with_native_output(
+        checkout: &Path,
+        generated_source: &str,
+        host_abi: bool,
+        source_digest_digit: char,
+    ) -> Result<ProductionToolchainSemanticFixture, Box<dyn std::error::Error>> {
         let derive_root = checkout.join("crates/incan_derive");
         fs::create_dir_all(derive_root.join("src"))?;
         fs::write(
@@ -1421,9 +1431,17 @@ mod tests {
                 derive_root.display()
             ),
         )?;
-        fs::write(provider_root.join("src/lib.rs"), "pub fn support() {}\n")?;
+        fs::write(provider_root.join("src/lib.rs"), generated_source)?;
         let manifest_path = provider_root.join("support_provider.incnlib");
         let mut manifest = crate::library_manifest::LibraryManifest::new("support_provider", "0.5.0");
+        manifest.contract_metadata.provider.semantic_source_digest =
+            Some(format!("sha256:{}", source_digest_digit.to_string().repeat(64)));
+        if host_abi {
+            manifest.rust_abi = Some(crate::library_manifest::LibraryRustAbi {
+                schema_version: crate::library_manifest::RUST_ABI_SCHEMA_VERSION,
+                items: Vec::new(),
+            });
+        }
         manifest.contract_metadata.provider.implementation_facets.push(
             crate::library_manifest::ProviderImplementationFacet {
                 id: "derive-support".to_string(),
@@ -1743,6 +1761,107 @@ mod tests {
             &second_specs,
         );
         assert_ne!(second_fingerprint, changed_fingerprint);
+        Ok(())
+    }
+
+    #[test]
+    fn sdk_semantic_state_and_fingerprint_ignore_native_provider_outputs_issue931() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let first_checkout = temp.path().join("macos-source");
+        let second_checkout = temp.path().join("linux-source");
+        let first = production_toolchain_semantic_fixture_with_native_output(
+            &first_checkout,
+            "pub fn host_marker() -> &'static str { \"macos\" }\n",
+            false,
+            'a',
+        )?;
+        let second = production_toolchain_semantic_fixture_with_native_output(
+            &second_checkout,
+            "pub fn host_marker() -> &'static str { \"linux\" }\n",
+            true,
+            'a',
+        )?;
+        let first_physical = first
+            .inventory
+            .components
+            .get("support")
+            .and_then(|component| component.providers.first())
+            .ok_or("first fixture did not publish the support provider")?;
+        let second_physical = second
+            .inventory
+            .components
+            .get("support")
+            .and_then(|component| component.providers.first())
+            .ok_or("second fixture did not publish the support provider")?;
+        assert_ne!(
+            first_physical.digest, second_physical.digest,
+            "the regression requires distinct physical native artifacts"
+        );
+
+        let first_semantic = semantic_lock_state(
+            &first_checkout,
+            Some(&first.inventory),
+            Some(&first.components),
+            None,
+            &first.provider_plan,
+            &first.specs,
+        )?;
+        let second_semantic = semantic_lock_state(
+            &second_checkout,
+            Some(&second.inventory),
+            Some(&second.components),
+            None,
+            &second.provider_plan,
+            &second.specs,
+        )?;
+        assert_eq!(first_semantic, second_semantic);
+        assert_eq!(first_semantic.sdk, second_semantic.sdk);
+
+        let selection = CargoFeatureSelection::default();
+        let first_fingerprint = compute_resolved_fingerprint_with_sdk_paths(
+            &first.specs,
+            &[],
+            &selection,
+            Some(&first_checkout),
+            &first_semantic,
+            &first.specs,
+        );
+        let second_fingerprint = compute_resolved_fingerprint_with_sdk_paths(
+            &second.specs,
+            &[],
+            &selection,
+            Some(&second_checkout),
+            &second_semantic,
+            &second.specs,
+        );
+        assert_eq!(first_fingerprint, second_fingerprint);
+
+        let changed = production_toolchain_semantic_fixture_with_native_output(
+            &temp.path().join("changed-source"),
+            "pub fn host_marker() -> &'static str { \"linux\" }\n",
+            true,
+            'b',
+        )?;
+        let changed_semantic = semantic_lock_state(
+            &temp.path().join("changed-source"),
+            Some(&changed.inventory),
+            Some(&changed.components),
+            None,
+            &changed.provider_plan,
+            &changed.specs,
+        )?;
+        assert_ne!(second_semantic, changed_semantic);
+        assert_ne!(
+            second_fingerprint,
+            compute_resolved_fingerprint_with_sdk_paths(
+                &changed.specs,
+                &[],
+                &selection,
+                Some(&temp.path().join("changed-source")),
+                &changed_semantic,
+                &changed.specs,
+            )
+        );
         Ok(())
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1531,6 +1531,103 @@ regex = "1"
 }
 
 #[test]
+fn cold_rooted_workspace_lock_publishes_and_strict_library_build_agrees_issue931()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = tempfile::tempdir()?;
+    fs::create_dir_all(root.path().join("src"))?;
+    fs::write(
+        root.path().join("incan.toml"),
+        r#"[project]
+name = "hees_ai"
+version = "0.0.1"
+
+[project.scripts]
+library = "src/lib.incn"
+
+[workspace]
+members = ["consumer"]
+default-members = ["hees_ai", "consumer"]
+
+[workspace.dependencies]
+hees_ai = { path = "." }
+"#,
+    )?;
+    fs::write(
+        root.path().join("src/lib.incn"),
+        "from std.json import JsonValue\n\n\npub def answer() -> int:\n  return 42\n",
+    )?;
+
+    let consumer = root.path().join("consumer");
+    fs::create_dir_all(consumer.join("src"))?;
+    fs::write(
+        consumer.join("incan.toml"),
+        r#"[project]
+name = "hees_consumer"
+version = "0.0.1"
+
+[project.scripts]
+main = "src/main.incn"
+
+[dependencies]
+hees_ai = { workspace = true }
+"#,
+    )?;
+    fs::write(
+        consumer.join("src/main.incn"),
+        "from pub::hees_ai import answer\n\n\ndef main() -> None:\n  println(answer())\n",
+    )?;
+
+    let source_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let stdlib = source_root.join("crates/incan_stdlib/stdlib");
+    let toolchain_crates = source_root.join("crates");
+    let incan_home = root.path().join(".incan-home");
+    let provider_store = incan_home.join("cache/providers/sdk-v2");
+    let generated_target = incan_home.join("generated-target");
+    let run = |args: &[&str]| -> Result<Output, Box<dyn std::error::Error>> {
+        Ok(Command::new(incan_binary())
+            .args(args)
+            .current_dir(root.path())
+            .env("CARGO_NET_OFFLINE", "true")
+            .env("INCAN_NO_BANNER", "1")
+            .env("INCAN_LOCK_PREHEAT", "1")
+            .env("INCAN_SOURCE_ROOT", source_root)
+            .env("INCAN_STDLIB", &stdlib)
+            .env("INCAN_STDLIB_DIR", &stdlib)
+            .env("INCAN_TOOLCHAIN_CRATES_DIR", &toolchain_crates)
+            .env("INCAN_HOME", &incan_home)
+            .env("INCAN_INTERNAL_SDK_PROVIDER_STORE", &provider_store)
+            .env("INCAN_GENERATED_CARGO_TARGET_DIR", &generated_target)
+            .output()?)
+    };
+
+    assert!(!root.path().join("target").exists());
+    assert!(!incan_home.exists());
+    assert!(!root.path().join("incan.lock").exists());
+
+    let first_lock_output = run(&["lock"])?;
+    assert_success(&first_lock_output, "cold rooted workspace lock publication");
+    let lock_path = root.path().join("incan.lock");
+    let first_lock = fs::read(&lock_path)?;
+    let parsed = incan::lockfile::IncanLock::load(&lock_path)?;
+    assert!(!parsed.deps_fingerprint.is_empty());
+    assert!(root.path().join("target/lib/hees_ai.incnlib").is_file());
+    assert!(incan_home.is_dir());
+
+    let second_lock_output = run(&["lock"])?;
+    assert_success(&second_lock_output, "cold rooted workspace lock fixed point");
+    assert_eq!(first_lock, fs::read(&lock_path)?);
+
+    let build_output = run(&["build", "--lib", "--member", "hees_ai"])?;
+    assert_success(&build_output, "rooted workspace library build after lock publication");
+    assert_eq!(first_lock, fs::read(&lock_path)?);
+
+    let strict_output = run(&["build", "--lib", "--member", "hees_ai", "--locked"])?;
+    assert_success(&strict_output, "strict rooted workspace library build");
+    assert_eq!(first_lock, fs::read(&lock_path)?);
+    Ok(())
+}
+
+#[test]
 fn locked_build_synthesizes_unreferenced_selected_workspace_member_cargo_root() -> Result<(), Box<dyn std::error::Error>>
 {
     let root = tempfile::tempdir()?;

--- a/tests/generated_rust_artifact_tests.rs
+++ b/tests/generated_rust_artifact_tests.rs
@@ -239,6 +239,16 @@ license-files = ["LICENSE-MIT", "LICENSE-APACHE"]
     let manifest = LibraryManifest::read_from_path(&artifact_root.join("artifact_widgets_core.incnlib"))?;
     assert_eq!(manifest.name, "artifact_widgets_core");
     assert_eq!(manifest.version, "4.5.6");
+    let semantic_source_digest = manifest
+        .contract_metadata
+        .provider
+        .semantic_source_digest
+        .as_deref()
+        .ok_or("generated provider manifest omitted its authored semantic source digest")?;
+    assert!(
+        semantic_source_digest.starts_with("sha256:") && semantic_source_digest.len() == 71,
+        "generated provider manifest carried an invalid authored semantic source digest: {semantic_source_digest}"
+    );
     assert!(
         manifest.exports.models.iter().any(|model| model.name == "Widget"),
         "generated .incnlib should export Widget, got {:#?}",

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -34,6 +34,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Lockfiles**: Compiled providers now publish a digest of their authored manifest and selected Incan source inputs for canonical semantic identity, while generated Rust and host ABI metadata remain under the byte-exact physical artifact digest. Equivalent native provider builds therefore share one SDK inventory and dependency fingerprint across macOS and Linux without weakening strict locks or user-authored path dependency identity (#931).
 - **Compiler**: Published Rust ABI metadata now excludes traits introduced only by unrelated downstream crates in the loaded inspection graph, keeping SDK provider identities and workspace dependency fingerprints stable across cache state and host platforms (#924).
 - **Tooling**: Canonical lock publication now keeps its persistent cross-process guard under ignored compiler target state instead of leaving `.incan.lock.incan.lock` in the project root (#912).
 - **SDK providers**: Official stdlib component packages now preserve their source-owned Apache-2.0 license in generated Cargo metadata, so downstream dependency audits no longer classify synthesized provider crates as unlicensed (#920).

--- a/workspaces/docs-site/docs/tooling/how-to/dependencies.md
+++ b/workspaces/docs-site/docs/tooling/how-to/dependencies.md
@@ -107,6 +107,8 @@ incan lock
 
 `incan.lock` embeds the resolved `Cargo.lock` and a fingerprint of your dependency inputs. **Commit it to version control** for reproducible builds.
 
+For compiled SDK providers, the fingerprint identifies checked provider contracts, dependency and feature choices, and authored Incan inputs. Native Rust output and host-derived ABI metadata remain covered by each installed provider artifact's exact integrity digest, but do not make an otherwise equivalent macOS and Linux SDK selection semantically different. User-authored path dependencies remain part of the semantic fingerprint.
+
 ### Default build/test behavior
 
 If `incan.lock` doesn't exist and you run `incan build` or `incan test` without strict flags, the lock file is created automatically on first build.


### PR DESCRIPTION
## Summary

Stabilizes canonical dependency fingerprints for equivalent compiler-owned native provider builds across macOS and Linux. Generated providers now publish a validated digest of authored Incan inputs, and the semantic provider projection binds that digest to normalized checked contracts, dependencies, feature selections, and Cargo requirements instead of treating host-generated Rust and ABI metadata as semantic identity.

The byte-exact physical artifact digest is unchanged, legacy artifacts without the new field retain the v1 semantic projection, and user-authored path dependencies remain path-sensitive under the existing project-root rules.

Closes #931.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: locks produced from equivalent authored SDK/provider inputs remain valid across native host builds; real source, contract, feature, dependency, and user path changes still invalidate strict locks.
- **Internals**: compiled provider manifests carry an optional authored-source digest. Source bytes are keyed by stable logical module identity, including selected compiler-owned shared stdlib modules outside a component package root. Semantic provider identity v2 excludes generated Rust and host-derived ABI while physical artifact integrity remains byte-exact.
- **Risks**: incorrect source selection could over- or under-invalidate locks. Coverage includes relocation, shared toolchain source, outside-root and symlink rejection, host-output equality, and source/contract/feature/path drift. Artifacts without the new digest deliberately use the existing v1 projection.
- **Version**: advances the workspace candidate to `0.5.0-dev.22` under the coordinated v0.5 line.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification, final head `e72fc0b5623230e86c168d3267fbc38738e56a4d`:

- Focused `issue931` regressions passed on stable and Rust 1.93.0: 4/4 on each toolchain. The exact cold rooted-workspace lock regression also passed in the final full suite.
- Fully source-pinned `make pre-commit` passed: 3,159/3,159 tests, formatting, rustdoc, clippy, cargo-deny, release smoke, 60 examples checked / 35 run / 1 excluded / 0 failed, and 9/9 benchmark builds.
- Exact Hees source snapshot `93556ef3625b7a56425a7aa29b054b4ecb986f0c`, target-free with a fresh provider home, used the frozen dev.22 compiler built from the final head (SHA-256 `748f374c326337b385bcd785073b1cb63cf4d4cf5a38e0a88e267721743b8f60`). Bare root `incan lock` exited 0 and wrote canonical lock SHA-256 `7b17f61f925199a94a5781a995eda39e9d59920acbeecacfaccacdfcb640dab3` with deps fingerprint `sha256:92b55d38dc8edce67d36c9348a5c959e1587f068715ceb11ea03e23d91a93fa9`; immediate relock exited 0 with byte-identical output; normal `build --lib --member hees_ai` and strict `build --lib --member hees_ai --locked` both exited 0 and preserved that lock.

### Hosted-check status

Hosted smoke web-example, examples, and benchmark checks are currently red. Comparative CI evidence shows the same Rust 1.97.1 generated `stdlib-data` regex `String + String` E0308 diagnostics on current main and this PR, so this PR does not introduce the failure. The exact compiler regression is reopened as #896; this PR is held from merge until that independent repair restores the required hosted smoke checks.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- `workspaces/docs-site/docs/tooling/how-to/dependencies.md`
- `workspaces/docs-site/docs/release_notes/0_5.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
