### PR TITLE
bugfix - prevent nested source self imports and cover f-string calls (#976, #979)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "blake2",
  "blake3",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "serde",
  "serde_json",
@@ -1529,14 +1529,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1545,14 +1545,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "axum",
  "incan_core",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "axum",
  "incan_stdlib",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-dev.38"
+version = "0.5.0-dev.39"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -3398,6 +3398,84 @@ def main() -> int:
     }
 
     #[test]
+    /// Verifies that a direct zero-argument call remains an ordinary call expression inside an f-string interpolation.
+    fn test_parse_fstring_expr_direct_zero_arg_call() -> Result<(), Vec<CompileError>> {
+        let source = "def enabled() -> bool:\n  return True\n\ndef render() -> str:\n  return f\"enabled:{enabled()}\"\n";
+        let program = parse_str(source)?;
+        let render = match &program.declarations[1].node {
+            Declaration::Function(function) => function,
+            _ => {
+                return Err(vec![CompileError::new(
+                    "parser test internal error: expected render function".to_string(),
+                    program.declarations[1].span,
+                )]);
+            }
+        };
+        let interpolation = match &render.body[0].node {
+            Statement::Return(Some(expr)) => match &expr.node {
+                Expr::FString(parts) => match &parts[1] {
+                    FStringPart::Expr { expr, .. } => expr,
+                    _ => {
+                        return Err(vec![CompileError::new(
+                            "parser test internal error: expected f-string interpolation".to_string(),
+                            expr.span,
+                        )]);
+                    }
+                },
+                _ => {
+                    return Err(vec![CompileError::new(
+                        "parser test internal error: expected f-string return value".to_string(),
+                        expr.span,
+                    )]);
+                }
+            },
+            _ => {
+                return Err(vec![CompileError::new(
+                    "parser test internal error: expected return expression".to_string(),
+                    render.body[0].span,
+                )]);
+            }
+        };
+
+        let expected_interpolation_start = match source.rfind("{enabled()}") {
+            Some(start) => start,
+            None => {
+                return Err(vec![CompileError::new(
+                    "parser test internal error: missing direct-call interpolation".to_string(),
+                    render.body[0].span,
+                )]);
+            }
+        };
+        let expected_callee_start = match source.rfind("enabled()") {
+            Some(start) => start,
+            None => {
+                return Err(vec![CompileError::new(
+                    "parser test internal error: missing direct-call callee".to_string(),
+                    render.body[0].span,
+                )]);
+            }
+        };
+
+        assert_eq!(interpolation.span.start, expected_interpolation_start);
+        assert_eq!(
+            interpolation.span.end,
+            expected_interpolation_start + "{enabled()}".len()
+        );
+        let Expr::Call(callee, type_args, args) = &interpolation.node else {
+            return Err(vec![CompileError::new(
+                "parser test internal error: expected direct call interpolation".to_string(),
+                interpolation.span,
+            )]);
+        };
+        assert!(type_args.is_empty());
+        assert!(args.is_empty());
+        assert!(matches!(&callee.node, Expr::Ident(name) if name == "enabled"));
+        assert_eq!(callee.span.start, expected_callee_start);
+        assert_eq!(callee.span.end, expected_callee_start + "enabled".len());
+        Ok(())
+    }
+
+    #[test]
     fn test_parse_fstring_expr_span_method_call_with_index() -> Result<(), Vec<CompileError>> {
         let source = "def render(users: List[str]) -> str:\n  return f\"user: {users[unknown_idx].upper()}\"\n";
         let program = parse_str(source)?;

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -26,7 +26,7 @@ use crate::frontend::library_exports::{CheckedExportKind, CheckedNamedExport, co
 use crate::frontend::library_manifest_index::{LibraryArtifactKind, LibraryManifestIndex, LibraryManifestIndexEntry};
 use crate::frontend::module::{
     SourceModuleImportResolution, canonicalize_source_module_segments, resolve_program_source_imports,
-    resolve_source_module_import,
+    resolve_source_module_import_from_source_file, self_import_diagnostic_message,
 };
 use crate::frontend::registry_metadata::{
     CHECKED_REGISTRY_METADATA_SCHEMA_VERSION, CheckedRegistryMetadataPackage, CheckedRegistryPackageIdentity,
@@ -2230,8 +2230,24 @@ fn collect_unprojected_provider_modules(
         })?;
         let base_dir = file_path.parent().unwrap_or(session.source_root.as_path());
         for resolved in resolve_program_source_imports(&ast, base_dir, Some(&session.source_root)) {
-            if let SourceModuleImportResolution::Local(module) = resolved.resolution {
-                pending.push((module.file_path, module.module_name, module.path_segments));
+            match resolved.resolution {
+                SourceModuleImportResolution::Local(module) => {
+                    pending.push((module.file_path, module.module_name, module.path_segments));
+                }
+                SourceModuleImportResolution::SelfImport {
+                    module_ref,
+                    import_path,
+                    can_use_root_import,
+                } => {
+                    let error = diagnostics::CompileError::new(
+                        self_import_diagnostic_message(&module_ref, &import_path, can_use_root_import),
+                        resolved.span,
+                    );
+                    return Err(CliError::failure(
+                        diagnostics::format_error(file_path.to_string_lossy().as_ref(), &source, &error).trim_end(),
+                    ));
+                }
+                SourceModuleImportResolution::Stdlib { .. } | SourceModuleImportResolution::External => {}
             }
         }
         modules.push(ParsedModule {
@@ -2390,10 +2406,25 @@ fn propagate_provider_feature_predicates(
             let Declaration::Import(import) = &declaration.node else {
                 continue;
             };
-            let SourceModuleImportResolution::Local(target) =
-                resolve_source_module_import(base_dir, Some(source_root), import)
-            else {
-                continue;
+            let target = match resolve_source_module_import_from_source_file(
+                base_dir,
+                Some(source_root),
+                Some(&module.file_path),
+                import,
+            ) {
+                SourceModuleImportResolution::Local(target) => target,
+                SourceModuleImportResolution::SelfImport {
+                    module_ref,
+                    import_path,
+                    can_use_root_import,
+                } => {
+                    return Err(CliError::failure(self_import_diagnostic_message(
+                        &module_ref,
+                        &import_path,
+                        can_use_root_import,
+                    )));
+                }
+                SourceModuleImportResolution::Stdlib { .. } | SourceModuleImportResolution::External => continue,
             };
             let target_path = canonical_provider_source_path(&target.file_path);
             let Some(target_module) = modules_by_path.get(&target_path) else {

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -30,7 +30,7 @@ use crate::frontend::library_manifest_index::{
 };
 use crate::frontend::module::{
     SourceModuleImportResolution, canonicalize_source_module_segments, logical_module_segments_from_file,
-    logical_source_import_candidates, resolve_program_source_imports,
+    logical_source_import_candidates, resolve_program_source_imports, self_import_diagnostic_message,
 };
 use crate::frontend::testing_markers::{
     TestingMarkerSemantics, load_testing_marker_semantics, testing_marker_semantics_from_manifest,
@@ -3571,6 +3571,7 @@ fn collect_modules_detailed_from_seeds(
             }
         }
         for resolved in resolve_program_source_imports(&ast, current_base, Some(&session.source_root)) {
+            let span = resolved.span;
             match resolved.resolution {
                 SourceModuleImportResolution::Stdlib { module_path } => {
                     if stdlib::stdlib_stub_path(&module_path).is_none() {
@@ -3610,6 +3611,21 @@ fn collect_modules_detailed_from_seeds(
                         .entry(file_path.clone())
                         .or_default()
                         .insert(dep_path_str);
+                }
+                SourceModuleImportResolution::SelfImport {
+                    module_ref,
+                    import_path,
+                    can_use_root_import,
+                } => {
+                    return Err(CliDiagnosticFailure::single(
+                        file_path,
+                        source,
+                        diagnostics::CompileError::new(
+                            self_import_diagnostic_message(&module_ref, &import_path, can_use_root_import),
+                            span,
+                        ),
+                        diagnostics::DiagnosticPhase::Typecheck,
+                    ));
                 }
                 SourceModuleImportResolution::External => {}
             }

--- a/src/cli/test_runner/module_graph.rs
+++ b/src/cli/test_runner/module_graph.rs
@@ -10,7 +10,9 @@ use crate::cli::prelude::ParsedModule;
 use crate::compiled_sdk::CompiledSdkModules;
 use crate::frontend::ast::Program;
 use crate::frontend::library_manifest_index::LibraryManifestIndex;
-use crate::frontend::module::{SourceModuleImportResolution, resolve_program_source_imports};
+use crate::frontend::module::{
+    SourceModuleImportResolution, resolve_program_source_imports, self_import_diagnostic_message,
+};
 use crate::frontend::vocab_desugar_pass;
 use crate::frontend::{diagnostics, lexer, parser};
 use crate::provider::ProviderPlan;
@@ -80,6 +82,17 @@ fn queue_resolved_source_import(
                 ));
             }
             return Ok(Some(module_ref.file_path));
+        }
+        SourceModuleImportResolution::SelfImport {
+            module_ref,
+            import_path,
+            can_use_root_import,
+        } => {
+            return Err(self_import_diagnostic_message(
+                &module_ref,
+                &import_path,
+                can_use_root_import,
+            ));
         }
         SourceModuleImportResolution::External => {}
     }

--- a/src/frontend/module.rs
+++ b/src/frontend/module.rs
@@ -38,6 +38,15 @@ impl SourceModuleRef {
 pub(crate) enum SourceModuleImportResolution {
     /// Import resolved to a local Incan source file.
     Local(SourceModuleRef),
+    /// Import resolved to the importing source file itself.
+    ///
+    /// Source-graph consumers must reject this before typechecking or Rust emission. A bare import is
+    /// same-directory-relative, so a nested collision that intends the project root must spell `crate::...`.
+    SelfImport {
+        module_ref: SourceModuleRef,
+        import_path: Vec<String>,
+        can_use_root_import: bool,
+    },
     /// Import points at an Incan stdlib source module. Callers that materialize stdlib source decide how to load it.
     Stdlib { module_path: Vec<String> },
     /// Import is not a source-backed Incan module, or no matching local source file exists.
@@ -61,6 +70,7 @@ pub(crate) fn resolve_program_source_imports(
     base_dir: &Path,
     source_root: Option<&Path>,
 ) -> Vec<ResolvedProgramSourceImport> {
+    let current_source_file = program.source_path.as_deref().map(Path::new);
     program
         .declarations
         .iter()
@@ -70,7 +80,12 @@ pub(crate) fn resolve_program_source_imports(
             };
             let mut resolved = vec![ResolvedProgramSourceImport {
                 span: decl.span,
-                resolution: resolve_source_module_import(base_dir, source_root, import),
+                resolution: resolve_source_module_import_from_source_file(
+                    base_dir,
+                    source_root,
+                    current_source_file,
+                    import,
+                ),
             }];
 
             if let ImportKind::From { module, items } = &import.kind
@@ -106,6 +121,19 @@ pub(crate) fn resolve_source_module_import(
     source_root: Option<&Path>,
     import: &ImportDecl,
 ) -> SourceModuleImportResolution {
+    resolve_source_module_import_from_source_file(base_dir, source_root, None, import)
+}
+
+/// Resolve one import declaration while retaining the importing source-file identity when it is known.
+///
+/// A located local module that is the importing file is classified as [`SourceModuleImportResolution::SelfImport`].
+/// This keeps accidental self imports from entering the source graph and becoming recursive generated Rust.
+pub(crate) fn resolve_source_module_import_from_source_file(
+    base_dir: &Path,
+    source_root: Option<&Path>,
+    current_source_file: Option<&Path>,
+    import: &ImportDecl,
+) -> SourceModuleImportResolution {
     let Some((path, candidates)) = source_import_candidates(import) else {
         return SourceModuleImportResolution::External;
     };
@@ -123,10 +151,11 @@ pub(crate) fn resolve_source_module_import(
     }
 
     let identity_root = effective_source_root(base_dir, source_root);
+    let can_use_root_import = !path.is_absolute && path.parent_levels == 0;
 
     let primary_base = primary_import_base_dir(base_dir, source_root, path);
     if let Some(module_ref) = resolve_first_source_candidate(&primary_base, identity_root.as_deref(), &candidates) {
-        return SourceModuleImportResolution::Local(module_ref);
+        return classify_local_source_import(module_ref, current_source_file, &path.segments, can_use_root_import);
     }
 
     if !path.is_absolute
@@ -135,10 +164,55 @@ pub(crate) fn resolve_source_module_import(
         && root != primary_base
         && let Some(module_ref) = resolve_first_source_candidate(&root, Some(&root), &candidates)
     {
-        return SourceModuleImportResolution::Local(module_ref);
+        return classify_local_source_import(module_ref, current_source_file, &path.segments, can_use_root_import);
     }
 
     SourceModuleImportResolution::External
+}
+
+/// Classify a located source module while enforcing the no-self-import invariant.
+fn classify_local_source_import(
+    module_ref: SourceModuleRef,
+    current_source_file: Option<&Path>,
+    import_path: &[String],
+    can_use_root_import: bool,
+) -> SourceModuleImportResolution {
+    if current_source_file.is_some_and(|source_file| source_files_match(source_file, &module_ref.file_path)) {
+        return SourceModuleImportResolution::SelfImport {
+            module_ref,
+            import_path: import_path.to_vec(),
+            can_use_root_import,
+        };
+    }
+    SourceModuleImportResolution::Local(module_ref)
+}
+
+/// Return whether two source paths name the same file, accounting for canonical and relative spellings.
+fn source_files_match(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
+/// Render the common diagnostic for an accidental source-module self import.
+pub(crate) fn self_import_diagnostic_message(
+    module_ref: &SourceModuleRef,
+    import_path: &[String],
+    can_use_root_import: bool,
+) -> String {
+    let message = format!(
+        "module `{}` imports itself; remove this import",
+        module_ref.path_segments.join(".")
+    );
+    if can_use_root_import && module_ref.path_segments != import_path {
+        format!(
+            "{message} or use `crate::{}` to import a project-root module",
+            import_path.join(".")
+        )
+    } else {
+        message
+    }
 }
 
 /// Resolve an `import` / `from ... import ...` into an on-disk Incan module file path.
@@ -149,7 +223,9 @@ pub(crate) fn resolve_source_module_import(
 pub fn resolve_import_path(base_dir: &Path, import: &ImportDecl) -> Option<PathBuf> {
     match resolve_source_module_import(base_dir, None, import) {
         SourceModuleImportResolution::Local(module_ref) => Some(module_ref.file_path),
-        SourceModuleImportResolution::Stdlib { .. } | SourceModuleImportResolution::External => None,
+        SourceModuleImportResolution::SelfImport { .. }
+        | SourceModuleImportResolution::Stdlib { .. }
+        | SourceModuleImportResolution::External => None,
     }
 }
 
@@ -892,6 +968,72 @@ source-root = "library"
         assert_eq!(module_ref.file_path, sibling.canonicalize()?);
         assert_eq!(module_ref.path_segments, vec!["pkg".to_string(), "bar".to_string()]);
         assert_eq!(module_ref.module_name, "pkg_bar");
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_program_source_imports_does_not_admit_same_leaf_self_import() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let src = tmp.path().join("src");
+        let nested = src.join("substrait");
+        std::fs::create_dir_all(&nested)?;
+        let nested_registry = nested.join("schema_registry.incn");
+        std::fs::write(&nested_registry, "from schema_registry import registered_columns\n")?;
+
+        let source = std::fs::read_to_string(&nested_registry)?;
+        let tokens =
+            lexer::lex(&source).map_err(|errors| std::io::Error::other(format!("fixture should lex: {errors:?}")))?;
+        let source_path = nested_registry.to_string_lossy();
+        let program = parser::parse_with_context_and_surfaces(&tokens, Some(source_path.as_ref()), None, None)
+            .map_err(|errors| std::io::Error::other(format!("fixture should parse: {errors:?}")))?;
+
+        let resolved = resolve_program_source_imports(&program, &nested, Some(&src));
+        let canonical_nested_registry = nested_registry.canonicalize()?;
+        assert!(matches!(
+            &resolved[0].resolution,
+            SourceModuleImportResolution::SelfImport { module_ref, import_path, can_use_root_import }
+                if module_ref.file_path == canonical_nested_registry
+                    && import_path == &["schema_registry"]
+                    && *can_use_root_import
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_source_module_import_keeps_explicit_root_and_distinct_sibling_precedence()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let src = tmp.path().join("src");
+        let nested = src.join("substrait");
+        std::fs::create_dir_all(&nested)?;
+        let root_registry = src.join("schema_registry.incn");
+        let nested_registry = nested.join("schema_registry.incn");
+        let consumer = nested.join("consumer.incn");
+        std::fs::write(&root_registry, "pub const ROOT: int = 1\n")?;
+        std::fs::write(&nested_registry, "pub const NESTED: int = 2\n")?;
+        std::fs::write(&consumer, "pub const CONSUMER: int = 3\n")?;
+
+        let bare_import = relative_module_import(&["schema_registry"]);
+        let SourceModuleImportResolution::Local(sibling) =
+            resolve_source_module_import_from_source_file(&nested, Some(&src), Some(&consumer), &bare_import)
+        else {
+            return Err("expected a distinct same-directory module to remain preferred".into());
+        };
+        assert_eq!(sibling.file_path, nested_registry.canonicalize()?);
+
+        let root_import = ImportDecl {
+            visibility: Visibility::Private,
+            kind: ImportKind::Module(ImportPath::absolute(vec!["schema_registry".to_string()])),
+            alias: None,
+        };
+        let SourceModuleImportResolution::Local(root) =
+            resolve_source_module_import_from_source_file(&nested, Some(&src), Some(&nested_registry), &root_import)
+        else {
+            return Err("expected an explicit root import to select the root module".into());
+        };
+        assert_eq!(root.file_path, root_registry.canonicalize()?);
+
         Ok(())
     }
 

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -47,7 +47,9 @@ use crate::frontend::contract_metadata::{
 };
 use crate::frontend::diagnostics::{CompileError, DiagnosticPhase, phase_for_typecheck_span};
 use crate::frontend::library_manifest_index::{LibraryManifestIndex, LibraryManifestIndexEntry};
-use crate::frontend::module::{SourceModuleImportResolution, resolve_program_source_imports};
+use crate::frontend::module::{
+    SourceModuleImportResolution, resolve_program_source_imports, self_import_diagnostic_message,
+};
 use crate::frontend::symbols::{FunctionInfo, ResolvedType, SymbolKind as FrontendSymbolKind, TypeInfo};
 use crate::frontend::typechecker::stdlib_loader::{StdlibAstCache, StdlibFunctionLspMetadata};
 use crate::frontend::{lexer, parser, typechecker};
@@ -519,8 +521,24 @@ impl IncanLanguageServer {
 
         // Seed stack with direct imports from the entry AST
         for resolved in resolve_program_source_imports(ast, &entry_base, source_root) {
-            if let SourceModuleImportResolution::Local(module_ref) = resolved.resolution {
-                stack.push((module_ref, resolved.span));
+            match resolved.resolution {
+                SourceModuleImportResolution::Local(module_ref) => stack.push((module_ref, resolved.span)),
+                SourceModuleImportResolution::SelfImport {
+                    module_ref,
+                    import_path,
+                    can_use_root_import,
+                } => entry_diags.push(Diagnostic {
+                    range: span_to_range(entry_source, resolved.span.start, resolved.span.end),
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: None,
+                    code_description: None,
+                    source: Some("incan".to_string()),
+                    message: self_import_diagnostic_message(&module_ref, &import_path, can_use_root_import),
+                    related_information: None,
+                    tags: None,
+                    data: None,
+                }),
+                SourceModuleImportResolution::Stdlib { .. } | SourceModuleImportResolution::External => {}
             }
         }
 
@@ -597,10 +615,33 @@ impl IncanLanguageServer {
 
             // Queue nested dependencies
             let current_base = canonical.parent().unwrap_or(&entry_base);
+            let mut dependency_diags = Vec::new();
             for resolved in resolve_program_source_imports(&dep_ast, current_base, source_root) {
-                if let SourceModuleImportResolution::Local(nested_ref) = resolved.resolution {
-                    stack.push((nested_ref, Span::default()));
+                match resolved.resolution {
+                    SourceModuleImportResolution::Local(nested_ref) => stack.push((nested_ref, Span::default())),
+                    SourceModuleImportResolution::SelfImport {
+                        module_ref,
+                        import_path,
+                        can_use_root_import,
+                    } => dependency_diags.push(Diagnostic {
+                        range: span_to_range(&dep_source, resolved.span.start, resolved.span.end),
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        code: None,
+                        code_description: None,
+                        source: Some("incan".to_string()),
+                        message: self_import_diagnostic_message(&module_ref, &import_path, can_use_root_import),
+                        related_information: None,
+                        tags: None,
+                        data: None,
+                    }),
+                    SourceModuleImportResolution::Stdlib { .. } | SourceModuleImportResolution::External => {}
                 }
+            }
+            if !dependency_diags.is_empty()
+                && let Some(uri) = dep_uri.clone()
+            {
+                let version = dep_doc.map(|document| document.version);
+                self.client.publish_diagnostics(uri, dependency_diags, version).await;
             }
 
             result.push(ParsedModule {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -9147,6 +9147,30 @@ def main() -> None:
     Ok(())
 }
 
+/// Verifies that a direct zero-argument call in an f-string survives the complete CLI pipeline.
+#[test]
+fn fstring_interpolation_zero_arg_function_call_issue979() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "fstring_zero_arg_call_issue979", "")?;
+    fs::write(
+        &main_path,
+        r#"def enabled() -> bool:
+  return True
+
+def main() -> None:
+  println(f"enabled:{enabled()}")
+"#,
+    )?;
+
+    let main_arg = main_path.to_str().ok_or("main path was not valid UTF-8")?;
+    let check = run_incan(tmp.path(), &["check", main_arg, "--sdk-profile", "minimal"])?;
+    assert_success(&check, "incan check with a direct f-string zero-argument call");
+    let output = run_incan(tmp.path(), &["run", main_arg, "--sdk-profile", "minimal"])?;
+    assert_success(&output, "incan run with a direct f-string zero-argument call");
+    assert_eq!(String::from_utf8(output.stdout)?, "enabled:true\n");
+    Ok(())
+}
+
 #[test]
 fn build_static_str_const_rust_string_struct_field() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7216,6 +7216,135 @@ def main() -> None:
         Ok(())
     }
 
+    /// Regression (GitHub #976): an explicit `crate::` import must select the root module even when a nested module
+    /// has the same leaf name.
+    #[test]
+    fn test_run_explicit_root_import_over_same_leaf_nested_module() -> Result<(), Box<dyn std::error::Error>> {
+        let project_dir = make_temp_dir("incan_explicit_root_import");
+        let src_dir = project_dir.join("src");
+        let nested_dir = src_dir.join("substrait");
+        std::fs::create_dir_all(&nested_dir)?;
+        std::fs::write(
+            project_dir.join("incan.toml"),
+            "[project]\nname = \"explicit_root_import\"\nversion = \"0.1.0\"\n",
+        )?;
+
+        let main_path = src_dir.join("main.incn");
+        std::fs::write(
+            &main_path,
+            r#"from substrait.schema_registry import selected_value
+
+def main() -> None:
+  println(selected_value())
+"#,
+        )?;
+        std::fs::write(
+            src_dir.join("schema_registry.incn"),
+            r#"pub def root_value() -> str:
+  return "root registry"
+"#,
+        )?;
+        std::fs::write(
+            nested_dir.join("schema_registry.incn"),
+            r#"from crate::schema_registry import root_value
+
+pub def selected_value() -> str:
+  return root_value()
+"#,
+        )?;
+
+        let run_output = incan_command()
+            .args(["run", main_path.to_string_lossy().as_ref()])
+            .env("INCAN_SOURCE_ROOT", env!("CARGO_MANIFEST_DIR"))
+            .env(
+                "INCAN_STDLIB",
+                Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/incan_stdlib/stdlib"),
+            )
+            .env_remove("INCAN_STDLIB_DIR")
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            run_output.status.success(),
+            "explicit root import project failed: status={:?} stderr={}",
+            run_output.status,
+            String::from_utf8_lossy(&run_output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&run_output.stdout).contains("root registry"),
+            "explicit root import did not run the root module: stdout={} stderr={}",
+            String::from_utf8_lossy(&run_output.stdout),
+            String::from_utf8_lossy(&run_output.stderr)
+        );
+
+        Ok(())
+    }
+
+    /// Regression (GitHub #976): a bare import that resolves to its own nested source file must give root guidance.
+    #[test]
+    fn test_build_rejects_same_leaf_self_import_with_root_guidance() -> Result<(), Box<dyn std::error::Error>> {
+        let project_dir = make_temp_dir("incan_same_leaf_self_import");
+        let src_dir = project_dir.join("src");
+        let nested_dir = src_dir.join("substrait");
+        std::fs::create_dir_all(&nested_dir)?;
+        std::fs::write(
+            project_dir.join("incan.toml"),
+            "[project]\nname = \"same_leaf_self_import\"\nversion = \"0.1.0\"\n",
+        )?;
+
+        let main_path = src_dir.join("main.incn");
+        std::fs::write(
+            &main_path,
+            r#"from substrait.schema_registry import registered_columns
+
+def main() -> None:
+  println(registered_columns())
+"#,
+        )?;
+        std::fs::write(
+            src_dir.join("schema_registry.incn"),
+            r#"pub def registered_columns() -> str:
+  return "root registry"
+"#,
+        )?;
+        std::fs::write(
+            nested_dir.join("schema_registry.incn"),
+            r#"from schema_registry import registered_columns
+
+pub def registered_columns() -> str:
+  return registered_columns()
+"#,
+        )?;
+
+        let output = incan_command()
+            .args(["build", main_path.to_string_lossy().as_ref()])
+            .env("INCAN_SOURCE_ROOT", env!("CARGO_MANIFEST_DIR"))
+            .env(
+                "INCAN_STDLIB",
+                Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/incan_stdlib/stdlib"),
+            )
+            .env_remove("INCAN_STDLIB_DIR")
+            .env("CARGO_NET_OFFLINE", "true")
+            .output()?;
+        assert!(
+            !output.status.success(),
+            "self-importing source module unexpectedly built successfully:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("imports itself"),
+            "expected a self-import diagnostic, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("crate::schema_registry"),
+            "expected root-import guidance, got:\n{stderr}"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn test_run_async_task_and_time_facade() -> Result<(), Box<dyn std::error::Error>> {
         let project_dir = make_temp_dir("incan_async_task_time_facade_test");

--- a/workspaces/docs-site/docs/release_notes/0_5.md
+++ b/workspaces/docs-site/docs/release_notes/0_5.md
@@ -38,6 +38,7 @@ Incan 0.5 is the backend-foundation and Hees.ai proof-lane release. It starts th
 
 ## Bugfixes
 
+- **Compiler**: A nested source module no longer silently imports itself when a same-leaf bare import collides with the module name. Use `crate::module_name` for an intended project-root import (#976).
 - **Language**: Built-in mutable `Set[T]` values now expose `add(value)` consistently with the documented collection surface. The operation typechecks as `None`, lowers to `HashSet::insert`, and preserves set deduplication (#963).
 - **Compiler**: Public computed properties on models and classes now travel through checked API metadata and `.incnlib` contracts, so consumers of a compiled library can typecheck property access using the published result type (#952).
 - **SDK providers**: Source SDK preparation now validates the catalog's declared compiler range before compiling any component. A stale compiler therefore reports the incompatible source-SDK requirement directly instead of emitting unrelated provider type errors later in preparation (#945).


### PR DESCRIPTION
## Summary

Fix #976 by rejecting a nested source import that resolves to the importing file itself. The diagnostic explains that an explicit `crate::module_name` import is the project-root spelling.

For #979, add parser and complete-CLI regressions for direct zero-argument calls inside f-string interpolation, such as `f"enabled:{enabled()}"`. No production parser change is included: this form already worked on the current base branch.

Closes #976
Closes #979

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [x] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: A bare nested import that targets its own source file now fails with actionable root-import guidance. Existing `crate::module_name` imports remain valid. The #979 f-string call form continues to work and is now protected by regression coverage.
- **Internals**: `SelfImport` is resolved before a module enters compiler, build-provider, test-graph, or LSP dependency flows; each consumer maps it to the shared diagnostic.
- **Risks**: Deliberate self-imports that previously led to recursive module resolution now fail early. Bare-import precedence is otherwise unchanged.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit` passed after a clean rebase onto `origin/main` at `cee6fbfc1`: 3,420 tests, Rustdoc, Clippy, cargo-deny, release assertion canary, 60 example checks (35 run), and 9 benchmark builds.
- `python -m mkdocs build --strict` passed from `workspaces/docs-site`.
- Focused resolver, parser-AST, CLI f-string, explicit-root execution, and self-import-diagnostic regressions passed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/release_notes/0_5.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
