### PR TITLE
bugfix - stabilize cold Rust String helper metadata (#896)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "blake2",
  "blake3",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "serde",
  "serde_json",
@@ -1528,14 +1528,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "axum",
  "incan_core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.22"
+version = "0.5.0-dev.23"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -7,6 +7,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::lang::types::collections::{self, CollectionTypeId};
 
+/// Return whether a Rust display names the canonical owned `String` type.
+///
+/// Rust metadata can expose `String` with implementation-only allocator arguments. Classify only the three canonical
+/// paths, while deliberately ignoring the generic arguments so `String<alloc::alloc::Global>` retains string
+/// semantics without accepting unrelated types that merely end in `String`.
+#[must_use]
+pub fn rust_display_is_owned_string(display: &str) -> bool {
+    let normalized = display.trim().replace(' ', "");
+    let base = normalized.split('<').next().unwrap_or(normalized.as_str());
+    matches!(base, "String" | "std::string::String" | "alloc::string::String")
+}
+
 /// Whether an item is visible across crate boundaries for ordinary `pub` Rust APIs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum RustVisibility {

--- a/crates/incan_core/src/interop/metadata.rs
+++ b/crates/incan_core/src/interop/metadata.rs
@@ -179,18 +179,18 @@ pub struct MetadataFreeMethodSignatureRule {
     pub is_unsafe: bool,
 }
 
-/// One parameter in a metadata-free Rust free-function signature.
+/// One parameter in a registry-backed Rust free-function signature.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MetadataFreeFunctionParamRule {
+pub struct RustFunctionParamRule {
     pub name: Option<&'static str>,
     pub type_display: &'static str,
 }
 
-/// Complete callable signature for one metadata-free Rust free-function surface.
+/// Complete callable contract for one registry-backed Rust free-function surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MetadataFreeFunctionSignatureRule {
+pub struct RustFunctionSignatureRule {
     pub path: &'static str,
-    pub params: &'static [MetadataFreeFunctionParamRule],
+    pub params: &'static [RustFunctionParamRule],
     pub return_type: &'static str,
     pub is_async: bool,
     pub is_unsafe: bool,
@@ -268,29 +268,69 @@ pub const METADATA_FREE_METHOD_SIGNATURE_RULES: &[MetadataFreeMethodSignatureRul
     },
 ];
 
-/// Metadata-free Rust free-function signatures used when rust-inspect cannot inspect sysroot crates.
+/// Authoritative signatures for compiler-owned runtime helpers whose source typing must be cache-independent.
+pub const COMPILER_OWNED_FUNCTION_SIGNATURE_RULES: &[RustFunctionSignatureRule] = &[
+    RustFunctionSignatureRule {
+        path: "incan_stdlib::strings::str_slice_byte_range",
+        params: &[
+            RustFunctionParamRule {
+                name: Some("s"),
+                type_display: "&str",
+            },
+            RustFunctionParamRule {
+                name: Some("start"),
+                type_display: "i64",
+            },
+            RustFunctionParamRule {
+                name: Some("end"),
+                type_display: "i64",
+            },
+        ],
+        return_type: "String",
+        is_async: false,
+        is_unsafe: false,
+    },
+    RustFunctionSignatureRule {
+        path: "incan_stdlib::strings::str_slice_from_byte_offset",
+        params: &[
+            RustFunctionParamRule {
+                name: Some("s"),
+                type_display: "&str",
+            },
+            RustFunctionParamRule {
+                name: Some("start"),
+                type_display: "i64",
+            },
+        ],
+        return_type: "String",
+        is_async: false,
+        is_unsafe: false,
+    },
+];
+
+/// Metadata-free Rust free-function signatures used when rust-inspect cannot inspect a stable Rust surface.
 ///
 /// rust-inspect intentionally indexes Cargo workspace crates and path/registry dependencies; sysroot crates such as
-/// `std` are not always available as ordinary metadata roots. Keep this table to stable std APIs whose signatures are
-/// part of Rust's public contract and whose result shapes matter for Incan source typing.
-pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[MetadataFreeFunctionSignatureRule] = &[
-    MetadataFreeFunctionSignatureRule {
+/// `std` are not always available as ordinary metadata roots. Keep this table to stable APIs whose signatures are part
+/// of Rust's public contract and whose result shapes matter for Incan source typing.
+pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[RustFunctionSignatureRule] = &[
+    RustFunctionSignatureRule {
         path: "std::io::stdin",
         params: &[],
         return_type: "std::io::Stdin",
         is_async: false,
         is_unsafe: false,
     },
-    MetadataFreeFunctionSignatureRule {
+    RustFunctionSignatureRule {
         path: "std::io::stdout",
         params: &[],
         return_type: "std::io::Stdout",
         is_async: false,
         is_unsafe: false,
     },
-    MetadataFreeFunctionSignatureRule {
+    RustFunctionSignatureRule {
         path: "std::fs::metadata",
-        params: &[MetadataFreeFunctionParamRule {
+        params: &[RustFunctionParamRule {
             name: Some("path"),
             type_display: "impl AsRef<std::path::Path>",
         }],
@@ -298,9 +338,9 @@ pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[MetadataFreeFunctionSignatur
         is_async: false,
         is_unsafe: false,
     },
-    MetadataFreeFunctionSignatureRule {
+    RustFunctionSignatureRule {
         path: "std::fs::symlink_metadata",
-        params: &[MetadataFreeFunctionParamRule {
+        params: &[RustFunctionParamRule {
             name: Some("path"),
             type_display: "impl AsRef<std::path::Path>",
         }],
@@ -308,9 +348,9 @@ pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[MetadataFreeFunctionSignatur
         is_async: false,
         is_unsafe: false,
     },
-    MetadataFreeFunctionSignatureRule {
+    RustFunctionSignatureRule {
         path: "std::fs::read",
-        params: &[MetadataFreeFunctionParamRule {
+        params: &[RustFunctionParamRule {
             name: Some("path"),
             type_display: "impl AsRef<std::path::Path>",
         }],
@@ -318,9 +358,9 @@ pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[MetadataFreeFunctionSignatur
         is_async: false,
         is_unsafe: false,
     },
-    MetadataFreeFunctionSignatureRule {
+    RustFunctionSignatureRule {
         path: "std::fs::read_dir",
-        params: &[MetadataFreeFunctionParamRule {
+        params: &[RustFunctionParamRule {
             name: Some("path"),
             type_display: "impl AsRef<std::path::Path>",
         }],
@@ -328,9 +368,9 @@ pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[MetadataFreeFunctionSignatur
         is_async: false,
         is_unsafe: false,
     },
-    MetadataFreeFunctionSignatureRule {
+    RustFunctionSignatureRule {
         path: "std::fs::read_to_string",
-        params: &[MetadataFreeFunctionParamRule {
+        params: &[RustFunctionParamRule {
             name: Some("path"),
             type_display: "impl AsRef<std::path::Path>",
         }],
@@ -338,14 +378,14 @@ pub const METADATA_FREE_FUNCTION_SIGNATURE_RULES: &[MetadataFreeFunctionSignatur
         is_async: false,
         is_unsafe: false,
     },
-    MetadataFreeFunctionSignatureRule {
+    RustFunctionSignatureRule {
         path: "std::fs::write",
         params: &[
-            MetadataFreeFunctionParamRule {
+            RustFunctionParamRule {
                 name: Some("path"),
                 type_display: "impl AsRef<std::path::Path>",
             },
-            MetadataFreeFunctionParamRule {
+            RustFunctionParamRule {
                 name: Some("contents"),
                 type_display: "impl AsRef<[u8]>",
             },
@@ -386,7 +426,25 @@ pub fn metadata_free_function_signature(rust_path: &str) -> Option<RustFunctionS
     let rule = METADATA_FREE_FUNCTION_SIGNATURE_RULES
         .iter()
         .find(|rule| rule.path == rust_path)?;
-    Some(RustFunctionSig {
+    Some(function_signature_from_rule(rule))
+}
+
+/// Return the authoritative callable contract for a compiler-owned Rust runtime helper.
+///
+/// These helpers are part of the compiler/runtime ABI, so their source typing must not vary with the availability or
+/// freshness of optional rust-inspect metadata. Keep this set deliberately narrow: ordinary Rust dependencies remain
+/// owned by their extracted metadata.
+#[must_use]
+pub fn compiler_owned_function_signature(rust_path: &str) -> Option<RustFunctionSig> {
+    let rule = COMPILER_OWNED_FUNCTION_SIGNATURE_RULES
+        .iter()
+        .find(|rule| rule.path == rust_path)?;
+    Some(function_signature_from_rule(rule))
+}
+
+/// Materialize a portable callable signature from one registry rule.
+fn function_signature_from_rule(rule: &RustFunctionSignatureRule) -> RustFunctionSig {
+    RustFunctionSig {
         type_params: Vec::new(),
         params: rule
             .params
@@ -399,7 +457,7 @@ pub fn metadata_free_function_signature(rust_path: &str) -> Option<RustFunctionS
         return_type: rule.return_type.to_string(),
         is_async: rule.is_async,
         is_unsafe: rule.is_unsafe,
-    })
+    }
 }
 
 /// A single parameter in a Rust function signature (display strings only for Phase 1).
@@ -1532,6 +1590,36 @@ pub fn run_inline<D: FnMut(&mut Data, &OutputCallbackInfo)>(callback: D) {
         assert!(!signature.is_async);
         assert!(!signature.is_unsafe);
         assert!(metadata_free_function_signature("std::fs::remove_file").is_none());
+    }
+
+    #[test]
+    fn compiler_owned_function_signatures_preserve_owned_stdlib_slice_results() -> Result<(), String> {
+        let expected = [
+            (
+                "incan_stdlib::strings::str_slice_byte_range",
+                vec![(Some("s"), "&str"), (Some("start"), "i64"), (Some("end"), "i64")],
+            ),
+            (
+                "incan_stdlib::strings::str_slice_from_byte_offset",
+                vec![(Some("s"), "&str"), (Some("start"), "i64")],
+            ),
+        ];
+
+        for (path, expected_params) in expected {
+            let signature = compiler_owned_function_signature(path)
+                .ok_or_else(|| format!("{path} should have a compiler-owned signature"))?;
+            assert!(signature.type_params.is_empty(), "{path}");
+            assert_eq!(signature.return_type, "String", "{path}");
+            assert_eq!(signature.params.len(), expected_params.len(), "{path}");
+            for (actual, (expected_name, expected_type)) in signature.params.iter().zip(expected_params) {
+                assert_eq!(actual.name.as_deref(), expected_name, "{path}");
+                assert_eq!(actual.type_display, expected_type, "{path}");
+            }
+            assert!(!signature.is_async, "{path}");
+            assert!(!signature.is_unsafe, "{path}");
+        }
+        assert!(compiler_owned_function_signature("demo::str_slice_byte_range").is_none());
+        Ok(())
     }
 
     #[test]

--- a/crates/incan_core/src/interop/mod.rs
+++ b/crates/incan_core/src/interop/mod.rs
@@ -21,7 +21,7 @@ pub use metadata::{
     RustModuleChild, RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo,
     RustTypeMetadataCompleteness, RustTypeShape, RustTypeShapePathFallback, RustVariantInfo, RustVisibility,
     metadata_free_function_signature, metadata_free_method_signature, parse_rust_type_shape_text,
-    render_rust_type_shape, render_rust_type_shape_path, rust_display_is_callable_bound,
+    render_rust_type_shape, render_rust_type_shape_path, rust_display_is_callable_bound, rust_display_is_owned_string,
     rust_source_borrowed_type_param_bound_display, rust_source_callable_bound_for_type_param,
     rust_source_type_param_has_as_fd_bound, split_top_level_rust_args, strip_rust_borrow_lifetimes,
 };

--- a/crates/incan_core/src/interop/mod.rs
+++ b/crates/incan_core/src/interop/mod.rs
@@ -13,15 +13,16 @@ pub use capabilities::{RUST_CAPABILITY_BOUNDS, is_rust_capability_bound};
 pub use coercions::{CoercionPolicy, admitted_builtin_coercion};
 pub use extension_traits::fallback_rust_trait_methods;
 pub use metadata::{
-    METADATA_FREE_FUNCTION_SIGNATURE_RULES, METADATA_FREE_METHOD_BORROW_RULES, METADATA_FREE_METHOD_SIGNATURE_RULES,
-    MetadataFreeArgClass, MetadataFreeFunctionParamRule, MetadataFreeFunctionSignatureRule,
-    MetadataFreeMethodArgBorrowPolicy, MetadataFreeMethodBorrowRule, MetadataFreeMethodParamRule,
-    MetadataFreeMethodSignatureRule, MetadataFreeReceiverClass, RUST_NEVER_TYPE_DISPLAY, RustCollectionFamily,
-    RustFieldInfo, RustFunctionSig, RustImplementedTrait, RustItemKind, RustItemMetadata, RustMethodSig,
+    COMPILER_OWNED_FUNCTION_SIGNATURE_RULES, METADATA_FREE_FUNCTION_SIGNATURE_RULES, METADATA_FREE_METHOD_BORROW_RULES,
+    METADATA_FREE_METHOD_SIGNATURE_RULES, MetadataFreeArgClass, MetadataFreeMethodArgBorrowPolicy,
+    MetadataFreeMethodBorrowRule, MetadataFreeMethodParamRule, MetadataFreeMethodSignatureRule,
+    MetadataFreeReceiverClass, RUST_NEVER_TYPE_DISPLAY, RustCollectionFamily, RustFieldInfo, RustFunctionParamRule,
+    RustFunctionSig, RustFunctionSignatureRule, RustImplementedTrait, RustItemKind, RustItemMetadata, RustMethodSig,
     RustModuleChild, RustModuleChildKind, RustModuleInfo, RustParam, RustTraitAssoc, RustTraitInfo, RustTypeInfo,
     RustTypeMetadataCompleteness, RustTypeShape, RustTypeShapePathFallback, RustVariantInfo, RustVisibility,
-    metadata_free_function_signature, metadata_free_method_signature, parse_rust_type_shape_text,
-    render_rust_type_shape, render_rust_type_shape_path, rust_display_is_callable_bound, rust_display_is_owned_string,
-    rust_source_borrowed_type_param_bound_display, rust_source_callable_bound_for_type_param,
-    rust_source_type_param_has_as_fd_bound, split_top_level_rust_args, strip_rust_borrow_lifetimes,
+    compiler_owned_function_signature, metadata_free_function_signature, metadata_free_method_signature,
+    parse_rust_type_shape_text, render_rust_type_shape, render_rust_type_shape_path, rust_display_is_callable_bound,
+    rust_display_is_owned_string, rust_source_borrowed_type_param_bound_display,
+    rust_source_callable_bound_for_type_param, rust_source_type_param_has_as_fd_bound, split_top_level_rust_args,
+    strip_rust_borrow_lifetimes,
 };

--- a/src/backend/ir/conversions.rs
+++ b/src/backend/ir/conversions.rs
@@ -631,9 +631,9 @@ pub(super) fn is_owned_string_type(ty: &IrType) -> bool {
 
 /// Return whether an IR value participates in Incan string operators.
 ///
-/// Rust inspection can preserve an owned `String` result as a Rust-path shape instead of canonicalizing it to
-/// [`IrType::String`]. Operator planning must recognize both representations so generated code does not depend on the
-/// inspection cache or host platform.
+/// Structured Rust metadata is normalized to [`IrType::String`] at the frontend boundary. Exact displays retained for
+/// Rust callback parameters still need the canonical owned-string fallback until closure metadata carries a semantic
+/// string shape.
 fn is_string_like_type(ty: &IrType) -> bool {
     is_owned_string_type(ty)
         || is_borrowed_string_like_type(ty)
@@ -1065,8 +1065,7 @@ mod tests {
     use crate::backend::ir::types::Mutability;
 
     #[test]
-    fn string_addition_recognizes_inspected_owned_rust_string_shapes_issue896() -> Result<(), Box<dyn std::error::Error>>
-    {
+    fn string_addition_recognizes_canonical_rust_string_metadata_issue896() -> Result<(), Box<dyn std::error::Error>> {
         let left = IrExpr::new(
             IrExprKind::Var {
                 name: "out".to_string(),
@@ -1077,6 +1076,7 @@ mod tests {
         );
 
         for right_ty in [
+            IrType::String,
             IrType::Struct("String".to_string()),
             IrType::Struct("std::string::String".to_string()),
             IrType::Struct("alloc::string::String".to_string()),
@@ -1086,6 +1086,7 @@ mod tests {
             IrType::RustDisplay("String".to_string()),
             IrType::RustDisplay("std::string::String".to_string()),
             IrType::RustDisplay("alloc::string::String".to_string()),
+            IrType::Ref(Box::new(IrType::String)),
         ] {
             let right = IrExpr::new(
                 IrExprKind::Call {
@@ -1108,7 +1109,7 @@ mod tests {
             let plan = determine_binop_plan(&BinOp::Add, &left, &right);
             let BinOpEmitKind::StdlibCall { path, borrow_args } = plan.emit else {
                 return Err(format!(
-                    "String + inspected Rust String must use string-aware lowering, right={right_ty:?}"
+                    "canonical Rust string operands must use string-aware lowering, right={right_ty:?}"
                 )
                 .into());
             };
@@ -1116,6 +1117,22 @@ mod tests {
             assert!(borrow_args);
             assert_eq!(plan.result_ty, IrType::String);
         }
+
+        // Rust callback parameters retain an exact display instead of flowing through structured return metadata.
+        // Both sides of `x + x` therefore arrive as `RustDisplay(String)` in the lowering IR.
+        let callback_param = IrExpr::new(
+            IrExprKind::Var {
+                name: "x".to_string(),
+                access: VarAccess::Read,
+                ref_kind: VarRefKind::Value,
+            },
+            IrType::RustDisplay("String".to_string()),
+        );
+        let callback_plan = determine_binop_plan(&BinOp::Add, &callback_param, &callback_param);
+        assert!(
+            matches!(callback_plan.emit, BinOpEmitKind::StdlibCall { borrow_args: true, .. }),
+            "a Rust Fn(String) closure body must lower x + x through str_concat"
+        );
         Ok(())
     }
 

--- a/src/backend/ir/conversions.rs
+++ b/src/backend/ir/conversions.rs
@@ -175,6 +175,7 @@ use super::reference_shape::expr_has_rust_reference_shape;
 use super::types::Mutability;
 use super::{IrExpr, IrExprKind, IrType, TypedExpr};
 use crate::numeric_adapters::{ir_type_to_numeric_ty, numeric_op_from_ir, pow_exponent_kind_from_ir};
+use incan_core::interop::rust_display_is_owned_string;
 use incan_core::lang::types::collections::{self, CollectionTypeId};
 use incan_core::lang::types::numerics::{self, NumericFamily};
 use incan_core::{NumericOp, NumericTy, needs_float_promotion, result_numeric_type};
@@ -625,7 +626,7 @@ pub(super) fn is_owned_string_type(ty: &IrType) -> bool {
         || matches!(
             ty,
             IrType::Struct(name) | IrType::NamedGeneric(name, _) | IrType::RustDisplay(name)
-                if matches!(name.as_str(), "String" | "std::string::String" | "alloc::string::String")
+                if rust_display_is_owned_string(name)
         )
 }
 
@@ -1086,6 +1087,7 @@ mod tests {
             IrType::RustDisplay("String".to_string()),
             IrType::RustDisplay("std::string::String".to_string()),
             IrType::RustDisplay("alloc::string::String".to_string()),
+            IrType::RustDisplay("std::string::String<alloc::alloc::Global>".to_string()),
             IrType::Ref(Box::new(IrType::String)),
         ] {
             let right = IrExpr::new(

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -2933,9 +2933,10 @@ impl Default for AstLowering {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::ir::expr::{CollectionMethodKind, IrExprKind, MethodKind, StringMethodKind, UnaryOp};
-    use crate::backend::ir::stmt::IrStmtKind;
-    use crate::frontend::{lexer, parser};
+    use crate::backend::ir::conversions::{BinOpEmitKind, determine_binop_plan};
+    use crate::backend::ir::expr::{BinOp, CollectionMethodKind, IrExprKind, MethodKind, StringMethodKind, UnaryOp};
+    use crate::backend::ir::stmt::{AssignTarget, IrStmtKind};
+    use crate::frontend::{lexer, parser, typechecker::TypeChecker};
 
     fn must_ok<T, E: std::fmt::Debug>(result: Result<T, E>) -> T {
         match result {
@@ -2953,6 +2954,61 @@ mod tests {
         });
         let mut lowering = AstLowering::new();
         lowering.lower_program(&ast)
+    }
+
+    #[test]
+    fn rust_string_slice_import_add_assign_preserves_owned_rhs_issue896() -> Result<(), String> {
+        let source = r#"
+from rust::incan_stdlib::strings import str_slice_byte_range
+
+def concat_slice(text: str) -> str:
+    mut out = ""
+    out += str_slice_byte_range(text, 0, 1)
+    return out
+"#;
+        let tokens = lexer::lex(source).map_err(|errs| format!("lex failed: {errs:?}"))?;
+        let ast = parser::parse(&tokens).map_err(|errs| format!("parse failed: {errs:?}"))?;
+        let mut checker = TypeChecker::new();
+        checker
+            .check_program(&ast)
+            .map_err(|errs| format!("typecheck failed: {errs:?}"))?;
+
+        let mut lowering = AstLowering::new_with_type_info(checker.type_info().clone());
+        let program = lowering
+            .lower_program(&ast)
+            .map_err(|err| format!("lowering failed: {err:?}"))?;
+        let function = program
+            .declarations
+            .iter()
+            .find_map(|decl| match &decl.kind {
+                IrDeclKind::Function(function) if function.name == "concat_slice" => Some(function),
+                _ => None,
+            })
+            .ok_or_else(|| "expected lowered function `concat_slice`".to_string())?;
+        let value = function
+            .body
+            .iter()
+            .find_map(|statement| match &statement.kind {
+                IrStmtKind::Assign {
+                    target: AssignTarget::Var(name),
+                    value,
+                } if name == "out" && matches!(value.kind, IrExprKind::BinOp { .. }) => Some(value),
+                _ => None,
+            })
+            .ok_or_else(|| format!("expected lowered `out += ...` assignment, got {:?}", function.body))?;
+        let IrExprKind::BinOp { op, left, right } = &value.kind else {
+            return Err(format!("expected binary addition, got {:?}", value.kind));
+        };
+
+        assert_eq!(*op, BinOp::Add);
+        assert_eq!(left.ty, IrType::String);
+        assert_eq!(right.ty, IrType::String);
+        let BinOpEmitKind::StdlibCall { path, borrow_args } = determine_binop_plan(op, left, right).emit else {
+            return Err("owned Rust string RHS should lower through a stdlib call".to_string());
+        };
+        assert_eq!(path.to_string(), "incan_stdlib :: strings :: str_concat");
+        assert!(borrow_args);
+        Ok(())
     }
 
     fn spanned<T>(node: T) -> ast::Spanned<T> {

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -1007,6 +1007,7 @@ enum ActiveSdkInventoryError {
 }
 
 impl ActiveSdkInventoryError {
+    /// Render the validated inventory failure for the CLI when no source rebuild is possible.
     fn into_cli_error(self) -> CliError {
         match self {
             Self::Rebuildable(error) => CliError::failure(error.to_string()),
@@ -1015,6 +1016,7 @@ impl ActiveSdkInventoryError {
     }
 }
 
+/// Identify inventory failures that a source checkout can repair by republishing providers.
 fn is_rebuildable_sdk_inventory_error(error: &crate::provider::SdkInventoryError) -> bool {
     matches!(
         error,

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -1001,42 +1001,17 @@ fn split_env_cargo_args(value: Option<&str>) -> Vec<String> {
         .collect()
 }
 
-enum ActiveSdkInventoryError {
-    Rebuildable(crate::provider::SdkInventoryError),
-    Failure(CliError),
-}
-
-impl ActiveSdkInventoryError {
-    /// Render the validated inventory failure for the CLI when no source rebuild is possible.
-    fn into_cli_error(self) -> CliError {
-        match self {
-            Self::Rebuildable(error) => CliError::failure(error.to_string()),
-            Self::Failure(error) => error,
-        }
-    }
-}
-
-/// Identify inventory failures that a source checkout can repair by republishing providers.
-fn is_rebuildable_sdk_inventory_error(error: &crate::provider::SdkInventoryError) -> bool {
-    matches!(
-        error,
-        crate::provider::SdkInventoryError::UnsupportedSchema { .. }
-            | crate::provider::SdkInventoryError::MissingProviderCodegenRevision
-            | crate::provider::SdkInventoryError::ProviderCodegenRevisionMismatch { .. }
-    )
-}
-
 /// Discover the active component-aware SDK relative to the selected toolchain or an explicit override.
-fn discover_active_sdk_inventory() -> Result<Option<Arc<SdkInventory>>, ActiveSdkInventoryError> {
+fn discover_active_sdk_inventory() -> CliResult<Option<Arc<SdkInventory>>> {
     let explicit = env::var_os(SDK_INVENTORY_OVERRIDE_ENV)
         .filter(|path| !path.is_empty())
         .map(PathBuf::from);
     let inventory_path = if let Some(path) = explicit.as_ref() {
         if !path.is_file() {
-            return Err(ActiveSdkInventoryError::Failure(CliError::failure(format!(
+            return Err(CliError::failure(format!(
                 "{SDK_INVENTORY_OVERRIDE_ENV} points to missing SDK inventory {}",
                 path.display()
-            ))));
+            )));
         }
         Some(path.clone())
     } else {
@@ -1054,43 +1029,20 @@ fn discover_active_sdk_inventory() -> Result<Option<Arc<SdkInventory>>, ActiveSd
     let Some(path) = inventory_path else {
         return Ok(None);
     };
-    let inventory = SdkInventory::read_from_path(&path).map_err(|error| {
-        if is_rebuildable_sdk_inventory_error(&error) {
-            ActiveSdkInventoryError::Rebuildable(error)
-        } else {
-            ActiveSdkInventoryError::Failure(CliError::failure(error.to_string()))
-        }
-    })?;
+    let inventory = SdkInventory::read_from_path(&path).map_err(|error| CliError::failure(error.to_string()))?;
     inventory
         .validate_compiler_compatibility(
             crate::version::INCAN_VERSION,
             crate::version::SDK_PROVIDER_CODEGEN_REVISION,
         )
-        .map_err(|error| {
-            if is_rebuildable_sdk_inventory_error(&error) {
-                ActiveSdkInventoryError::Rebuildable(error)
-            } else {
-                ActiveSdkInventoryError::Failure(CliError::failure(error.to_string()))
-            }
-        })?;
+        .map_err(|error| CliError::failure(error.to_string()))?;
     Ok(Some(Arc::new(inventory)))
 }
 
 /// Discover an installed SDK inventory or publish the source checkout's component providers on demand.
 pub(crate) fn prepare_or_discover_sdk_inventory() -> CliResult<Option<Arc<SdkInventory>>> {
-    match discover_active_sdk_inventory() {
-        Ok(Some(inventory)) => return Ok(Some(inventory)),
-        Ok(None) => {}
-        Err(ActiveSdkInventoryError::Rebuildable(error)) => {
-            if env::var_os(SDK_PROVIDER_BUILD_ENV).is_none()
-                && crate::cli::prelude::find_stdlib_dir()
-                    .is_some_and(|root| root.join(SDK_SOURCE_CATALOG_FILE).is_file())
-            {
-                return prepare_sdk_provider_inventory().map(Some);
-            }
-            return Err(ActiveSdkInventoryError::Rebuildable(error).into_cli_error());
-        }
-        Err(error) => return Err(error.into_cli_error()),
+    if let Some(inventory) = discover_active_sdk_inventory()? {
+        return Ok(Some(inventory));
     }
     if env::var_os(SDK_PROVIDER_BUILD_ENV).is_some() {
         return Ok(None);
@@ -6448,37 +6400,5 @@ def main() -> None:
         assert!(analysis.type_info_for_module_path(&["first".to_string()]).is_some());
         assert!(analysis.type_info_for_module_path(&["second".to_string()]).is_some());
         Ok(())
-    }
-
-    #[test]
-    fn stale_sdk_inventory_without_source_reports_its_codegen_incompatibility() {
-        let error =
-            ActiveSdkInventoryError::Rebuildable(crate::provider::SdkInventoryError::ProviderCodegenRevisionMismatch {
-                sdk_identity: "incan@0.5.0".to_string(),
-                actual: 1,
-                expected: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
-            })
-            .into_cli_error();
-
-        assert!(error.message.contains("provider codegen revision 1"));
-        assert!(error.message.contains("requires revision"));
-    }
-
-    #[test]
-    fn every_stale_provider_inventory_form_is_rebuildable_from_source() {
-        let stale_forms = [
-            crate::provider::SdkInventoryError::UnsupportedSchema {
-                actual: 1,
-                expected: crate::provider::SDK_INVENTORY_SCHEMA_VERSION,
-            },
-            crate::provider::SdkInventoryError::MissingProviderCodegenRevision,
-            crate::provider::SdkInventoryError::ProviderCodegenRevisionMismatch {
-                sdk_identity: "incan@0.5.0".to_string(),
-                actual: 1,
-                expected: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
-            },
-        ];
-
-        assert!(stale_forms.iter().all(is_rebuildable_sdk_inventory_error));
     }
 }

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -559,7 +559,10 @@ fn prepare_sdk_provider_inventory() -> CliResult<Arc<SdkInventory>> {
         let inventory =
             SdkInventory::read_from_path(&inventory_path).map_err(|error| CliError::failure(error.to_string()))?;
         inventory
-            .validate_compiler_version(crate::version::INCAN_VERSION)
+            .validate_compiler_compatibility(
+                crate::version::INCAN_VERSION,
+                crate::version::SDK_PROVIDER_CODEGEN_REVISION,
+            )
             .map_err(|error| CliError::failure(error.to_string()))?;
         record_sdk_provider_root(&artifact_root)?;
         return Ok(Arc::new(inventory));
@@ -853,6 +856,7 @@ fn source_catalog_inventory(catalog: &SdkSourceCatalog, root: &Path) -> SdkInven
         sdk_id: catalog.sdk_id.clone(),
         sdk_version: catalog.sdk_version.clone(),
         compiler_requirement: catalog.compiler_requirement.clone(),
+        provider_codegen_revision: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
         components,
         profiles: catalog.profiles.clone(),
     }
@@ -997,17 +1001,40 @@ fn split_env_cargo_args(value: Option<&str>) -> Vec<String> {
         .collect()
 }
 
+enum ActiveSdkInventoryError {
+    Rebuildable(crate::provider::SdkInventoryError),
+    Failure(CliError),
+}
+
+impl ActiveSdkInventoryError {
+    fn into_cli_error(self) -> CliError {
+        match self {
+            Self::Rebuildable(error) => CliError::failure(error.to_string()),
+            Self::Failure(error) => error,
+        }
+    }
+}
+
+fn is_rebuildable_sdk_inventory_error(error: &crate::provider::SdkInventoryError) -> bool {
+    matches!(
+        error,
+        crate::provider::SdkInventoryError::UnsupportedSchema { .. }
+            | crate::provider::SdkInventoryError::MissingProviderCodegenRevision
+            | crate::provider::SdkInventoryError::ProviderCodegenRevisionMismatch { .. }
+    )
+}
+
 /// Discover the active component-aware SDK relative to the selected toolchain or an explicit override.
-pub(crate) fn discover_active_sdk_inventory() -> CliResult<Option<Arc<SdkInventory>>> {
+fn discover_active_sdk_inventory() -> Result<Option<Arc<SdkInventory>>, ActiveSdkInventoryError> {
     let explicit = env::var_os(SDK_INVENTORY_OVERRIDE_ENV)
         .filter(|path| !path.is_empty())
         .map(PathBuf::from);
     let inventory_path = if let Some(path) = explicit.as_ref() {
         if !path.is_file() {
-            return Err(CliError::failure(format!(
+            return Err(ActiveSdkInventoryError::Failure(CliError::failure(format!(
                 "{SDK_INVENTORY_OVERRIDE_ENV} points to missing SDK inventory {}",
                 path.display()
-            )));
+            ))));
         }
         Some(path.clone())
     } else {
@@ -1025,17 +1052,43 @@ pub(crate) fn discover_active_sdk_inventory() -> CliResult<Option<Arc<SdkInvento
     let Some(path) = inventory_path else {
         return Ok(None);
     };
-    let inventory = SdkInventory::read_from_path(&path).map_err(|error| CliError::failure(error.to_string()))?;
+    let inventory = SdkInventory::read_from_path(&path).map_err(|error| {
+        if is_rebuildable_sdk_inventory_error(&error) {
+            ActiveSdkInventoryError::Rebuildable(error)
+        } else {
+            ActiveSdkInventoryError::Failure(CliError::failure(error.to_string()))
+        }
+    })?;
     inventory
-        .validate_compiler_version(crate::version::INCAN_VERSION)
-        .map_err(|error| CliError::failure(error.to_string()))?;
+        .validate_compiler_compatibility(
+            crate::version::INCAN_VERSION,
+            crate::version::SDK_PROVIDER_CODEGEN_REVISION,
+        )
+        .map_err(|error| {
+            if is_rebuildable_sdk_inventory_error(&error) {
+                ActiveSdkInventoryError::Rebuildable(error)
+            } else {
+                ActiveSdkInventoryError::Failure(CliError::failure(error.to_string()))
+            }
+        })?;
     Ok(Some(Arc::new(inventory)))
 }
 
 /// Discover an installed SDK inventory or publish the source checkout's component providers on demand.
 pub(crate) fn prepare_or_discover_sdk_inventory() -> CliResult<Option<Arc<SdkInventory>>> {
-    if let Some(inventory) = discover_active_sdk_inventory()? {
-        return Ok(Some(inventory));
+    match discover_active_sdk_inventory() {
+        Ok(Some(inventory)) => return Ok(Some(inventory)),
+        Ok(None) => {}
+        Err(ActiveSdkInventoryError::Rebuildable(error)) => {
+            if env::var_os(SDK_PROVIDER_BUILD_ENV).is_none()
+                && crate::cli::prelude::find_stdlib_dir()
+                    .is_some_and(|root| root.join(SDK_SOURCE_CATALOG_FILE).is_file())
+            {
+                return prepare_sdk_provider_inventory().map(Some);
+            }
+            return Err(ActiveSdkInventoryError::Rebuildable(error).into_cli_error());
+        }
+        Err(error) => return Err(error.into_cli_error()),
     }
     if env::var_os(SDK_PROVIDER_BUILD_ENV).is_some() {
         return Ok(None);
@@ -6393,5 +6446,37 @@ def main() -> None:
         assert!(analysis.type_info_for_module_path(&["first".to_string()]).is_some());
         assert!(analysis.type_info_for_module_path(&["second".to_string()]).is_some());
         Ok(())
+    }
+
+    #[test]
+    fn stale_sdk_inventory_without_source_reports_its_codegen_incompatibility() {
+        let error =
+            ActiveSdkInventoryError::Rebuildable(crate::provider::SdkInventoryError::ProviderCodegenRevisionMismatch {
+                sdk_identity: "incan@0.5.0".to_string(),
+                actual: 1,
+                expected: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
+            })
+            .into_cli_error();
+
+        assert!(error.message.contains("provider codegen revision 1"));
+        assert!(error.message.contains("requires revision"));
+    }
+
+    #[test]
+    fn every_stale_provider_inventory_form_is_rebuildable_from_source() {
+        let stale_forms = [
+            crate::provider::SdkInventoryError::UnsupportedSchema {
+                actual: 1,
+                expected: crate::provider::SDK_INVENTORY_SCHEMA_VERSION,
+            },
+            crate::provider::SdkInventoryError::MissingProviderCodegenRevision,
+            crate::provider::SdkInventoryError::ProviderCodegenRevisionMismatch {
+                sdk_identity: "incan@0.5.0".to_string(),
+                actual: 1,
+                expected: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
+            },
+        ];
+
+        assert!(stale_forms.iter().all(is_rebuildable_sdk_inventory_error));
     }
 }

--- a/src/frontend/typechecker/check_expr/calls.rs
+++ b/src/frontend/typechecker/check_expr/calls.rs
@@ -8,7 +8,10 @@ use crate::frontend::diagnostics::{CompileError, errors};
 use crate::frontend::resolved_type_subst::substitute_resolved_type;
 use crate::frontend::symbols::{FieldInfo, FunctionInfo, FunctionOverloadInfo, ResolvedType, SymbolKind, TypeInfo};
 use crate::frontend::typechecker::IdentKind;
-use incan_core::interop::{RustFieldInfo, RustItemKind, RustTypeInfo, metadata_free_function_signature};
+use incan_core::interop::{
+    RustFieldInfo, RustFunctionSig, RustItemKind, RustTypeInfo, compiler_owned_function_signature,
+    metadata_free_function_signature,
+};
 use incan_core::lang::derives::{self, DeriveId};
 use incan_core::lang::keywords::{self, KeywordId};
 use incan_core::lang::stdlib;
@@ -332,6 +335,16 @@ impl TypeChecker {
                             self.check_call_args(args);
                             return ResolvedType::Unknown;
                         }
+                        if let Some(sig) = compiler_owned_function_signature(info.path.as_str()) {
+                            return self.validate_and_record_rust_import_function_call(
+                                info.path.as_str(),
+                                &sig,
+                                args,
+                                span,
+                                callee.span,
+                                expected_return_ty,
+                            );
+                        }
                         let metadata = info
                             .metadata
                             .clone()
@@ -339,29 +352,14 @@ impl TypeChecker {
                         if let Some(meta) = metadata.as_ref() {
                             match &meta.kind {
                                 RustItemKind::Function(sig) => {
-                                    let error_count_before = self.errors.len();
-                                    let result = self.validate_rust_function_call_with_expected(
+                                    return self.validate_and_record_rust_import_function_call(
                                         info.path.as_str(),
                                         sig,
                                         args,
                                         span,
+                                        callee.span,
                                         expected_return_ty,
                                     );
-                                    if self.errors.len() == error_count_before {
-                                        self.record_expr_type(
-                                            callee.span,
-                                            self.resolved_function_type_from_rust_sig_for_owner_path(
-                                                sig,
-                                                false,
-                                                info.path.as_str(),
-                                            ),
-                                        );
-                                        self.type_info
-                                            .expressions
-                                            .ident_kinds
-                                            .insert((callee.span.start, callee.span.end), IdentKind::RustImport);
-                                    }
-                                    return result;
                                 }
                                 RustItemKind::Type(type_info)
                                     if !type_info.fields.is_empty()
@@ -406,29 +404,14 @@ impl TypeChecker {
                                 }
                             }
                         } else if let Some(sig) = metadata_free_function_signature(info.path.as_str()) {
-                            let error_count_before = self.errors.len();
-                            let result = self.validate_rust_function_call_with_expected(
+                            return self.validate_and_record_rust_import_function_call(
                                 info.path.as_str(),
                                 &sig,
                                 args,
                                 span,
+                                callee.span,
                                 expected_return_ty,
                             );
-                            if self.errors.len() == error_count_before {
-                                self.record_expr_type(
-                                    callee.span,
-                                    self.resolved_function_type_from_rust_sig_for_owner_path(
-                                        &sig,
-                                        false,
-                                        info.path.as_str(),
-                                    ),
-                                );
-                                self.type_info
-                                    .expressions
-                                    .ident_kinds
-                                    .insert((callee.span.start, callee.span.end), IdentKind::RustImport);
-                            }
-                            return result;
                         } else if rust_path_last_segment_looks_like_type(info.path.as_str()) {
                             return self.check_metadata_free_rust_named_field_constructor_call(
                                 info.path.as_str(),
@@ -822,6 +805,31 @@ impl TypeChecker {
             return ResolvedType::RustPath(path.to_string());
         }
         ResolvedType::Unknown
+    }
+
+    /// Validate one Rust import call and record its callable semantics when validation succeeds.
+    fn validate_and_record_rust_import_function_call(
+        &mut self,
+        path: &str,
+        signature: &RustFunctionSig,
+        args: &[CallArg],
+        span: Span,
+        callee_span: Span,
+        expected_return_ty: Option<&ResolvedType>,
+    ) -> ResolvedType {
+        let error_count_before = self.errors.len();
+        let result = self.validate_rust_function_call_with_expected(path, signature, args, span, expected_return_ty);
+        if self.errors.len() == error_count_before {
+            self.record_expr_type(
+                callee_span,
+                self.resolved_function_type_from_rust_sig_for_owner_path(signature, false, path),
+            );
+            self.type_info
+                .expressions
+                .ident_kinds
+                .insert((callee_span.start, callee_span.end), IdentKind::RustImport);
+        }
+        result
     }
 
     /// Type-check a Rust struct field argument with the metadata-provided target type as context.

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -1555,6 +1555,9 @@ impl TypeChecker {
             "()" => ResolvedType::Unit,
             _ if normalized.ends_with('>') => {
                 if let Some((base, args)) = Self::rust_generic_base_and_args(normalized.as_str()) {
+                    if matches!(base, "String" | "std::string::String" | "alloc::string::String") {
+                        return ResolvedType::Str;
+                    }
                     let tail = base.rsplit("::").next().unwrap_or(base);
                     match collection_type_id(tail) {
                         Some(CollectionTypeId::Option) => {

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -1398,7 +1398,8 @@ impl TypeChecker {
     /// Map structured rust-inspect [`RustTypeShape`] into a [`ResolvedType`] for field access and pattern typing.
     ///
     /// `Option`/`Result` become [`ResolvedType::Generic`] with constructor names `Option` and `Result`. Concrete paths
-    /// use [`Self::render_rust_shape_path`] so generic arguments stay attached to [`ResolvedType::RustPath`].
+    /// are rendered through the ordinary Rust-display resolver so a structured metadata path receives the same
+    /// primitive classification as its textual fallback (notably owned Rust strings).
     pub(crate) fn resolved_type_from_rust_shape(&self, shape: &RustTypeShape) -> ResolvedType {
         match shape {
             RustTypeShape::Never => ResolvedType::Never,
@@ -1425,7 +1426,9 @@ impl TypeChecker {
                     .collect(),
             ),
             RustTypeShape::Ref(inner) => ResolvedType::Ref(Box::new(self.resolved_type_from_rust_shape(inner))),
-            RustTypeShape::RustPath { path, args } => ResolvedType::RustPath(Self::render_rust_shape_path(path, args)),
+            RustTypeShape::RustPath { path, args } => {
+                self.resolved_type_from_rust_display(Self::render_rust_shape_path(path, args).as_str())
+            }
             RustTypeShape::TypeParam(name) => ResolvedType::TypeVar(name.clone()),
             RustTypeShape::Unknown => ResolvedType::Unknown,
         }

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -85,8 +85,8 @@ use crate::rust_inspect::{Inspector, RustMetadataCache};
 use helpers::{collection_name, collection_type_id, render_resolved_type_as_rust_arg, stringlike_type_id};
 use incan_core::interop::{
     RUST_NEVER_TYPE_DISPLAY, RustFunctionSig, RustItemKind, RustItemMetadata, RustParam, RustTypeShape,
-    metadata_free_method_signature, render_rust_type_shape_path, split_top_level_rust_args,
-    strip_rust_borrow_lifetimes,
+    metadata_free_method_signature, render_rust_type_shape_path, rust_display_is_owned_string,
+    split_top_level_rust_args, strip_rust_borrow_lifetimes,
 };
 use incan_core::lang::conventions;
 use incan_core::lang::decorators::{self as core_decorators, DecoratorId};
@@ -1430,10 +1430,7 @@ impl TypeChecker {
                 // `String` has an implementation allocator argument in some rustc metadata views. That argument
                 // does not change the language-level string value contract, so retain `str` semantics from the
                 // canonical nominal path instead of rendering it as an opaque generic Rust display.
-                if matches!(
-                    path.as_str(),
-                    "String" | "std::string::String" | "alloc::string::String"
-                ) {
+                if rust_display_is_owned_string(path) {
                     return ResolvedType::Str;
                 }
                 self.resolved_type_from_rust_display(Self::render_rust_shape_path(path, args).as_str())
@@ -1533,6 +1530,9 @@ impl TypeChecker {
                 ResolvedType::Ref(Box::new(inner_ty))
             };
         }
+        if rust_display_is_owned_string(normalized.as_str()) {
+            return ResolvedType::Str;
+        }
         match normalized.as_str() {
             "{unknown}" => ResolvedType::Unknown,
             "bool" => ResolvedType::Bool,
@@ -1550,12 +1550,12 @@ impl TypeChecker {
             "u64" => ResolvedType::Numeric(NumericTypeId::U64),
             "u128" => ResolvedType::Numeric(NumericTypeId::U128),
             "usize" => ResolvedType::Numeric(NumericTypeId::USize),
-            "str" | "&str" | "String" | "std::string::String" | "alloc::string::String" => ResolvedType::Str,
+            "str" | "&str" => ResolvedType::Str,
             "Vec<u8>" | "std::vec::Vec<u8>" | "alloc::vec::Vec<u8>" | "&[u8]" => ResolvedType::Bytes,
             "()" => ResolvedType::Unit,
             _ if normalized.ends_with('>') => {
                 if let Some((base, args)) = Self::rust_generic_base_and_args(normalized.as_str()) {
-                    if matches!(base, "String" | "std::string::String" | "alloc::string::String") {
+                    if rust_display_is_owned_string(base) {
                         return ResolvedType::Str;
                     }
                     let tail = base.rsplit("::").next().unwrap_or(base);

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -1427,6 +1427,15 @@ impl TypeChecker {
             ),
             RustTypeShape::Ref(inner) => ResolvedType::Ref(Box::new(self.resolved_type_from_rust_shape(inner))),
             RustTypeShape::RustPath { path, args } => {
+                // `String` has an implementation allocator argument in some rustc metadata views. That argument
+                // does not change the language-level string value contract, so retain `str` semantics from the
+                // canonical nominal path instead of rendering it as an opaque generic Rust display.
+                if matches!(
+                    path.as_str(),
+                    "String" | "std::string::String" | "alloc::string::String"
+                ) {
+                    return ResolvedType::Str;
+                }
                 self.resolved_type_from_rust_display(Self::render_rust_shape_path(path, args).as_str())
             }
             RustTypeShape::TypeParam(name) => ResolvedType::TypeVar(name.clone()),

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -1555,9 +1555,6 @@ impl TypeChecker {
             "()" => ResolvedType::Unit,
             _ if normalized.ends_with('>') => {
                 if let Some((base, args)) = Self::rust_generic_base_and_args(normalized.as_str()) {
-                    if rust_display_is_owned_string(base) {
-                        return ResolvedType::Str;
-                    }
                     let tail = base.rsplit("::").next().unwrap_or(base);
                     match collection_type_id(tail) {
                         Some(CollectionTypeId::Option) => {

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3426,6 +3426,21 @@ fn test_resolved_type_from_builtin_borrowed_displays_stays_stable() {
 }
 
 #[test]
+fn test_resolved_type_from_structured_rust_string_shapes_is_str() {
+    let checker = TypeChecker::new();
+    for path in ["String", "std::string::String", "alloc::string::String"] {
+        assert_eq!(
+            checker.resolved_type_from_rust_shape(&RustTypeShape::RustPath {
+                path: path.to_string(),
+                args: vec![],
+            }),
+            ResolvedType::Str,
+            "structured Rust metadata path {path} must retain Incan string semantics"
+        );
+    }
+}
+
+#[test]
 fn test_resolved_param_type_from_builtin_borrowed_displays_preserves_ref_payload() {
     let checker = TypeChecker::new();
     assert_eq!(

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3464,6 +3464,26 @@ fn test_resolved_type_from_generic_rust_string_display_is_str() {
 }
 
 #[test]
+fn test_noncanonical_rust_string_like_shapes_remain_external() {
+    let checker = TypeChecker::new();
+
+    for display in ["demo::String", "StringBuilder", "demo::String<alloc::alloc::Global>"] {
+        assert_eq!(
+            checker.resolved_type_from_rust_display(display),
+            ResolvedType::RustPath(display.to_string()),
+            "noncanonical Rust type {display} must not acquire Incan string semantics"
+        );
+    }
+    assert_eq!(
+        checker.resolved_type_from_rust_shape(&RustTypeShape::RustPath {
+            path: "demo::String".to_string(),
+            args: vec![],
+        }),
+        ResolvedType::RustPath("demo::String".to_string())
+    );
+}
+
+#[test]
 fn test_resolved_param_type_from_builtin_borrowed_displays_preserves_ref_payload() {
     let checker = TypeChecker::new();
     assert_eq!(
@@ -4184,6 +4204,72 @@ def f() -> None:
         result.is_ok(),
         "expected permissive fallback when metadata is unavailable, got {result:?}"
     );
+    Ok(())
+}
+
+#[cfg(feature = "rust_inspect")]
+#[test]
+fn compiler_owned_function_contract_overrides_stale_warm_metadata() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from rust::incan_stdlib::strings import str_slice_byte_range
+
+def slice(text: str) -> str:
+  return str_slice_byte_range(text, 0, 1)
+"#;
+    let tokens = lexer::lex(source).map_err(|errors| std::io::Error::other(format!("lex failed: {errors:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errors| std::io::Error::other(format!("parse failed: {errors:?}")))?;
+    let mut checker = TypeChecker::new();
+    let tmp = seeded_rust_inspect_workspace()?;
+    let manifest_dir = tmp.path().to_path_buf();
+    checker.set_rust_inspect_manifest_dir(manifest_dir.clone());
+    checker
+        .rust_inspect_cache
+        .insert_test_item(
+            &manifest_dir,
+            RustItemMetadata {
+                canonical_path: "incan_stdlib::strings::str_slice_byte_range".to_string(),
+                definition_path: Some("incan_stdlib::strings::str_slice_byte_range".to_string()),
+                visibility: RustVisibility::Public,
+                kind: RustItemKind::Function(RustFunctionSig {
+                    type_params: Vec::new(),
+                    params: vec![
+                        RustParam {
+                            name: Some("s".to_string()),
+                            type_display: "&str".to_string(),
+                        },
+                        RustParam {
+                            name: Some("start".to_string()),
+                            type_display: "i64".to_string(),
+                        },
+                        RustParam {
+                            name: Some("end".to_string()),
+                            type_display: "i64".to_string(),
+                        },
+                    ],
+                    return_type: "i64".to_string(),
+                    is_async: false,
+                    is_unsafe: false,
+                }),
+            },
+        )
+        .map_err(|error| std::io::Error::other(format!("seed stale rust-inspect function: {error}")))?;
+    let Some(RustItemMetadata {
+        kind: RustItemKind::Function(stale_signature),
+        ..
+    }) = checker.rust_item_metadata_for_path("incan_stdlib::strings::str_slice_byte_range")
+    else {
+        return Err(std::io::Error::other("expected stale warm helper metadata to be visible").into());
+    };
+    assert_eq!(
+        stale_signature.return_type, "i64",
+        "the regression must exercise a warm metadata result that disagrees with the compiler-owned contract"
+    );
+
+    checker.check_program(&ast).map_err(|errors| {
+        std::io::Error::other(format!(
+            "compiler-owned String return must win over stale warm metadata: {errors:?}"
+        ))
+    })?;
     Ok(())
 }
 

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3438,6 +3438,18 @@ fn test_resolved_type_from_structured_rust_string_shapes_is_str() {
             "structured Rust metadata path {path} must retain Incan string semantics"
         );
     }
+
+    assert_eq!(
+        checker.resolved_type_from_rust_shape(&RustTypeShape::RustPath {
+            path: "std::string::String".to_string(),
+            args: vec![RustTypeShape::RustPath {
+                path: "alloc::alloc::Global".to_string(),
+                args: vec![],
+            }],
+        }),
+        ResolvedType::Str,
+        "a canonical String path must retain string semantics when rustc exposes its allocator argument"
+    );
 }
 
 #[test]

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -3453,6 +3453,17 @@ fn test_resolved_type_from_structured_rust_string_shapes_is_str() {
 }
 
 #[test]
+fn test_resolved_type_from_generic_rust_string_display_is_str() {
+    let checker = TypeChecker::new();
+
+    assert_eq!(
+        checker.resolved_type_from_rust_display("std::string::String<alloc::alloc::Global>"),
+        ResolvedType::Str,
+        "an implementation allocator argument must not erase canonical Rust String semantics"
+    );
+}
+
+#[test]
 fn test_resolved_param_type_from_builtin_borrowed_displays_preserves_ref_payload() {
     let checker = TypeChecker::new();
     assert_eq!(

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1498,6 +1498,7 @@ mod tests {
             sdk_id: "incan".to_string(),
             sdk_version: "0.5.0".to_string(),
             compiler_requirement: "^0.5".to_string(),
+            provider_codegen_revision: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
             components: BTreeMap::from([(
                 "support".to_string(),
                 crate::provider::SdkComponent {
@@ -1872,6 +1873,7 @@ mod tests {
             sdk_id: "incan".to_string(),
             sdk_version: "0.5.0".to_string(),
             compiler_requirement: "^0.5".to_string(),
+            provider_codegen_revision: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
             components: BTreeMap::from([(
                 "stdlib-data".to_string(),
                 crate::provider::SdkComponent {

--- a/src/provider/features.rs
+++ b/src/provider/features.rs
@@ -1604,6 +1604,7 @@ serializer = { path = "../serializer", optional = true, default-features = false
             sdk_id: "incan".to_string(),
             sdk_version: "0.5.0".to_string(),
             compiler_requirement: ">=0.5.0-dev.16,<0.6.0".to_string(),
+            provider_codegen_revision: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
             components: BTreeMap::from([(
                 "runtime".to_string(),
                 crate::provider::SdkComponent {

--- a/src/provider/plan.rs
+++ b/src/provider/plan.rs
@@ -1953,6 +1953,7 @@ mod tests {
             sdk_id: "incan".to_string(),
             sdk_version: "0.5.0".to_string(),
             compiler_requirement: ">=0.5.0-dev.5,<0.6.0".to_string(),
+            provider_codegen_revision: crate::version::SDK_PROVIDER_CODEGEN_REVISION,
             components: BTreeMap::from([(
                 "stdlib-core".to_string(),
                 super::super::SdkComponent {

--- a/src/provider/sdk.rs
+++ b/src/provider/sdk.rs
@@ -1023,7 +1023,7 @@ mod tests {
   "sdk_id": "incan",
   "sdk_version": "0.5.0",
   "compiler_requirement": ">=0.5.0-dev.5,<0.6.0",
-  "provider_codegen_revision": 2,
+  "provider_codegen_revision": 3,
   "components": {
     "stdlib-core": {
       "version": "0.5.0",
@@ -1154,10 +1154,10 @@ mod tests {
         let inventory = SdkInventory::from_json(INVENTORY, Path::new("/sdk"))?;
 
         let error = inventory
-            .validate_compiler_compatibility("0.5.0-dev.5", 3)
+            .validate_compiler_compatibility("0.5.0-dev.5", 4)
             .err()
             .ok_or("expected incompatible provider codegen revision")?;
-        assert!(error.to_string().contains("provider codegen revision 2"));
+        assert!(error.to_string().contains("provider codegen revision 3"));
         Ok(())
     }
 
@@ -1165,7 +1165,7 @@ mod tests {
     fn rejects_pre_revision_inventory_schema() {
         let stale = INVENTORY
             .replace("\"schema_version\": 2", "\"schema_version\": 1")
-            .replace("  \"provider_codegen_revision\": 2,\n", "");
+            .replace("  \"provider_codegen_revision\": 3,\n", "");
         let error = SdkInventory::from_json(&stale, Path::new("/sdk"));
 
         assert!(matches!(
@@ -1176,7 +1176,7 @@ mod tests {
 
     #[test]
     fn rejects_current_schema_without_provider_codegen_revision() {
-        let missing_revision = INVENTORY.replace("  \"provider_codegen_revision\": 2,\n", "");
+        let missing_revision = INVENTORY.replace("  \"provider_codegen_revision\": 3,\n", "");
 
         assert!(matches!(
             SdkInventory::from_json(&missing_revision, Path::new("/sdk")),

--- a/src/provider/sdk.rs
+++ b/src/provider/sdk.rs
@@ -1023,7 +1023,7 @@ mod tests {
   "sdk_id": "incan",
   "sdk_version": "0.5.0",
   "compiler_requirement": ">=0.5.0-dev.5,<0.6.0",
-  "provider_codegen_revision": 4,
+  "provider_codegen_revision": 5,
   "components": {
     "stdlib-core": {
       "version": "0.5.0",
@@ -1154,10 +1154,10 @@ mod tests {
         let inventory = SdkInventory::from_json(INVENTORY, Path::new("/sdk"))?;
 
         let error = inventory
-            .validate_compiler_compatibility("0.5.0-dev.5", 5)
+            .validate_compiler_compatibility("0.5.0-dev.5", 6)
             .err()
             .ok_or("expected incompatible provider codegen revision")?;
-        assert!(error.to_string().contains("provider codegen revision 4"));
+        assert!(error.to_string().contains("provider codegen revision 5"));
         Ok(())
     }
 
@@ -1165,7 +1165,7 @@ mod tests {
     fn rejects_pre_revision_inventory_schema() {
         let stale = INVENTORY
             .replace("\"schema_version\": 2", "\"schema_version\": 1")
-            .replace("  \"provider_codegen_revision\": 4,\n", "");
+            .replace("  \"provider_codegen_revision\": 5,\n", "");
         let error = SdkInventory::from_json(&stale, Path::new("/sdk"));
 
         assert!(matches!(
@@ -1176,7 +1176,7 @@ mod tests {
 
     #[test]
     fn rejects_current_schema_without_provider_codegen_revision() {
-        let missing_revision = INVENTORY.replace("  \"provider_codegen_revision\": 4,\n", "");
+        let missing_revision = INVENTORY.replace("  \"provider_codegen_revision\": 5,\n", "");
 
         assert!(matches!(
             SdkInventory::from_json(&missing_revision, Path::new("/sdk")),

--- a/src/provider/sdk.rs
+++ b/src/provider/sdk.rs
@@ -14,7 +14,7 @@ pub const SDK_INVENTORY_FILE: &str = "sdk-inventory.json";
 /// Source catalog used by SDK publishers to build the installed inventory.
 pub const SDK_SOURCE_CATALOG_FILE: &str = "sdk-components.toml";
 /// Current JSON schema version for SDK inventory files.
-pub const SDK_INVENTORY_SCHEMA_VERSION: u32 = 1;
+pub const SDK_INVENTORY_SCHEMA_VERSION: u32 = 2;
 
 /// One compiled provider artifact advertised by an SDK component.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,6 +61,8 @@ pub struct SdkInventory {
     pub sdk_version: String,
     /// Compiler compatibility requirement authored by the SDK.
     pub compiler_requirement: String,
+    /// Target-independent revision of the compiler code generator that emitted the providers.
+    pub provider_codegen_revision: u32,
     /// Complete known component catalog, including unavailable entries.
     pub components: BTreeMap<String, SdkComponent>,
     /// Named profile membership owned by this SDK release.
@@ -217,6 +219,21 @@ pub enum SdkInventoryError {
         /// Compiler-supported schema version.
         expected: u32,
     },
+    /// The inventory predates the compiler's target-independent provider codegen marker.
+    #[error("SDK inventory schema 2 is missing its provider codegen revision")]
+    MissingProviderCodegenRevision,
+    /// The immutable providers were emitted by an incompatible compiler code generator.
+    #[error(
+        "SDK {sdk_identity} was generated with provider codegen revision {actual}, but this compiler requires revision {expected}"
+    )]
+    ProviderCodegenRevisionMismatch {
+        /// Stable SDK identity recorded by the inventory.
+        sdk_identity: String,
+        /// Revision recorded by the provider publisher.
+        actual: u32,
+        /// Revision required by the active compiler.
+        expected: u32,
+    },
     /// A required identity, version, path, digest, profile, or edge is invalid.
     #[error("invalid SDK inventory: {0}")]
     Invalid(String),
@@ -286,6 +303,7 @@ struct RawSdkInventory {
     sdk_id: String,
     sdk_version: String,
     compiler_requirement: String,
+    provider_codegen_revision: Option<u32>,
     components: BTreeMap<String, RawSdkComponent>,
     profiles: BTreeMap<String, Vec<String>>,
 }
@@ -509,6 +527,9 @@ impl SdkInventory {
                 expected: SDK_INVENTORY_SCHEMA_VERSION,
             });
         }
+        let provider_codegen_revision = raw
+            .provider_codegen_revision
+            .ok_or(SdkInventoryError::MissingProviderCodegenRevision)?;
         validate_nonempty_identifier("SDK id", &raw.sdk_id)?;
         Version::parse(&raw.sdk_version)
             .map_err(|error| SdkInventoryError::Invalid(format!("invalid sdk_version: {error}")))?;
@@ -577,6 +598,7 @@ impl SdkInventory {
             sdk_id: raw.sdk_id,
             sdk_version: raw.sdk_version,
             compiler_requirement: raw.compiler_requirement,
+            provider_codegen_revision,
             components,
             profiles,
         })
@@ -627,6 +649,7 @@ impl SdkInventory {
             sdk_id: self.sdk_id.clone(),
             sdk_version: self.sdk_version.clone(),
             compiler_requirement: self.compiler_requirement.clone(),
+            provider_codegen_revision: Some(self.provider_codegen_revision),
             components,
             profiles: self
                 .profiles
@@ -761,6 +784,24 @@ impl SdkInventory {
                 self.identity(),
                 self.compiler_requirement
             )))
+        }
+    }
+
+    /// Verify both the semantic compiler requirement and the provider codegen revision.
+    pub fn validate_compiler_compatibility(
+        &self,
+        compiler_version: &str,
+        provider_codegen_revision: u32,
+    ) -> Result<(), SdkInventoryError> {
+        self.validate_compiler_version(compiler_version)?;
+        if self.provider_codegen_revision == provider_codegen_revision {
+            Ok(())
+        } else {
+            Err(SdkInventoryError::ProviderCodegenRevisionMismatch {
+                sdk_identity: self.identity(),
+                actual: self.provider_codegen_revision,
+                expected: provider_codegen_revision,
+            })
         }
     }
 
@@ -978,10 +1019,11 @@ mod tests {
 
     const INVENTORY: &str = r#"
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "sdk_id": "incan",
   "sdk_version": "0.5.0",
   "compiler_requirement": ">=0.5.0-dev.5,<0.6.0",
+  "provider_codegen_revision": 2,
   "components": {
     "stdlib-core": {
       "version": "0.5.0",
@@ -1105,6 +1147,41 @@ mod tests {
             .ok_or("expected incompatible compiler version")?;
         assert!(error.to_string().contains("requires compiler"));
         Ok(())
+    }
+
+    #[test]
+    fn rejects_incompatible_provider_codegen_revision() -> TestResult {
+        let inventory = SdkInventory::from_json(INVENTORY, Path::new("/sdk"))?;
+
+        let error = inventory
+            .validate_compiler_compatibility("0.5.0-dev.5", 3)
+            .err()
+            .ok_or("expected incompatible provider codegen revision")?;
+        assert!(error.to_string().contains("provider codegen revision 2"));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_pre_revision_inventory_schema() {
+        let stale = INVENTORY
+            .replace("\"schema_version\": 2", "\"schema_version\": 1")
+            .replace("  \"provider_codegen_revision\": 2,\n", "");
+        let error = SdkInventory::from_json(&stale, Path::new("/sdk"));
+
+        assert!(matches!(
+            error,
+            Err(SdkInventoryError::UnsupportedSchema { actual: 1, expected: 2 })
+        ));
+    }
+
+    #[test]
+    fn rejects_current_schema_without_provider_codegen_revision() {
+        let missing_revision = INVENTORY.replace("  \"provider_codegen_revision\": 2,\n", "");
+
+        assert!(matches!(
+            SdkInventory::from_json(&missing_revision, Path::new("/sdk")),
+            Err(SdkInventoryError::MissingProviderCodegenRevision)
+        ));
     }
 
     #[test]

--- a/src/provider/sdk.rs
+++ b/src/provider/sdk.rs
@@ -1023,7 +1023,7 @@ mod tests {
   "sdk_id": "incan",
   "sdk_version": "0.5.0",
   "compiler_requirement": ">=0.5.0-dev.5,<0.6.0",
-  "provider_codegen_revision": 3,
+  "provider_codegen_revision": 4,
   "components": {
     "stdlib-core": {
       "version": "0.5.0",
@@ -1154,10 +1154,10 @@ mod tests {
         let inventory = SdkInventory::from_json(INVENTORY, Path::new("/sdk"))?;
 
         let error = inventory
-            .validate_compiler_compatibility("0.5.0-dev.5", 4)
+            .validate_compiler_compatibility("0.5.0-dev.5", 5)
             .err()
             .ok_or("expected incompatible provider codegen revision")?;
-        assert!(error.to_string().contains("provider codegen revision 3"));
+        assert!(error.to_string().contains("provider codegen revision 4"));
         Ok(())
     }
 
@@ -1165,7 +1165,7 @@ mod tests {
     fn rejects_pre_revision_inventory_schema() {
         let stale = INVENTORY
             .replace("\"schema_version\": 2", "\"schema_version\": 1")
-            .replace("  \"provider_codegen_revision\": 3,\n", "");
+            .replace("  \"provider_codegen_revision\": 4,\n", "");
         let error = SdkInventory::from_json(&stale, Path::new("/sdk"));
 
         assert!(matches!(
@@ -1176,7 +1176,7 @@ mod tests {
 
     #[test]
     fn rejects_current_schema_without_provider_codegen_revision() {
-        let missing_revision = INVENTORY.replace("  \"provider_codegen_revision\": 3,\n", "");
+        let missing_revision = INVENTORY.replace("  \"provider_codegen_revision\": 4,\n", "");
 
         assert!(matches!(
             SdkInventory::from_json(&missing_revision, Path::new("/sdk")),

--- a/src/version.rs
+++ b/src/version.rs
@@ -16,4 +16,4 @@ pub const INCAN_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// This is deliberately independent of the public compiler version: an installed SDK
 /// seed is immutable and may outlive a version-neutral compiler code-generation fix.
 /// Increase it whenever a change can require every SDK provider to be regenerated.
-pub const SDK_PROVIDER_CODEGEN_REVISION: u32 = 2;
+pub const SDK_PROVIDER_CODEGEN_REVISION: u32 = 3;

--- a/src/version.rs
+++ b/src/version.rs
@@ -16,4 +16,4 @@ pub const INCAN_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// This is deliberately independent of the public compiler version: an installed SDK
 /// seed is immutable and may outlive a version-neutral compiler code-generation fix.
 /// Increase it whenever a change can require every SDK provider to be regenerated.
-pub const SDK_PROVIDER_CODEGEN_REVISION: u32 = 3;
+pub const SDK_PROVIDER_CODEGEN_REVISION: u32 = 4;

--- a/src/version.rs
+++ b/src/version.rs
@@ -13,7 +13,7 @@ pub const INCAN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Compatibility revision for generated SDK provider Rust.
 ///
-/// This is deliberately independent of the public compiler version: an installed SDK
-/// seed is immutable and may outlive a version-neutral compiler code-generation fix.
-/// Increase it whenever a change can require every SDK provider to be regenerated.
+/// This is deliberately independent of the public compiler version: an installed SDK seed is immutable and may
+/// outlive a version-neutral compiler code-generation fix. Increase it whenever a change can require every SDK
+/// provider to be regenerated.
 pub const SDK_PROVIDER_CODEGEN_REVISION: u32 = 5;

--- a/src/version.rs
+++ b/src/version.rs
@@ -10,3 +10,10 @@
 
 /// The Incan compiler version string (for example, `0.1.0`).
 pub const INCAN_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Compatibility revision for generated SDK provider Rust.
+///
+/// This is deliberately independent of the public compiler version: an installed SDK
+/// seed is immutable and may outlive a version-neutral compiler code-generation fix.
+/// Increase it whenever a change can require every SDK provider to be regenerated.
+pub const SDK_PROVIDER_CODEGEN_REVISION: u32 = 2;

--- a/src/version.rs
+++ b/src/version.rs
@@ -16,4 +16,4 @@ pub const INCAN_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// This is deliberately independent of the public compiler version: an installed SDK
 /// seed is immutable and may outlive a version-neutral compiler code-generation fix.
 /// Increase it whenever a change can require every SDK provider to be regenerated.
-pub const SDK_PROVIDER_CODEGEN_REVISION: u32 = 4;
+pub const SDK_PROVIDER_CODEGEN_REVISION: u32 = 5;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -4949,6 +4949,10 @@ pub def append_range(text: str, start: int, end: int) -> str:
   mut out = ""
   out += str_slice_byte_range(text, start, end)
   return out
+
+
+pub def join_ranges(text: str, start: int, middle: int, end: int) -> str:
+  return str_slice_byte_range(text, start, middle) + str_slice_byte_range(text, middle, end)
 "#,
     )?;
 
@@ -4972,6 +4976,10 @@ pub def append_range(text: str, start: int, end: int) -> str:
     assert!(
         !compact_generated.contains("out=out+str_slice_byte_range"),
         "a direct Rust String result must not reach generated Rust's owned `String + String` path:\n{generated}"
+    );
+    assert!(
+        compact_generated.contains("incan_stdlib::strings::str_concat(&str_slice_byte_range(&text,start,middle),&str_slice_byte_range(&text,middle,end),)"),
+        "binary concatenation of direct Rust String results must use the string helper:\n{generated}"
     );
     Ok(())
 }

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -14,9 +14,9 @@
     },
     {
       "path": "crates/incan_core/src/interop/metadata.rs",
-      "category": "registry-backed Rust collection metadata policy and shared Rust type-shape parsing, including borrowed impl-trait interop bounds",
-      "expected_count": 25,
-      "expected_fingerprint": "0x14563632957da1e4"
+      "category": "registry-backed Rust collection and compiler-owned function metadata policy, plus shared Rust type-shape parsing including canonical owned String displays with allocator arguments",
+      "expected_count": 26,
+      "expected_fingerprint": "0x313c8a3ca86c1175"
     },
     {
       "path": "crates/rust_inspect/src/cache.rs",
@@ -80,9 +80,9 @@
     },
     {
       "path": "src/backend/ir/conversions.rs",
-      "category": "central argument conversion shape checks",
-      "expected_count": 3,
-      "expected_fingerprint": "0x4d96219944d67d53"
+      "category": "central argument conversion and canonical owned Rust String shape checks",
+      "expected_count": 2,
+      "expected_fingerprint": "0xc102811ab1ea1d38"
     },
     {
       "path": "src/backend/ir/emit/decls/functions.rs",
@@ -344,9 +344,9 @@
     },
     {
       "path": "src/frontend/typechecker/mod.rs",
-      "category": "Rust display type parsing and nominal String canonicalization, source type-name validation, and stdlib derive compatibility",
-      "expected_count": 39,
-      "expected_fingerprint": "0x81c4c95b10579d08"
+      "category": "Rust display type parsing and shared nominal String canonicalization, source type-name validation, and stdlib derive compatibility",
+      "expected_count": 38,
+      "expected_fingerprint": "0xddf8ee5a4184529a"
     },
     {
       "path": "src/frontend/typechecker/stdlib_loader.rs",

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -344,9 +344,9 @@
     },
     {
       "path": "src/frontend/typechecker/mod.rs",
-      "category": "Rust display type parsing, source type-name validation, and stdlib derive compatibility",
-      "expected_count": 38,
-      "expected_fingerprint": "0x20ee81b12feea769"
+      "category": "Rust display type parsing and nominal String canonicalization, source type-name validation, and stdlib derive compatibility",
+      "expected_count": 39,
+      "expected_fingerprint": "0x81c4c95b10579d08"
     },
     {
       "path": "src/frontend/typechecker/stdlib_loader.rs",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7236,7 +7236,7 @@ async def main() -> None:
   "sdk_id": "incan",
   "sdk_version": "0.5.0",
   "compiler_requirement": ">=0.5.0-dev.6,<0.6.0",
-  "provider_codegen_revision": 2,
+  "provider_codegen_revision": 3,
   "components": {},
   "profiles": {"default": []}
 }"#,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7071,8 +7071,9 @@ async def main() -> None:
         Ok(())
     }
 
-    #[test]
-    fn test_run_std_regex_rfc059_surface_from_cold_sdk_provider() -> Result<(), Box<dyn std::error::Error>> {
+    fn assert_std_regex_surface_from_cold_sdk_provider(
+        fresh_cargo_home: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;
         let source = tmp.path().join("std_regex_surface.incn");
         fs::copy(
@@ -7082,14 +7083,29 @@ async def main() -> None:
         let generated_project = tmp.path().join("target/incan/std_regex_surface");
         let provider_store = tmp.path().join("sdk-provider-store");
         let generated_cargo_target = tmp.path().join("generated-cargo-target");
+        let cargo_home = tmp.path().join("cargo-home");
 
-        let output = incan_command()
+        let mut command = incan_command();
+        command
             .current_dir(tmp.path())
+            .env("INCAN_SOURCE_ROOT", env!("CARGO_MANIFEST_DIR"))
+            .env(
+                "INCAN_STDLIB",
+                Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/incan_stdlib/stdlib"),
+            )
+            .env_remove("INCAN_STDLIB_DIR")
+            .env_remove("INCAN_SDK_INVENTORY")
+            .env_remove("INCAN_HOME")
             .env("INCAN_INTERNAL_SDK_PROVIDER_STORE", &provider_store)
             .env("INCAN_GENERATED_CARGO_TARGET_DIR", &generated_cargo_target)
             .arg("run")
-            .arg(&source)
-            .output()?;
+            .arg(&source);
+        if fresh_cargo_home {
+            // The explicit acceptance lane starts without a Cargo registry or crate cache, so it permits Cargo to
+            // populate the isolated home while resolving the generated std.regex consumer's direct dependency.
+            command.env("CARGO_HOME", &cargo_home).env_remove("CARGO_NET_OFFLINE");
+        }
+        let output = command.output()?;
 
         assert!(
             output.status.success(),
@@ -7198,19 +7214,23 @@ async def main() -> None:
             2,
             "every borrowed regex capture name should be copied into an owned dictionary key:\n{generated_core}"
         );
+        let compact_generated_core = generated_core
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect::<String>();
         assert_eq!(
-            generated_core
-                .matches("&str_slice_byte_range(&text, last_end, start)")
+            compact_generated_core
+                .matches("incan_stdlib::strings::str_concat(&out,&str_slice_byte_range(&text,last_end,start),)")
                 .count(),
             3,
-            "every replacement loop should concatenate the owned Rust byte-range result through the string helper:\n{generated_core}"
+            "every replacement loop should pass the owned Rust byte-range result directly to str_concat:\n{generated_core}"
         );
         assert_eq!(
-            generated_core
-                .matches("&str_slice_from_byte_offset(&text, last_end)")
+            compact_generated_core
+                .matches("incan_stdlib::strings::str_concat(&out,&str_slice_from_byte_offset(&text,last_end),)")
                 .count(),
             3,
-            "every replacement loop should concatenate the owned Rust suffix through the string helper:\n{generated_core}"
+            "every replacement loop should pass the owned Rust suffix directly to str_concat:\n{generated_core}"
         );
         assert!(
             !generated_core.contains("out = out + str_slice"),
@@ -7220,8 +7240,18 @@ async def main() -> None:
     }
 
     #[test]
-    fn stale_sdk_inventory_rebuilds_regex_provider_with_current_codegen_revision()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_run_std_regex_rfc059_surface_from_cold_sdk_provider() -> Result<(), Box<dyn std::error::Error>> {
+        assert_std_regex_surface_from_cold_sdk_provider(false)
+    }
+
+    #[test]
+    #[ignore = "requires an online crates.io registry to populate a genuinely fresh Cargo home"]
+    fn test_run_std_regex_rfc059_surface_from_fresh_cargo_home() -> Result<(), Box<dyn std::error::Error>> {
+        assert_std_regex_surface_from_cold_sdk_provider(true)
+    }
+
+    #[test]
+    fn explicit_stale_sdk_inventory_fails_closed() -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;
         let source = tmp.path().join("std_regex_surface.incn");
         fs::copy(
@@ -7241,9 +7271,8 @@ async def main() -> None:
   "profiles": {"default": []}
 }"#,
         )?;
-        let provider_store = tmp.path().join("rebuilt-sdk-provider-store");
+        let provider_store = tmp.path().join("unused-sdk-provider-store");
         let generated_cargo_target = tmp.path().join("generated-cargo-target");
-        let generated_project = tmp.path().join("target/incan/std_regex_surface");
 
         let output = incan_command()
             .current_dir(tmp.path())
@@ -7256,48 +7285,26 @@ async def main() -> None:
             .arg(&source)
             .output()?;
         assert!(
-            output.status.success(),
-            "a schema-2 inventory from the prior provider-codegen revision should rebuild from source when available: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            !output.status.success(),
+            "an explicit SDK inventory is authoritative and must not be replaced from nearby source: status={:?}\nstdout:\n{}\nstderr:\n{}",
             output.status,
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
-
-        let inventory_paths = fs::read_dir(&provider_store)?
-            .filter_map(Result::ok)
-            .map(|entry| entry.path().join("sdk-inventory.json"))
-            .filter(|path| path.is_file())
-            .collect::<Vec<_>>();
-        assert_eq!(inventory_paths.len(), 1, "expected one regenerated SDK inventory");
-        let rebuilt_inventory = incan::provider::SdkInventory::read_from_path(&inventory_paths[0])?;
-        rebuilt_inventory.validate_compiler_compatibility(
-            incan::version::INCAN_VERSION,
-            incan::version::SDK_PROVIDER_CODEGEN_REVISION,
-        )?;
-        let consumer_cargo = fs::read_to_string(generated_project.join("Cargo.toml"))?;
+        let stderr = strip_ansi_escapes(&String::from_utf8_lossy(&output.stderr));
         assert!(
-            consumer_cargo.contains("incan_stdlib_data"),
-            "a rebuilt SDK must remain provider-backed in the generated consumer:\n{consumer_cargo}"
+            stderr.contains("generated with provider codegen revision 4") && stderr.contains("requires revision 5"),
+            "the failure should report the exact incompatible provider revision:\n{stderr}"
         );
         assert!(
-            !generated_project.join("src/__incan_std").exists(),
-            "a rebuilt SDK must not fall back to an inlined stdlib source tree"
-        );
-        let provider_root = inventory_paths[0].parent().ok_or("inventory had no parent")?;
-        let generated_core = fs::read_to_string(provider_root.join("components/stdlib-data/src/regex/_core.rs"))?;
-        assert!(
-            generated_core.contains("str_concat("),
-            "the regenerated std.regex provider must lower owned-string concatenation through str_concat:\n{generated_core}"
-        );
-        assert!(
-            !generated_core.contains("out = out + str_slice"),
-            "the regenerated std.regex provider must not retain stale String + String lowering:\n{generated_core}"
+            !provider_store.exists(),
+            "rejecting an explicit incompatible SDK inventory must not publish replacement providers"
         );
         Ok(())
     }
 
     #[test]
-    fn stale_sdk_inventory_rebuild_keeps_lock_preheat_provider_backed() -> Result<(), Box<dyn std::error::Error>> {
+    fn explicit_legacy_sdk_inventory_blocks_lock_preheat() -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;
         let project = tmp.path().join("provider_backed_library");
         fs::create_dir_all(project.join("src"))?;
@@ -7318,7 +7325,7 @@ async def main() -> None:
   "profiles": {"default": []}
 }"#,
         )?;
-        let provider_store = tmp.path().join("rebuilt-sdk-provider-store");
+        let provider_store = tmp.path().join("unused-sdk-provider-store");
         let generated_cargo_target = tmp.path().join("generated-cargo-target");
         let configure = |command: &mut Command| {
             command
@@ -7334,38 +7341,21 @@ async def main() -> None:
         configure(&mut lock);
         let lock = lock.arg("lock").output()?;
         assert!(
-            lock.status.success(),
-            "stale SDK lock preheat should rebuild from source: {}",
+            !lock.status.success(),
+            "an explicit legacy SDK inventory must fail before lock preheat can replace it: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            lock.status,
+            String::from_utf8_lossy(&lock.stdout),
             String::from_utf8_lossy(&lock.stderr)
         );
-        let mut build = incan_command();
-        configure(&mut build);
-        let build = build.args(["build", "--lib", "--locked"]).output()?;
+        let stderr = strip_ansi_escapes(&String::from_utf8_lossy(&lock.stderr));
         assert!(
-            build.status.success(),
-            "provider-backed library build after stale SDK lock preheat failed: {}",
-            String::from_utf8_lossy(&build.stderr)
-        );
-
-        let library_cargo = fs::read_to_string(project.join("target/lib/Cargo.toml"))?;
-        assert!(
-            library_cargo.contains("incan_stdlib_core"),
-            "library output must retain the rebuilt stdlib-core provider dependency:\n{library_cargo}"
+            stderr.contains("unsupported SDK inventory schema 1") && stderr.contains("expected 2"),
+            "the failure should report the exact unsupported inventory schema:\n{stderr}"
         );
         assert!(
-            !project.join("target/lib/src/__incan_std").exists(),
-            "library output must not inline the SDK after stale-seed recovery"
+            !provider_store.exists(),
+            "rejecting an explicit legacy SDK inventory must not publish replacement providers"
         );
-        let inventory_path = fs::read_dir(&provider_store)?
-            .filter_map(Result::ok)
-            .map(|entry| entry.path().join("sdk-inventory.json"))
-            .find(|path| path.is_file())
-            .ok_or("expected rebuilt SDK inventory")?;
-        let rebuilt_inventory = incan::provider::SdkInventory::read_from_path(&inventory_path)?;
-        rebuilt_inventory.validate_compiler_compatibility(
-            incan::version::INCAN_VERSION,
-            incan::version::SDK_PROVIDER_CODEGEN_REVISION,
-        )?;
         Ok(())
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7220,6 +7220,155 @@ async def main() -> None:
     }
 
     #[test]
+    fn stale_sdk_inventory_rebuilds_regex_provider_with_current_codegen_revision()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let source = tmp.path().join("std_regex_surface.incn");
+        fs::copy(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/valid/std_regex_surface.incn"),
+            &source,
+        )?;
+        let stale_inventory = tmp.path().join("stale-sdk-inventory.json");
+        fs::write(
+            &stale_inventory,
+            r#"{
+  "schema_version": 1,
+  "sdk_id": "incan",
+  "sdk_version": "0.5.0",
+  "compiler_requirement": ">=0.5.0-dev.6,<0.6.0",
+  "components": {},
+  "profiles": {"default": []}
+}"#,
+        )?;
+        let provider_store = tmp.path().join("rebuilt-sdk-provider-store");
+        let generated_cargo_target = tmp.path().join("generated-cargo-target");
+        let generated_project = tmp.path().join("target/incan/std_regex_surface");
+
+        let output = incan_command()
+            .current_dir(tmp.path())
+            .env_remove("INCAN_STDLIB")
+            .env_remove("INCAN_STDLIB_DIR")
+            .env("INCAN_SDK_INVENTORY", &stale_inventory)
+            .env("INCAN_INTERNAL_SDK_PROVIDER_STORE", &provider_store)
+            .env("INCAN_GENERATED_CARGO_TARGET_DIR", &generated_cargo_target)
+            .arg("run")
+            .arg(&source)
+            .output()?;
+        assert!(
+            output.status.success(),
+            "a stale installed SDK inventory should rebuild from source when available: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let inventory_paths = fs::read_dir(&provider_store)?
+            .filter_map(Result::ok)
+            .map(|entry| entry.path().join("sdk-inventory.json"))
+            .filter(|path| path.is_file())
+            .collect::<Vec<_>>();
+        assert_eq!(inventory_paths.len(), 1, "expected one regenerated SDK inventory");
+        let rebuilt_inventory = incan::provider::SdkInventory::read_from_path(&inventory_paths[0])?;
+        rebuilt_inventory.validate_compiler_compatibility(
+            incan::version::INCAN_VERSION,
+            incan::version::SDK_PROVIDER_CODEGEN_REVISION,
+        )?;
+        let consumer_cargo = fs::read_to_string(generated_project.join("Cargo.toml"))?;
+        assert!(
+            consumer_cargo.contains("incan_stdlib_data"),
+            "a rebuilt SDK must remain provider-backed in the generated consumer:\n{consumer_cargo}"
+        );
+        assert!(
+            !generated_project.join("src/__incan_std").exists(),
+            "a rebuilt SDK must not fall back to an inlined stdlib source tree"
+        );
+        let provider_root = inventory_paths[0].parent().ok_or("inventory had no parent")?;
+        let generated_core = fs::read_to_string(provider_root.join("components/stdlib-data/src/regex/_core.rs"))?;
+        assert!(
+            generated_core.contains("str_concat("),
+            "the regenerated std.regex provider must lower owned-string concatenation through str_concat:\n{generated_core}"
+        );
+        assert!(
+            !generated_core.contains("out = out + str_slice"),
+            "the regenerated std.regex provider must not retain stale String + String lowering:\n{generated_core}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stale_sdk_inventory_rebuild_keeps_lock_preheat_provider_backed() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project = tmp.path().join("provider_backed_library");
+        fs::create_dir_all(project.join("src"))?;
+        fs::write(
+            project.join("incan.toml"),
+            "[project]\nname = \"provider_backed_library\"\nversion = \"0.1.0\"\n\n[project.scripts]\nlibrary = \"src/lib.incn\"\n",
+        )?;
+        fs::write(project.join("src/lib.incn"), "pub def answer() -> int:\n  return 42\n")?;
+        let stale_inventory = tmp.path().join("stale-sdk-inventory.json");
+        fs::write(
+            &stale_inventory,
+            r#"{
+  "schema_version": 1,
+  "sdk_id": "incan",
+  "sdk_version": "0.5.0",
+  "compiler_requirement": ">=0.5.0-dev.6,<0.6.0",
+  "components": {},
+  "profiles": {"default": []}
+}"#,
+        )?;
+        let provider_store = tmp.path().join("rebuilt-sdk-provider-store");
+        let generated_cargo_target = tmp.path().join("generated-cargo-target");
+        let configure = |command: &mut Command| {
+            command
+                .current_dir(&project)
+                .env_remove("INCAN_STDLIB")
+                .env_remove("INCAN_STDLIB_DIR")
+                .env("INCAN_SDK_INVENTORY", &stale_inventory)
+                .env("INCAN_INTERNAL_SDK_PROVIDER_STORE", &provider_store)
+                .env("INCAN_GENERATED_CARGO_TARGET_DIR", &generated_cargo_target);
+        };
+
+        let mut lock = incan_command();
+        configure(&mut lock);
+        let lock = lock.arg("lock").output()?;
+        assert!(
+            lock.status.success(),
+            "stale SDK lock preheat should rebuild from source: {}",
+            String::from_utf8_lossy(&lock.stderr)
+        );
+        let mut build = incan_command();
+        configure(&mut build);
+        let build = build.args(["build", "--lib", "--locked"]).output()?;
+        assert!(
+            build.status.success(),
+            "provider-backed library build after stale SDK lock preheat failed: {}",
+            String::from_utf8_lossy(&build.stderr)
+        );
+
+        let library_cargo = fs::read_to_string(project.join("target/lib/Cargo.toml"))?;
+        assert!(
+            library_cargo.contains("incan_stdlib_core"),
+            "library output must retain the rebuilt stdlib-core provider dependency:\n{library_cargo}"
+        );
+        assert!(
+            !project.join("target/lib/src/__incan_std").exists(),
+            "library output must not inline the SDK after stale-seed recovery"
+        );
+        let inventory_path = fs::read_dir(&provider_store)?
+            .filter_map(Result::ok)
+            .map(|entry| entry.path().join("sdk-inventory.json"))
+            .find(|path| path.is_file())
+            .ok_or("expected rebuilt SDK inventory")?;
+        let rebuilt_inventory = incan::provider::SdkInventory::read_from_path(&inventory_path)?;
+        rebuilt_inventory.validate_compiler_compatibility(
+            incan::version::INCAN_VERSION,
+            incan::version::SDK_PROVIDER_CODEGEN_REVISION,
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn test_run_std_regex_unsupported_safe_engine_pattern_reports_error() -> Result<(), Box<dyn std::error::Error>> {
         let output = incan_command()
             .args([

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7236,7 +7236,7 @@ async def main() -> None:
   "sdk_id": "incan",
   "sdk_version": "0.5.0",
   "compiler_requirement": ">=0.5.0-dev.6,<0.6.0",
-  "provider_codegen_revision": 3,
+  "provider_codegen_revision": 4,
   "components": {},
   "profiles": {"default": []}
 }"#,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7232,10 +7232,11 @@ async def main() -> None:
         fs::write(
             &stale_inventory,
             r#"{
-  "schema_version": 1,
+  "schema_version": 2,
   "sdk_id": "incan",
   "sdk_version": "0.5.0",
   "compiler_requirement": ">=0.5.0-dev.6,<0.6.0",
+  "provider_codegen_revision": 2,
   "components": {},
   "profiles": {"default": []}
 }"#,
@@ -7256,7 +7257,7 @@ async def main() -> None:
             .output()?;
         assert!(
             output.status.success(),
-            "a stale installed SDK inventory should rebuild from source when available: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            "a schema-2 inventory from the prior provider-codegen revision should rebuild from source when available: status={:?}\nstdout:\n{}\nstderr:\n{}",
             output.status,
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)

--- a/tests/semantic_core_parity_strings.rs
+++ b/tests/semantic_core_parity_strings.rs
@@ -36,6 +36,12 @@ fn semantics_vs_runtime_concat_and_contains() {
 }
 
 #[test]
+fn compiler_owned_byte_slice_helpers_keep_the_registered_runtime_abi() {
+    let _: fn(&str, i64, i64) -> String = rt_str_slice_byte_range;
+    let _: fn(&str, i64) -> String = rt_str_slice_from_byte_offset;
+}
+
+#[test]
 fn semantics_vs_runtime_index_and_slice() -> Result<(), StringAccessError> {
     let s = "héllo";
     // Index

--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -369,10 +369,11 @@ fn write_fixture_sdk_provider_seed(root: &Path, profile: &str) -> Result<PathBuf
         );
     }
     let inventory = serde_json::json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "sdk_id": "incan-fixture",
         "sdk_version": "0.5.0",
         "compiler_requirement": ">=0.5.0-dev.6,<0.6.0",
+        "provider_codegen_revision": incan::version::SDK_PROVIDER_CODEGEN_REVISION,
         "components": inventory_components,
         "profiles": {
             "minimal": ["stdlib-core"],
@@ -663,6 +664,12 @@ fn toolchain_archive_packager_writes_archive_checksum_and_release_metadata() -> 
         .arg(&extracted)
         .status()?;
     assert!(extract.success(), "toolchain archive extraction failed");
+    let shipped_inventory =
+        incan::provider::SdkInventory::read_from_path(&extracted.join("share/incan/sdk/sdk-inventory.json"))?;
+    shipped_inventory.validate_compiler_compatibility(
+        incan::version::INCAN_VERSION,
+        incan::version::SDK_PROVIDER_CODEGEN_REVISION,
+    )?;
     let metadata = Command::new("cargo")
         .args(["metadata", "--no-deps", "--format-version", "1", "--manifest-path"])
         .arg(extracted.join("crates/Cargo.toml"))


### PR DESCRIPTION
## Summary

This PR makes the compiler-owned Rust string helper contract deterministic in cold and warm SDK-provider builds. A genuinely fresh `CARGO_HOME` previously lost the return metadata for `str_slice_byte_range` and `str_slice_from_byte_offset` before IR lowering, so accepted Incan `out += helper(...)` source emitted invalid Rust `String + String`; a warmed inspection cache hid the defect.

The two compiler-owned helpers now have one exact signature registry that wins consistently over optional Rust-inspection metadata. Provider revision 5 invalidates artifacts generated under the old semantic contract, while invalid explicit or installed SDK inventories fail closed instead of silently rebuilding from nearby source.

PR #932 merged first as `488232e10`; this branch is now rebased onto that `main` and advances the release from dev.22 to dev.23. The rebase is patch-identical to the reviewed stack and produces the same final source tree.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Direct calls to the two internal Rust byte-slice helpers retain Incan `str` semantics in both cold and warm builds. Compound assignment lowers through `str_concat` instead of generating invalid Rust `String + String`.
- **Internals**: A bounded compiler-owned signature registry supplies the complete ABI for exactly the two helpers before optional rust-inspect metadata is consulted. Shared call validation records the same semantic facts for compiler-owned and inspected Rust functions. Exact nominal Rust `String` normalization and generated-provider invalidation remain narrowly scoped.
- **Risks**: The special contract is exact-path based; there is no suffix match or broad `Unknown` fallback. Stale explicit or installed SDK inventories now fail closed and require a matching SDK rather than borrowing source from a nearby checkout.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Stable and Rust 1.93 focused suites cover both complete helper ABIs, deliberately stale warm metadata, direct-import IR lowering, negative nominal String cases, native ABI parity, fail-closed inventories, and the semantic-string audit.
- Truly fresh online `CARGO_HOME` provider tests passed on stable (262.68s) and Rust 1.93 (285.12s).
- Exact dev.23 `make pre-commit` passed: 3,171/3,171 tests, Clippy, cargo-deny, assertion canary, 60 example checks/runs, web and nested-project builds, and 9 benchmark builds.
- The exact dev.23 release binary populated an empty Cargo home and SDK provider store, ran the full `std.regex` surface, and generated `stdlib-data` with three byte-range and three suffix sites under `str_concat` and no raw `out = out + str_slice` site.
- The web consumer then built successfully against that same fresh provider store and Cargo home.
- Independent scope/architecture, maintainability/Rust-prose, and test-style review passes are clean.
- The reviewed stacked head `38feae15f` passed all 42 hosted checks. Rebasing onto merged #932 produced a patch-identical range-diff and byte-identical final source tree at `467a549fe`.

## Merge sequencing

#932 was merged first because its cold-provider invalidation exposes this defect. This PR was then rebased onto the resulting `main`; no implementation or generated output changed during that history-only rewrite.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

This repairs compiler/runtime metadata behavior without adding or changing a public language or stdlib API.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #896
