### PR TITLE
bugfix - preserve derived trait owners across modules (#946)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "blake2",
  "blake3",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "serde",
  "serde_json",
@@ -1529,14 +1529,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1545,14 +1545,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "axum",
  "incan_core",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "axum",
  "incan_stdlib",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.31"
+version = "0.5.0-dev.32"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -796,7 +796,7 @@ impl TypeChecker {
                             name: canonical,
                             source_name: Some(trait_name.clone()),
                             type_args: Vec::new(),
-                            module_path: None,
+                            module_path: Some(module_path.clone()),
                         });
                     }
                 }
@@ -819,7 +819,7 @@ impl TypeChecker {
                             name: derive_name.clone(),
                             source_name: Some(trait_name.clone()),
                             type_args: Vec::new(),
-                            module_path: None,
+                            module_path: Some(module_segments.to_vec()),
                         });
                     }
                 } else if self.lookup_trait_info(derive_name).is_some() {

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -18275,7 +18275,7 @@ def main() -> NodeId:
 }
 
 #[test]
-fn test_user_module_derive_on_newtype_uses_identity_bearing_trait_adoption() -> Result<(), Box<dyn std::error::Error>> {
+fn test_user_module_derives_on_newtypes_use_owner_bearing_trait_adoptions() -> Result<(), Box<dyn std::error::Error>> {
     let yaml_source = r#"
 __derives__ = [Serialize]
 
@@ -18286,9 +18286,13 @@ pub trait Serialize:
 "#;
     let source = r#"
 import yaml
+from yaml import Serialize as YamlSerialize
 
 @derive(yaml)
 pub type Token = newtype str
+
+@derive(YamlSerialize)
+pub type AliasToken = newtype str
 
 def encode[T with yaml.Serialize](value: T) -> str:
   return value.to_yaml()
@@ -18305,14 +18309,35 @@ def main() -> str:
         .map_err(|errors| std::io::Error::other(format!("custom newtype derive failed: {errors:?}")))?;
     let exports = collect_checked_public_exports(&ast, &checker);
     let manifest = LibraryManifest::from_checked_exports("custom_newtype", "0.1.0", &exports);
-    let token = manifest.exports.newtypes.first().ok_or("missing Token export")?;
+    let token = manifest
+        .exports
+        .newtypes
+        .iter()
+        .find(|newtype| newtype.name == "Token")
+        .ok_or("missing Token export")?;
     assert!(
-        token
-            .trait_adoptions
-            .iter()
-            .any(|adoption| adoption.name == "yaml.Serialize" && adoption.source_name.as_deref() == Some("Serialize")),
-        "expected identity-bearing yaml.Serialize adoption, got {:?}",
+        token.trait_adoptions.iter().any(|adoption| {
+            adoption.name == "yaml.Serialize"
+                && adoption.source_name.as_deref() == Some("Serialize")
+                && adoption.module_path.as_deref() == Some(&["yaml".to_string()])
+        }),
+        "expected identity- and owner-bearing yaml.Serialize adoption, got {:?}",
         token.trait_adoptions
+    );
+    let alias_token = manifest
+        .exports
+        .newtypes
+        .iter()
+        .find(|newtype| newtype.name == "AliasToken")
+        .ok_or("missing AliasToken export")?;
+    assert!(
+        alias_token.trait_adoptions.iter().any(|adoption| {
+            adoption.name == "YamlSerialize"
+                && adoption.source_name.as_deref() == Some("Serialize")
+                && adoption.module_path.as_deref() == Some(&["yaml".to_string()])
+        }),
+        "expected directly imported YamlSerialize adoption to retain its canonical owner, got {:?}",
+        alias_token.trait_adoptions
     );
     Ok(())
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1117,6 +1117,94 @@ def test_artifact_path() -> None:
 }
 
 #[test]
+fn compiled_json_trait_owner_crosses_library_boundaries_issue946() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let provider_root = tmp.path().join("json_provider");
+    let _provider_main = write_minimal_project(
+        &provider_root,
+        "json_provider",
+        "\n[sdk]\nprofile = \"minimal\"\ncomponents = [\"stdlib-data\"]\n",
+    )?;
+    fs::write(
+        provider_root.join("src/lib.incn"),
+        "pub from crate.codec import encode_item\npub from crate.models import Item\n",
+    )?;
+    fs::write(
+        provider_root.join("src/models.incn"),
+        r#"from std.serde import json
+
+@derive(json)
+pub model Item:
+  pub value: str
+"#,
+    )?;
+    fs::write(
+        provider_root.join("src/codec.incn"),
+        r#"from std.serde.json import Serialize
+from crate.models import Item
+
+pub def encode_item(item: Item) -> str:
+  return item.to_json()
+"#,
+    )?;
+
+    let provider_build = run_incan(&provider_root, &["build", "--lib"])?;
+    assert_success(
+        &provider_build,
+        "multi-module JSON provider library with a direct Serialize import",
+    );
+    let generated_encoder = fs::read_to_string(provider_root.join("target/lib/src/codec.rs"))?;
+    assert!(
+        generated_encoder.contains("__incan_std::serde::json::Serialize::to_json(&item)"),
+        "generated encoder must retain the canonical source trait owner:\n{generated_encoder}"
+    );
+    assert!(
+        !generated_encoder.contains("return json::Serialize::to_json(&item)"),
+        "generated encoder cannot rely on another source module's `json` import:\n{generated_encoder}"
+    );
+
+    let consumer_root = tmp.path().join("consumer");
+    let consumer_main = write_minimal_project(
+        &consumer_root,
+        "json_consumer",
+        "[dependencies]\njson_provider = { path = \"../json_provider\" }\n",
+    )?;
+    fs::write(
+        &consumer_main,
+        r#"from pub::json_provider import Item, encode_item
+
+def main() -> None:
+  println(encode_item(Item(value="ok")))
+"#,
+    )?;
+    let tests_dir = consumer_root.join("tests");
+    fs::create_dir_all(&tests_dir)?;
+    fs::write(
+        tests_dir.join("test_json_provider.incn"),
+        r#"from pub::json_provider import Item, encode_item
+from std.testing import assert_eq
+
+def test_compiled_json_provider() -> None:
+  assert_eq(encode_item(Item(value="ok")), "{\"value\":\"ok\"}")
+"#,
+    )?;
+
+    let consumer_run = run_incan(&consumer_root, &["run"])?;
+    assert_success(&consumer_run, "consumer of the compiled multi-module JSON provider");
+    assert!(
+        String::from_utf8_lossy(&consumer_run.stdout).contains("{\"value\":\"ok\"}"),
+        "unexpected compiled JSON provider output:\n{}",
+        String::from_utf8_lossy(&consumer_run.stdout)
+    );
+    let consumer_test = run_incan(&consumer_root, &["test"])?;
+    assert_success(
+        &consumer_test,
+        "package test batch consuming the compiled multi-module JSON provider",
+    );
+    Ok(())
+}
+
+#[test]
 fn data_component_owns_hashing_without_linking_the_codecs_provider() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(

--- a/tests/codegen_snapshot_tests.rs
+++ b/tests/codegen_snapshot_tests.rs
@@ -3533,6 +3533,51 @@ def main() -> str:
     );
 }
 
+#[test]
+fn test_direct_json_trait_import_keeps_canonical_owner_across_modules_issue946() {
+    let models_source = r#"
+from std.serde import json
+
+@derive(json)
+pub model Item:
+  pub value: str
+"#;
+    let encode_source = r#"
+from std.serde.json import Serialize
+from crate.models import Item
+
+pub def encode(item: Item) -> str:
+  return item.to_json()
+"#;
+    let root_source = r#"
+from crate.encode import encode
+from crate.models import Item
+"#;
+    let models_ast = parse_incan_program(models_source, "JSON model module");
+    let encode_ast = parse_incan_program(encode_source, "JSON encoder module");
+    let root_ast = parse_incan_program(root_source, "JSON library root");
+    let mut codegen = codegen_with_builtin_stdlib_inventory();
+    codegen.add_module_with_path_segments("models", &models_ast, vec!["models".to_string()]);
+    codegen.add_module_with_path_segments("encode", &encode_ast, vec!["encode".to_string()]);
+    let (_root_code, modules) = codegen
+        .try_generate_multi_file_nested(&root_ast, &[vec!["models".to_string()], vec!["encode".to_string()]])
+        .unwrap_or_else(|err| panic!("multi-module JSON library should codegen: {err:?}"));
+    let Some(encode_module) = modules.get(&vec!["encode".to_string()]) else {
+        panic!("missing generated encoder module");
+    };
+    let rust_code = normalize_codegen_output(encode_module);
+    let compact = rust_code.chars().filter(|ch| !ch.is_whitespace()).collect::<String>();
+
+    assert!(
+        compact.contains("crate::__incan_std::serde::json::Serialize::to_json(&item)"),
+        "directly imported source traits must preserve their canonical owner in each generated module:\n{rust_code}"
+    );
+    assert!(
+        !compact.contains("returnjson::Serialize::to_json(&item)"),
+        "the encoder module does not import the source `json` module:\n{rust_code}"
+    );
+}
+
 /// RFC 024: module-level derive metadata should let `@derive(json)` adopt serde traits and emit Rust derives.
 #[test]
 fn test_rfc024_module_derive_json_codegen() {

--- a/tests/snapshots/codegen_snapshot_tests__std_serde_json_import.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_serde_json_import.snap
@@ -114,7 +114,7 @@ fn main() {
         }),
     );
     let _ = println!(
-        "{}", json::Serialize::to_json(& Config { host : "localhost".to_string(), port :
-        8080, debug : true },)
+        "{}", crate ::__incan_std::serde::json::Serialize::to_json(& Config { host :
+        "localhost".to_string(), port : 8080, debug : true },)
     );
 }

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -37,6 +37,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: Derived source traits now retain their canonical declaring module when imported directly into another source module, so method calls across compiled-library boundaries emit provider-qualified Rust paths instead of depending on an unrelated local module alias. Multi-module JSON libraries can therefore define `@derive(json)` models separately from `Serialize`-using helpers and publish both through a package facade (#946).
 - **Lockfiles**: Compiled providers now publish a digest of their authored manifest and selected Incan source inputs for canonical semantic identity, while generated Rust and host ABI metadata remain under the byte-exact physical artifact digest. Equivalent native provider builds therefore share one SDK inventory and dependency fingerprint across macOS and Linux without weakening strict locks or user-authored path dependency identity (#931).
 - **Compiler**: Published Rust ABI metadata now excludes traits introduced only by unrelated downstream crates in the loaded inspection graph, keeping SDK provider identities and workspace dependency fingerprints stable across cache state and host platforms (#924).
 - **Compiler**: Legacy `read_file` and `write_file` builtins now convert Rust filesystem errors into their declared owned Incan `str` error type, so string operations on `Result` errors compile through generated Rust (#874).


### PR DESCRIPTION
## Summary

This PR preserves the canonical declaring module for RFC 024 synthetic trait adoptions. A model derived in one source module can now use a directly imported trait from another module without generated Rust depending on the first module's local alias, fixing multi-module `std.serde.json` libraries that previously emitted unresolved `json::Serialize` paths.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Multi-module libraries can define `@derive(json)` models separately from helpers that import `Serialize`, then publish and consume both through a package facade.
- **Internals**: Derive collection now records the canonical imported module path for module derives and directly imported trait derives. Checked library metadata and downstream lowering therefore share one owner fact, and generated modules emit provider-qualified trait paths.
- **Risks**: Trait-call paths for derived source traits become canonical rather than module-local. Existing single-module JSON codegen changes only by using the equivalent provider-qualified path.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Reproduced #946 on the prior `main` as generated Rust E0433 for unresolved `json::Serialize`.
- Stable and Rust 1.93 focused matrices each passed semantic metadata, multi-module codegen, a fresh compiled `stdlib-data` provider, a separate package run, and a package test batch.
- `make pre-commit` passed 3,362 tests, Clippy, cargo-deny, the release assertion canary, web and nested-project builds, 60 examples, and 9 benchmarks before the conflict-free version-only rebase.
- The exact dev.32 head passed nightly formatting, changed-rustdoc validation, Clippy with `-D warnings`, the documentation build, and diff hygiene.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_5.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #946
