### PR TITLE
fix(parser): allow trailing comma in decorator arguments

### DIFF
--- a/crates/incan_syntax/src/parser/decl/decorators.rs
+++ b/crates/incan_syntax/src/parser/decl/decorators.rs
@@ -40,6 +40,11 @@ impl<'a> Parser<'a> {
         let mut args = Vec::new();
         if !self.check_punct(PunctuationId::RParen) {
             loop {
+                // Allow trailing comma: check for ) at start of loop iteration
+                if self.check_punct(PunctuationId::RParen) {
+                    break;
+                }
+
                 // Check for named argument (name: Type or name=value)
                 if let TokenKind::Ident(name) = &self.peek().kind {
                     let name = name.clone();


### PR DESCRIPTION
## Summary

The decorator argument parser did not handle trailing commas, causing a parse error when the final argument was followed by a comma:

```incan
@describe(arg1, arg2,)
```

This is inconsistent with ordinary multiline function calls which accept trailing commas.

## Fix

Adds a check for `)` at the start of each loop iteration in `decorator_args()`, matching the pattern used in `call_args()` for regular function calls.

This is a one-line semantic fix (3 lines including comment and blank line) that makes decorator argument syntax consistent with function call syntax.

## Reproduction

The issue was filed as #1000 with a detailed reproduction case. The fix allows the trailing comma to be consumed and the parser to break before attempting to parse `)` as an expression.

Fixes #1000